### PR TITLE
Tadpole v3: two body parts in Docker, MQTT nervous system, shared circ

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.github
+.claude
+__pycache__
+*.pyc
+.spark.log
+.spark.last
+health.txt
+stimulus.txt
+beats.count
+*.db
+docs/journal
+tadpole/mock-gmail
+tadpole/backups

--- a/brain/Dockerfile
+++ b/brain/Dockerfile
@@ -23,9 +23,6 @@ RUN chmod +x /opt/bin/stimulus /opt/bin/mqtt-pub /opt/bin/mqtt-sub \
     /opt/bin/local-secret \
     /opt/bin/life/spark.sh /opt/bin/life/spark-loop.sh /opt/bin/life/spark-organ.sh \
     /opt/bin/ganglion/live.sh \
-    /opt/bin/comms/live.sh \
-    /opt/bin/gmail \
-    /opt/bin/tadpole/organs/*/live.sh \
     && chmod -R a+rwX /opt/bin
 
 # Writable HOME for any UID
@@ -33,5 +30,5 @@ ENV HOME=/tmp/home
 RUN mkdir -p /tmp/home/.life/locks && chmod -R 777 /tmp/home
 
 ENV PATH="/opt/bin:$PATH"
-WORKDIR /opt/bin/tadpole
+WORKDIR /opt/bin/brain
 ENTRYPOINT ["/opt/bin/life/spark-loop.sh"]

--- a/brain/life.conf
+++ b/brain/life.conf
@@ -1,0 +1,5 @@
+ORGANS=../ganglion:organs/pfc:../tadpole/organs/hippocampus
+MQTT_HOST=mqtt
+MQTT_PORT=1883
+BODY_PART=brain
+DEFAULT_ORGAN=pfc

--- a/brain/life.conf
+++ b/brain/life.conf
@@ -3,3 +3,4 @@ MQTT_HOST=mqtt
 MQTT_PORT=1883
 BODY_PART=brain
 DEFAULT_ORGAN=pfc
+MEMORY_DB=/opt/bin/tadpole/organs/hippocampus/memory.db

--- a/brain/organs/pfc/live.sh
+++ b/brain/organs/pfc/live.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+DIR="$(cd "$(dirname "$0")" && pwd)"
+exec python3 "$DIR/pfc.py"

--- a/brain/organs/pfc/organ.conf
+++ b/brain/organs/pfc/organ.conf
@@ -1,0 +1,1 @@
+CADENCE=1

--- a/brain/organs/pfc/pfc.py
+++ b/brain/organs/pfc/pfc.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""PFC organ — prefrontal cortex. Thinks about emails using claude -p."""
+import json, os, subprocess, sys
+from pathlib import Path
+
+DIR = Path(__file__).resolve().parent
+CONF_DIR = os.environ.get("CONF_DIR", str(DIR.parent.parent))
+sys.path.insert(0, str(DIR.parent.parent.parent))
+import muscles
+
+log = lambda msg: muscles.log("pfc", msg)
+
+
+def think(prompt):
+    """Call claude -p. Returns response or None."""
+    try:
+        r = subprocess.run(
+            ["claude", "-p"], input=prompt,
+            capture_output=True, text=True, timeout=120, cwd=CONF_DIR,
+        )
+        if r.returncode != 0:
+            log(f"claude error: {r.stderr[:200]}")
+            return None
+        return r.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+        log(f"claude exception: {e}")
+        return None
+
+
+def handle_new_email(thread_id, circ_ref):
+    """Read email from circ, recall memories, think, reply via comms."""
+    raw = muscles.circ.get(circ_ref)
+    if not raw:
+        log(f"circ miss: {circ_ref}"); return False
+    try:
+        email = json.loads(raw)
+    except json.JSONDecodeError:
+        log(f"bad JSON: {circ_ref}"); return False
+
+    fr, subj, body = email.get("from","?"), email.get("subject",""), email.get("body","")
+    mem_text, _ = muscles.run(["memories", "search", "--", f"{fr} {subj}"], timeout=15)
+
+    parts = []
+    if mem_text:
+        parts.append(f"Relevant memories:\n{mem_text}\n")
+    parts.append(f"Email from {fr}\nSubject: {subj}\n\n{body}\n\n"
+                 "Write a reply. No subject line — just the body.")
+
+    reply = think("\n".join(parts))
+    if not reply:
+        log(f"no reply for {thread_id}"); return False
+
+    reply_ref = muscles.circ.put(reply)
+    if not reply_ref:
+        log("circ put failed"); return False
+
+    muscles.stimulus.send("comms", f"send-reply brain {thread_id} circ:{reply_ref}")
+    muscles.memories.store(
+        f"Email from {fr} about '{subj}': {body[:200]}",
+        importance=6, env=muscles.memory_env(CONF_DIR),
+    )
+    log(f"replied to {thread_id}"); return True
+
+
+def main():
+    muscles.ensure_memory_db(CONF_DIR)
+    lines = muscles.stimulus.consume(str(DIR)).strip().splitlines()
+    processed = errors = 0
+
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            if line.startswith("new-email"):
+                p = line.split()
+                if len(p) < 3 or not p[2].startswith("circ:"):
+                    log(f"bad format: {line}"); errors += 1; continue
+                ok = handle_new_email(p[1], p[2][5:])
+                processed += ok; errors += not ok
+            elif line.startswith("sent"):
+                tid = line.split()[1] if len(line.split()) > 1 else "?"
+                log(f"confirmed sent {tid}"); processed += 1
+            else:
+                log(f"unknown: {line}"); errors += 1
+        except Exception as e:
+            log(f"error on '{line}': {e}"); errors += 1
+
+    if not lines or all(not l.strip() for l in lines):
+        muscles.stimulus.send("comms", "check-email brain")
+        log("idle, told comms to check")
+
+    status = f"ok processed={processed} errors={errors}" if lines else "ok idle"
+    (DIR / "health.txt").write_text(status + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/comms/comms.py
+++ b/comms/comms.py
@@ -1,25 +1,28 @@
 #!/usr/bin/env python3
 """Comms organ — stimulus-driven communication I/O.
 
-The comms organ does NOT check email on its own. It processes stimulus signals:
-  - "check-email [query]" -> search Gmail, notify brain of new emails
-  - "send-reply <thread_id> circ:<hash>" -> send a reply, notify brain
+Supports two modes:
+  - Mock gmail (GMAIL_MOCK_DIR set): file-based inbox/sent via JSON files
+  - Real gmail (default): GAS bridge via gmail CLI muscle
 
-Each cycle:
-1. Consume stimulus
-2. Process each signal
-3. Write health and exit
+Stimulus signals:
+  - "check-email <reply_to> [query]" -> check for new emails, notify reply_to
+  - "send-reply <reply_to> <thread_id> circ:<hash>" -> send a reply
+  - "send-email <reply_to> circ:<hash>" -> compose and send new email
+
+Each cycle: consume stimulus, process signals, write health, exit.
 """
 import json
 import os
+import shutil
 import sys
 from pathlib import Path
 
 DIR = Path(__file__).resolve().parent
 CONF_DIR = os.environ.get("CONF_DIR", "")
+GMAIL_MOCK_DIR = os.environ.get("GMAIL_MOCK_DIR", "")
 
 # muscles.py lives at BIN_ROOT (peer to comms/). Spark sets PYTHONPATH.
-# Fallback: comms/ is one level below BIN_ROOT, so DIR.parent works.
 sys.path.insert(0, str(DIR.parent))
 import muscles
 
@@ -28,8 +31,109 @@ def log(msg):
     muscles.log("comms", msg)
 
 
+# ---- Mock gmail (file-based) ----
+
+def mock_check_email(reply_to):
+    """Scan GMAIL_MOCK_DIR/inbox/ for .json files, move to .processed/, notify."""
+    inbox = Path(GMAIL_MOCK_DIR) / "inbox"
+    if not inbox.is_dir():
+        log("mock check-email: no inbox directory")
+        return 0
+
+    processed = inbox / ".processed"
+    processed.mkdir(parents=True, exist_ok=True)
+
+    count = 0
+    for f in sorted(inbox.glob("*.json")):
+        try:
+            data = json.loads(f.read_text())
+        except (json.JSONDecodeError, OSError) as e:
+            log(f"mock check-email: bad file {f.name}: {e}")
+            continue
+
+        payload = json.dumps({
+            "id": data.get("id", f.stem),
+            "from": data.get("from", "unknown"),
+            "subject": data.get("subject", "(no subject)"),
+            "body": data.get("body", ""),
+        })
+        ref = muscles.circ.put(payload)
+        if not ref:
+            log(f"mock check-email: failed to store {f.name} in circ")
+            continue
+
+        # Move to processed = "mark as read"
+        shutil.move(str(f), str(processed / f.name))
+
+        muscles.stimulus.send(reply_to, f"new-email {data.get('id', f.stem)} circ:{ref}")
+        count += 1
+
+    log(f"mock check-email: notified {reply_to} of {count} emails")
+    return count
+
+
+def mock_send_reply(reply_to, thread_id, circ_ref):
+    """Write reply JSON to GMAIL_MOCK_DIR/sent/."""
+    body = muscles.circ.get(circ_ref)
+    if not body:
+        log(f"mock send-reply: could not retrieve circ:{circ_ref}")
+        return False
+
+    sent_dir = Path(GMAIL_MOCK_DIR) / "sent"
+    sent_dir.mkdir(parents=True, exist_ok=True)
+
+    out_file = sent_dir / f"{thread_id}_reply.json"
+    out_file.write_text(json.dumps({
+        "id": thread_id,
+        "to": reply_to,
+        "subject": f"Re: {thread_id}",
+        "body": body,
+    }, indent=2))
+
+    muscles.stimulus.send(reply_to, f"sent {thread_id}")
+    log(f"mock send-reply: wrote {out_file.name}")
+    return True
+
+
+def mock_send_email(reply_to, circ_ref):
+    """Write new email JSON to GMAIL_MOCK_DIR/sent/."""
+    raw = muscles.circ.get(circ_ref)
+    if not raw:
+        log(f"mock send-email: could not retrieve circ:{circ_ref}")
+        return False
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        log(f"mock send-email: circ:{circ_ref} is not valid JSON")
+        return False
+
+    to_addr = payload.get("to", "")
+    subject = payload.get("subject", "")
+    body_text = payload.get("body", "")
+    if not to_addr or not body_text:
+        log(f"mock send-email: missing 'to' or 'body'")
+        return False
+
+    sent_dir = Path(GMAIL_MOCK_DIR) / "sent"
+    sent_dir.mkdir(parents=True, exist_ok=True)
+
+    # Use a unique-ish filename from the hash
+    out_file = sent_dir / f"{circ_ref[:12]}_new.json"
+    out_file.write_text(json.dumps({
+        "to": to_addr,
+        "subject": subject,
+        "body": body_text,
+    }, indent=2))
+
+    muscles.stimulus.send(reply_to, f"email-sent {to_addr}")
+    log(f"mock send-email: wrote {out_file.name}")
+    return True
+
+
+# ---- Real gmail (GAS bridge) ----
+
 def gmail_search(query, count=5):
-    """Search Gmail via the gmail muscle. Returns parsed JSON or None."""
     out, ok = muscles.run(["gmail", "search", query, "--count", str(count)])
     if ok and out:
         try:
@@ -40,7 +144,6 @@ def gmail_search(query, count=5):
 
 
 def gmail_get(msg_id):
-    """Get a full email via the gmail muscle."""
     out, ok = muscles.run(["gmail", "get", msg_id])
     if ok and out:
         try:
@@ -51,30 +154,17 @@ def gmail_get(msg_id):
 
 
 def gmail_reply(thread_id, body_file):
-    """Reply to a thread via the gmail muscle using --body-file."""
     _, ok = muscles.run(["gmail", "reply", thread_id, "--body-file", body_file])
     return ok
 
 
-def gmail_label(msg_id, remove=None, add=None):
-    """Modify labels on a message."""
-    cmd = ["gmail", "label", msg_id]
-    if remove:
-        cmd.extend(["--remove", remove])
-    if add:
-        cmd.extend(["--add", add])
-    _, ok = muscles.run(cmd)
-    return ok
-
-
 def gmail_read(thread_id):
-    """Mark a thread as read via the gmail muscle."""
     _, ok = muscles.run(["gmail", "read", thread_id])
     return ok
 
 
-def handle_check_email(reply_to, query=None):
-    """Check Gmail for unread emails, notify requesting organ of each."""
+def real_check_email(reply_to, query=None):
+    """Check Gmail for unread emails via GAS bridge, notify requesting organ."""
     if not query:
         query = "label:Tadpole is:unread"
 
@@ -83,7 +173,6 @@ def handle_check_email(reply_to, query=None):
         log("check-email: no results")
         return 0
 
-    # Handle both array and {threads/messages: [...]} shapes
     threads = data if isinstance(data, list) else data.get("threads", data.get("messages", []))
     if not threads:
         log("check-email: no unread emails")
@@ -98,12 +187,11 @@ def handle_check_email(reply_to, query=None):
         email_from = thread.get("from", "unknown")
         email_subject = thread.get("subject", "(no subject)")
 
-        # Get full email content (GAS bridge returns {thread_id, messages: [...], count})
         full = gmail_get(email_id)
         if full:
             msgs = full.get("messages", [])
             if msgs:
-                msg = msgs[-1]  # latest message in thread
+                msg = msgs[-1]
                 email_from = msg.get("from", email_from)
                 email_subject = msg.get("subject", email_subject)
                 email_body = msg.get("plain", msg.get("html", ""))
@@ -112,7 +200,6 @@ def handle_check_email(reply_to, query=None):
         else:
             email_body = thread.get("snippet", "")
 
-        # Build email payload and store in circulatory system
         payload = json.dumps({
             "id": email_id,
             "from": email_from,
@@ -124,9 +211,7 @@ def handle_check_email(reply_to, query=None):
             log(f"check-email: failed to store email {email_id} in circ")
             continue
 
-        # Mark as read immediately to prevent re-processing on next check
         gmail_read(email_id)
-
         muscles.stimulus.send(reply_to, f"new-email {email_id} circ:{ref}")
         count += 1
 
@@ -134,8 +219,8 @@ def handle_check_email(reply_to, query=None):
     return count
 
 
-def handle_send_reply(reply_to, thread_id, circ_ref):
-    """Send reply from circ, mark as read, store memory. Uses circ cache path directly."""
+def real_send_reply(reply_to, thread_id, circ_ref):
+    """Send reply via GAS bridge gmail muscle."""
     circ_dir = os.environ.get("CIRC_DIR", os.path.expanduser("~/.life/circ"))
     circ_path = os.path.join(circ_dir, circ_ref)
 
@@ -149,22 +234,17 @@ def handle_send_reply(reply_to, thread_id, circ_ref):
         log(f"send-reply: gmail reply failed for {thread_id}")
         return False
 
-    # Note: gmail_read() already called during check-email (mark-as-read before processing)
-    # No need to call again here — email is already read.
-
     muscles.memories.store(
         f"Sent reply to thread {thread_id}: {body[:200]}",
         importance=5, env=muscles.memory_env(CONF_DIR),
     )
-
     muscles.stimulus.send(reply_to, f"sent {thread_id}")
-
     log(f"send-reply: replied to {thread_id}")
     return True
 
 
-def handle_send_email(reply_to, circ_ref):
-    """Compose and send a new email. Full payload (to, subject, body, format) from circ JSON."""
+def real_send_email(reply_to, circ_ref):
+    """Compose and send a new email via GAS bridge gmail muscle."""
     import tempfile as _tempfile
 
     raw = muscles.circ.get(circ_ref)
@@ -184,17 +264,15 @@ def handle_send_email(reply_to, circ_ref):
     fmt = payload.get("format", "markdown")
 
     if not to_addr or not body:
-        log(f"send-email: payload missing 'to' or 'body' in circ:{circ_ref}")
+        log(f"send-email: payload missing 'to' or 'body'")
         return False
 
-    # Write body to a temp circ file for --body-file
     tmp = _tempfile.NamedTemporaryFile(
         mode="w", suffix=".md", delete=False, dir=_tempfile.gettempdir()
     )
     try:
         tmp.write(body)
         tmp.close()
-
         cmd = ["gmail", "send", to_addr, "--subject", subject, "--body-file", tmp.name, "--format", fmt]
         _, ok = muscles.run(cmd)
     finally:
@@ -211,14 +289,39 @@ def handle_send_email(reply_to, circ_ref):
         f"Sent email to {to_addr} about '{subject}': {body[:200]}",
         importance=5, env=muscles.memory_env(CONF_DIR),
     )
-
     muscles.stimulus.send(reply_to, f"email-sent {to_addr}")
     log(f"send-email: sent to {to_addr} re: {subject}")
     return True
 
 
+# ---- Dispatch (mock vs real) ----
+
+def handle_check_email(reply_to, query=None):
+    if GMAIL_MOCK_DIR:
+        return mock_check_email(reply_to)
+    return real_check_email(reply_to, query)
+
+
+def handle_send_reply(reply_to, thread_id, circ_ref):
+    if GMAIL_MOCK_DIR:
+        return mock_send_reply(reply_to, thread_id, circ_ref)
+    return real_send_reply(reply_to, thread_id, circ_ref)
+
+
+def handle_send_email(reply_to, circ_ref):
+    if GMAIL_MOCK_DIR:
+        return mock_send_email(reply_to, circ_ref)
+    return real_send_email(reply_to, circ_ref)
+
+
+# ---- Main ----
+
 def main():
     lines = muscles.stimulus.consume(str(DIR)).strip().splitlines()
+
+    # Auto-check on idle when COMMS_AUTO_CHECK=1
+    if not lines and os.environ.get("COMMS_AUTO_CHECK") == "1":
+        lines = ["check-email brain"]
 
     if not lines:
         (DIR / "health.txt").write_text("ok idle\n")
@@ -234,7 +337,6 @@ def main():
 
         try:
             if line.startswith("check-email"):
-                # "check-email <reply-to> [query]"
                 parts = line.split(None, 2)
                 if len(parts) < 2:
                     log(f"check-email: missing reply-to: {line}")
@@ -242,31 +344,28 @@ def main():
                     continue
                 reply_to = parts[1]
                 query = parts[2] if len(parts) > 2 else None
-                n = handle_check_email(reply_to, query)
+                handle_check_email(reply_to, query)
                 processed += 1
 
             elif line.startswith("send-email"):
-                # "send-email <reply-to> circ:<hash>"
                 parts = line.split()
                 if len(parts) < 3:
-                    log(f"send-email: bad format (expected: send-email <reply-to> circ:<hash>): {line}")
+                    log(f"send-email: bad format: {line}")
                     errors += 1
                     continue
                 reply_to = parts[1]
                 circ_ref = parts[2]
                 if not circ_ref.startswith("circ:"):
-                    log(f"send-email: expected circ:<hash> as third token: {line}")
+                    log(f"send-email: expected circ:<hash>: {line}")
                     errors += 1
                     continue
-                ref = circ_ref[5:]
-                ok = handle_send_email(reply_to, ref)
+                ok = handle_send_email(reply_to, circ_ref[5:])
                 if ok:
                     processed += 1
                 else:
                     errors += 1
 
             elif line.startswith("send-reply"):
-                # "send-reply <reply-to> <thread_id> circ:<hash>"
                 parts = line.split()
                 if len(parts) < 4:
                     log(f"send-reply: bad format: {line}")
@@ -279,8 +378,7 @@ def main():
                     log(f"send-reply: expected circ:ref, got: {circ_ref}")
                     errors += 1
                     continue
-                ref = circ_ref[5:]  # strip "circ:"
-                ok = handle_send_reply(reply_to, thread_id, ref)
+                ok = handle_send_reply(reply_to, thread_id, circ_ref[5:])
                 if ok:
                     processed += 1
                 else:

--- a/ganglion/ganglion.py
+++ b/ganglion/ganglion.py
@@ -281,6 +281,12 @@ def mqtt_listen_and_spark(organ_lookup, duration=50):
                 continue
 
             organ_path = organ_lookup.get(target_type)
+            if not organ_path and target_type == BODY:
+                default = os.environ.get("DEFAULT_ORGAN", "")
+                if default:
+                    organ_path = organ_lookup.get(default)
+                    if organ_path:
+                        log(f"body-part stimulus -> default organ '{default}'")
             if not organ_path:
                 log(f"stimulus for unknown organ '{target_type}' — ignoring")
                 continue

--- a/ganglion/ganglion.py
+++ b/ganglion/ganglion.py
@@ -94,7 +94,7 @@ def spark_organ(organ_path):
         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
     )
 
-    log(f"sparked {name}")
+    log(f"sparked {Path(organ_path_str).name}")
 
 
 def scan_local(db, organ_list):

--- a/life/spark.sh
+++ b/life/spark.sh
@@ -116,7 +116,7 @@ for dir in "${ORGAN_DIRS[@]}"; do
 
     log "$name: launching"
     date +%s > "$dir/.spark.last"
-    "$dir/live.sh" >> "$dir/.spark.log" 2>&1
+    "$dir/live.sh" 2>&1 | tee -a "$dir/.spark.log"
     log "$name: finished"
   ) 9>"$lock_file" &
 

--- a/life/textbook/nervous-system.md
+++ b/life/textbook/nervous-system.md
@@ -46,6 +46,8 @@ stimulus send tail "food circ:a1b2c3d4"
 
 **Send by type** — "deliver this to any organ of type X." Delivered to the first local match. If no local match, published to MQTT for remote delivery.
 
+**Send by body part** — "deliver this to `brain`" when you don't know which organ handles it. If the target matches the body part name (e.g., `brain`) and no organ of that type exists, the system falls back to the `DEFAULT_ORGAN` configured in `life.conf`. For example, `DEFAULT_ORGAN=pfc` in the brain means `stimulus send brain "think about this"` routes to the `pfc` organ. This lets other body parts address a whole body part without knowing its internal organ layout.
+
 **Query by type** — "give me the health of all organs of type X." Reads from the local registry. No network round-trip — the registry is pre-populated by ganglion-to-ganglion broadcasts.
 
 ## Health Is Local

--- a/stimulus
+++ b/stimulus
@@ -52,6 +52,24 @@ case "$cmd" in
       done
     fi
 
+    # Fall back to DEFAULT_ORGAN if target is the body part name
+    if [ "$delivered" = false ] && [ "$target_type" = "$BODY" ] && [ -n "${DEFAULT_ORGAN:-}" ]; then
+      if [ -n "${ORGANS:-}" ]; then
+        IFS=':' read -ra _paths <<< "$ORGANS"
+        for op in "${_paths[@]}"; do
+          op="${op#"${op%%[![:space:]]*}"}"
+          op="${op%"${op##*[![:space:]]}"}"
+          [ -z "$op" ] && continue
+          [[ "$op" != /* ]] && op="$conf_dir/$op"
+          if [ "$(basename "$op")" = "$DEFAULT_ORGAN" ] && [ -d "$op" ]; then
+            echo "$message" >> "$op/stimulus.txt"
+            delivered=true
+            break
+          fi
+        done
+      fi
+    fi
+
     # Fall back to MQTT for remote delivery
     if [ "$delivered" = false ]; then
       if [ -n "${MQTT_HOST:-}" ] && command -v mqtt-pub >/dev/null 2>&1; then

--- a/tadpole.sh
+++ b/tadpole.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# tadpole.sh — launch or stop the tadpole organism.
+# Usage: ./tadpole.sh [up|down|logs]
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+export HOST_UID="$(id -u)"
+export HOST_GID="$(id -g)"
+
+# Pass through Anthropic env vars (already exported by caller or shell)
+# docker-compose.yml references ANTHROPIC_API_KEY, ANTHROPIC_BASE_URL, ANTHROPIC_MODEL
+
+CMD="${1:-up}"
+
+case "$CMD" in
+  down|stop)
+    docker compose -f "$DIR/tadpole/docker-compose.yml" down "$@"
+    ;;
+  logs)
+    shift
+    docker compose -f "$DIR/tadpole/docker-compose.yml" logs "$@"
+    ;;
+  up|start|"")
+    # Ensure mock gmail directories exist
+    mkdir -p "$DIR/tadpole/mock-gmail"/{inbox,sent,drafts}
+
+    echo "=== Tadpole Organism ==="
+    echo "Starting mqtt + brain + body..."
+    echo ""
+    echo "Mock gmail: $DIR/tadpole/mock-gmail/"
+    echo "  Drop a .json file in inbox/ to simulate an incoming email."
+    echo "  Replies appear in sent/"
+    echo ""
+
+    docker compose -f "$DIR/tadpole/docker-compose.yml" up --build "$@"
+    ;;
+  *)
+    docker compose -f "$DIR/tadpole/docker-compose.yml" "$@"
+    ;;
+esac

--- a/tadpole/CLAUDE.md
+++ b/tadpole/CLAUDE.md
@@ -1,0 +1,21 @@
+# Tadpole — Minimal Organism for Testing
+
+You are a tadpole: the smallest viable organism in the life system.
+Your brain is the PFC organ. Your body runs comms (email I/O).
+
+## Architecture
+- **Brain container**: ganglion + PFC + hippocampus
+- **Body container**: ganglion + comms
+- **MQTT broker**: local mosquitto, anonymous auth
+
+## How You Work
+1. Comms organ checks for new emails (mock gmail in testing)
+2. When an email arrives, comms creates stimulus for the brain
+3. PFC thinks about the stimulus and produces a reply
+4. Reply goes back through comms to send
+
+## Rules
+- You are running in Docker. No internet access unless configured.
+- In test mode, gmail is mocked via filesystem (mock-gmail directory).
+- Keep responses short and helpful.
+- Never access real email accounts in test mode.

--- a/tadpole/docker-compose.yml
+++ b/tadpole/docker-compose.yml
@@ -51,6 +51,8 @@ services:
       - SPARK_INTERVAL=${SPARK_INTERVAL:-10}
       - GANGLION_LISTEN_DURATION=5
       - CIRC_DIR=/opt/circ
+      - GMAIL_MOCK_DIR=/opt/mock-gmail
+      - COMMS_AUTO_CHECK=1
     volumes:
       - circ:/opt/circ
       - ${MOCK_GMAIL_DIR:-./mock-gmail}:/opt/mock-gmail
@@ -59,3 +61,7 @@ services:
 volumes:
   mqtt-data:
   circ:
+    driver_opts:
+      type: tmpfs
+      device: tmpfs
+      o: mode=1777

--- a/tadpole/docker-compose.yml
+++ b/tadpole/docker-compose.yml
@@ -4,45 +4,58 @@ services:
     ports:
       - "${MQTT_PORT:-1883}:1883"
     volumes:
-      - ./mosquitto-docker.conf:/mosquitto/config/mosquitto.conf:ro
+      - ./mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
+      - mqtt-data:/mosquitto/data
     healthcheck:
       test: ["CMD", "mosquitto_sub", "-h", "localhost", "-t", "$$SYS/#", "-W", "1", "-C", "1"]
       interval: 1s
       timeout: 3s
       retries: 5
 
-  body-a:
+  brain:
     build:
       context: ..
-      dockerfile: tadpole/Dockerfile
+      dockerfile: brain/Dockerfile
     depends_on:
       mqtt:
         condition: service_healthy
+    user: "${HOST_UID:-1000}:${HOST_GID:-1000}"
     environment:
       - MQTT_HOST=mqtt
       - MQTT_PORT=1883
-      - BODY_PART=body-a
-      - CIRC_LOCAL_ONLY=1
+      - BODY_PART=brain
+      - SPARK_INTERVAL=${SPARK_INTERVAL:-10}
+      - DEFAULT_ORGAN=pfc
+      - GANGLION_LISTEN_DURATION=5
+      - CIRC_DIR=/opt/circ
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - ANTHROPIC_BASE_URL=${ANTHROPIC_BASE_URL:-}
+      - ANTHROPIC_MODEL=${ANTHROPIC_MODEL:-}
     volumes:
-      - body-a-data:/opt/bin/tadpole/work
-    entrypoint: ["sleep", "infinity"]
+      - circ:/opt/circ
+      - ./CLAUDE.md:/opt/bin/brain/CLAUDE.md:ro
+    entrypoint: ["/opt/bin/life/spark-loop.sh"]
 
-  body-b:
+  body:
     build:
       context: ..
       dockerfile: tadpole/Dockerfile
     depends_on:
       mqtt:
         condition: service_healthy
+    user: "${HOST_UID:-1000}:${HOST_GID:-1000}"
     environment:
       - MQTT_HOST=mqtt
       - MQTT_PORT=1883
-      - BODY_PART=body-b
-      - CIRC_LOCAL_ONLY=1
+      - BODY_PART=body
+      - SPARK_INTERVAL=${SPARK_INTERVAL:-10}
+      - GANGLION_LISTEN_DURATION=5
+      - CIRC_DIR=/opt/circ
     volumes:
-      - body-b-data:/opt/bin/tadpole/work
-    entrypoint: ["sleep", "infinity"]
+      - circ:/opt/circ
+      - ${MOCK_GMAIL_DIR:-./mock-gmail}:/opt/mock-gmail
+    entrypoint: ["/bin/bash", "-c", "cat > /opt/bin/tadpole/life.conf <<'CONF'\nORGANS=../ganglion:../comms\nMQTT_HOST=mqtt\nMQTT_PORT=1883\nBODY_PART=body\nDEFAULT_ORGAN=comms\nCONF\nexec /opt/bin/life/spark-loop.sh"]
 
 volumes:
-  body-a-data:
-  body-b-data:
+  mqtt-data:
+  circ:

--- a/tadpole/mock-gmail/inbox/test001.json
+++ b/tadpole/mock-gmail/inbox/test001.json
@@ -1,0 +1,1 @@
+{"id":"test001","from":"tester@example.com","subject":"QA Test","body":"Can you hear me?"}

--- a/tadpole/mosquitto.conf
+++ b/tadpole/mosquitto.conf
@@ -1,0 +1,5 @@
+listener 1883
+allow_anonymous true
+persistence true
+persistence_location /mosquitto/data/
+max_queued_messages 1000


### PR DESCRIPTION
## Summary

The tadpole organism: two Docker containers connected by MQTT and a shared circulatory volume. Built by a team (architect + 3 engineers + critic + QA).

**Brain container:** ganglion + PFC + hippocampus
**Body container:** ganglion + comms
**MQTT broker:** mosquitto with persistence for QoS 1
**Circulatory system:** shared Docker volume

## How to Run

```bash
./tadpole.sh              # start (mock gmail)
./tadpole.sh down         # stop
```

Mock email (separate terminal):
```bash
echo '{"id":"001","from":"you@example.com","subject":"Hello","body":"Hey!"}' \
  > tadpole/mock-gmail/inbox/001.json
cat tadpole/mock-gmail/sent/*.json
```

## What Changed

- **tadpole.sh** — single command launcher via docker compose (40 lines)
- **tadpole/docker-compose.yml** — mqtt + brain + body services, shared circ volume
- **tadpole/Dockerfile** — adds nodejs/claude CLI, world-writable for any UID
- **brain/Dockerfile** — same pattern, brain-only organs
- **brain/organs/pfc/pfc.py** — 98 lines, `claude -p` with env auth only, no hardcoded model
- **comms/comms.py** — mock gmail via file move (inbox → processed), real gmail preserved
- **ganglion/ganglion.py** — DEFAULT_ORGAN routing for body part addressing
- **stimulus** — DEFAULT_ORGAN fallback in local delivery
- **life/textbook/nervous-system.md** — documents body part addressing
- **tadpole/CLAUDE.md** — tadpole identity
- **tadpole/mosquitto.conf** — anonymous auth, persistence true

## Design Principles

- Body parts are isolated (brain can't read email, comms can't think)
- Mock gmail uses file move, not label manipulation
- PFC uses plain `claude -p` — env provides auth
- Everything decays (circ is transient)
- Brutally simple: 3 organs, 2 systems, 2 containers

## Review

- Critic: PASS (1 bug found and fixed — ganglion NameError)
- Neil persona: matches agreed design document
- No PII, no hardcoded secrets

## Checklist

- [x] No PII
- [x] No hardcoded secrets
- [x] Syntax verified (all .py + .sh files)
- [x] Critic PASS
- [x] Matches agreed design document

Generated with [Claude Code](https://claude.com/claude-code)