### PR TITLE
Local-lab fixes: paths and flock

### DIFF
--- a/organism/README.md
+++ b/organism/README.md
@@ -15,10 +15,9 @@ organism/
  |   |-- pong/
  |       |-- live
  |       |-- cadence       # contains: 1
- |   |   |-- .lock         # created by spark-cron
+ |       |-- .lock         # created by spark-cron
  |       |-- .ticks        # created by spark-cron
  |-- .circulatory/
- |-- .ticks/
 ```
 
 **`organs/ping/live`** -- sends a stimulus to pong:
@@ -276,17 +275,16 @@ fi
 #!/bin/bash
 # Mock Spark (Cron)
 IFS=':' read -ra ADDR <<< "$ORGANS"
-mkdir -p "$TICK_DIR"
 
 for organ_path in "${ADDR[@]}"; do
-  organ_name=$(basename "$organ_path")
   CADENCE=$(cat "$organ_path/cadence" 2>/dev/null || echo 1)
   TICK_FILE="$organ_path/.ticks"
   CURRENT_TICK=$(cat "$TICK_FILE" 2>/dev/null || echo 0)
 
   if [ "$CURRENT_TICK" -ge "$CADENCE" ]; then
     echo "0" > "$TICK_FILE"
-    spark-one "$organ_name"
+    LOCK_FILE="$organ_path/.lock"
+    flock -n "$LOCK_FILE" -c "$organ_path/live" &
   else
     echo $((CURRENT_TICK + 1)) > "$TICK_FILE"
   fi

--- a/organism/local-lab/bin/spark-cron
+++ b/organism/local-lab/bin/spark-cron
@@ -10,7 +10,8 @@ for organ_path in "${ADDR[@]}"; do
 
   if [ "$CURRENT_TICK" -ge "$CADENCE" ]; then
     echo "0" > "$TICK_FILE"
-    spark-one "$organ_name"
+    LOCK_FILE="$organ_path/.lock"
+    flock -n "$LOCK_FILE" -c "$organ_path/live" &
   else
     echo $((CURRENT_TICK + 1)) > "$TICK_FILE"
   fi

--- a/organism/local-lab/local-lab.sh
+++ b/organism/local-lab/local-lab.sh
@@ -3,12 +3,12 @@ export ORGANS="./organs/ping:./organs/pong"
 export PATH="$(pwd)/bin:$PATH"
 
 # remove temporary files
-rm -f .organs/ping/.lock
-rm -f .organs/ping/.ticks
-rm -f .organs/pong/.lock
-rm -f .organs/pong/.ticks
-rm -rf .organs/ping/.stimulus
-rm -rf .organs/pong/.stimulus
+rm -f organs/ping/.lock
+rm -f organs/ping/.ticks
+rm -f organs/pong/.lock
+rm -f organs/pong/.ticks
+rm -rf organs/ping/.stimulus
+rm -rf organs/pong/.stimulus
 
 spark-cron # .ticks = 0 -> increments to 1
 spark-cron # .ticks = 1 >= cadence 1 -> fires both organs


### PR DESCRIPTION
## Summary
- Fix `local-lab.sh` cleanup paths (`.organs/` → `organs/`)
- Fix `spark-cron` to use `flock` directly per the textbook spec, instead of delegating to `spark-one`

Tested: `local-lab.sh` runs clean — ping fires, pong receives.

This PR stays open as the working branch for ongoing organism development.

## Test plan
- [x] `cd organism/local-lab && bash local-lab.sh` → ping/pong output confirmed

Generated with [Claude Code](https://claude.com/claude-code)