### PR TITLE
Fix circ-get binary corruption from Drive

### DIFF
--- a/circ-get
+++ b/circ-get
@@ -33,18 +33,18 @@ if command -v gas >/dev/null 2>&1; then
   fid=$(echo "$files" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['files'][0]['id'] if d.get('files') else '')" 2>/dev/null)
 
   if [ -n "$fid" ]; then
-    data=$(gas drive.download "id=$fid" 2>/dev/null)
-    # Extract base64 data and decode
-    decoded=$(echo "$data" | python3 -c "import sys,json,base64; d=json.load(sys.stdin); sys.stdout.buffer.write(base64.b64decode(d['data']))" 2>/dev/null)
-
-    # Cache locally for next time
+    # Decode directly to file — never capture binary in a bash variable
     mkdir -p "$LOCAL_DIR"
-    echo "$decoded" > "$LOCAL_DIR/$hash"
+    gas drive.download "id=$fid" 2>/dev/null | python3 -c "
+import sys, json, base64
+d = json.load(sys.stdin)
+sys.stdout.buffer.write(base64.b64decode(d['data']))
+" > "$LOCAL_DIR/$hash"
 
     if [ -n "$output" ]; then
-      echo "$decoded" > "$output"
+      cp "$LOCAL_DIR/$hash" "$output"
     else
-      echo "$decoded"
+      cat "$LOCAL_DIR/$hash"
     fi
     exit 0
   fi


### PR DESCRIPTION
## Summary

The Drive fallback path in circ-get captured decoded binary in a bash variable (strips null bytes) then used echo to write it (adds trailing newline). Both corrupt binary payloads.

Fix: pipe gas output directly through python3 base64 decoder into the cache file. No bash variable, no echo. Binary-safe.

## Test plan

- [x] Text payloads still work (tadpole tests)
- [x] Code review: no bash variable capture of binary data

🤖 Generated with [Claude Code](https://claude.com/claude-code)