### PR TITLE
Add organism biology textbook

### DIFF
--- a/life/organism/README.md
+++ b/life/organism/README.md
@@ -1,0 +1,46 @@
+# Organism Biology Textbook
+
+The living specification of the organism architecture.
+
+This directory contains the tested, agreed-upon specs for how the organism works.
+Each file is a concise contract -- not aspirational, but what actually ships.
+Each file is a testable, incremental spec.
+
+## Table of Contents
+
+| File | What it covers |
+|------|---------------|
+| [layers.md](layers.md) | The 3-layer activation model (Spark, Spinal Cord, Organs) |
+| [organ-contract.md](organ-contract.md) | The organ interface: organ.json, live.sh, health.json |
+| [stimulus.md](stimulus.md) | Per-organ stimulus.jsonl format and atomicity guarantees |
+| [spark.md](spark.md) | Layer 0: the life spark specification |
+
+## Terminology
+
+| Term | Meaning |
+|------|---------|
+| **Organ** | Autonomous, thinking component. Has `live.sh` (required) + `organ.json` and `health.json` (optional). |
+| **Muscle** | Capability that executes but does not think. No CLAUDE.md, no autonomy. |
+| **Nerve** | Communication channel (MQTT bus, GAS bridge, etc). |
+| **Life Spark** | Layer 0 launcher. Intentionally dumb. Reads config, kicks organs. |
+| **Soul** | `CLAUDE.md` -- identity DNA for the whole organism. |
+| **Constitution** | Stable identity anchor, changed only by mutual agreement. |
+
+## Status Values
+
+An organ reports one of these in `health.json`:
+
+- **ok**: Organ completed its last cycle successfully.
+- **degraded**: Running but with errors or missing dependencies.
+- **down**: Not running or unreachable. Spark will attempt restart on next cycle.
+
+## How This Directory Grows
+
+1. Spec is agreed upon.
+2. Engineer agent writes it here.
+3. Critic agent reviews it.
+4. Tests validate it.
+5. Implementation follows the spec, not the other way around.
+
+If the implementation diverges from these specs, the spec is updated first,
+then the implementation follows. The spec is the source of truth.

--- a/life/organism/layers.md
+++ b/life/organism/layers.md
@@ -1,0 +1,76 @@
+# Layers: The 3-Layer Activation Model
+
+The organism activates through three layers. Lower layers are dumber and more
+reliable. Higher layers are smarter and more autonomous.
+
+## Layer 0 -- Life Spark
+
+**What**: A bash script (`life/spark.sh`) that runs on every machine.
+**Trigger**: Cron every minute (`* * * * *`). For sub-minute frequency, use
+systemd timers.
+**Config**: Discovers organ directories via argument, `$ORGANS` env, local `organs.conf`, or `~/organs.conf` (first match wins).
+**Intelligence**: Zero. No LLM, no network calls. Pure filesystem checks.
+
+The spark does exactly this:
+1. Discover organ directories (see [spark.md](spark.md) for 4 discovery methods)
+2. For each organ: does `live.sh` exist and is it executable? -- skip if no
+3. Is it already running? (`kill -0` PID check) -- skip if yes
+4. If `organ.json` exists, check cadence -- skip if not yet due
+5. All clear: launch `live.sh` via nohup, record PID and timestamp
+
+The spark is the heartbeat. It provides **periodic activation** -- organs that
+need to run every N minutes get kicked by the spark on schedule.
+
+See [spark.md](spark.md) for the full specification.
+
+## Layer 1 -- Spinal Cord
+
+**What**: An organ (not a daemon). Kicked by the spark like any other organ.
+**Purpose**: Bridges real-time signals (MQTT) into organ-local stimulus files.
+**How it works**:
+1. Spark kicks the spinal cord on its cadence
+2. Spinal cord connects to MQTT broker (TLS 8883)
+3. Drains queued messages from subscribed topics
+4. Routes each message to the target organ's `stimulus.jsonl`
+5. After writing stimulus, calls `life/spark.sh` directly (event-driven trigger)
+6. Disconnects and exits
+
+This is the key insight: **Layer 0 + Layer 1 together provide both periodic
+and event-driven activation.**
+
+- Periodic: Cron kicks spark, spark kicks organs on cadence
+- Event-driven: MQTT message arrives, spinal cord writes stimulus, spinal cord
+  kicks spark, spark sees the organ needs attention and launches it
+
+The spinal cord is NOT persistent. It runs, drains, writes, kicks, exits.
+The spark will kick it again next cycle to drain any new messages.
+
+## Layer 2+ -- Organs
+
+**What**: Autonomous components with full decision-making within their domain.
+**Examples**: Brain, circadian rhythm, future research organ, future memory organ.
+**Contract**: `live.sh` (required) + optional `organ.json` and `health.json` (see [organ-contract.md](organ-contract.md))
+
+Each organ:
+- Is launched by the spark (Layer 0)
+- Reads its own `stimulus.jsonl` for incoming signals (written by Layer 1)
+- Reports health via `health.json`
+- Has full autonomy to decide what to do within its domain
+- Runs as a singleton (one instance at a time, enforced by flock)
+
+Organs do not communicate directly with each other. All inter-organ
+communication flows through the nervous system (MQTT) and gets routed
+by the spinal cord (Layer 1) into per-organ stimulus files.
+
+## Why Three Layers
+
+| Property | Layer 0 (Spark) | Layer 1 (Spinal Cord) | Layer 2+ (Organs) |
+|----------|----------------|----------------------|-------------------|
+| Intelligence | None | Minimal (routing) | Full (LLM, heuristics) |
+| Persistence | None (cron) | None (spark-kicked) | None (spark-kicked) |
+| Network | None | MQTT only | Whatever they need |
+| Failure mode | Cron restarts | Spark restarts | Spark restarts |
+| Singleton | N/A | Yes (flock) | Yes (flock) |
+
+If Layer 2 dies, Layer 0 restarts it. If Layer 1 dies, Layer 0 restarts it.
+If Layer 0 dies, cron restarts it. The dumber layers protect the smarter ones.

--- a/life/organism/organ-contract.md
+++ b/life/organism/organ-contract.md
@@ -1,0 +1,91 @@
+# Organ Contract
+
+Every organ lives in its own directory under `organs/<name>/`.
+This document defines the interface that all organs MUST implement.
+
+## Required Files
+
+### live.sh -- Entry Point
+
+The spark launches this script. It must be executable. Conventions:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+ORGAN_DIR="$(cd "$(dirname "$0")" && pwd)"
+ORGAN_NAME="$(basename "$ORGAN_DIR")"
+
+# Singleton guard (flock — exit 0 if already running, not an error)
+exec 9>"$ORGAN_DIR/.spark.lock"
+flock -n 9 || { echo "Already running"; exit 0; }
+
+# --- Do the organ's actual work here ---
+
+# Report health when done
+cat > "$ORGAN_DIR/health.json" <<EOF
+{"status":"ok","ts":"$(date -Iseconds)","message":"cycle complete"}
+EOF
+```
+
+**Rules**:
+- `set -euo pipefail` -- fail fast, fail loud
+- `flock` for singleton enforcement -- exit 0 if already running (not an error). The FD number is arbitrary.
+- Exit 0 on success, non-zero on failure
+- Language-agnostic: `live.sh` can exec into Python, Node, or anything via its shebang
+
+## Optional Files
+
+### organ.json -- Manifest
+
+Declares what the organ is and how the spark should manage it.
+If missing, the organ runs every spark cycle with no cadence gating.
+
+```json
+{
+  "name": "brain",
+  "description": "Central decision-maker and orchestrator",
+  "cadence": 5
+}
+```
+
+**Field definitions**:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| cadence | int | Minutes between sparks. If missing, organ runs every cycle. |
+| name | string | Human-readable organ identifier |
+| description | string | Human-readable purpose |
+| co_locate | list[string] | **[Planned]** Organ names that must share the same host |
+
+Only `cadence` affects spark behavior. All other fields are informational
+or used by the organ itself.
+
+### health.json -- Self-Reported Status
+
+Written by the organ itself. The spark does not currently read this file;
+it exists for monitoring and future immune-system use.
+
+```json
+{
+  "status": "ok",
+  "ts": "2026-03-16T14:30:00-07:00",
+  "message": "processed 42 items"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| status | string | One of: `ok`, `degraded`, `down` |
+| ts | string | ISO 8601 timestamp |
+| message | string | Optional human-readable note |
+
+### stimulus.jsonl -- Input Queue
+
+Per-organ stimulus file. See [stimulus.md](stimulus.md) for the full spec.
+Written by the spinal cord (Layer 1) or other systems. Read by the organ.
+
+### CLAUDE.md -- Identity DNA
+
+For LLM-based organs only. Defines the organ's personality, role, and
+behavioral constraints. The brain has one; a pure-Python organ does not need one.

--- a/life/organism/spark.md
+++ b/life/organism/spark.md
@@ -1,0 +1,113 @@
+# Life Spark -- Layer 0 Specification
+
+The spark is the heartbeat of the organism. It is intentionally dumb.
+
+**Location**: `life/spark.sh` (lives in `~/bin` on every machine)
+**Trigger**: Cron every minute: `* * * * * ~/bin/life/spark.sh`
+**Config**: Organ directories discovered in priority order (first match wins)
+
+## Properties
+
+- **No intelligence.** No LLM, no API calls, no network access.
+- **No persistence.** Runs, checks, launches, exits. Cron calls it again.
+- **Pure filesystem.** Reads config files, checks PIDs, writes timestamps.
+- **Idempotent.** Running it twice in a row produces the same result.
+- **Fast.** Must complete in under 1 second.
+
+## Organ Discovery
+
+The spark finds organ directories using the first source that matches:
+
+| Priority | Source | Example |
+|----------|--------|---------|
+| 1 | **Argument** — a manifest file path passed on the command line | `spark.sh /path/to/manifest.conf` |
+| 2 | **`$ORGANS` env** — colon-separated directory paths (like `PATH`) | `ORGANS=/opt/brain:/opt/eyes spark.sh` |
+| 3 | **Local manifest** — `organs.conf` next to the script | `life/organs.conf` |
+| 4 | **Home manifest** — `~/organs.conf` | `~/organs.conf` |
+
+A manifest file lists one organ directory path per line. Blank lines and
+`#` comments are ignored. Relative paths resolve from the manifest's directory.
+
+```conf
+# organs.conf -- organs managed on this machine
+/home/user/organs/brain
+# /home/user/organs/circadian  # uncomment when ready
+```
+
+Each path must contain an executable `live.sh`. The `organ.json` manifest
+is optional — if missing, the organ runs every spark cycle (no cadence gating).
+
+## Algorithm
+
+```
+for each discovered organ directory:
+    path = organ directory
+
+    1. VALIDATE: does path/live.sh exist and is it executable?
+       no  -> warn, skip
+
+    2. SINGLETON CHECK: is the organ already running?
+       - read PID from path/.spark.pid
+       - check with kill -0 <pid>
+       running -> skip (already active)
+
+       NOTE: The spark does NOT check dependencies. Dependency checking
+       is the organ's responsibility at startup.
+
+    3. CADENCE CHECK (only if path/organ.json exists):
+       - parse organ.json for cadence field
+       - read epoch from path/.spark.last
+       - if (now - last) < cadence minutes -> skip
+       - if organ.json is missing or has no cadence -> run every cycle
+
+    4. LAUNCH:
+       - nohup path/live.sh >> path/.spark.log 2>&1 &
+       - write PID to path/.spark.pid
+       - write epoch to path/.spark.last
+       - log: "started <organ_name> (PID $!)"
+```
+
+## Cadence Values
+
+| Value | Meaning |
+|-------|---------|
+| Integer (e.g., `5`) | Spark every N minutes |
+| `"manual"` | Never auto-sparked. Only launched by explicit command. |
+| `"on-stimulus-or-cooldown"` | Spark when `stimulus.jsonl` exists and has size > 0 bytes (file size check only, no JSONL parsing), otherwise respect a cooldown period (`cooldown_minutes`, falling back to `health_ttl_minutes`). |
+
+For `"on-stimulus-or-cooldown"`: the spark checks if `stimulus.jsonl` exists
+and has size > 0 bytes (the spark does not parse the JSONL content -- it just
+checks file size). If yes, spark the organ (respecting singleton). If no,
+fall back to `cooldown_minutes` from organ.json as the cooldown period. If
+`cooldown_minutes` is not specified, `health_ttl_minutes` is used as the fallback.
+
+## Sub-Minute Frequency
+
+For sub-minute frequency, use a systemd timer instead of cron.
+For most organs, once per minute is sufficient. The spinal cord + immediate
+stimulus pattern handles real-time needs without sub-minute spark frequency.
+
+## Logging
+
+The spark logs to stderr (captured by cron or systemd). Each decision is
+logged at a single line:
+
+```
+2026-03-16T14:30:01 SPARK brain: sparked (pid 12345)
+2026-03-16T14:30:01 SPARK circadian: skipped (outside activity window)
+2026-03-16T14:30:01 SPARK spinal-cord: skipped (already running, pid 12340)
+```
+
+## Failure Modes
+
+| Failure | Result |
+|---------|--------|
+| No organs configured | Spark exits cleanly (code 0), logs message |
+| live.sh missing or not executable | Skip that organ, log warning |
+| organ.json missing | Organ runs every cycle (no cadence gating) |
+| organ.json invalid JSON | Skip cadence check, treat as missing |
+| live.sh fails (non-zero exit) | Organ reports health, spark retries next cycle |
+| Spark itself crashes | Cron restarts it next minute |
+
+The spark never crashes the organism. Every error is logged and skipped.
+The next cron cycle gets another chance.

--- a/life/organism/stimulus.md
+++ b/life/organism/stimulus.md
@@ -1,0 +1,99 @@
+# Stimulus Specification
+
+Stimulus is how signals reach organs. Each organ has its own `stimulus.jsonl`
+file in its organ directory (`organs/<name>/stimulus.jsonl`).
+
+This is a per-organ file -- NOT the global `stimulus-queue.jsonl` from the
+earlier architecture. The new design routes stimulus to individual organs
+via the spinal cord (Layer 1).
+
+## Format
+
+JSONL: one JSON object per line, newline-terminated.
+
+### Minimum Fields
+
+Every stimulus line MUST have:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| type | string | What kind of stimulus (e.g., `"email"`, `"chat"`, `"health_alert"`, `"cron"`) |
+| ts | string | ISO 8601 UTC timestamp (e.g., `"2026-03-16T21:30:00Z"`) |
+| body | string | The stimulus content |
+
+### Optional Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| priority | string | `"batch"` | `"immediate"` or `"batch"` |
+| content_hash | string | -- | 16-char SHA-256 hex prefix for dedup |
+| sender | string | -- | Who/what sent this stimulus |
+| subject | string | -- | Subject line (for emails, alerts) |
+| snippet | string | -- | Short preview (for UI display) |
+
+### Examples
+
+```jsonl
+{"type":"email","ts":"2026-03-16T21:30:00Z","body":"Can you check the deploy?","sender":"ops","subject":"Deploy check","priority":"immediate","content_hash":"a1b2c3d4e5f6a7b8"}
+{"type":"health_alert","ts":"2026-03-16T21:31:00Z","body":"Phone tentacle offline for 5 minutes","sender":"brainstem","priority":"batch"}
+{"type":"chat","ts":"2026-03-16T21:35:00Z","body":"What's your status?","sender":"neil","content_hash":"f8e7d6c5b4a39281"}
+```
+
+## Timezone
+
+Stimulus timestamps are always **UTC** (with trailing `Z`).
+This differs from health.json which uses naive local time.
+When in doubt, use UTC for stimulus.
+
+## Atomicity
+
+### Writing Stimulus
+
+On Linux, short O_APPEND writes to regular files are effectively atomic
+due to kernel inode locking. Keep each stimulus line well under 4096 bytes.
+This is a Linux implementation behavior, not a POSIX guarantee.
+
+This means multiple writers (spinal cord, brainstem, direct injection) can
+safely append to the same file without explicit locking, as long as each
+write is a single echo/write call well under 4096 bytes.
+
+### Reading and Consuming Stimulus
+
+The organ must read and remove processed lines. Recommended pattern:
+
+```bash
+exec 9>stimulus.jsonl.lock
+flock 9
+lines=$(cat stimulus.jsonl)
+> stimulus.jsonl
+exec 9>&-
+# process $lines
+```
+
+Alternatively, `mv stimulus.jsonl stimulus.processing` works but may lose
+lines written between the rename and the next append.
+
+## Deduplication
+
+Content hashing is recommended but not required.
+
+When used, `content_hash` is a 16-character hex prefix of the SHA-256 hash
+of the stimulus body. Organs that track seen hashes can skip duplicates.
+
+```python
+import hashlib
+content_hash = hashlib.sha256(body.encode()).hexdigest()[:16]
+```
+
+The existing idempotent stimulus infrastructure in the codebase already
+uses this pattern. New organs should follow it for consistency.
+
+## Priority
+
+- `"immediate"`: Organ should process this stimulus as soon as possible.
+  The spinal cord kicks the spark after writing immediate stimulus,
+  providing near-real-time activation.
+- `"batch"`: Organ processes this on its next regular cycle. No extra
+  spark kick needed.
+
+Default is `"batch"` if omitted.


### PR DESCRIPTION
## Summary
- 5 spec files in `life/organism/`: README (index), layers, organ contract, stimulus, spark
- All specs reconciled with current `spark.sh` implementation
- Planned/unimplemented features marked `[Planned]`
- Scrubbed of PII and internal references
- Reviewed by triforce team (researcher + engineer + critic, 14 issues found and fixed)

## Files
| File | Lines | What it covers |
|------|-------|---------------|
| README.md | 46 | Index, terminology, status values |
| layers.md | 76 | 3-layer activation model (Spark → Spinal Cord → Organs) |
| organ-contract.md | 91 | Organ interface: organ.json, live.sh, health.json |
| stimulus.md | 99 | Per-organ stimulus.jsonl format and atomicity |
| spark.md | 113 | Layer 0 specification |

## Critic fixes applied
- organ.json marked optional (matches implementation)
- Health status vocabulary aligned with existing life/README.md (ok/degraded/down)
- All 4 organ discovery methods documented
- Launch command matches spark.sh (direct execution, not `bash`)
- Singleton check uses `kill -0` (matches spark.sh)
- Bloat trimmed: systemd example, dual consumption patterns, Python template

🤖 Generated with [Claude Code](https://claude.com/claude-code)