### PR TITLE
Portable flock shim for macOS

### DIFF
--- a/flock
+++ b/flock
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""flock shim — portable file locking for macOS.
+
+On Linux, the real flock (util-linux) is used. This shim exists for
+macOS and other systems where flock is not installed.
+
+Supports the subset used by life/spark.sh:
+  flock -n <fd>           Non-blocking lock on inherited file descriptor
+  flock -n <file> <cmd>   Non-blocking lock on file, then run command
+"""
+import sys, fcntl, os, subprocess
+
+def usage():
+    print("Usage: flock -n <fd>  or  flock -n <file> <command...>", file=sys.stderr)
+    sys.exit(2)
+
+args = sys.argv[1:]
+if not args or args[0] != "-n":
+    usage()
+args = args[1:]  # consume -n
+
+if not args:
+    usage()
+
+target = args[0]
+
+# Case 1: flock -n <fd> — lock inherited file descriptor
+if target.isdigit():
+    fd = int(target)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except (IOError, OSError):
+        sys.exit(1)
+    sys.exit(0)
+
+# Case 2: flock -n <file> <command...> — lock file then run command
+if len(args) < 2:
+    usage()
+
+lockfile = args[0]
+command = args[1:]
+
+try:
+    fd = os.open(lockfile, os.O_CREAT | os.O_RDWR)
+    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+except (IOError, OSError):
+    sys.exit(1)
+
+result = subprocess.run(command)
+os.close(fd)
+sys.exit(result.returncode)


### PR DESCRIPTION
## Summary

Python-based flock using `fcntl.flock()` — works on macOS where util-linux flock doesn't exist.

Supports the two patterns spark.sh uses:
- `flock -n <fd>` — lock inherited file descriptor
- `flock -n <file> <cmd>` — lock file then run command

On Linux, the real flock takes precedence (earlier in PATH).

## Test plan

- [x] 9/9 tadpole tests passing on Linux
- [x] fd-based locking verified
- [x] File-based locking verified
- [x] Test on macOS (Neil)

🤖 Generated with [Claude Code](https://claude.com/claude-code)