### PR TITLE
fix(a8s): outbox stays in agent root; route forces from = sender

### DIFF
--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -15,7 +15,7 @@ Filesystem-based message routing between independent Claude Code, Gemini, and Co
 
    a8s never writes into the user's project directories — with one exception below.
 
-4. **Mailboxes are isolated from agents.** `.inbox/`, `.outbox/`, and `.trash/` live under `~/.a8s/mailboxes/<NAME>/`, *not* inside the participant's project directory. Agents see messaging only through the `tell` / `says` skills — they can't `ls` their own mailbox or peek at other agents' traffic. Messages no longer follow the agent dir if it's copied/relocated; that's an accepted tradeoff for v1 (messages were already documented as transient).
+4. **Mailboxes are split: outbox local, inbox/trash isolated.** `.inbox/` and `.trash/` live under `~/.a8s/mailboxes/<NAME>/` — the agent never sees them and only interacts with messaging through the `tell` / `says` skills. `.outbox/` lives **inside** the agent's project root because the agent has to write to it, and a strict workspace sandbox (e.g. codex `--full-auto`) can only write within its own workdir. Routing re-stamps the `from` field to the enclosing participant's name on every read, so an agent can't spoof a senderless prompt or impersonate another sender by writing a hand-crafted JSON.
 
 5. **Each participant runs with CWD set to its own root** so its own settings (`.claude/settings*`, `.gemini/`, etc.) load correctly.
 
@@ -23,7 +23,7 @@ Filesystem-based message routing between independent Claude Code, Gemini, and Co
 
 - Scans one or more directories for participant roots — directories containing `CLAUDE.md`, `GEMINI.md`, or `CODEX.md`. Default scan root is the current directory; override with `--dir <path>`.
 - Maps each participant's name (and aliases) to its directory.
-- Watches each participant's `~/.a8s/mailboxes/<NAME>/.outbox/` for outgoing message JSON; routes them to the recipient's inbox at the same scope.
+- Watches each participant's `<root>/.outbox/` for outgoing message JSON; routes them to the recipient's `~/.a8s/mailboxes/<NAME>/.inbox/`. On read, the `from` field is force-set to the actual enclosing participant's name (defense against an agent spoofing the sender by hand-writing JSON).
 - When a participant's inbox has messages, launches the participant with a prompt built from the **first** message and immediately moves that message to its `.trash/` (also under `~/.a8s/mailboxes/<NAME>/`).
 - Enforces single-instance-per-name (the same name cannot run concurrently with itself).
 - After a participant process exits, re-checks its inbox; if more messages remain, prompt again.
@@ -114,7 +114,7 @@ Without `loop`, a8s makes one pass and waits for any launched processes to exit 
 
 ## Message format
 
-Messages are JSON files dropped into the sender's outbox at `~/.a8s/mailboxes/<NAME>/.outbox/`:
+Messages are JSON files dropped into the sender's outbox at `<sender-root>/.outbox/`:
 
 ```json
 {
@@ -142,7 +142,7 @@ FILE: {files[0].path}
 
 ## The `tell` and `says` CLIs and the registry
 
-a8s ships two sender-side shell commands, both siblings of `a8s` in `~/bin/`. Both write a message JSON into the **caller's** outbox at `~/.a8s/mailboxes/<NAME>/.outbox/` and exit — routing happens later when `a8s` next runs (step or loop).
+a8s ships two sender-side shell commands, both siblings of `a8s` in `~/bin/`. Both write a message JSON into the **caller's** local `<root>/.outbox/` and exit — routing happens later when `a8s` next runs (step or loop) and re-stamps the message with the actual sender name.
 
 | Command | What it does                                                      | Outbox `to` field |
 | ------- | ----------------------------------------------------------------- | ----------------- |
@@ -183,16 +183,18 @@ If `$PWD` is not inside any registered participant, `tell` fails with a clear er
 ```
 projects/
   my-claude-project/
-    CLAUDE.md      ← agent dirs stay clean — only marker files and project content
+    CLAUDE.md
+    .outbox/                       ← agent writes here (sandbox-writable)
   my-gemini-project/
     GEMINI.md
+    .outbox/
 
-~/.a8s/                              ← all a8s state lives here
-  a8s.json                           ← participant registry
-  log.txt                            ← supervisor log (ISO-timestamped lines)
+~/.a8s/                            ← supervisor-only state
+  a8s.json                         ← participant registry
+  log.txt                          ← supervisor log (ISO-timestamped lines)
   mailboxes/
-    CLAUDE/.inbox/.outbox/.trash/    ← keyed by the registered name (sanitized)
-    GEMINI/.inbox/.outbox/.trash/
+    CLAUDE/.inbox/.trash/          ← keyed by registered name (sanitized);
+    GEMINI/.inbox/.trash/            agents never see these
 ```
 
 ```

--- a/apps/a8s/a8s.py
+++ b/apps/a8s/a8s.py
@@ -13,13 +13,15 @@ Surface (CLI):
                                 Codex user scope
   logs <name> [--tail N] [-f] — docker-logs-style filter on the supervisor log
 
-State (all under ~/.a8s/):
-  a8s.json                    — participant registry (name -> kind, root, aliases)
-  mailboxes/<NAME>/           — .inbox / .outbox / .trash, isolated from agent dirs
-                                so participants only see messaging via their skills
-  log.txt                     — supervisor log: ISO-timestamped, captures every line
+State:
+  ~/.a8s/a8s.json             — participant registry (name -> kind, root, aliases)
+  ~/.a8s/mailboxes/<NAME>/    — .inbox / .trash, isolated from the agent itself
+  ~/.a8s/log.txt              — supervisor log: ISO-timestamped, captures every line
                                 that goes through `out()` (including subprocess
                                 output captured by `run_with_prefix`)
+  <agent-root>/.outbox/       — agent writes here; route_outboxes re-stamps `from`
+                                to the enclosing participant on every read so an
+                                agent can't spoof the sender by hand-writing JSON
 """
 
 from __future__ import annotations
@@ -78,12 +80,20 @@ def inbox_dir(name: str) -> Path:
     return mailbox_dir(name) / ".inbox"
 
 
-def outbox_dir(name: str) -> Path:
-    return mailbox_dir(name) / ".outbox"
-
-
 def trash_dir(name: str) -> Path:
     return mailbox_dir(name) / ".trash"
+
+
+def outbox_dir(root: Path) -> Path:
+    """Outbox lives **inside the agent's own dir** so the agent can write to it
+    even under a strict workspace sandbox (codex --full-auto). Inbox and trash
+    stay isolated under ~/.a8s/ where the agent never sees them.
+
+    `route_outboxes()` re-stamps the `from` field to the enclosing participant's
+    name on every read, so an agent can't spoof a senderless prompt by writing
+    a JSON with `from: ""`.
+    """
+    return root / ".outbox"
 
 
 def _emit(line: str) -> None:
@@ -180,9 +190,12 @@ def find_participant(parts: list[Participant], query: str) -> Participant | None
 # ---------- mailboxes ----------
 
 def ensure_mailboxes(p: Participant) -> None:
-    """Create the centralized mailbox dirs for `p` under ~/.a8s/mailboxes/."""
-    for d in (inbox_dir(p.name), outbox_dir(p.name), trash_dir(p.name)):
+    """Create mailbox dirs for `p`. Inbox and trash live under ~/.a8s/ (hidden
+    from the agent); outbox lives in the agent's own root (so the agent can
+    actually write to it under a workspace sandbox)."""
+    for d in (inbox_dir(p.name), trash_dir(p.name)):
         d.mkdir(parents=True, exist_ok=True)
+    outbox_dir(p.root).mkdir(parents=True, exist_ok=True)
 
 
 def unique_path(p: Path) -> Path:
@@ -203,7 +216,7 @@ def route_outboxes(participants: list[Participant]) -> int:
     routed = 0
     for sender in participants:
         ensure_mailboxes(sender)
-        outbox = outbox_dir(sender.name)
+        outbox = outbox_dir(sender.root)
         for f in sorted(outbox.iterdir()):
             if not (f.is_file() and f.name.endswith(".json")):
                 continue
@@ -213,6 +226,11 @@ def route_outboxes(participants: list[Participant]) -> int:
             except (OSError, json.JSONDecodeError) as e:
                 out(f"[{sender.name}] outbox parse error on {f.name}: {e}")
                 continue
+            # Defense: the outbox is writable by the agent, so it could try to
+            # spoof a senderless prompt with `from: ""` or impersonate someone
+            # else. Force `from` to the actual enclosing participant — outbox
+            # location is the unforgeable identity.
+            msg["from"] = sender.name
             recipient_name = (msg.get("to") or "").strip()
             if not recipient_name:
                 # broadcast: fan out to every other participant.
@@ -220,7 +238,8 @@ def route_outboxes(participants: list[Participant]) -> int:
                 for recipient in others:
                     ensure_mailboxes(recipient)
                     dest = unique_path(inbox_dir(recipient.name) / f.name)
-                    shutil.copyfile(f, dest)
+                    with dest.open("w", encoding="utf-8") as out_f:
+                        json.dump(msg, out_f, indent=2)
                 f.unlink()
                 out(f"broadcast: {sender.name} -> {len(others)}: {_preview(msg.get('content', ''))}")
                 routed += len(others)
@@ -231,7 +250,9 @@ def route_outboxes(participants: list[Participant]) -> int:
                 continue
             ensure_mailboxes(recipient)
             dest = unique_path(inbox_dir(recipient.name) / f.name)
-            f.rename(dest)
+            with dest.open("w", encoding="utf-8") as out_f:
+                json.dump(msg, out_f, indent=2)
+            f.unlink()
             out(f"routed: {sender.name} -> {recipient.name}: {_preview(msg.get('content', ''))}")
             routed += 1
     return routed
@@ -696,8 +717,8 @@ def _split_content_and_files(raw: str) -> tuple[str, list[dict]]:
     return "\n".join(lines).rstrip(), files
 
 
-def _write_outbox(sender_name: str, _sender_root: Path, to: str, content: str, files: list[dict]) -> Path:
-    outbox = outbox_dir(sender_name)
+def _write_outbox(sender_name: str, sender_root: Path, to: str, content: str, files: list[dict]) -> Path:
+    outbox = outbox_dir(sender_root)
     outbox.mkdir(parents=True, exist_ok=True)
     now = datetime.now(timezone.utc)
     msg = {
@@ -766,14 +787,14 @@ def cmd_clear(scan_dir: Path) -> int:
     cleared = 0
     for p in parts:
         ensure_mailboxes(p)
-        for d in (inbox_dir(p.name), outbox_dir(p.name), trash_dir(p.name)):
+        for d in (inbox_dir(p.name), trash_dir(p.name), outbox_dir(p.root)):
             for f in d.iterdir():
                 if f.is_file():
                     f.unlink()
                     cleared += 1
-        # Defensive: also wipe legacy mailbox dirs that may still sit inside
-        # the agent root from older a8s versions.
-        for sub in (".inbox", ".outbox", ".trash"):
+        # Defensive: wipe legacy <root>/.inbox / .trash dirs from before the
+        # mailbox-isolation change. (`.outbox` is current, handled above.)
+        for sub in (".inbox", ".trash"):
             legacy = p.root / sub
             if legacy.is_dir():
                 for f in legacy.iterdir():


### PR DESCRIPTION
## Problem

You hit two related issues running the agents:

1. **Codex `--full-auto` sandbox can't write to `~/.a8s/mailboxes/CODEX/.outbox`** — the previous PR (#49) moved outbox there for isolation, but codex's workspace-write sandbox only allows writes within its own workdir. The error you saw:

   > CODEX> Noted. I'm still blocked from broadcasting via `says` because the current sandbox cannot write to `/Users/neilo/.a8s/mailboxes/CODEX/.outbox`

2. **A8s shouldn't trust the `from` field of outbox JSONs** — once the outbox is writable by the agent, a hand-crafted JSON could set `from: ""` to mimic a senderless prompt (which `build_prompt` delivers as raw content with no wrapper — effectively system-prompt privilege) or set `from: "<other-name>"` to impersonate.

## Fix

**Outbox stays in the agent's own root.** Inbox and trash stay isolated.

```
<agent-root>/.outbox/         ← agent writes here (sandbox-writable)
~/.a8s/mailboxes/<NAME>/
  .inbox/                     ← agent never reads/writes
  .trash/                     ← agent never reads/writes
```

Asymmetric, but it matches the access model: agents need write access to outbox to drop messages; the inbox and trash exist purely for the supervisor and the wake machinery, and the agent never has business touching them.

**`route_outboxes` force-overwrites `msg["from"] = sender.name`** on every read before delivery. The outbox location is the unforgeable identity — whatever's in `<X>/.outbox/` is *by construction* from X. Whatever the JSON claims is overwritten.

## Files

- `apps/a8s/a8s.py`:
  - `outbox_dir(root: Path)` (was `outbox_dir(name)`); inbox/trash unchanged.
  - `ensure_mailboxes` creates `<root>/.outbox` plus `~/.a8s/mailboxes/<NAME>/{.inbox,.trash}/`.
  - `route_outboxes` re-stamps `from`, then writes the (possibly modified) JSON to the recipient inbox via `json.dump` rather than `f.rename`.
  - `cmd_clear` wipes all three locations plus legacy `<root>/.inbox/.trash` from older versions.
  - Module docstring updated to reflect the asymmetric layout.
- `apps/a8s/README.md`: design principle 4 rewritten ("Mailboxes are split"), state-layout snippet, routing description.

## Test plan

- [x] After clean run, every agent dir has `.outbox/`; `~/.a8s/mailboxes/` contains only `.inbox/` + `.trash/` per participant.
- [x] Seeded a malicious JSON in `codex-agent/.outbox/` with `from: ""`; after routing, the gemini inbox copy correctly shows `from: "CODEX"` — spoofing prevented.
- [ ] (manual) Live run with codex `--full-auto` no longer hits the sandbox-write error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)