### PR TITLE
Fix stimulus read-then-truncate race condition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ health.txt
 stimulus.txt
 .spark.last
 .spark.log
+.stimulus.processing

--- a/life/textbook/stimulus.md
+++ b/life/textbook/stimulus.md
@@ -15,23 +15,14 @@ Short writes (under 4096 bytes) with `>>` are effectively atomic on Linux. Multi
 
 ## Reading
 
-The organ reads and empties the file when it runs:
+The organ reads and clears stimulus using the `stimulus` CLI:
 
 ```bash
-lines=$(cat stimulus.txt)
-> stimulus.txt
+lines=$(stimulus consume "$DIR")
 # process $lines
 ```
 
-For concurrent-safe consumption, use flock:
-
-```bash
-exec 9>stimulus.txt.lock
-flock 9
-lines=$(cat stimulus.txt)
-> stimulus.txt
-exec 9>&-
-```
+`stimulus consume` atomically renames stimulus.txt before reading it, so no lines are lost between the read and the clear. Organs should never `cat + truncate` directly.
 
 ## What Goes in a Line
 

--- a/stimulus
+++ b/stimulus
@@ -11,6 +11,7 @@ usage() {
   echo "  stimulus send <type> \"message\"       # signal organ by type"
   echo "  stimulus send <type>:<id> \"message\"  # signal specific organ"
   echo "  stimulus query [type]                 # query registry"
+  echo "  stimulus consume [dir]                # read and clear stimulus.txt"
   exit 1
 }
 
@@ -82,6 +83,19 @@ case "$cmd" in
     else
       sqlite3 -separator "	" "$DB" \
         "SELECT type, id, body_part, health_status, health_text, last_seen FROM organs ORDER BY type, id;"
+    fi
+    ;;
+
+  consume)
+    # Atomically read and clear stimulus.txt. Outputs lines to stdout.
+    # Uses rename-then-read so no lines are lost between read and clear.
+    dir="${1:-$PWD}"
+    stim="$dir/stimulus.txt"
+    tmp="$dir/.stimulus.processing"
+    if [ -f "$stim" ] && [ -s "$stim" ]; then
+      mv "$stim" "$tmp"
+      cat "$tmp"
+      rm -f "$tmp"
     fi
     ;;
 

--- a/tadpole/organs/stomach/live.sh
+++ b/tadpole/organs/stomach/live.sh
@@ -6,10 +6,7 @@ set -euo pipefail
 DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Consume stimulus
-if [ -f "$DIR/stimulus.txt" ]; then
-  cat "$DIR/stimulus.txt" > /dev/null
-  > "$DIR/stimulus.txt"
-fi
+stimulus consume "$DIR" > /dev/null
 
 # Produce a payload
 meals=0

--- a/tadpole/organs/tail/live.sh
+++ b/tadpole/organs/tail/live.sh
@@ -4,12 +4,7 @@ set -euo pipefail
 DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Read and consume stimulus
-if [ -f "$DIR/stimulus.txt" ]; then
-  stimulus=$(cat "$DIR/stimulus.txt")
-  > "$DIR/stimulus.txt"
-else
-  stimulus=""
-fi
+stimulus=$(stimulus consume "$DIR")
 
 swims=0
 [ -f "$DIR/swims.count" ] && swims=$(cat "$DIR/swims.count")


### PR DESCRIPTION
## Summary

Replace `cat + truncate` with atomic `rename-then-read` in all organs.

The old pattern loses lines written between the read and the truncate:
```bash
# BAD: race window between cat and >
lines=$(cat stimulus.txt)
> stimulus.txt
```

The new pattern is atomic — no window for lost writes:
```bash
# GOOD: rename is atomic, then read from renamed file
mv stimulus.txt .stimulus.processing
lines=$(cat .stimulus.processing)
rm -f .stimulus.processing
```

Updated: tail, stomach, and textbook stimulus.md.

## Test plan

- [x] 9/9 tadpole tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)