### PR TITLE
feat(a8s): isolate mailboxes + supervisor log + a8s logs

### DIFF
--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -15,7 +15,7 @@ Filesystem-based message routing between independent Claude Code, Gemini, and Co
 
    a8s never writes into the user's project directories — with one exception below.
 
-4. **Mailboxes travel with the participant.** `.inbox/`, `.outbox/`, and `.trash/` live *inside* each participant's own directory so that messages move with the directory if it is copied, archived, or relocated.
+4. **Mailboxes are isolated from agents.** `.inbox/`, `.outbox/`, and `.trash/` live under `~/.a8s/mailboxes/<NAME>/`, *not* inside the participant's project directory. Agents see messaging only through the `tell` / `says` skills — they can't `ls` their own mailbox or peek at other agents' traffic. Messages no longer follow the agent dir if it's copied/relocated; that's an accepted tradeoff for v1 (messages were already documented as transient).
 
 5. **Each participant runs with CWD set to its own root** so its own settings (`.claude/settings*`, `.gemini/`, etc.) load correctly.
 
@@ -23,10 +23,10 @@ Filesystem-based message routing between independent Claude Code, Gemini, and Co
 
 - Scans one or more directories for participant roots — directories containing `CLAUDE.md`, `GEMINI.md`, or `CODEX.md`. Default scan root is the current directory; override with `--dir <path>`.
 - Maps each participant's name (and aliases) to its directory.
-- Watches each `.outbox/` for outgoing message JSON; routes them to the recipient's `.inbox/`.
-- When a participant's `.inbox/` has messages, launches the participant with a prompt built from the **first** message and immediately moves that message to `.trash/`.
+- Watches each participant's `~/.a8s/mailboxes/<NAME>/.outbox/` for outgoing message JSON; routes them to the recipient's inbox at the same scope.
+- When a participant's inbox has messages, launches the participant with a prompt built from the **first** message and immediately moves that message to its `.trash/` (also under `~/.a8s/mailboxes/<NAME>/`).
 - Enforces single-instance-per-name (the same name cannot run concurrently with itself).
-- After a participant process exits, re-checks its `.inbox/`; if more messages remain, prompt again.
+- After a participant process exits, re-checks its inbox; if more messages remain, prompt again.
 - Captures stdout/stderr and prefixes each line with `NAME> `.
 
 ### Name parsing
@@ -100,10 +100,11 @@ A participant woken by a8s can run arbitrary commands within whatever permission
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `a8s` (no arguments)                  | **Step mode.** Run one pass of the routing loop, prompt for input, repeat — similar to `psql`. Good for interactive testing without multiple terminals. |
 | `a8s loop [names...]`                 | Run continuously until `Ctrl+C` or a sibling `a8s stop`.                                                                                                |
-| `a8s prompt <name> "<message>"`       | Queue a **senderless** message in `<name>`'s `.inbox/`. The next `step`/`loop` pass wakes `<name>` and delivers the raw prompt (no `from:` wrapper). Safe to run while `a8s loop` is active in another terminal. |
-| `a8s prompt all "<message>"`          | Same, but queue the message in **every** discovered participant's `.inbox/`. Useful for roll calls and global instructions.                             |
-| `a8s clear`                           | Wipe every `.inbox/`, `.outbox/`, `.trash/` and flag every participant for a fresh conversation on its next wake.                                       |
+| `a8s prompt <name> "<message>"`       | Queue a **senderless** message in `<name>`'s inbox. The next `step`/`loop` pass wakes `<name>` and delivers the raw prompt (no `from:` wrapper). Safe to run while `a8s loop` is active in another terminal. |
+| `a8s prompt all "<message>"`          | Same, but queue the message in **every** discovered participant's inbox. Useful for roll calls and global instructions.                                 |
+| `a8s clear`                           | Wipe every participant's mailbox dirs and flag each for a fresh conversation on its next wake.                                                          |
 | `a8s install`                         | Install every skill under `apps/a8s/skills/` into each supported tool's user scope. Idempotent.                                                         |
+| `a8s logs <name> [--tail N] [-f]`     | Print supervisor-log lines mentioning `<name>` (like `docker logs`). `--tail N` limits output, `-f` follows.                                            |
 | `a8s stop`                            | Signal any running `a8s loop` to exit.                                                                                                                  |
 | `a8s --dir <path>`                    | Set the scan root for participant discovery.                                                                                                            |
 | `a8s --interval <seconds>`            | Loop poll interval (default `1.0`).                                                                                                                     |
@@ -113,7 +114,7 @@ Without `loop`, a8s makes one pass and waits for any launched processes to exit 
 
 ## Message format
 
-Messages are JSON files dropped into `.outbox/`:
+Messages are JSON files dropped into the sender's outbox at `~/.a8s/mailboxes/<NAME>/.outbox/`:
 
 ```json
 {
@@ -141,7 +142,7 @@ FILE: {files[0].path}
 
 ## The `tell` and `says` CLIs and the registry
 
-a8s ships two sender-side shell commands, both siblings of `a8s` in `~/bin/`. Both write a message JSON into the **caller's** `.outbox/` and exit — routing happens later when `a8s` next runs (step or loop).
+a8s ships two sender-side shell commands, both siblings of `a8s` in `~/bin/`. Both write a message JSON into the **caller's** outbox at `~/.a8s/mailboxes/<NAME>/.outbox/` and exit — routing happens later when `a8s` next runs (step or loop).
 
 | Command | What it does                                                      | Outbox `to` field |
 | ------- | ----------------------------------------------------------------- | ----------------- |
@@ -182,11 +183,16 @@ If `$PWD` is not inside any registered participant, `tell` fails with a clear er
 ```
 projects/
   my-claude-project/
-    CLAUDE.md
-    .inbox/    .outbox/    .trash/      ← created by a8s on first run
+    CLAUDE.md      ← agent dirs stay clean — only marker files and project content
   my-gemini-project/
     GEMINI.md
-    .inbox/    .outbox/    .trash/
+
+~/.a8s/                              ← all a8s state lives here
+  a8s.json                           ← participant registry
+  log.txt                            ← supervisor log (ISO-timestamped lines)
+  mailboxes/
+    CLAUDE/.inbox/.outbox/.trash/    ← keyed by the registered name (sanitized)
+    GEMINI/.inbox/.outbox/.trash/
 ```
 
 ```
@@ -195,6 +201,22 @@ $ a8s loop
 $ a8s prompt my-claude-project "Ask my-gemini-project to summarize ./notes.md"
 $ a8s stop
 ```
+
+### Supervisor log
+
+Every line a8s prints (system messages, routing decisions, prefixed agent output) is also appended to `~/.a8s/log.txt` with an ISO-8601 UTC timestamp. The same `PRINT_LOCK` that keeps stdout interleaving clean across concurrent loop workers also guards the log file, so log lines stay atomic.
+
+Use `a8s logs <name>` to filter the log for a specific participant — same shape as `docker logs`:
+
+```bash
+a8s logs CLAUDE              # all log lines mentioning CLAUDE
+a8s logs CLAUDE --tail 100   # last 100
+a8s logs CLAUDE -f           # tail-follow new lines as they're written
+```
+
+Matching is case-insensitive on word boundaries, so a lookup for `CLAUDE` catches `CLAUDE> ...`, `[CLAUDE] waking ...`, and `routed: GEMINI -> CLAUDE` lines alike.
+
+The log grows without rotation in v1 — truncate or rotate manually if needed.
 
 ### Reset / fresh start
 

--- a/apps/a8s/a8s.py
+++ b/apps/a8s/a8s.py
@@ -1,12 +1,25 @@
 """a8s — Agent Infinity System.
 
-Discovery, step REPL, outbox->inbox routing, subprocess waking, loop/stop,
-clear (with one-shot fresh flag), and a participant registry under
-~/.a8s/a8s.json that backs the `tell` CLI.
+Filesystem-based message router for independent Claude Code, Gemini CLI,
+and Codex CLI project directories ("participants") to communicate.
 
-Per-tool skill installation for Gemini/Codex is not yet implemented; the
-Claude install path piggybacks on ~/bin/install.sh via a symlink in
-~/bin/docs/.
+Surface (CLI):
+  step / loop / stop          — one routing pass / continuous mode / signal stop
+  prompt <name|all> <msg>     — queue a senderless message to inbox(es)
+  tell <name> <msg>           — direct routed message (sibling CLI ~/bin/tell)
+  says <msg>                  — broadcast routed message (sibling CLI ~/bin/says)
+  clear                       — wipe mailboxes + log; flag fresh on next wake
+  install                     — install canonical skills into Claude / Gemini /
+                                Codex user scope
+  logs <name> [--tail N] [-f] — docker-logs-style filter on the supervisor log
+
+State (all under ~/.a8s/):
+  a8s.json                    — participant registry (name -> kind, root, aliases)
+  mailboxes/<NAME>/           — .inbox / .outbox / .trash, isolated from agent dirs
+                                so participants only see messaging via their skills
+  log.txt                     — supervisor log: ISO-timestamped, captures every line
+                                that goes through `out()` (including subprocess
+                                output captured by `run_with_prefix`)
 """
 
 from __future__ import annotations
@@ -49,6 +62,12 @@ def _log_path() -> Path:
 
 def _safe_name(name: str) -> str:
     return re.sub(r"[^A-Za-z0-9_-]", "_", name)
+
+
+def _preview(content: str, n: int = 80) -> str:
+    """Single-line snippet of `content` for log readability."""
+    s = (content or "").replace("\n", " ").replace("\r", " ").strip()
+    return s if len(s) <= n else s[: n - 1] + "…"
 
 
 def mailbox_dir(name: str) -> Path:
@@ -203,7 +222,7 @@ def route_outboxes(participants: list[Participant]) -> int:
                     dest = unique_path(inbox_dir(recipient.name) / f.name)
                     shutil.copyfile(f, dest)
                 f.unlink()
-                out(f"broadcast: {sender.name} -> {len(others)} ({f.name})")
+                out(f"broadcast: {sender.name} -> {len(others)}: {_preview(msg.get('content', ''))}")
                 routed += len(others)
                 continue
             recipient = by_name.get(recipient_name.lower())
@@ -213,7 +232,7 @@ def route_outboxes(participants: list[Participant]) -> int:
             ensure_mailboxes(recipient)
             dest = unique_path(inbox_dir(recipient.name) / f.name)
             f.rename(dest)
-            out(f"routed: {sender.name} -> {recipient.name} ({dest.name})")
+            out(f"routed: {sender.name} -> {recipient.name}: {_preview(msg.get('content', ''))}")
             routed += 1
     return routed
 
@@ -458,7 +477,8 @@ def wake_once(p: Participant, msg_path: Path) -> None:
     trashed = unique_path(trash_dir(p.name) / msg_path.name)
     msg_path.rename(trashed)
     fresh = consume_fresh(p.root)
-    out(f"[{p.name}] waking from {trashed.name}" + (" (fresh)" if fresh else ""))
+    flag = " (fresh)" if fresh else ""
+    out(f"[{p.name}] waking from {trashed.name}{flag}: {_preview(msg.get('content', ''))}")
     cmd = build_command(p.kind, prompt, fresh=fresh)
     run_with_prefix(p.name, cmd, p.root)
 
@@ -716,8 +736,7 @@ def cmd_tell(args: list[str]) -> int:
     target_name, _target_info = target
 
     _write_outbox(sender_name, Path(sender_info["root"]), target_name, content, files)
-    preview = (content[:60] + "…") if len(content) > 60 else content
-    print(f"tell -> {target_name}: {preview}")
+    out(f"tell -> {target_name}: {_preview(content)}")
     return 0
 
 
@@ -735,8 +754,7 @@ def cmd_says(args: list[str]) -> int:
     sender_name, sender_info = sender
 
     _write_outbox(sender_name, Path(sender_info["root"]), "", content, files)
-    preview = (content[:60] + "…") if len(content) > 60 else content
-    print(f"says: {preview}")
+    out(f"says ({sender_name}): {_preview(content)}")
     return 0
 
 
@@ -763,7 +781,12 @@ def cmd_clear(scan_dir: Path) -> int:
                         f.unlink()
                         cleared += 1
     mark_fresh([p.root for p in parts])
+    log = _log_path()
+    log_size = log.stat().st_size if log.is_file() else 0
+    log.write_text("")
     print(f"cleared {cleared} message(s) across {len(parts)} participant(s)")
+    if log_size:
+        print(f"truncated supervisor log ({log_size} bytes)")
     print("next wake for each will start a new conversation")
     return 0
 
@@ -1015,7 +1038,7 @@ def cmd_prompt(scan_dir: Path, args: list[str]) -> int:
             return 1
         for p in parts:
             _queue_prompt(p, prompt)
-        out(f"queued prompt to {len(parts)} participant(s); next step/loop will wake them")
+        out(f"queued prompt to {len(parts)} participant(s): {_preview(prompt)}")
         return 0
 
     target = find_participant(parts, name)
@@ -1023,7 +1046,7 @@ def cmd_prompt(scan_dir: Path, args: list[str]) -> int:
         print(f"no participant named {name!r}", file=sys.stderr)
         return 1
     _queue_prompt(target, prompt)
-    out(f"queued prompt to {target.name}; next step/loop will wake")
+    out(f"queued prompt to {target.name}: {_preview(prompt)}")
     return 0
 
 

--- a/apps/a8s/a8s.py
+++ b/apps/a8s/a8s.py
@@ -37,15 +37,57 @@ PRINT_LOCK: threading.Lock | None = None
 UNRESTRICTED: bool = False
 
 
+def _a8s_dir() -> Path:
+    base = Path.home() / ".a8s"
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def _log_path() -> Path:
+    return _a8s_dir() / "log.txt"
+
+
+def _safe_name(name: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_-]", "_", name)
+
+
+def mailbox_dir(name: str) -> Path:
+    return _a8s_dir() / "mailboxes" / _safe_name(name)
+
+
+def inbox_dir(name: str) -> Path:
+    return mailbox_dir(name) / ".inbox"
+
+
+def outbox_dir(name: str) -> Path:
+    return mailbox_dir(name) / ".outbox"
+
+
+def trash_dir(name: str) -> Path:
+    return mailbox_dir(name) / ".trash"
+
+
+def _emit(line: str) -> None:
+    """Write `line` (already terminated) to stdout and append a timestamped
+    copy to the supervisor log at ~/.a8s/log.txt."""
+    ts = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    log_line = f"{ts} {line}" if not line.endswith("\n") else f"{ts} {line}"
+    sys.stdout.write(line)
+    sys.stdout.flush()
+    try:
+        with _log_path().open("a", encoding="utf-8") as f:
+            f.write(log_line if log_line.endswith("\n") else log_line + "\n")
+    except OSError:
+        pass
+
+
 def out(text: str = "", end: str = "\n") -> None:
     line = text + end
     if PRINT_LOCK is not None:
         with PRINT_LOCK:
-            sys.stdout.write(line)
-            sys.stdout.flush()
+            _emit(line)
     else:
-        sys.stdout.write(line)
-        sys.stdout.flush()
+        _emit(line)
 
 
 @dataclass(frozen=True)
@@ -119,8 +161,9 @@ def find_participant(parts: list[Participant], query: str) -> Participant | None
 # ---------- mailboxes ----------
 
 def ensure_mailboxes(p: Participant) -> None:
-    for sub in (".inbox", ".outbox", ".trash"):
-        (p.root / sub).mkdir(exist_ok=True)
+    """Create the centralized mailbox dirs for `p` under ~/.a8s/mailboxes/."""
+    for d in (inbox_dir(p.name), outbox_dir(p.name), trash_dir(p.name)):
+        d.mkdir(parents=True, exist_ok=True)
 
 
 def unique_path(p: Path) -> Path:
@@ -141,7 +184,7 @@ def route_outboxes(participants: list[Participant]) -> int:
     routed = 0
     for sender in participants:
         ensure_mailboxes(sender)
-        outbox = sender.root / ".outbox"
+        outbox = outbox_dir(sender.name)
         for f in sorted(outbox.iterdir()):
             if not (f.is_file() and f.name.endswith(".json")):
                 continue
@@ -157,7 +200,7 @@ def route_outboxes(participants: list[Participant]) -> int:
                 others = [p for p in participants if p.name != sender.name]
                 for recipient in others:
                     ensure_mailboxes(recipient)
-                    dest = unique_path(recipient.root / ".inbox" / f.name)
+                    dest = unique_path(inbox_dir(recipient.name) / f.name)
                     shutil.copyfile(f, dest)
                 f.unlink()
                 out(f"broadcast: {sender.name} -> {len(others)} ({f.name})")
@@ -168,7 +211,7 @@ def route_outboxes(participants: list[Participant]) -> int:
                 out(f"[{sender.name}] unknown recipient {recipient_name!r} in {f.name}")
                 continue
             ensure_mailboxes(recipient)
-            dest = unique_path(recipient.root / ".inbox" / f.name)
+            dest = unique_path(inbox_dir(recipient.name) / f.name)
             f.rename(dest)
             out(f"routed: {sender.name} -> {recipient.name} ({dest.name})")
             routed += 1
@@ -176,7 +219,7 @@ def route_outboxes(participants: list[Participant]) -> int:
 
 
 def next_inbox_message(p: Participant) -> Path | None:
-    inbox = p.root / ".inbox"
+    inbox = inbox_dir(p.name)
     if not inbox.is_dir():
         return None
     files = sorted(f for f in inbox.iterdir() if f.is_file() and f.name.endswith(".json"))
@@ -407,12 +450,12 @@ def wake_once(p: Participant, msg_path: Path) -> None:
             msg = json.load(f)
     except (OSError, json.JSONDecodeError) as e:
         out(f"[{p.name}] inbox parse error on {msg_path.name}: {e}")
-        bad = unique_path(p.root / ".trash" / msg_path.name)
+        bad = unique_path(trash_dir(p.name) / msg_path.name)
         msg_path.rename(bad)
         return
 
     prompt = build_prompt(msg)
-    trashed = unique_path(p.root / ".trash" / msg_path.name)
+    trashed = unique_path(trash_dir(p.name) / msg_path.name)
     msg_path.rename(trashed)
     fresh = consume_fresh(p.root)
     out(f"[{p.name}] waking from {trashed.name}" + (" (fresh)" if fresh else ""))
@@ -633,9 +676,9 @@ def _split_content_and_files(raw: str) -> tuple[str, list[dict]]:
     return "\n".join(lines).rstrip(), files
 
 
-def _write_outbox(sender_name: str, sender_root: Path, to: str, content: str, files: list[dict]) -> Path:
-    outbox = sender_root / ".outbox"
-    outbox.mkdir(exist_ok=True)
+def _write_outbox(sender_name: str, _sender_root: Path, to: str, content: str, files: list[dict]) -> Path:
+    outbox = outbox_dir(sender_name)
+    outbox.mkdir(parents=True, exist_ok=True)
     now = datetime.now(timezone.utc)
     msg = {
         "date": now.isoformat().replace("+00:00", "Z"),
@@ -644,7 +687,7 @@ def _write_outbox(sender_name: str, sender_root: Path, to: str, content: str, fi
         "content": content,
         "files": files,
     }
-    safe_sender = re.sub(r"[^A-Za-z0-9_-]", "_", sender_name)
+    safe_sender = _safe_name(sender_name)
     fname = f"{now.strftime('%Y%m%dT%H%M%S%f')}_{safe_sender}.json"
     dest = unique_path(outbox / fname)
     with dest.open("w", encoding="utf-8") as f:
@@ -705,15 +748,90 @@ def cmd_clear(scan_dir: Path) -> int:
     cleared = 0
     for p in parts:
         ensure_mailboxes(p)
-        for sub in (".inbox", ".outbox", ".trash"):
-            for f in (p.root / sub).iterdir():
+        for d in (inbox_dir(p.name), outbox_dir(p.name), trash_dir(p.name)):
+            for f in d.iterdir():
                 if f.is_file():
                     f.unlink()
                     cleared += 1
+        # Defensive: also wipe legacy mailbox dirs that may still sit inside
+        # the agent root from older a8s versions.
+        for sub in (".inbox", ".outbox", ".trash"):
+            legacy = p.root / sub
+            if legacy.is_dir():
+                for f in legacy.iterdir():
+                    if f.is_file():
+                        f.unlink()
+                        cleared += 1
     mark_fresh([p.root for p in parts])
     print(f"cleared {cleared} message(s) across {len(parts)} participant(s)")
     print("next wake for each will start a new conversation")
     return 0
+
+
+def cmd_logs(args: list[str]) -> int:
+    if not args:
+        print("usage: a8s logs <name> [--tail N] [-f|--follow]", file=sys.stderr)
+        return 2
+    name = args[0]
+    tail_n: int | None = None
+    follow = False
+    i = 1
+    while i < len(args):
+        a = args[i]
+        if a in ("-f", "--follow"):
+            follow = True
+            i += 1
+        elif a == "--tail" and i + 1 < len(args):
+            try:
+                tail_n = int(args[i + 1])
+            except ValueError:
+                print(f"--tail: not an integer: {args[i + 1]!r}", file=sys.stderr)
+                return 2
+            i += 2
+        elif a.startswith("--tail="):
+            try:
+                tail_n = int(a.split("=", 1)[1])
+            except ValueError:
+                print(f"--tail: not an integer: {a!r}", file=sys.stderr)
+                return 2
+            i += 1
+        else:
+            print(f"unknown logs arg: {a!r}", file=sys.stderr)
+            return 2
+
+    log = _log_path()
+    if not log.is_file():
+        print(f"no log yet at {log}", file=sys.stderr)
+        return 1
+
+    pattern = re.compile(rf"\b{re.escape(name)}\b", re.IGNORECASE)
+
+    with log.open("r", encoding="utf-8", errors="replace") as f:
+        existing = [ln for ln in f if pattern.search(ln)]
+    if tail_n is not None:
+        existing = existing[-tail_n:]
+    for ln in existing:
+        sys.stdout.write(ln)
+    sys.stdout.flush()
+
+    if not follow:
+        return 0
+
+    # Follow: re-open and seek to end, then poll for new lines.
+    try:
+        with log.open("r", encoding="utf-8", errors="replace") as f:
+            f.seek(0, 2)  # SEEK_END
+            while True:
+                line = f.readline()
+                if not line:
+                    import time
+                    time.sleep(0.25)
+                    continue
+                if pattern.search(line):
+                    sys.stdout.write(line)
+                    sys.stdout.flush()
+    except KeyboardInterrupt:
+        return 0
 
 
 def cmd_stop() -> int:
@@ -760,6 +878,7 @@ COMMANDS: list[tuple[str, str, str]] = [
     ("says",    "<message>",         "Broadcast routed message to every other participant. Sender = participant enclosing CWD."),
     ("clear",   "",                  "Wipe all mailboxes and flag every participant for fresh conversation on next wake."),
     ("install", "",                  "Install canonical skills from apps/a8s/skills/ into each supported tool's user scope."),
+    ("logs",    "<name> [--tail N] [-f]",  "Show recent supervisor-log lines mentioning <name> (like `docker logs`). -f follows."),
 ]
 
 REPL_EXTRAS: list[tuple[str, str, str]] = [
@@ -808,6 +927,8 @@ def dispatch(cmd: str, args: list[str], scan_dir: Path, interval: float) -> int:
         return cmd_clear(scan_dir)
     if cmd == "install":
         return cmd_install()
+    if cmd == "logs":
+        return cmd_logs(args)
     raise ValueError(f"unknown command: {cmd!r}")
 
 
@@ -873,7 +994,7 @@ def _queue_prompt(p: Participant, content: str) -> Path:
         "files": [],
     }
     fname = f"{now.strftime('%Y%m%dT%H%M%S%f')}_PROMPT.json"
-    dest = unique_path(p.root / ".inbox" / fname)
+    dest = unique_path(inbox_dir(p.name) / fname)
     with dest.open("w", encoding="utf-8") as f:
         json.dump(msg, f, indent=2)
     return dest


### PR DESCRIPTION
Closes #46, #47, #48 — three related changes landing together because they share a goal: agents can't observe their own messaging, but a human/supervisor can.

## Summary

| Change                                            | Issue | Why                                                                                                                          |
| ------------------------------------------------- | ----- | ---------------------------------------------------------------------------------------------------------------------------- |
| Mailboxes move to `~/.a8s/mailboxes/<NAME>/`      | #46   | Gemini and others kept `ls`'ing their own dir and reading raw JSONs. Now they only see the `tell` / `says` skills.           |
| Supervisor log at `~/.a8s/log.txt`                | #47   | Without per-agent visibility, *somebody* still needs to see the swarm. The log is the only sanctioned outside view.          |
| New `a8s logs <name>` command                     | #48   | `docker logs`-style reader so a supervisor can grep one agent out of the timeline. `--tail N` and `-f` supported.            |

## Mailbox isolation (#46)

Path moves from `<agent-root>/.{inbox,outbox,trash}/` → `~/.a8s/mailboxes/<NAME>/.{inbox,outbox,trash}/`. `<NAME>` is the registered participant name run through `re.sub(r"[^A-Za-z0-9_-]", "_", name)` so duplicates like `CLAUDE 1` map to `CLAUDE_1`. New helpers `inbox_dir(name)` / `outbox_dir(name)` / `trash_dir(name)` are used everywhere a mailbox path was computed before.

`cmd_clear` also defensively wipes any legacy `<root>/.inbox/.outbox/.trash` files from older a8s installations so a single `clear` cleans the whole machine.

**Design principle revision** — "Mailboxes travel with the participant" → "Mailboxes are isolated from agents." Messages no longer follow a relocated agent dir. v1 already documented messages as transient, so this is the right tradeoff for stronger isolation.

## Supervisor log (#47)

Every call to `out()` now writes both to stdout and to `~/.a8s/log.txt` with an ISO-8601 UTC prefix. `run_with_prefix` already routed subprocess lines through `out()`, so agent output is captured for free. `PRINT_LOCK` guards both sinks so concurrent worker output stays line-atomic across stdout + log.

No rotation in v1 — file grows; truncate manually if needed (documented).

## `a8s logs` (#48)

```
a8s logs <name> [--tail N] [-f|--follow]
```

Case-insensitive word-boundary match on the name. Catches `<NAME>>` prefixed subprocess output, `[<NAME>]` system messages, and routing lines like `routed: X -> NAME`. `-f` polls every 250 ms and prints new matching lines until Ctrl+C.

## Files

- `apps/a8s/a8s.py`: `_emit()` (stdout + log fan-out), mailbox path helpers, `cmd_logs`, dispatch + `COMMANDS` entry, plumbing in every existing mailbox path reference.
- `apps/a8s/README.md`: design principle 4 rewritten, example layout updated, new "Supervisor log" section, `logs` row in command table, all references to old in-agent-dir mailboxes purged.

## Test plan

- [x] After clean run + `prompt all`, agent dirs contain only marker files; no `.inbox/.outbox/.trash` leakage.
- [x] Mailboxes are at `~/.a8s/mailboxes/<NAME>/.{inbox,outbox,trash}/`; messages route correctly between them.
- [x] `~/.a8s/log.txt` accumulates ISO-timestamped lines for both `[a8s] ...` system messages and `NAME> ...` subprocess output.
- [x] `a8s logs CLAUDE --tail 2` prints just the matching tail.
- [ ] (manual) `a8s logs CLAUDE -f` follows new lines and exits cleanly on Ctrl+C — best validated against a live `loop` in another terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)