### PR TITLE
fix(a8s): prompt queues inbox message instead of direct wake

### DIFF
--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -100,8 +100,8 @@ A participant woken by a8s can run arbitrary commands within whatever permission
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `a8s` (no arguments)                  | **Step mode.** Run one pass of the routing loop, prompt for input, repeat — similar to `psql`. Good for interactive testing without multiple terminals. |
 | `a8s loop [names...]`                 | Run continuously until `Ctrl+C` or a sibling `a8s stop`.                                                                                                |
-| `a8s prompt <name> "<message>"`       | Wake `<name>` directly with this prompt (no inbox routing, no `from:` wrapping). Useful for human-driven testing or one-shot instructions.              |
-| `a8s prompt all "<message>"`          | Same as above but wakes **every** discovered participant concurrently with the same prompt. Useful for roll calls and global instructions.              |
+| `a8s prompt <name> "<message>"`       | Queue a **senderless** message in `<name>`'s `.inbox/`. The next `step`/`loop` pass wakes `<name>` and delivers the raw prompt (no `from:` wrapper). Safe to run while `a8s loop` is active in another terminal. |
+| `a8s prompt all "<message>"`          | Same, but queue the message in **every** discovered participant's `.inbox/`. Useful for roll calls and global instructions.                             |
 | `a8s clear`                           | Wipe every `.inbox/`, `.outbox/`, `.trash/` and flag every participant for a fresh conversation on its next wake.                                       |
 | `a8s install`                         | Install every skill under `apps/a8s/skills/` into each supported tool's user scope. Idempotent.                                                         |
 | `a8s stop`                            | Signal any running `a8s loop` to exit.                                                                                                                  |
@@ -127,16 +127,17 @@ Messages are JSON files dropped into `.outbox/`:
 }
 ```
 
-When delivered, the participant is woken with a recipient-neutral prompt. The verb phrase depends on whether the message was direct (`tell`) or a broadcast (`says`):
+When delivered, the participant is woken with a recipient-neutral prompt. The shape depends on `from` and `to`:
 
 ```
-[{date}] {from} tells you ({to}): {content}    # direct
-[{date}] {from} says: {content}                # broadcast (to is empty / missing)
+[{date}] {from} tells you ({to}): {content}    # direct       (from set, to set)
+[{date}] {from} says: {content}                # broadcast    (from set, to empty)
+{content}                                      # raw prompt   (from empty)
 
 FILE: {files[0].path}
 ```
 
-`FILE:` lines are omitted when there are no files. The direct template includes the recipient's own name in parens so the wake context is unambiguous about who is being addressed. Recipients of a broadcast are not told who else got it (the recipient list is implicit and ephemeral). The template never identifies the sender as human or AI.
+`FILE:` lines are omitted when there are no files. The direct template includes the recipient's own name in parens so the wake context is unambiguous about who is being addressed. Recipients of a broadcast are not told who else got it (the recipient list is implicit and ephemeral). A senderless message (queued by `a8s prompt`) is delivered as raw content — no wrapper. The template never identifies the sender as human or AI.
 
 ## The `tell` and `says` CLIs and the registry
 

--- a/apps/a8s/a8s.py
+++ b/apps/a8s/a8s.py
@@ -184,19 +184,20 @@ def next_inbox_message(p: Participant) -> Path | None:
 
 
 def build_prompt(msg: dict) -> str:
-    sender = msg.get("from", "")
+    sender = (msg.get("from") or "").strip()
     content = msg.get("content", "")
     date = msg.get("date", "")
     recipient = (msg.get("to") or "").strip()
-    if recipient:
-        verb_phrase = f"tells you ({recipient})"
+    if not sender:
+        # No sender = a direct prompt (queued by `a8s prompt`); deliver raw.
+        header = content
     else:
-        verb_phrase = "says"
-    header = (
-        f"[{date}] {sender} {verb_phrase}: {content}"
-        if date
-        else f"{sender} {verb_phrase}: {content}"
-    )
+        verb_phrase = f"tells you ({recipient})" if recipient else "says"
+        header = (
+            f"[{date}] {sender} {verb_phrase}: {content}"
+            if date
+            else f"{sender} {verb_phrase}: {content}"
+        )
     parts = [header]
     files = msg.get("files") or []
     if files:
@@ -754,7 +755,7 @@ COMMANDS: list[tuple[str, str, str]] = [
     ("step",    "",                  "Run one routing pass (deliver outboxes, drain inboxes)."),
     ("loop",    "",                  "Run continuously until Ctrl+C or `a8s stop`."),
     ("stop",    "",                  "Signal a running `a8s loop` to exit."),
-    ("prompt",  "<name|all> <message>",  'Wake <name> (or every participant if "all") with this raw prompt — no "from" wrapper. "all" wakes concurrently.'),
+    ("prompt",  "<name|all> <message>",  'Queue a senderless message in <name>\'s inbox (or all). Wakes via the next step/loop pass. Use "all" to broadcast a prompt.'),
     ("tell",    "<name> <message>",  "Direct routed message to <name>. Sender = participant enclosing CWD."),
     ("says",    "<message>",         "Broadcast routed message to every other participant. Sender = participant enclosing CWD."),
     ("clear",   "",                  "Wipe all mailboxes and flag every participant for fresh conversation on next wake."),
@@ -855,11 +856,27 @@ def repl(scan_dir: Path, interval: float) -> int:
 
 # ---------- CLI ----------
 
-def _wake_with_prompt(p: Participant, prompt: str) -> int:
-    fresh = consume_fresh(p.root)
-    out(f"[{p.name}] direct prompt" + (" (fresh)" if fresh else ""))
-    cmd = build_command(p.kind, prompt, fresh=fresh)
-    return run_with_prefix(p.name, cmd, p.root)
+def _queue_prompt(p: Participant, content: str) -> Path:
+    """Drop a senderless message JSON directly into <p>/.inbox/.
+
+    The empty `from` is the signal to `build_prompt` to deliver the
+    raw content without a `tells you` / `says` wrapper. The next
+    inbox-drain (via `step` or `loop`) wakes the participant.
+    """
+    ensure_mailboxes(p)
+    now = datetime.now(timezone.utc)
+    msg = {
+        "date": now.isoformat().replace("+00:00", "Z"),
+        "from": "",
+        "to": p.name,
+        "content": content,
+        "files": [],
+    }
+    fname = f"{now.strftime('%Y%m%dT%H%M%S%f')}_PROMPT.json"
+    dest = unique_path(p.root / ".inbox" / fname)
+    with dest.open("w", encoding="utf-8") as f:
+        json.dump(msg, f, indent=2)
+    return dest
 
 
 def cmd_prompt(scan_dir: Path, args: list[str]) -> int:
@@ -875,23 +892,18 @@ def cmd_prompt(scan_dir: Path, args: list[str]) -> int:
         if not parts:
             print("no participants found", file=sys.stderr)
             return 1
-        global PRINT_LOCK
-        if PRINT_LOCK is None:
-            PRINT_LOCK = threading.Lock()
-        threads: list[threading.Thread] = []
         for p in parts:
-            t = threading.Thread(target=_wake_with_prompt, args=(p, prompt), daemon=False)
-            t.start()
-            threads.append(t)
-        for t in threads:
-            t.join()
+            _queue_prompt(p, prompt)
+        out(f"queued prompt to {len(parts)} participant(s); next step/loop will wake them")
         return 0
 
     target = find_participant(parts, name)
     if target is None:
         print(f"no participant named {name!r}", file=sys.stderr)
         return 1
-    return _wake_with_prompt(target, prompt)
+    _queue_prompt(target, prompt)
+    out(f"queued prompt to {target.name}; next step/loop will wake")
+    return 0
 
 
 def main(argv: list[str]) -> int:


### PR DESCRIPTION
Closes #44

## Problem

`a8s prompt <name> <message>` (and `prompt all`) did a direct `subprocess.Popen` wake. When `a8s loop` was running in another terminal, the loop's single-instance check was in-process and didn't see the prompt's child — running both at once raced.

Hit when starting a multi-agent project:
```
# terminal 1
a8s loop
# terminal 2
a8s prompt all "Let's work on issue #39 together..."
# loop and prompt fight over the same wakes
```

## Fix

`cmd_prompt` now writes a senderless message JSON straight into the recipient's `.inbox/` and returns immediately:

```json
{ "from": "", "to": "<name>", "content": "<msg>", "files": [...] }
```

The next `step` or `loop` iteration drains the inbox normally, with its own busy/lock semantics. Concurrent loop + prompt is now safe.

## Wake template

`build_prompt` already branched on `to` for direct vs broadcast; now it branches on `from` first:

| `from`     | `to`     | Template                                            |
| ---------- | -------- | --------------------------------------------------- |
| set        | set      | `[<date>] <from> tells you (<to>): <content>`       |
| set        | empty    | `[<date>] <from> says: <content>`                   |
| **empty**  | (any)    | `<content>` — raw, no wrapper                       |

Queued prompts arrive in the model's context as just the prompt text — same effective payload the previous synchronous wake produced.

## Files

- `apps/a8s/a8s.py`: `_queue_prompt()` helper; rewritten `cmd_prompt`; `build_prompt` gains the empty-from case.
- `apps/a8s/README.md`: command table + wake-template snippet updated.

## Test plan

- [x] `a8s prompt CLAUDE "..."` writes one inbox JSON with `from: ""`, returns immediately
- [x] `a8s prompt all "..."` queues one JSON to every discovered participant
- [x] `build_prompt` renders the three cases correctly: prompt → raw content, direct → `tells you`, broadcast → `says`
- [x] `tell` and `says` still produce expected outboxes (regression — their `from` is non-empty)
- [ ] Manual: `a8s loop` in one terminal + `a8s prompt all "..."` in another no longer races

🤖 Generated with [Claude Code](https://claude.com/claude-code)