### PR TITLE
Sanitize stimulus query input

### DIFF
--- a/stimulus
+++ b/stimulus
@@ -73,6 +73,10 @@ case "$cmd" in
     fi
     if [ $# -ge 1 ]; then
       target_type="$1"
+      # Sanitize: only allow alphanumeric, dash, underscore
+      if ! echo "$target_type" | grep -qE '^[a-zA-Z0-9_-]+$'; then
+        echo "stimulus query: invalid type '$target_type'" >&2; exit 1
+      fi
       sqlite3 -separator "	" "$DB" \
         "SELECT type, id, body_part, health_status, health_text, last_seen FROM organs WHERE type='$target_type' ORDER BY id;"
     else


### PR DESCRIPTION
## Summary

The `stimulus query <type>` command interpolated user input directly into a SQL string. Now validates that the type argument matches `[a-zA-Z0-9_-]+` before using it in the query. Invalid input gets a clean error message.

## Test plan

- [x] Normal queries still work
- [x] Invalid input rejected: `stimulus query "'; DROP TABLE organs;--"` → error

🤖 Generated with [Claude Code](https://claude.com/claude-code)