### PR TITLE
Demo all three layers with circ in ping/pong

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 node_modules/
 
 # Organism
+.circulatory*
 .lock*
 .memory*
 .stimulus*

--- a/organism/README.md
+++ b/organism/README.md
@@ -15,7 +15,7 @@ cd organism/local-lab && bash local-lab.sh
 
 **What just happened:** Ping wrote a message, pushed it into the circulatory system (`circ push`), and sent the content hash to pong via the nervous system (`stimulus send`). Pong received the hash, pulled the payload (`circ get`), and read the message. All three layers -- spark, stimulus, circ -- working together.
 
-**Prerequisites:** bash, flock, jq, sha256sum.
+**Prerequisites:** bash, flock, jq.
 
 ---
 
@@ -27,9 +27,9 @@ The organism treats autonomous programs as **organs** within **body parts** (con
 
 | Layer | Name | Purpose |
 |-------|------|---------|
-| **0** | **Spark** (Metabolism) | Lifecycle and scheduling. Time-based cadence, `flock` concurrency. |
+| **0** | **Spark** (Metabolism) | Lifecycle and scheduling. Cooldown-based firing, `flock` concurrency. |
 | **1** | **Stimulus** (Nervous System) | Async signaling. Low-latency nerve impulses between organs via **ganglion** routing. |
-| **2** | **Circ** (Circulatory System) | Data transport. Content-addressed blobs (SHA-256) moved between body parts via **artery** caching. |
+| **2** | **Circ** (Circulatory System) | Data transport. Content-addressed blobs moved between body parts via **artery** caching. |
 
 ### The CLI Contract
 
@@ -39,11 +39,11 @@ Organs interact with all layers through three CLI tools on `$PATH`: `stimulus`, 
 
 ## The Spark (Layer 0)
 
-The spark manages organ lifecycle: an organ runs **if and only if** it is not already running and its cadence has been met. Every organ is a directory containing `live` -- the universal entry point.
+The spark manages organ lifecycle: an organ runs **if and only if** it is not already running and its cooldown has been met. Every organ is a directory containing `live` -- the universal entry point.
 
 ### Three Spark Drivers
 
-**`spark-cron` (Standard)** -- Triggered by `crontab` once per minute. Iterates `$ORGANS` (colon-delimited list of organ paths) and sparks each organ whose cadence is met.
+**`spark-cron` (Standard)** -- Triggered by `crontab` once per minute. Iterates `$ORGANS` (colon-delimited list of organ paths) and sparks each organ whose cooldown is met.
 
 **`spark-loop` (Fast cycle)** -- A `while true` loop with configurable sleep. Usage: `spark-loop <sleep-seconds>`.
 
@@ -53,26 +53,26 @@ The spark manages organ lifecycle: an organ runs **if and only if** it is not al
 
 All spark drivers use `flock -n` on `<organ_dir>/.lock`. If the lock is held, the spark silently exits -- no duplicate processes.
 
-### Cadence
+### Cooldown
 
-An organ defines its rate via a `cadence` file (single integer). The spark tracks ticks in `<organ_dir>/.ticks`. Logic: if `tick >= cadence`, fire and reset to 0; otherwise increment.
+An organ defines its rate via a `cooldown` file (single integer). The spark tracks ticks in `<organ_dir>/.ticks`. Logic: if `tick >= cooldown`, fire and reset to 0; otherwise increment.
 
-| Cadence | Behavior | Ticks: 0 → 1 → 2 → 3 → 4 → 5 |
-|---------|----------|-------------------------------|
+| Cooldown | Behavior | Ticks: 0 → 1 → 2 → 3 → 4 → 5 |
+|----------|----------|-------------------------------|
 | **1** | Every other tick | skip, **fire**, skip, **fire**, skip, **fire** |
 | **3** | Every 4th tick | skip, skip, skip, **fire**, skip, skip |
 | **0** | Every tick | **fire**, **fire**, **fire**, **fire**, **fire**, **fire** |
 
-> **Note:** Cadence is a threshold, not a frequency. Cadence 0 means fire every tick (tick always meets threshold). Cadence 1 means fire every *other* tick. Set cadence to 0 for maximum firing rate.
+> **Note:** Cooldown is a threshold, not a frequency. Cooldown 0 means fire every tick (tick always meets threshold). Cooldown 1 means fire every *other* tick. Set cooldown to 0 for maximum firing rate.
 
 ```bash
 # Core spark logic (production version backgrounds with &)
 for organ_path in ${ORGANS//:/ }; do
-  CADENCE=$(cat "$organ_path/cadence" 2>/dev/null || echo 1)
+  COOLDOWN=$(cat "$organ_path/cooldown" 2>/dev/null || echo 1)
   TICK_FILE="$organ_path/.ticks"
   CURRENT_TICK=$(cat "$TICK_FILE" 2>/dev/null || echo 0)
 
-  if [ "$CURRENT_TICK" -ge "$CADENCE" ]; then
+  if [ "$CURRENT_TICK" -ge "$COOLDOWN" ]; then
     echo "0" > "$TICK_FILE"
     LOCK_FILE="$organ_path/.lock"
     flock -n "$LOCK_FILE" -c "$organ_path/live" &
@@ -124,15 +124,14 @@ Stimuli are buffered on disk -- if an organ is dormant, signals wait until it fi
 
 ## The Circulatory System (Layer 2)
 
-The circulatory system moves large data blobs between body parts using content-addressed storage (SHA-256).
+The circulatory system moves large data blobs between body parts using content-addressed storage.
 
 ### The `circ` CLI Contract
 
 | Command | Returns |
 |---------|---------|
-| `circ push <path>` | SHA-256 hash to stdout. Stores in local cache, registers with remote relay. Non-zero exit if file not found. |
+| `circ push <path>` | Content hash to stdout. Stores in local cache, registers with remote relay. Non-zero exit if file not found. |
 | `circ get <hash>` | Absolute file path to stdout. Non-zero exit if hash not found. |
-| `circ status` | Connection health string. |
 
 Unknown commands must exit non-zero with usage information.
 
@@ -142,7 +141,7 @@ Unknown commands must exit non-zero with usage information.
 
 A `circ` implementation must:
 
-1. **push**: Validate the file exists. Compute SHA-256 hash. Store the file content-addressed (atomic write: temp file + rename). Print the hash to stdout.
+1. **push**: Validate the file exists. Compute a content hash (algorithm is implementation-defined). Store the file content-addressed (atomic write: temp file + rename). Print the hash to stdout.
 2. **get**: Look up the hash in local cache. If found, print the absolute path to stdout. If not found, exit non-zero with error to stderr.
 3. Resolve the `.circulatory/` storage directory relative to the implementation's install location (not the caller's working directory), so all organs on the same body part share one cache.
 
@@ -157,7 +156,7 @@ Each body part runs an **artery** managing the local `.circulatory/` cache and s
 ```text
 organ_name/
  |-- live             # Entry point (required, must be executable)
- |-- cadence           # Firing rate as integer (optional, defaults to 1)
+ |-- cooldown          # Firing threshold as integer (optional, defaults to 1)
  |-- src/              # Internal logic (any language)
  |-- .stimulus/        # Incoming signals (volatile, created by ganglion)
  |-- .memory/          # Persistent local state (non-critical, may not survive migration)
@@ -200,7 +199,7 @@ local-lab/
  |-- bin/
  |   |-- stimulus          # Mock nervous system (writes to .stimulus/, calls spark-one)
  |   |-- circ              # Mock circulatory system (content-addressed .circulatory/ dir)
- |   |-- spark-cron        # Mock spark (iterates $ORGANS, checks cadence, fires organs)
+ |   |-- spark-cron        # Mock spark (iterates $ORGANS, checks cooldown, fires organs)
  |   |-- spark-one         # Mock immediate excitation (fires one organ by name)
  |-- organs/
  |   |-- ping/live         # Pushes a payload via circ, sends hash via stimulus
@@ -224,7 +223,7 @@ To build your own organ, copy `organs/ping/` as a template. Your `live` script m
 
 ### `live` exits non-zero
 
-The spark does not retry. The `flock` lock is released and the organ waits for its next cadence tick (or next excitation). Organs should handle their own retries internally or write failure state to `.memory/`.
+The spark does not retry. The `flock` lock is released and the organ waits for its next cooldown tick (or next excitation). Organs should handle their own retries internally or write failure state to `.memory/`.
 
 ### `circ get` fails
 

--- a/organism/README.md
+++ b/organism/README.md
@@ -20,23 +20,44 @@ organism/
  |-- .circulatory/
 ```
 
-**`organs/ping/live`** -- sends a stimulus to pong:
+**`organs/ping/live`** -- pushes a payload and signals pong:
 
 ```bash
 #!/bin/bash
 cd "$(dirname "$0")"
 echo "[ping] fired"
-stimulus send --to pong --body '{"msg": "hello from ping"}'
+
+# Write a message and push it into the circulatory system
+MSG_FILE=$(mktemp)
+echo "hello from ping at $(date +%s)" > "$MSG_FILE"
+HASH=$(circ push "$MSG_FILE")
+rm "$MSG_FILE"
+
+echo "[ping] pushed payload: $HASH"
+stimulus send --to pong --body "{\"hash\": \"$HASH\"}"
 ```
 
-**`organs/pong/live`** -- digests stimuli in sorted order:
+**`organs/pong/live`** -- pulls payloads from the circulatory system:
 
 ```bash
 #!/bin/bash
 cd "$(dirname "$0")"
 for f in $(ls .stimulus/*.json 2>/dev/null | sort); do
-  echo "[pong] got: $(cat "$f")"
+  HASH=$(jq -r '.hash' "$f")
   rm "$f"
+
+  if [ -z "$HASH" ] || [ "$HASH" = "null" ]; then
+    echo "[pong] stimulus missing hash, skipping"
+    continue
+  fi
+
+  FILE_PATH=$(circ get "$HASH")
+  if [ $? -ne 0 ]; then
+    echo "[pong] circ get failed for $HASH"
+    continue
+  fi
+
+  echo "[pong] got: $(cat "$FILE_PATH")"
 done
 ```
 
@@ -50,7 +71,8 @@ spark-cron # .ticks = 0 -> increments to 1
 spark-cron # .ticks = 1 >= cadence 1 -> fires both organs
 sleep 1
 # [ping] fired
-# [pong] got: {"msg": "hello from ping"}
+# [ping] pushed payload: 52921...
+# [pong] got: hello from ping at 1774627933
 ```
 
 ---
@@ -248,7 +270,8 @@ spark-one "$TARGET"
 #!/bin/bash
 # Mock Circulatory System
 CMD=$1
-HEART_DIR="./.circulatory"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+HEART_DIR="$DIR/../.circulatory"
 mkdir -p "$HEART_DIR"
 
 if [ "$CMD" == "push" ]; then

--- a/organism/README.md
+++ b/organism/README.md
@@ -17,78 +17,11 @@ cd organism/local-lab && bash local-lab.sh
 
 **Prerequisites:** bash, flock, jq, sha256sum.
 
-### How it works
-
-```text
-local-lab/
- |-- bin/              # Mock CLIs (see Local Lab section)
- |-- organs/
- |   |-- ping/
- |   |   |-- live
- |   |   |-- cadence       # contains: 1
- |   |-- pong/
- |       |-- live
- |       |-- cadence       # contains: 1
- |-- .circulatory/         # content-addressed blob store
-```
-
-**`organs/ping/live`** -- pushes a payload and signals pong:
-
-```bash
-#!/bin/bash
-cd "$(dirname "$0")"
-echo "[ping] fired"
-
-MSG_FILE=$(mktemp)
-echo "hello from ping at $(date)" > "$MSG_FILE"
-HASH=$(circ push "$MSG_FILE")
-rm "$MSG_FILE"
-
-if [ -z "$HASH" ]; then
-  echo "[ping] circ push failed" >&2
-  exit 1
-fi
-
-echo "[ping] pushed payload: ${HASH:0:12}..."
-stimulus send --to pong --body "{\"hash\": \"$HASH\"}"
-```
-
-**`organs/pong/live`** -- pulls payloads from the circulatory system:
-
-```bash
-#!/bin/bash
-cd "$(dirname "$0")"
-shopt -s nullglob
-files=(.stimulus/*.json)
-shopt -u nullglob
-
-for f in "${files[@]}"; do
-  HASH=$(jq -r '.hash' "$f" 2>/dev/null)
-
-  if [ -z "$HASH" ] || [ "$HASH" = "null" ]; then
-    echo "[pong] stimulus missing hash, skipping"
-    rm "$f"
-    continue
-  fi
-
-  FILE_PATH=$(circ get "$HASH")
-  if [ $? -ne 0 ]; then
-    echo "[pong] circ get failed for ${HASH:0:12}..."
-    rm "$f"
-    continue
-  fi
-
-  rm "$f"
-  echo "[pong] retrieved ${HASH:0:12}..."
-  echo "[pong] got: $(cat "$FILE_PATH")"
-done
-```
-
 ---
 
 ## Architecture Overview
 
-The organism treats autonomous programs as **organs** within **body parts** (containers, VMs, or local environments). Organs are portable, self-contained, and infrastructure-agnostic — swap MQTT for local files, S3 for a shared folder, without changing a single line of organ code. A body part needs only a **filesystem** and **program execution**.
+The organism treats autonomous programs as **organs** within **body parts** (containers, VMs, or local environments). Organs are portable, self-contained, and infrastructure-agnostic -- swap MQTT for local files, S3 for a shared folder, without changing a single line of organ code. A body part needs only a **filesystem** and **program execution**.
 
 ### The Three Layers
 
@@ -110,11 +43,11 @@ The spark manages organ lifecycle: an organ runs **if and only if** it is not al
 
 ### Three Spark Drivers
 
-**`spark-cron` (Standard)** -- Triggered by `crontab` once per minute. Iterates `$ORGANS` and sparks each organ whose cadence is met.
+**`spark-cron` (Standard)** -- Triggered by `crontab` once per minute. Iterates `$ORGANS` (colon-delimited list of organ paths) and sparks each organ whose cadence is met.
 
 **`spark-loop` (Fast cycle)** -- A `while true` loop with configurable sleep. Usage: `spark-loop <sleep-seconds>`.
 
-**`spark-one` (Immediate)** -- Targets a single organ for immediate execution. Used by the ganglion to excite an organ when a stimulus arrives. Excitation is **best-effort**: `flock -n` silently skips if the organ is already running.
+**`spark-one` (Immediate)** -- Targets a single organ by name for immediate execution. Resolves the organ path by searching `$ORGANS`. Used by the ganglion to excite an organ when a stimulus arrives. Excitation is **best-effort**: `flock -n` silently skips if the organ is already running. Exits non-zero if the organ name is not found in `$ORGANS`.
 
 ### Concurrency: `flock`
 
@@ -133,7 +66,7 @@ An organ defines its rate via a `cadence` file (single integer). The spark track
 > **Note:** Cadence is a threshold, not a frequency. Cadence 0 means fire every tick (tick always meets threshold). Cadence 1 means fire every *other* tick. Set cadence to 0 for maximum firing rate.
 
 ```bash
-# Core spark logic
+# Core spark logic (production version backgrounds with &)
 for organ_path in ${ORGANS//:/ }; do
   CADENCE=$(cat "$organ_path/cadence" 2>/dev/null || echo 1)
   TICK_FILE="$organ_path/.ticks"
@@ -161,7 +94,20 @@ The nervous system carries **intent** -- small async signals between organs.
 stimulus send --to <organ_name> --body '<json_payload>'
 ```
 
-Returns exit `0` if handed to the ganglion. Does not guarantee delivery. When sparked, an organ checks `.stimulus/` for JSON files, processes them in **lexicographic order** (sorted by filename), and deletes each after processing.
+Returns exit `0` if handed to the ganglion (or written to the target's `.stimulus/` directory in the local mock). Returns non-zero if the target organ is not found in `$ORGANS`. Does not guarantee delivery.
+
+When sparked, an organ checks `.stimulus/` for JSON files, processes them in **lexicographic order** (sorted by filename), and deletes each after processing.
+
+### Stimulus Implementation Requirements
+
+A `stimulus` implementation must:
+
+1. Parse `send --to <name> --body '<json>'` from arguments.
+2. Resolve the target organ's path by searching `$ORGANS` (colon-delimited) for a matching `basename`.
+3. Create the target's `.stimulus/` directory if it does not exist.
+4. Write the JSON body to a unique file in `.stimulus/` (use `mktemp` with `.json` suffix for lexicographic ordering).
+5. Call `spark-one <organ_name>` to excite the target organ.
+6. Exit non-zero if the target organ is not found.
 
 ### The Ganglion
 
@@ -184,11 +130,21 @@ The circulatory system moves large data blobs between body parts using content-a
 
 | Command | Returns |
 |---------|---------|
-| `circ push <path>` | SHA-256 hash to stdout. Stores in local cache, registers with remote relay. |
-| `circ get <hash>` | Absolute file path to stdout. Non-zero exit on failure. |
+| `circ push <path>` | SHA-256 hash to stdout. Stores in local cache, registers with remote relay. Non-zero exit if file not found. |
+| `circ get <hash>` | Absolute file path to stdout. Non-zero exit if hash not found. |
 | `circ status` | Connection health string. |
 
+Unknown commands must exit non-zero with usage information.
+
 **Flow:** Organ A runs `circ push data.txt`, gets a hash, sends it via stimulus to Organ B. Organ B runs `circ get <hash>` and gets a local path.
+
+### Circ Implementation Requirements
+
+A `circ` implementation must:
+
+1. **push**: Validate the file exists. Compute SHA-256 hash. Store the file content-addressed (atomic write: temp file + rename). Print the hash to stdout.
+2. **get**: Look up the hash in local cache. If found, print the absolute path to stdout. If not found, exit non-zero with error to stderr.
+3. Resolve the `.circulatory/` storage directory relative to the implementation's install location (not the caller's working directory), so all organs on the same body part share one cache.
 
 Each body part runs an **artery** managing the local `.circulatory/` cache and syncing with the remote relay (S3, NATS, shared volume). Blobs are ephemeral -- TTLs and pruning prevent storage exhaustion.
 
@@ -221,11 +177,12 @@ python3 src/main.py
 The standard organ cycle:
 
 1. **Awaken** -- `live` triggered by spark.
-2. **Digest** -- read `.stimulus/*.json` in sorted order, delete after processing.
-3. **Process** -- run internal logic. Pull data with `circ get` if needed.
-4. **Respond** -- signal other organs with `stimulus send`.
+2. **Digest** -- read `.stimulus/*.json` in sorted order. Parse each payload. On parse failure, log and delete the file.
+3. **Process** -- run internal logic. Pull data with `circ get` if needed. Check exit codes.
+4. **Respond** -- signal other organs with `stimulus send`. Check exit codes.
 5. **Output** -- push new data with `circ push`, send hash via stimulus.
-6. **Exit** -- process ends, `flock` lock released.
+6. **Cleanup** -- delete each stimulus file only after it has been fully processed. Never delete before processing completes.
+7. **Exit** -- process ends, `flock` lock released.
 
 ### Dependencies
 
@@ -235,143 +192,31 @@ Organs carry their own dependencies: `node_modules/` for Node.js, `venv/` for Py
 
 ## Local Lab
 
-These four scripts replace production infrastructure (MQTT, S3, cron) with local filesystem operations. Put them in `bin/` and add to your `$PATH`. No network required.
+The `local-lab/` directory contains a complete working mock of the organism. It replaces production infrastructure (MQTT, S3, cron) with local filesystem operations. No network required.
 
-```bash
-export ORGANS="./organs/brain:./organs/mouth"
-export PATH="$(pwd)/bin:$PATH"
+```text
+local-lab/
+ |-- local-lab.sh         # Resets state and runs the ping/pong demo
+ |-- bin/
+ |   |-- stimulus          # Mock nervous system (writes to .stimulus/, calls spark-one)
+ |   |-- circ              # Mock circulatory system (content-addressed .circulatory/ dir)
+ |   |-- spark-cron        # Mock spark (iterates $ORGANS, checks cadence, fires organs)
+ |   |-- spark-one         # Mock immediate excitation (fires one organ by name)
+ |-- organs/
+ |   |-- ping/live         # Pushes a payload via circ, sends hash via stimulus
+ |   |-- pong/live         # Receives stimulus, pulls payload via circ, prints it
+ |-- .circulatory/         # Content-addressed blob store (created at runtime)
 ```
 
-> **Important:** The local lab mocks run organs synchronously for deterministic output. In production, spark backgrounds organs with `flock -n ... &` and stimulus delivery is async via the ganglion. An organ that sends a stimulus to itself will block in the local lab but work in production.
+The mock CLIs implement the contracts described above with these simplifications:
 
-### Mock `bin/stimulus`
+- **Synchronous execution.** Production spark backgrounds organs with `flock -n ... &`. The mocks run organs sequentially for deterministic output. An organ that sends a stimulus to itself will block in the local lab but work in production.
+- **Local-only routing.** The mock stimulus resolves organ paths from `$ORGANS` and writes directly to the filesystem. No ganglion, no network bus.
+- **No TTL/pruning.** The mock circ stores blobs indefinitely in `.circulatory/`. `local-lab.sh` cleans this directory on each run.
 
-Resolves the target organ from `$ORGANS`, writes the payload to `.stimulus/`, and fires the organ via `spark-one`.
+To run: `cd local-lab && bash local-lab.sh`
 
-```bash
-#!/bin/bash
-# Mock Nervous System
-CMD=""
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-cd "$DIR/.."
-
-while [[ $# -gt 0 ]]; do
-  case $1 in
-    send) CMD="send"; shift ;;
-    --to) TARGET="$2"; shift 2 ;;
-    --body) BODY="$2"; shift 2 ;;
-    *) shift ;;
-  esac
-done
-
-if [ "$CMD" != "send" ]; then
-  echo "Usage: stimulus send --to <organ> --body '<json>'" >&2
-  exit 1
-fi
-
-# Resolve organ path from $ORGANS
-IFS=':' read -ra ADDR <<< "$ORGANS"
-ORGAN_PATH=""
-for path in "${ADDR[@]}"; do
-  if [[ $(basename "$path") == "$TARGET" ]]; then
-    ORGAN_PATH="$path"
-    break
-  fi
-done
-
-if [ -z "$ORGAN_PATH" ]; then
-  echo "stimulus: organ not found: $TARGET" >&2
-  exit 1
-fi
-
-STIM_DIR="$ORGAN_PATH/.stimulus"
-mkdir -p "$STIM_DIR"
-TMPFILE=$(mktemp "$STIM_DIR/XXXXXX.json")
-echo "$BODY" > "$TMPFILE"
-
-spark-one "$TARGET"
-```
-
-### Mock `bin/circ`
-
-Content-addressed blob store backed by a local `.circulatory/` directory. Atomic writes via tmp+mv.
-
-```bash
-#!/bin/bash
-# Mock Circulatory System
-CMD=$1
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-HEART_DIR="$DIR/../.circulatory"
-mkdir -p "$HEART_DIR"
-
-if [ "$CMD" == "push" ]; then
-  FILE_PATH=$2
-  if [ ! -f "$FILE_PATH" ]; then
-    echo "circ push: file not found: $FILE_PATH" >&2
-    exit 1
-  fi
-  HASH=$(sha256sum "$FILE_PATH" | awk '{print $1}')
-  TMPFILE=$(mktemp "$HEART_DIR/.tmp.XXXXXX")
-  cp "$FILE_PATH" "$TMPFILE"
-  mv "$TMPFILE" "$HEART_DIR/$HASH"
-  echo "$HASH"
-elif [ "$CMD" == "get" ]; then
-  HASH=$2
-  if [ -f "$HEART_DIR/$HASH" ]; then
-    echo "$(realpath "$HEART_DIR/$HASH")"
-  else
-    echo "circ get: hash not found: $HASH" >&2
-    exit 1
-  fi
-else
-  echo "Usage: circ push <path> | circ get <hash>" >&2
-  exit 1
-fi
-```
-
-### Mock `bin/spark-cron`
-
-```bash
-#!/bin/bash
-# Mock Spark (Cron)
-# Note: runs organs sequentially (production backgrounds them)
-IFS=':' read -ra ADDR <<< "$ORGANS"
-
-for organ_path in "${ADDR[@]}"; do
-  CADENCE=$(cat "$organ_path/cadence" 2>/dev/null || echo 1)
-  TICK_FILE="$organ_path/.ticks"
-  CURRENT_TICK=$(cat "$TICK_FILE" 2>/dev/null || echo 0)
-
-  if [ "$CURRENT_TICK" -ge "$CADENCE" ]; then
-    echo "0" > "$TICK_FILE"
-    LOCK_FILE="$organ_path/.lock"
-    flock -n "$LOCK_FILE" -c "$organ_path/live"
-  else
-    echo $((CURRENT_TICK + 1)) > "$TICK_FILE"
-  fi
-done
-```
-
-### Mock `bin/spark-one`
-
-```bash
-#!/bin/bash
-# Immediate Excitation (best-effort: silently skips if organ is busy)
-# Note: runs synchronously in mock (production backgrounds with &)
-ORGAN_NAME=$1
-IFS=':' read -ra ADDR <<< "$ORGANS"
-
-for path in "${ADDR[@]}"; do
-  if [[ $(basename "$path") == "$ORGAN_NAME" ]]; then
-    LOCK_FILE="$path/.lock"
-    flock -n "$LOCK_FILE" -c "$path/live"
-    exit 0
-  fi
-done
-
-echo "spark-one: organ not found: $ORGAN_NAME" >&2
-exit 1
-```
+To build your own organ, copy `organs/ping/` as a template. Your `live` script must be executable, start with `cd "$(dirname "$0")"`, and interact only through `stimulus`, `circ`, and the filesystem.
 
 ---
 
@@ -385,13 +230,17 @@ The spark does not retry. The `flock` lock is released and the organ waits for i
 
 Returns non-zero exit code. The organ should check the return code and handle gracefully -- skip processing, log the error, or write to `.memory/` for retry on next spark.
 
+### `circ push` fails
+
+Returns non-zero exit code if the file does not exist or cannot be stored. The organ should check the return code and bail rather than sending an empty hash downstream.
+
 ### Bad JSON in `.stimulus/`
 
 Organs are responsible for validating stimulus payloads. If a file fails to parse, the organ should log the error, delete the file (to prevent re-processing), and continue with remaining stimuli.
 
 ### `stimulus send` fails
 
-Returns non-zero if the ganglion rejected the message. In the local lab mock, this only happens if the `send` subcommand is missing. The organ should check the exit code.
+Returns non-zero if the target organ is not found in `$ORGANS` or if the ganglion rejected the message. The organ should check the exit code.
 
 ### Organ already running (flock contention)
 

--- a/organism/README.md
+++ b/organism/README.md
@@ -1,23 +1,35 @@
 # Synthetic Organism: A Technical Field Manual
 By Neil C. Obremski and Knobert Esquire
 
-## Quickstart: Two Organs in 60 Seconds
+## Quickstart
+
+```bash
+cd organism/local-lab && bash local-lab.sh
+# === Local Lab: ping/pong demo ===
+# [ping] fired
+# [ping] pushed payload: 6d9409f85229...
+# [pong] retrieved 6d9409f85229...
+# [pong] got: hello from ping at Fri Mar 27 09:18:26 AM PDT 2026
+# === Done ===
+```
+
+**What just happened:** Ping wrote a message, pushed it into the circulatory system (`circ push`), and sent the content hash to pong via the nervous system (`stimulus send`). Pong received the hash, pulled the payload (`circ get`), and read the message. All three layers -- spark, stimulus, circ -- working together.
+
+**Prerequisites:** bash, flock, jq, sha256sum.
+
+### How it works
 
 ```text
-organism/
+local-lab/
  |-- bin/              # Mock CLIs (see Local Lab section)
  |-- organs/
  |   |-- ping/
  |   |   |-- live
  |   |   |-- cadence       # contains: 1
- |   |   |-- .lock         # created by spark-cron
- |   |   |-- .ticks        # created by spark-cron
  |   |-- pong/
  |       |-- live
  |       |-- cadence       # contains: 1
- |       |-- .lock         # created by spark-cron
- |       |-- .ticks        # created by spark-cron
- |-- .circulatory/
+ |-- .circulatory/         # content-addressed blob store
 ```
 
 **`organs/ping/live`** -- pushes a payload and signals pong:
@@ -27,13 +39,17 @@ organism/
 cd "$(dirname "$0")"
 echo "[ping] fired"
 
-# Write a message and push it into the circulatory system
 MSG_FILE=$(mktemp)
-echo "hello from ping at $(date +%s)" > "$MSG_FILE"
+echo "hello from ping at $(date)" > "$MSG_FILE"
 HASH=$(circ push "$MSG_FILE")
 rm "$MSG_FILE"
 
-echo "[ping] pushed payload: $HASH"
+if [ -z "$HASH" ]; then
+  echo "[ping] circ push failed" >&2
+  exit 1
+fi
+
+echo "[ping] pushed payload: ${HASH:0:12}..."
 stimulus send --to pong --body "{\"hash\": \"$HASH\"}"
 ```
 
@@ -42,37 +58,30 @@ stimulus send --to pong --body "{\"hash\": \"$HASH\"}"
 ```bash
 #!/bin/bash
 cd "$(dirname "$0")"
-for f in $(ls .stimulus/*.json 2>/dev/null | sort); do
-  HASH=$(jq -r '.hash' "$f")
-  rm "$f"
+shopt -s nullglob
+files=(.stimulus/*.json)
+shopt -u nullglob
+
+for f in "${files[@]}"; do
+  HASH=$(jq -r '.hash' "$f" 2>/dev/null)
 
   if [ -z "$HASH" ] || [ "$HASH" = "null" ]; then
     echo "[pong] stimulus missing hash, skipping"
+    rm "$f"
     continue
   fi
 
   FILE_PATH=$(circ get "$HASH")
   if [ $? -ne 0 ]; then
-    echo "[pong] circ get failed for $HASH"
+    echo "[pong] circ get failed for ${HASH:0:12}..."
+    rm "$f"
     continue
   fi
 
+  rm "$f"
+  echo "[pong] retrieved ${HASH:0:12}..."
   echo "[pong] got: $(cat "$FILE_PATH")"
 done
-```
-
-Run it (after creating mock CLIs from the Local Lab section):
-
-```bash
-chmod +x organs/*/live
-export ORGANS="./organs/ping:./organs/pong"
-export PATH="$(pwd)/bin:$PATH"
-spark-cron # .ticks = 0 -> increments to 1
-spark-cron # .ticks = 1 >= cadence 1 -> fires both organs
-sleep 1
-# [ping] fired
-# [ping] pushed payload: 52921...
-# [pong] got: hello from ping at 1774627933
 ```
 
 ---
@@ -120,6 +129,8 @@ An organ defines its rate via a `cadence` file (single integer). The spark track
 | **1** | Every other tick | skip, **fire**, skip, **fire**, skip, **fire** |
 | **3** | Every 4th tick | skip, skip, skip, **fire**, skip, skip |
 | **0** | Every tick | **fire**, **fire**, **fire**, **fire**, **fire**, **fire** |
+
+> **Note:** Cadence is a threshold, not a frequency. Cadence 0 means fire every tick (tick always meets threshold). Cadence 1 means fire every *other* tick. Set cadence to 0 for maximum firing rate.
 
 ```bash
 # Core spark logic
@@ -224,14 +235,18 @@ Organs carry their own dependencies: `node_modules/` for Node.js, `venv/` for Py
 
 ## Local Lab
 
-Replace production binaries with bash mocks for local development with no network.
+These four scripts replace production infrastructure (MQTT, S3, cron) with local filesystem operations. Put them in `bin/` and add to your `$PATH`. No network required.
 
 ```bash
 export ORGANS="./organs/brain:./organs/mouth"
-export PATH="$PATH:$(pwd)/bin"
+export PATH="$(pwd)/bin:$PATH"
 ```
 
+> **Important:** The local lab mocks run organs synchronously for deterministic output. In production, spark backgrounds organs with `flock -n ... &` and stimulus delivery is async via the ganglion. An organ that sends a stimulus to itself will block in the local lab but work in production.
+
 ### Mock `bin/stimulus`
+
+Resolves the target organ from `$ORGANS`, writes the payload to `.stimulus/`, and fires the organ via `spark-one`.
 
 ```bash
 #!/bin/bash
@@ -254,7 +269,22 @@ if [ "$CMD" != "send" ]; then
   exit 1
 fi
 
-STIM_DIR="./organs/$TARGET/.stimulus"
+# Resolve organ path from $ORGANS
+IFS=':' read -ra ADDR <<< "$ORGANS"
+ORGAN_PATH=""
+for path in "${ADDR[@]}"; do
+  if [[ $(basename "$path") == "$TARGET" ]]; then
+    ORGAN_PATH="$path"
+    break
+  fi
+done
+
+if [ -z "$ORGAN_PATH" ]; then
+  echo "stimulus: organ not found: $TARGET" >&2
+  exit 1
+fi
+
+STIM_DIR="$ORGAN_PATH/.stimulus"
 mkdir -p "$STIM_DIR"
 TMPFILE=$(mktemp "$STIM_DIR/XXXXXX.json")
 echo "$BODY" > "$TMPFILE"
@@ -262,9 +292,9 @@ echo "$BODY" > "$TMPFILE"
 spark-one "$TARGET"
 ```
 
-> **Note:** This mock calls `spark-one` synchronously — `stimulus send` blocks until the target organ completes. In production, stimulus delivery is async (the ganglion handles routing in the background).
-
 ### Mock `bin/circ`
+
+Content-addressed blob store backed by a local `.circulatory/` directory. Atomic writes via tmp+mv.
 
 ```bash
 #!/bin/bash
@@ -276,6 +306,10 @@ mkdir -p "$HEART_DIR"
 
 if [ "$CMD" == "push" ]; then
   FILE_PATH=$2
+  if [ ! -f "$FILE_PATH" ]; then
+    echo "circ push: file not found: $FILE_PATH" >&2
+    exit 1
+  fi
   HASH=$(sha256sum "$FILE_PATH" | awk '{print $1}')
   TMPFILE=$(mktemp "$HEART_DIR/.tmp.XXXXXX")
   cp "$FILE_PATH" "$TMPFILE"
@@ -289,6 +323,9 @@ elif [ "$CMD" == "get" ]; then
     echo "circ get: hash not found: $HASH" >&2
     exit 1
   fi
+else
+  echo "Usage: circ push <path> | circ get <hash>" >&2
+  exit 1
 fi
 ```
 
@@ -297,6 +334,7 @@ fi
 ```bash
 #!/bin/bash
 # Mock Spark (Cron)
+# Note: runs organs sequentially (production backgrounds them)
 IFS=':' read -ra ADDR <<< "$ORGANS"
 
 for organ_path in "${ADDR[@]}"; do
@@ -307,7 +345,7 @@ for organ_path in "${ADDR[@]}"; do
   if [ "$CURRENT_TICK" -ge "$CADENCE" ]; then
     echo "0" > "$TICK_FILE"
     LOCK_FILE="$organ_path/.lock"
-    flock -n "$LOCK_FILE" -c "$organ_path/live" &
+    flock -n "$LOCK_FILE" -c "$organ_path/live"
   else
     echo $((CURRENT_TICK + 1)) > "$TICK_FILE"
   fi
@@ -319,16 +357,20 @@ done
 ```bash
 #!/bin/bash
 # Immediate Excitation (best-effort: silently skips if organ is busy)
+# Note: runs synchronously in mock (production backgrounds with &)
 ORGAN_NAME=$1
 IFS=':' read -ra ADDR <<< "$ORGANS"
 
 for path in "${ADDR[@]}"; do
   if [[ $(basename "$path") == "$ORGAN_NAME" ]]; then
     LOCK_FILE="$path/.lock"
-    flock -n "$LOCK_FILE" -c "$path/live" &
+    flock -n "$LOCK_FILE" -c "$path/live"
     exit 0
   fi
 done
+
+echo "spark-one: organ not found: $ORGAN_NAME" >&2
+exit 1
 ```
 
 ---

--- a/organism/local-lab/bin/circ
+++ b/organism/local-lab/bin/circ
@@ -7,6 +7,10 @@ mkdir -p "$HEART_DIR"
 
 if [ "$CMD" == "push" ]; then
   FILE_PATH=$2
+  if [ ! -f "$FILE_PATH" ]; then
+    echo "circ push: file not found: $FILE_PATH" >&2
+    exit 1
+  fi
   HASH=$(sha256sum "$FILE_PATH" | awk '{print $1}')
   TMPFILE=$(mktemp "$HEART_DIR/.tmp.XXXXXX")
   cp "$FILE_PATH" "$TMPFILE"
@@ -20,4 +24,7 @@ elif [ "$CMD" == "get" ]; then
     echo "circ get: hash not found: $HASH" >&2
     exit 1
   fi
+else
+  echo "Usage: circ push <path> | circ get <hash>" >&2
+  exit 1
 fi

--- a/organism/local-lab/bin/circ
+++ b/organism/local-lab/bin/circ
@@ -1,7 +1,8 @@
 #!/bin/bash
 # Mock Circulatory System
 CMD=$1
-HEART_DIR="./.circulatory"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+HEART_DIR="$DIR/../.circulatory"
 mkdir -p "$HEART_DIR"
 
 if [ "$CMD" == "push" ]; then

--- a/organism/local-lab/bin/spark-cron
+++ b/organism/local-lab/bin/spark-cron
@@ -4,11 +4,11 @@
 IFS=':' read -ra ADDR <<< "$ORGANS"
 
 for organ_path in "${ADDR[@]}"; do
-  CADENCE=$(cat "$organ_path/cadence" 2>/dev/null || echo 1)
+  COOLDOWN=$(cat "$organ_path/cooldown" 2>/dev/null || echo 1)
   TICK_FILE="$organ_path/.ticks"
   CURRENT_TICK=$(cat "$TICK_FILE" 2>/dev/null || echo 0)
 
-  if [ "$CURRENT_TICK" -ge "$CADENCE" ]; then
+  if [ "$CURRENT_TICK" -ge "$COOLDOWN" ]; then
     echo "0" > "$TICK_FILE"
     LOCK_FILE="$organ_path/.lock"
     flock -n "$LOCK_FILE" -c "$organ_path/live"

--- a/organism/local-lab/bin/spark-cron
+++ b/organism/local-lab/bin/spark-cron
@@ -1,9 +1,9 @@
 #!/bin/bash
 # Mock Spark (Cron)
+# Note: runs organs sequentially (production spark backgrounds them)
 IFS=':' read -ra ADDR <<< "$ORGANS"
 
 for organ_path in "${ADDR[@]}"; do
-  organ_name=$(basename "$organ_path")
   CADENCE=$(cat "$organ_path/cadence" 2>/dev/null || echo 1)
   TICK_FILE="$organ_path/.ticks"
   CURRENT_TICK=$(cat "$TICK_FILE" 2>/dev/null || echo 0)
@@ -11,7 +11,7 @@ for organ_path in "${ADDR[@]}"; do
   if [ "$CURRENT_TICK" -ge "$CADENCE" ]; then
     echo "0" > "$TICK_FILE"
     LOCK_FILE="$organ_path/.lock"
-    flock -n "$LOCK_FILE" -c "$organ_path/live" &
+    flock -n "$LOCK_FILE" -c "$organ_path/live"
   else
     echo $((CURRENT_TICK + 1)) > "$TICK_FILE"
   fi

--- a/organism/local-lab/bin/spark-one
+++ b/organism/local-lab/bin/spark-one
@@ -1,12 +1,16 @@
 #!/bin/bash
 # Immediate Excitation (best-effort: silently skips if organ is busy)
+# Note: runs synchronously in mock (production backgrounds with &)
 ORGAN_NAME=$1
 IFS=':' read -ra ADDR <<< "$ORGANS"
 
 for path in "${ADDR[@]}"; do
   if [[ $(basename "$path") == "$ORGAN_NAME" ]]; then
     LOCK_FILE="$path/.lock"
-    flock -n "$LOCK_FILE" -c "$path/live" &
+    flock -n "$LOCK_FILE" -c "$path/live"
     exit 0
   fi
 done
+
+echo "spark-one: organ not found: $ORGAN_NAME" >&2
+exit 1

--- a/organism/local-lab/bin/stimulus
+++ b/organism/local-lab/bin/stimulus
@@ -18,7 +18,22 @@ if [ "$CMD" != "send" ]; then
   exit 1
 fi
 
-STIM_DIR="./organs/$TARGET/.stimulus"
+# Resolve organ path from $ORGANS (same as spark-one)
+IFS=':' read -ra ADDR <<< "$ORGANS"
+ORGAN_PATH=""
+for path in "${ADDR[@]}"; do
+  if [[ $(basename "$path") == "$TARGET" ]]; then
+    ORGAN_PATH="$path"
+    break
+  fi
+done
+
+if [ -z "$ORGAN_PATH" ]; then
+  echo "stimulus: organ not found: $TARGET" >&2
+  exit 1
+fi
+
+STIM_DIR="$ORGAN_PATH/.stimulus"
 mkdir -p "$STIM_DIR"
 TMPFILE=$(mktemp "$STIM_DIR/XXXXXX.json")
 echo "$BODY" > "$TMPFILE"

--- a/organism/local-lab/local-lab.sh
+++ b/organism/local-lab/local-lab.sh
@@ -14,6 +14,6 @@ rm -rf .circulatory
 
 echo "=== Local Lab: ping/pong demo ==="
 spark-cron # .ticks = 0 -> increments to 1
-spark-cron # .ticks = 1 >= cadence 1 -> fires both organs
+spark-cron # .ticks = 1 >= cooldown 1 -> fires both organs
 wait
 echo "=== Done ==="

--- a/organism/local-lab/local-lab.sh
+++ b/organism/local-lab/local-lab.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+cd "$(dirname "$0")"
 export ORGANS="./organs/ping:./organs/pong"
 export PATH="$(pwd)/bin:$PATH"
 
@@ -11,6 +12,8 @@ rm -rf organs/ping/.stimulus
 rm -rf organs/pong/.stimulus
 rm -rf .circulatory
 
+echo "=== Local Lab: ping/pong demo ==="
 spark-cron # .ticks = 0 -> increments to 1
 spark-cron # .ticks = 1 >= cadence 1 -> fires both organs
-sleep 1
+wait
+echo "=== Done ==="

--- a/organism/local-lab/local-lab.sh
+++ b/organism/local-lab/local-lab.sh
@@ -9,6 +9,7 @@ rm -f organs/pong/.lock
 rm -f organs/pong/.ticks
 rm -rf organs/ping/.stimulus
 rm -rf organs/pong/.stimulus
+rm -rf .circulatory
 
 spark-cron # .ticks = 0 -> increments to 1
 spark-cron # .ticks = 1 >= cadence 1 -> fires both organs

--- a/organism/local-lab/organs/ping/live
+++ b/organism/local-lab/organs/ping/live
@@ -4,9 +4,14 @@ echo "[ping] fired"
 
 # Write a message and push it into the circulatory system
 MSG_FILE=$(mktemp)
-echo "hello from ping at $(date +%s)" > "$MSG_FILE"
+echo "hello from ping at $(date)" > "$MSG_FILE"
 HASH=$(circ push "$MSG_FILE")
 rm "$MSG_FILE"
 
-echo "[ping] pushed payload: $HASH"
+if [ -z "$HASH" ]; then
+  echo "[ping] circ push failed" >&2
+  exit 1
+fi
+
+echo "[ping] pushed payload: ${HASH:0:12}..."
 stimulus send --to pong --body "{\"hash\": \"$HASH\"}"

--- a/organism/local-lab/organs/ping/live
+++ b/organism/local-lab/organs/ping/live
@@ -1,4 +1,12 @@
 #!/bin/bash
 cd "$(dirname "$0")"
 echo "[ping] fired"
-stimulus send --to pong --body '{"msg": "hello from ping"}'
+
+# Write a message and push it into the circulatory system
+MSG_FILE=$(mktemp)
+echo "hello from ping at $(date +%s)" > "$MSG_FILE"
+HASH=$(circ push "$MSG_FILE")
+rm "$MSG_FILE"
+
+echo "[ping] pushed payload: $HASH"
+stimulus send --to pong --body "{\"hash\": \"$HASH\"}"

--- a/organism/local-lab/organs/pong/live
+++ b/organism/local-lab/organs/pong/live
@@ -1,6 +1,19 @@
 #!/bin/bash
 cd "$(dirname "$0")"
 for f in $(ls .stimulus/*.json 2>/dev/null | sort); do
-  echo "[pong] got: $(cat "$f")"
+  HASH=$(jq -r '.hash' "$f")
   rm "$f"
+
+  if [ -z "$HASH" ] || [ "$HASH" = "null" ]; then
+    echo "[pong] stimulus missing hash, skipping"
+    continue
+  fi
+
+  FILE_PATH=$(circ get "$HASH")
+  if [ $? -ne 0 ]; then
+    echo "[pong] circ get failed for $HASH"
+    continue
+  fi
+
+  echo "[pong] got: $(cat "$FILE_PATH")"
 done

--- a/organism/local-lab/organs/pong/live
+++ b/organism/local-lab/organs/pong/live
@@ -1,19 +1,26 @@
 #!/bin/bash
 cd "$(dirname "$0")"
-for f in $(ls .stimulus/*.json 2>/dev/null | sort); do
-  HASH=$(jq -r '.hash' "$f")
-  rm "$f"
+shopt -s nullglob
+files=(.stimulus/*.json)
+shopt -u nullglob
+
+for f in "${files[@]}"; do
+  HASH=$(jq -r '.hash' "$f" 2>/dev/null)
 
   if [ -z "$HASH" ] || [ "$HASH" = "null" ]; then
     echo "[pong] stimulus missing hash, skipping"
+    rm "$f"
     continue
   fi
 
   FILE_PATH=$(circ get "$HASH")
   if [ $? -ne 0 ]; then
-    echo "[pong] circ get failed for $HASH"
+    echo "[pong] circ get failed for ${HASH:0:12}..."
+    rm "$f"
     continue
   fi
 
+  rm "$f"
+  echo "[pong] retrieved ${HASH:0:12}..."
   echo "[pong] got: $(cat "$FILE_PATH")"
 done


### PR DESCRIPTION
## Summary
- Ping now writes a message, pushes it via `circ push`, and sends the hash to pong via `stimulus send`
- Pong parses the hash from stimulus JSON with `jq`, retrieves the payload via `circ get`, and reads the message
- Fixed `circ` mock to resolve `.circulatory/` relative to `bin/` parent (not caller's cwd)
- `local-lab.sh` cleans `.circulatory/` on reset
- README updated: quickstart code blocks, expected output, and circ mock all match implementations

All three layers (spark, stimulus, circ) now demonstrated end-to-end in the local lab.

## Test plan
- [x] `cd organism/local-lab && bash local-lab.sh` produces:
  ```
  [ping] fired
  [ping] pushed payload: <hash>
  [pong] got: hello from ping at <timestamp>
  ```

Generated with [Claude Code](https://claude.com/claude-code)