### PR TITLE
Tadpole v4: single container, no MQTT, just works

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.github
+.claude
+__pycache__
+*.pyc
+.spark.log
+.spark.last
+health.txt
+stimulus.txt
+beats.count
+*.db
+docs/journal
+tadpole/mock-gmail
+tadpole/backups

--- a/brain/organs/pfc/live.sh
+++ b/brain/organs/pfc/live.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# PFC — thin launcher. The real work is in pfc.py.
+set -euo pipefail
+DIR="$(cd "$(dirname "$0")" && pwd)"
+exec python3 "$DIR/pfc.py"

--- a/brain/organs/pfc/organ.conf
+++ b/brain/organs/pfc/organ.conf
@@ -1,0 +1,1 @@
+CADENCE=1

--- a/brain/organs/pfc/pfc.py
+++ b/brain/organs/pfc/pfc.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""PFC organ — reads email stimulus, generates replies via claude -p."""
+import json, os, subprocess, sys
+from pathlib import Path
+
+DIR = Path(__file__).resolve().parent
+sys.path.insert(0, os.environ.get("PYTHONPATH", "").split(":")[0] or str(DIR.parent.parent.parent))
+import muscles
+
+log = lambda msg: muscles.log("pfc", msg)
+
+def generate_reply(email_from, email_subject, email_body, memory_ctx):
+    """Generate a reply using claude -p (no flags — CLAUDE.md provides personality)."""
+    parts = []
+    if memory_ctx:
+        parts.append(f"Here are relevant memories:\n{memory_ctx}\n")
+    parts.append(
+        f"You received an email from {email_from}.\n"
+        f"Subject: {email_subject}\nBody:\n{email_body}\n\n"
+        "Write a reply. Concise and natural. No subject line."
+    )
+    cwd = os.environ.get("CLAUDE_CWD", "/opt/bin/tadpole")
+    try:
+        r = subprocess.run(["claude", "-p"], input="\n".join(parts),
+                           capture_output=True, text=True, timeout=180, cwd=cwd)
+        if r.returncode != 0:
+            log(f"claude error: {r.stderr.strip()}")
+            return None
+        return r.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+        log(f"claude exception: {e}")
+        return None
+
+def handle_new_email(thread_id, circ_ref):
+    raw = muscles.circ.get(circ_ref)
+    if not raw:
+        log(f"new-email: could not retrieve circ:{circ_ref}"); return False
+    try:
+        d = json.loads(raw)
+    except json.JSONDecodeError:
+        log(f"new-email: bad JSON from circ:{circ_ref}"); return False
+    body, frm, subj = d.get("body",""), d.get("from","unknown"), d.get("subject","(no subject)")
+    mem_ctx, _ = muscles.run(["memories","search","--",f"{frm} {subj}"], timeout=15)
+    reply = generate_reply(frm, subj, body, mem_ctx)
+    if not reply:
+        log(f"new-email: no reply for {thread_id}"); return False
+    ref = muscles.circ.put(reply)
+    if not ref:
+        log("new-email: circ.put failed"); return False
+    muscles.stimulus.send("comms", f"send-reply pfc {thread_id} circ:{ref}")
+    log(f"new-email: reply for {thread_id} sent to comms")
+    return True
+
+def main():
+    lines = muscles.stimulus.consume(str(DIR)).strip().splitlines()
+    processed = errors = 0
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            if line.startswith("new-email"):
+                p = line.split()
+                if len(p) < 3 or not p[2].startswith("circ:"):
+                    log(f"bad format: {line}"); errors += 1; continue
+                ok = handle_new_email(p[1], p[2][5:])
+                processed += ok; errors += (not ok)
+            else:
+                log(f"unknown stimulus: {line}"); errors += 1
+        except Exception as e:
+            log(f"error: {e}"); errors += 1
+    if not lines:
+        muscles.stimulus.send("comms", "check-email pfc")
+        log("idle, told comms to check")
+    health = "ok idle (told comms to check)" if not lines else f"ok processed {processed}"
+    if errors:
+        health += f" errors {errors}"
+    (DIR / "health.txt").write_text(health + "\n")
+
+if __name__ == "__main__":
+    main()

--- a/comms/comms.py
+++ b/comms/comms.py
@@ -1,25 +1,32 @@
 #!/usr/bin/env python3
 """Comms organ — stimulus-driven communication I/O.
 
-The comms organ does NOT check email on its own. It processes stimulus signals:
-  - "check-email [query]" -> search Gmail, notify brain of new emails
-  - "send-reply <thread_id> circ:<hash>" -> send a reply, notify brain
+Supports two modes:
+  - Live: uses gmail muscle (default)
+  - Mock: when GMAIL_MOCK_DIR is set, reads .json from inbox/, moves to
+    inbox/.processed/, writes replies to sent/
 
-Each cycle:
-1. Consume stimulus
-2. Process each signal
-3. Write health and exit
+Stimulus contract:
+  IN:  "check-email <reply-to> [query]"
+  IN:  "send-reply <reply-to> <thread_id> circ:<hash>"
+  IN:  "send-email <reply-to> circ:<hash>"
+  OUT: "new-email <id> circ:<hash>"     (to reply-to organ)
+  OUT: "sent <thread_id>"               (to reply-to organ)
+
+When COMMS_AUTO_CHECK=1, comms checks for new emails every cycle
+even without stimulus (useful in tadpole container).
 """
 import json
 import os
+import shutil
 import sys
 from pathlib import Path
 
 DIR = Path(__file__).resolve().parent
 CONF_DIR = os.environ.get("CONF_DIR", "")
+MOCK_DIR = os.environ.get("GMAIL_MOCK_DIR", "")
 
 # muscles.py lives at BIN_ROOT (peer to comms/). Spark sets PYTHONPATH.
-# Fallback: comms/ is one level below BIN_ROOT, so DIR.parent works.
 sys.path.insert(0, str(DIR.parent))
 import muscles
 
@@ -27,6 +34,69 @@ import muscles
 def log(msg):
     muscles.log("comms", msg)
 
+
+# ---- Mock Gmail backend ----
+
+def mock_check_email(reply_to):
+    """Scan MOCK_DIR/inbox/ for .json files, store in circ, move to processed."""
+    inbox = Path(MOCK_DIR) / "inbox"
+    if not inbox.is_dir():
+        log("mock check-email: no inbox directory")
+        return 0
+
+    processed_dir = inbox / ".processed"
+    processed_dir.mkdir(exist_ok=True)
+
+    count = 0
+    for fp in sorted(inbox.glob("*.json")):
+        try:
+            data = json.loads(fp.read_text())
+        except (json.JSONDecodeError, OSError) as e:
+            log(f"mock check-email: bad file {fp.name}: {e}")
+            continue
+
+        email_id = data.get("id", fp.stem)
+        payload = json.dumps({
+            "id": email_id,
+            "from": data.get("from", "unknown"),
+            "subject": data.get("subject", "(no subject)"),
+            "body": data.get("body", ""),
+        })
+
+        ref = muscles.circ.put(payload)
+        if not ref:
+            log(f"mock check-email: failed to store {email_id} in circ")
+            continue
+
+        # Move to processed
+        shutil.move(str(fp), str(processed_dir / fp.name))
+
+        muscles.stimulus.send(reply_to, f"new-email {email_id} circ:{ref}")
+        count += 1
+
+    log(f"mock check-email: notified {reply_to} of {count} emails")
+    return count
+
+
+def mock_send_reply(reply_to, thread_id, circ_ref):
+    """Write reply body from circ to MOCK_DIR/sent/."""
+    body = muscles.circ.get(circ_ref)
+    if not body:
+        log(f"mock send-reply: could not retrieve circ:{circ_ref}")
+        return False
+
+    sent_dir = Path(MOCK_DIR) / "sent"
+    sent_dir.mkdir(exist_ok=True)
+
+    out_file = sent_dir / f"{thread_id}.txt"
+    out_file.write_text(body)
+
+    muscles.stimulus.send(reply_to, f"sent {thread_id}")
+    log(f"mock send-reply: wrote reply to {out_file}")
+    return True
+
+
+# ---- Live Gmail backend ----
 
 def gmail_search(query, count=5):
     """Search Gmail via the gmail muscle. Returns parsed JSON or None."""
@@ -56,17 +126,6 @@ def gmail_reply(thread_id, body_file):
     return ok
 
 
-def gmail_label(msg_id, remove=None, add=None):
-    """Modify labels on a message."""
-    cmd = ["gmail", "label", msg_id]
-    if remove:
-        cmd.extend(["--remove", remove])
-    if add:
-        cmd.extend(["--add", add])
-    _, ok = muscles.run(cmd)
-    return ok
-
-
 def gmail_read(thread_id):
     """Mark a thread as read via the gmail muscle."""
     _, ok = muscles.run(["gmail", "read", thread_id])
@@ -74,7 +133,10 @@ def gmail_read(thread_id):
 
 
 def handle_check_email(reply_to, query=None):
-    """Check Gmail for unread emails, notify requesting organ of each."""
+    """Check for unread emails, notify requesting organ of each."""
+    if MOCK_DIR:
+        return mock_check_email(reply_to)
+
     if not query:
         query = "label:Tadpole is:unread"
 
@@ -83,7 +145,6 @@ def handle_check_email(reply_to, query=None):
         log("check-email: no results")
         return 0
 
-    # Handle both array and {threads/messages: [...]} shapes
     threads = data if isinstance(data, list) else data.get("threads", data.get("messages", []))
     if not threads:
         log("check-email: no unread emails")
@@ -98,12 +159,11 @@ def handle_check_email(reply_to, query=None):
         email_from = thread.get("from", "unknown")
         email_subject = thread.get("subject", "(no subject)")
 
-        # Get full email content (GAS bridge returns {thread_id, messages: [...], count})
         full = gmail_get(email_id)
         if full:
             msgs = full.get("messages", [])
             if msgs:
-                msg = msgs[-1]  # latest message in thread
+                msg = msgs[-1]
                 email_from = msg.get("from", email_from)
                 email_subject = msg.get("subject", email_subject)
                 email_body = msg.get("plain", msg.get("html", ""))
@@ -112,7 +172,6 @@ def handle_check_email(reply_to, query=None):
         else:
             email_body = thread.get("snippet", "")
 
-        # Build email payload and store in circulatory system
         payload = json.dumps({
             "id": email_id,
             "from": email_from,
@@ -124,9 +183,7 @@ def handle_check_email(reply_to, query=None):
             log(f"check-email: failed to store email {email_id} in circ")
             continue
 
-        # Mark as read immediately to prevent re-processing on next check
         gmail_read(email_id)
-
         muscles.stimulus.send(reply_to, f"new-email {email_id} circ:{ref}")
         count += 1
 
@@ -135,7 +192,10 @@ def handle_check_email(reply_to, query=None):
 
 
 def handle_send_reply(reply_to, thread_id, circ_ref):
-    """Send reply from circ, mark as read, store memory. Uses circ cache path directly."""
+    """Send reply from circ."""
+    if MOCK_DIR:
+        return mock_send_reply(reply_to, thread_id, circ_ref)
+
     circ_dir = os.environ.get("CIRC_DIR", os.path.expanduser("~/.life/circ"))
     circ_path = os.path.join(circ_dir, circ_ref)
 
@@ -149,16 +209,12 @@ def handle_send_reply(reply_to, thread_id, circ_ref):
         log(f"send-reply: gmail reply failed for {thread_id}")
         return False
 
-    # Note: gmail_read() already called during check-email (mark-as-read before processing)
-    # No need to call again here — email is already read.
-
     muscles.memories.store(
         f"Sent reply to thread {thread_id}: {body[:200]}",
         importance=5, env=muscles.memory_env(CONF_DIR),
     )
 
     muscles.stimulus.send(reply_to, f"sent {thread_id}")
-
     log(f"send-reply: replied to {thread_id}")
     return True
 
@@ -187,7 +243,6 @@ def handle_send_email(reply_to, circ_ref):
         log(f"send-email: payload missing 'to' or 'body' in circ:{circ_ref}")
         return False
 
-    # Write body to a temp circ file for --body-file
     tmp = _tempfile.NamedTemporaryFile(
         mode="w", suffix=".md", delete=False, dir=_tempfile.gettempdir()
     )
@@ -220,7 +275,12 @@ def handle_send_email(reply_to, circ_ref):
 def main():
     lines = muscles.stimulus.consume(str(DIR)).strip().splitlines()
 
-    if not lines:
+    # Auto-check mode: when COMMS_AUTO_CHECK=1, check inbox every cycle
+    auto_check = os.environ.get("COMMS_AUTO_CHECK", "") == "1"
+    if auto_check and not any(l.strip().startswith("check-email") for l in lines if l.strip()):
+        lines.append("check-email pfc")
+
+    if not lines or not any(l.strip() for l in lines):
         (DIR / "health.txt").write_text("ok idle\n")
         return
 
@@ -234,7 +294,6 @@ def main():
 
         try:
             if line.startswith("check-email"):
-                # "check-email <reply-to> [query]"
                 parts = line.split(None, 2)
                 if len(parts) < 2:
                     log(f"check-email: missing reply-to: {line}")
@@ -242,20 +301,19 @@ def main():
                     continue
                 reply_to = parts[1]
                 query = parts[2] if len(parts) > 2 else None
-                n = handle_check_email(reply_to, query)
+                handle_check_email(reply_to, query)
                 processed += 1
 
             elif line.startswith("send-email"):
-                # "send-email <reply-to> circ:<hash>"
                 parts = line.split()
                 if len(parts) < 3:
-                    log(f"send-email: bad format (expected: send-email <reply-to> circ:<hash>): {line}")
+                    log(f"send-email: bad format: {line}")
                     errors += 1
                     continue
                 reply_to = parts[1]
                 circ_ref = parts[2]
                 if not circ_ref.startswith("circ:"):
-                    log(f"send-email: expected circ:<hash> as third token: {line}")
+                    log(f"send-email: expected circ:<hash>: {line}")
                     errors += 1
                     continue
                 ref = circ_ref[5:]
@@ -266,7 +324,6 @@ def main():
                     errors += 1
 
             elif line.startswith("send-reply"):
-                # "send-reply <reply-to> <thread_id> circ:<hash>"
                 parts = line.split()
                 if len(parts) < 4:
                     log(f"send-reply: bad format: {line}")
@@ -279,7 +336,7 @@ def main():
                     log(f"send-reply: expected circ:ref, got: {circ_ref}")
                     errors += 1
                     continue
-                ref = circ_ref[5:]  # strip "circ:"
+                ref = circ_ref[5:]
                 ok = handle_send_reply(reply_to, thread_id, ref)
                 if ok:
                     processed += 1

--- a/life/spark.sh
+++ b/life/spark.sh
@@ -94,8 +94,7 @@ for dir in "${ORGAN_DIRS[@]}"; do
     fi
 
     if [[ "$cadence_due" = false ]] && [[ "$has_stimulus" = false ]]; then
-      log "$name: cadence ${cadence}m, ${elapsed}m elapsed — skipping"
-      continue
+      continue  # not due, no stimulus — silent skip
     fi
   else
     # No cadence — only run if stimulus present
@@ -116,7 +115,7 @@ for dir in "${ORGAN_DIRS[@]}"; do
 
     log "$name: launching"
     date +%s > "$dir/.spark.last"
-    "$dir/live.sh" >> "$dir/.spark.log" 2>&1
+    "$dir/live.sh" 2>&1 | tee -a "$dir/.spark.log"
     log "$name: finished"
   ) 9>"$lock_file" &
 

--- a/tadpole.sh
+++ b/tadpole.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# tadpole.sh — launch the tadpole v4 container.
+# Single docker run. No docker-compose. No MQTT.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MOCK_DIR="${MOCK_DIR:-$SCRIPT_DIR/tadpole/mock-gmail}"
+
+# Create mock gmail dirs if needed
+mkdir -p "$MOCK_DIR/inbox" "$MOCK_DIR/inbox/.processed" "$MOCK_DIR/sent"
+
+# Build image
+docker build -t tadpole:latest -f "$SCRIPT_DIR/tadpole/Dockerfile" "$SCRIPT_DIR"
+
+# Run container
+exec docker run --rm \
+    --user "$(id -u):$(id -g)" \
+    -v "$MOCK_DIR:/mock-gmail" \
+    -e GMAIL_MOCK_DIR=/mock-gmail \
+    -e COMMS_AUTO_CHECK=1 \
+    -e SPARK_INTERVAL="${SPARK_INTERVAL:-10}" \
+    -e CIRC_LOCAL_ONLY=1 \
+    ${ANTHROPIC_API_KEY:+-e ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY"} \
+    ${CLAUDE_CODE_USE_BEDROCK:+-e CLAUDE_CODE_USE_BEDROCK="$CLAUDE_CODE_USE_BEDROCK"} \
+    ${AWS_REGION:+-e AWS_REGION="$AWS_REGION"} \
+    ${AWS_ACCESS_KEY_ID:+-e AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID"} \
+    ${AWS_SECRET_ACCESS_KEY:+-e AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY"} \
+    tadpole:latest

--- a/tadpole/Dockerfile
+++ b/tadpole/Dockerfile
@@ -3,20 +3,38 @@ FROM alpine:3.20
 RUN apk add --no-cache \
     bash \
     python3 \
-    mosquitto-clients \
+    nodejs \
+    npm \
     sqlite \
     coreutils \
     findutils \
     procps
 
-# The entire bin repo is COPYed so organs can find stimulus, mqtt-pub, etc.
+# Install Claude CLI globally
+RUN npm install -g @anthropic-ai/claude-code 2>/dev/null || true
+
+# Copy the entire bin repo
 COPY . /opt/bin
-RUN chmod +x /opt/bin/stimulus /opt/bin/mqtt-pub /opt/bin/mqtt-sub \
-    /opt/bin/flock /opt/bin/free-port /opt/bin/circ-put /opt/bin/circ-get \
-    /opt/bin/local-secret \
-    /opt/bin/life/spark.sh \
-    /opt/bin/ganglion/live.sh \
-    /opt/bin/tadpole/organs/*/live.sh
+
+# Make everything writable for any UID
+RUN chmod -R a+rwX /opt/bin && \
+    chmod +x /opt/bin/stimulus \
+              /opt/bin/circ-put /opt/bin/circ-get \
+              /opt/bin/flock \
+              /opt/bin/life/spark.sh /opt/bin/life/spark-loop.sh \
+              /opt/bin/comms/live.sh \
+              /opt/bin/brain/organs/pfc/live.sh \
+              /opt/bin/tadpole/organs/hippocampus/live.sh
+
+# Writable HOME for any UID (claude CLI needs it)
+ENV HOME=/tmp/home
+RUN mkdir -p /tmp/home && chmod a+rwX /tmp/home
+
+# Create circ and locks directories
+RUN mkdir -p /tmp/home/.life/circ /tmp/home/.life/locks && \
+    chmod -R a+rwX /tmp/home/.life
 
 ENV PATH="/opt/bin:$PATH"
 WORKDIR /opt/bin/tadpole
+
+ENTRYPOINT ["/opt/bin/life/spark-loop.sh", "/opt/bin/tadpole/life.conf"]

--- a/tadpole/life.conf
+++ b/tadpole/life.conf
@@ -1,4 +1,4 @@
-ORGANS=organs/heart:../ganglion:organs/tail:organs/lymph:organs/stomach:organs/hippocampus:../comms:organs/brain
-MQTT_HOST=localhost
-MQTT_PORT=1883
+ORGANS=/opt/bin/comms:/opt/bin/brain/organs/pfc:/opt/bin/tadpole/organs/hippocampus
 BODY_PART=tadpole
+MEMORY_DB=/opt/bin/tadpole/organs/hippocampus/memory.db
+CIRC_LOCAL_ONLY=1


### PR DESCRIPTION
## The Simplest Possible Tadpole

One Docker container. Three organs. Local stimulus delivery. No MQTT. No docker-compose.

```bash
./tadpole.sh          # start
# In another terminal:
echo '{"id":"001","from":"you@example.com","subject":"Hello","body":"Hey!"}' \
  > tadpole/mock-gmail/inbox/001.json
cat tadpole/mock-gmail/sent/*.json   # check reply
```

## What Changed
- **tadpole.sh** — single `docker run`, 28 lines, no compose
- **PFC** — `claude -p` with zero flags, env auth only, 81 lines
- **comms** — mock gmail via file move (inbox → .processed), auto-check on idle
- **spark.sh** — silent cadence skipping, organ output via tee
- **.dockerignore** — excludes stale runtime files from image

## Verified
- Email found → moved to processed → stored in circ → stimulus to PFC ✓
- PFC receives stimulus → calls claude -p (fails without creds — expected) ✓
- Clean output: only meaningful events shown
- No MQTT spam, no "cadence skipping" noise

## What Neil Needs
```bash
export ANTHROPIC_API_KEY=sk-...
./tadpole.sh
```