### PR TITLE
test(a8s): pytest suite for the modular split

### DIFF
--- a/apps/a8s/registry.py
+++ b/apps/a8s/registry.py
@@ -107,6 +107,11 @@ def resolve_name(query: str) -> tuple[str, list[str]]:
     Returns (kind, agent_names) where kind ∈ {"agent", "alias"}. For an alias,
     members are walked recursively; cycles raise ValueError. Unknown names
     raise KeyError.
+
+    A diamond (the same alias reached via two distinct parents) is NOT a cycle:
+    `path` tracks aliases currently on the recursion stack; `seen_aliases`
+    short-circuits second-and-later visits via different paths. Agents dedup
+    via `out_names` membership.
     """
     raw = _load_raw_registry()
     agents = raw["agents"]
@@ -117,22 +122,29 @@ def resolve_name(query: str) -> tuple[str, list[str]]:
     if q in agent_lookup:
         return "agent", [agent_lookup[q]]
     if q in alias_lookup:
-        seen: set[str] = set()
         out_names: list[str] = []
+        path: set[str] = set()           # aliases currently being recursed
+        seen_aliases: set[str] = set()   # aliases already fully expanded
 
         def walk(name: str) -> None:
             key = name.lower()
-            if key in seen:
-                raise ValueError(f"alias cycle detected at {name!r}")
-            seen.add(key)
             if key in agent_lookup:
                 resolved = agent_lookup[key]
                 if resolved not in out_names:
                     out_names.append(resolved)
                 return
             if key in alias_lookup:
-                for member in aliases[alias_lookup[key]]:
-                    walk(str(member))
+                if key in path:
+                    raise ValueError(f"alias cycle detected at {name!r}")
+                if key in seen_aliases:
+                    return  # diamond — already expanded via another parent
+                path.add(key)
+                try:
+                    for member in aliases[alias_lookup[key]]:
+                        walk(str(member))
+                finally:
+                    path.discard(key)
+                seen_aliases.add(key)
                 return
             raise KeyError(f"alias {alias_lookup[q]!r} references unknown name {name!r}")
 

--- a/apps/a8s/tests/conftest.py
+++ b/apps/a8s/tests/conftest.py
@@ -1,0 +1,46 @@
+"""pytest scaffolding for a8s.
+
+- Adds `apps/a8s/` to `sys.path` so tests can `import core, registry, ...`
+  the same way `a8s.py` does at runtime.
+- Provides a `fake_home` fixture that redirects `Path.home()` to a per-test
+  tmp dir so tests never touch the real `~/.a8s/`.
+- Provides an `agents_root` fixture pointing at the existing fixture dirs
+  under `apps/a8s/tests/agents/`.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# `apps/a8s/tests/conftest.py` -> `apps/a8s/`
+_PKG_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PKG_DIR))
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    """Redirect `Path.home()` to `tmp_path` so registry / agent / log files
+    land in an isolated location. Resets module-level mutable state in core."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    # Some platforms also honor USERPROFILE / HOMEPATH. Set HOME and clear
+    # the others to be safe.
+    monkeypatch.delenv("USERPROFILE", raising=False)
+
+    import core
+    # Make sure no prior test left a Lock attached.
+    core.PRINT_LOCK = None
+    yield tmp_path
+
+
+@pytest.fixture
+def agents_root() -> Path:
+    """Existing per-tool agent fixture directories under apps/a8s/tests/agents/."""
+    return _PKG_DIR / "tests" / "agents"
+
+
+@pytest.fixture
+def fixtures_dir() -> Path:
+    """Pytest-only fixtures (mock-cli, definition JSONs) under apps/a8s/tests/fixtures/."""
+    return Path(__file__).resolve().parent / "fixtures"

--- a/apps/a8s/tests/fixtures/mock-cli
+++ b/apps/a8s/tests/fixtures/mock-cli
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Deterministic mock agent CLI used in pytest. Echoes every argv element on
+# its own line, prefixed with "MOCK-CLI:" so tests can grep for them.
+# Exits 0.
+for arg in "$@"; do
+    printf 'MOCK-CLI: %s\n' "$arg"
+done

--- a/apps/a8s/tests/fixtures/mock.json
+++ b/apps/a8s/tests/fixtures/mock.json
@@ -1,0 +1,9 @@
+{
+  "description": "Test-only mock CLI definition. Each invoke* runs the bundled mock-cli script which echoes its argv.",
+  "invokePrompt":       ["$A8S_DIR/tests/fixtures/mock-cli", "verb=prompt", "$PROMPT"],
+  "invokeMessage":      ["$A8S_DIR/tests/fixtures/mock-cli", "verb=message", "$PROMPT"],
+  "invokeMessageAlias": ["$A8S_DIR/tests/fixtures/mock-cli", "verb=messageAlias", "$PROMPT"],
+  "invokeClear":        ["$A8S_DIR/tests/fixtures/mock-cli", "verb=clear"],
+  "promptMessage": "FROM:{sender}|TO:{recipient}|MSG:{message}",
+  "promptMessageAlias": "FROM:{sender}|TO:{recipient}|ALIAS:{alias}|OTHERS:{others_count}|MSG:{message}"
+}

--- a/apps/a8s/tests/test_daemon.py
+++ b/apps/a8s/tests/test_daemon.py
@@ -1,0 +1,228 @@
+"""Tests for daemon.py — pid-file lifecycle and end-to-end wake_once with the
+mock CLI.
+
+The mock CLI lives at tests/fixtures/mock-cli. tests/fixtures/mock.json
+defines an agent that routes every verb through it with deterministic
+templates. Tests assert on the per-agent log to verify what argv the wake
+subprocess actually received.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import time
+from pathlib import Path
+
+import pytest
+
+from core import (
+    Participant,
+    agent_log_path,
+    inbox_dir,
+    pid_path,
+    trash_dir,
+)
+from daemon import (
+    _read_handler_pid,
+    _try_atomic_claim,
+    acquire,
+    attached_loop,
+    release,
+)
+from mailbox import _queue_clear_sentinel, _queue_prompt, ensure_mailboxes
+from registry import save_aliases, save_registry
+
+
+# ---------- pid-file lifecycle ----------
+
+class TestAtomicClaim:
+    def test_first_claim_succeeds(self, fake_home):
+        assert _try_atomic_claim("X", 12345) is True
+        assert pid_path("X").read_text() == "12345"
+
+    def test_second_claim_fails(self, fake_home):
+        assert _try_atomic_claim("X", 1) is True
+        assert _try_atomic_claim("X", 2) is False
+        # Original pid still there.
+        assert pid_path("X").read_text() == "1"
+
+
+class TestReadHandlerPid:
+    def test_no_pid_file(self, fake_home):
+        assert _read_handler_pid("X") is None
+
+    def test_dead_pid_is_cleaned_up(self, fake_home):
+        # Use a pid that's almost certainly dead (max signed int).
+        agent_pid = 2**31 - 1
+        pid_path("X").parent.mkdir(parents=True, exist_ok=True)
+        pid_path("X").write_text(str(agent_pid))
+        assert _read_handler_pid("X") is None
+        assert not pid_path("X").is_file()
+
+    def test_live_pid(self, fake_home):
+        # Our own pid is live.
+        pid_path("X").parent.mkdir(parents=True, exist_ok=True)
+        pid_path("X").write_text(str(os.getpid()))
+        assert _read_handler_pid("X") == os.getpid()
+
+
+class TestAcquireRelease:
+    def test_acquire_when_free_then_release(self, fake_home):
+        acquire("X")
+        assert pid_path("X").read_text() == str(os.getpid())
+        release("X")
+        assert not pid_path("X").is_file()
+
+    def test_release_other_pid_is_noop(self, fake_home):
+        # Another (dead) pid in the file — release shouldn't unlink it because
+        # it doesn't belong to us. _read_handler_pid will clean dead ones, but
+        # release is intentionally guarded.
+        pid_path("X").parent.mkdir(parents=True, exist_ok=True)
+        pid_path("X").write_text("12345")
+        # Use a live pid so the cleanup doesn't fire.
+        # Actually we can't easily test "not ours but live" without spawning.
+        # Check the simpler case: garbage in the file shouldn't crash release.
+        release("X")  # garbage int parses, just doesn't match our pid
+        # File should still be there (we didn't write it).
+        # Actually: the file might or might not exist depending on whether
+        # _read_handler_pid was called; release itself just guards the unlink.
+        # Just assert no exception was raised.
+
+
+# ---------- attached_loop end-to-end with mock CLI ----------
+
+@pytest.fixture
+def mock_agent(fake_home, tmp_path, fixtures_dir):
+    """Register an agent named MOCK that uses the mock CLI definition."""
+    agent_root = tmp_path / "mock-agent"
+    agent_root.mkdir()
+    save_registry({
+        "MOCK": {
+            "root": str(agent_root),
+            "definition": str(fixtures_dir / "mock.json"),
+        },
+    })
+    p = Participant("MOCK", agent_root)
+    ensure_mailboxes(p)
+    return p
+
+
+def _read_log(name: str) -> str:
+    return agent_log_path(name).read_text() if agent_log_path(name).is_file() else ""
+
+
+class TestWakeOnceVerbs:
+    """Verify each verb produces the right argv via the mock CLI subprocess.
+    Asserts on lines the mock CLI echoes into the per-agent log."""
+
+    def test_prompt_verb_argv(self, mock_agent):
+        _queue_prompt(mock_agent, "show capabilities")
+        rc = attached_loop(["MOCK"], 0.1, single_pass=True)
+        assert rc == 0
+        log = _read_log("MOCK")
+        # mock-cli echoes each argv element prefixed with "MOCK-CLI:"
+        assert "MOCK> MOCK-CLI: verb=prompt" in log
+        assert "MOCK> MOCK-CLI: show capabilities" in log
+
+    def test_message_verb_argv_via_routing(self, fake_home, tmp_path, fixtures_dir):
+        # Two agents, both using mock.json.
+        for n in ("A", "B"):
+            (tmp_path / n).mkdir()
+        save_registry({
+            "A": {"root": str(tmp_path / "a"), "definition": str(fixtures_dir / "mock.json")},
+            "B": {"root": str(tmp_path / "b"), "definition": str(fixtures_dir / "mock.json")},
+        })
+        a = Participant("A", tmp_path / "a")
+        b = Participant("B", tmp_path / "b")
+        ensure_mailboxes(a)
+        ensure_mailboxes(b)
+        # A writes to B's outbox path... no, A's outbox.
+        from mailbox import _write_outbox
+        _write_outbox("A", a.root, "B", "design review", [])
+
+        # Run B's loop — its outbox is empty but B will receive A's routed msg.
+        # attached_loop routes ALL agents' outboxes via route_outboxes(handled).
+        # We need A's outbox to be routed too. Pass [A, B].
+        rc = attached_loop(["A", "B"], 0.1, single_pass=True)
+        assert rc == 0
+        log_b = _read_log("B")
+        # B's invokeMessage runs with the formatted promptMessage template
+        # containing "FROM:A|TO:B|MSG:design review".
+        assert "MOCK-CLI: verb=message" in log_b
+        assert "FROM:A|TO:B|MSG:design review" in log_b
+
+    def test_messageAlias_verb_with_others_count(self, fake_home, tmp_path, fixtures_dir):
+        # A, B, C all using mock.json. devs alias = [A, B, C]. A sends to devs.
+        from mailbox import _write_outbox
+        agents = {}
+        for n in ("A", "B", "C"):
+            d = tmp_path / n; d.mkdir()
+            agents[n] = Participant(n, d)
+        save_registry({
+            n: {"root": str(p.root), "definition": str(fixtures_dir / "mock.json")}
+            for n, p in agents.items()
+        })
+        save_aliases({"devs": ["A", "B", "C"]})
+        for p in agents.values():
+            ensure_mailboxes(p)
+
+        _write_outbox("A", agents["A"].root, "devs", "all-hands", [])
+        rc = attached_loop(["A", "B", "C"], 0.1, single_pass=True)
+        assert rc == 0
+        log_b = _read_log("B")
+        # Sender excluded → recipients = [B, C] → B sees others_count=1.
+        assert "MOCK-CLI: verb=messageAlias" in log_b
+        assert "FROM:A|TO:B|ALIAS:devs|OTHERS:1|MSG:all-hands" in log_b
+
+    def test_clear_verb_via_sentinel(self, mock_agent):
+        # Pre-queue a normal prompt + then a clear; the clear should wipe
+        # the prompt and only invokeClear should fire.
+        _queue_prompt(mock_agent, "stale")
+        _queue_clear_sentinel(mock_agent)
+        rc = attached_loop(["MOCK"], 0.1, single_pass=True)
+        assert rc == 0
+        log = _read_log("MOCK")
+        # invokeClear ran (with no prompt arg, just verb=clear).
+        assert "MOCK-CLI: verb=clear" in log
+        # The stale prompt was NOT processed (its content shouldn't appear
+        # as a wake line).
+        assert "MOCK> MOCK-CLI: stale" not in log
+        # Stale prompt landed in trash (read-time wipe).
+        assert any("PROMPT" in f.name for f in trash_dir("MOCK").iterdir())
+
+
+class TestAttachedLoopLifecycle:
+    def test_attaches_and_detaches(self, mock_agent):
+        # No messages — single_pass attaches, sees nothing, detaches.
+        rc = attached_loop(["MOCK"], 0.1, single_pass=True)
+        assert rc == 0
+        log = _read_log("MOCK")
+        assert f"[a8s] MOCK: attached (PID {os.getpid()})" in log
+        assert "[a8s] MOCK: detached" in log
+        # Pid file released.
+        assert not pid_path("MOCK").is_file()
+
+    def test_multi_agent_share_one_pid(self, fake_home, tmp_path, fixtures_dir):
+        # Two agents, one process — both pid files point at this pytest process.
+        for n in ("A", "B"):
+            (tmp_path / n).mkdir()
+        save_registry({
+            n: {"root": str(tmp_path / n.lower()), "definition": str(fixtures_dir / "mock.json")}
+            for n in ("A", "B")
+        })
+        # Use different roots for A vs B.
+        save_registry({
+            "A": {"root": str(tmp_path / "A"), "definition": str(fixtures_dir / "mock.json")},
+            "B": {"root": str(tmp_path / "B"), "definition": str(fixtures_dir / "mock.json")},
+        })
+        for n in ("A", "B"):
+            ensure_mailboxes(Participant(n, tmp_path / n))
+
+        rc = attached_loop(["A", "B"], 0.1, single_pass=True)
+        assert rc == 0
+        # Both agents attached + detached from the same pytest pid.
+        assert "shared" in _read_log("A")
+        assert "shared" in _read_log("B")
+        assert not pid_path("A").is_file()
+        assert not pid_path("B").is_file()

--- a/apps/a8s/tests/test_definitions.py
+++ b/apps/a8s/tests/test_definitions.py
@@ -1,0 +1,234 @@
+"""Tests for definitions.py — verb selection, prompt formatting, argv expansion,
+and auto-discovery."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from definitions import (
+    _autodiscover_definition,
+    _expand_argv,
+    build_command,
+    build_prompt,
+    default_definition_path,
+    load_definition,
+    select_verb,
+)
+
+
+# ---------- select_verb ----------
+
+class TestSelectVerb:
+    def test_clear_takes_precedence(self):
+        # Even with a sender + alias, clear:true wins.
+        msg = {"from": "GERRY", "to": "CLAUDE", "alias": "devs", "clear": True}
+        assert select_verb(msg) == "clear"
+
+    def test_senderless_is_prompt(self):
+        msg = {"from": "", "to": "CLAUDE", "content": "hi"}
+        assert select_verb(msg) == "prompt"
+
+    def test_missing_from_is_prompt(self):
+        msg = {"to": "CLAUDE", "content": "hi"}
+        assert select_verb(msg) == "prompt"
+
+    def test_with_alias_is_messageAlias(self):
+        msg = {"from": "GERRY", "to": "CLAUDE", "alias": "devs", "content": "hi"}
+        assert select_verb(msg) == "messageAlias"
+
+    def test_with_sender_no_alias_is_message(self):
+        msg = {"from": "GERRY", "to": "CLAUDE", "content": "hi"}
+        assert select_verb(msg) == "message"
+
+    def test_empty_alias_string_is_message(self):
+        msg = {"from": "GERRY", "to": "CLAUDE", "alias": "", "content": "hi"}
+        assert select_verb(msg) == "message"
+
+
+# ---------- build_prompt ----------
+
+DEFINITION = {
+    "promptMessage": "{sender} tells you ({recipient}): {message}",
+    "promptMessageAlias": "{sender} tells you ({recipient}) and {others_count} others on the {alias} alias: {message}",
+}
+
+
+class TestBuildPrompt:
+    def test_clear_returns_empty(self):
+        assert build_prompt({}, DEFINITION, "clear") == ""
+
+    def test_prompt_is_raw_content(self):
+        msg = {"from": "", "to": "CLAUDE", "content": "show capabilities"}
+        assert build_prompt(msg, DEFINITION, "prompt") == "show capabilities"
+
+    def test_prompt_appends_file_lines(self):
+        msg = {
+            "from": "",
+            "content": "see attached",
+            "files": [{"path": "/tmp/build.log"}, {"path": "/tmp/data.csv"}],
+        }
+        out = build_prompt(msg, DEFINITION, "prompt")
+        assert out == "see attached\n\nFILE: /tmp/build.log\nFILE: /tmp/data.csv"
+
+    def test_message_uses_promptMessage(self):
+        msg = {"from": "GERRY", "to": "CLAUDE", "content": "fix this"}
+        assert build_prompt(msg, DEFINITION, "message") == "GERRY tells you (CLAUDE): fix this"
+
+    def test_messageAlias_uses_promptMessageAlias(self):
+        msg = {
+            "from": "GERRY",
+            "to": "CLAUDE",
+            "content": "standup",
+            "alias": "devs",
+            "others_count": 1,
+        }
+        out = build_prompt(msg, DEFINITION, "messageAlias")
+        assert out == "GERRY tells you (CLAUDE) and 1 others on the devs alias: standup"
+
+    def test_message_with_date_prefix(self):
+        msg = {"from": "GERRY", "to": "CLAUDE", "content": "hi", "date": "2026-04-27T15:30:00Z"}
+        out = build_prompt(msg, DEFINITION, "message")
+        # Template doesn't include {date}, so it's prefixed.
+        assert out == "[2026-04-27T15:30:00Z] GERRY tells you (CLAUDE): hi"
+
+    def test_template_with_date_placeholder_no_prefix(self):
+        defn = {"promptMessage": "[{date}] {sender}: {message}"}
+        msg = {"from": "GERRY", "to": "CLAUDE", "content": "hi", "date": "X"}
+        out = build_prompt(msg, defn, "message")
+        # Prefix is suppressed because the template already includes {date}.
+        assert out == "[X] GERRY: hi"
+
+    def test_message_with_files(self):
+        msg = {
+            "from": "GERRY",
+            "to": "CLAUDE",
+            "content": "review",
+            "files": [{"path": "/x"}],
+        }
+        out = build_prompt(msg, DEFINITION, "message")
+        assert out == "GERRY tells you (CLAUDE): review\n\nFILE: /x"
+
+
+# ---------- build_command + _expand_argv ----------
+
+class TestBuildCommand:
+    def test_dispatches_to_invokePrompt(self):
+        defn = {"invokePrompt": ["claude", "-p", "$PROMPT"]}
+        argv = build_command(defn, "hello", "prompt")
+        assert argv == ["claude", "-p", "hello"]
+
+    def test_dispatches_to_invokeMessage(self):
+        defn = {"invokeMessage": ["claude", "--continue", "-p", "$PROMPT"]}
+        argv = build_command(defn, "x", "message")
+        assert argv == ["claude", "--continue", "-p", "x"]
+
+    def test_dispatches_to_invokeMessageAlias(self):
+        defn = {"invokeMessageAlias": ["claude", "-p", "$PROMPT"]}
+        argv = build_command(defn, "y", "messageAlias")
+        assert argv == ["claude", "-p", "y"]
+
+    def test_dispatches_to_invokeClear(self):
+        defn = {"invokeClear": ["claude", "-p", "/clear"]}
+        argv = build_command(defn, "", "clear")
+        assert argv == ["claude", "-p", "/clear"]
+
+    def test_unknown_verb_raises(self):
+        with pytest.raises(ValueError, match="unknown verb"):
+            build_command({}, "x", "bogus")
+
+    def test_missing_invoke_raises(self):
+        with pytest.raises(ValueError, match="invokeMessage"):
+            build_command({"invokePrompt": ["x"]}, "p", "message")
+
+    def test_a8s_dir_substitution(self):
+        from core import SCRIPT_DIR
+        defn = {"invokePrompt": ["$A8S_DIR/dummy-cli", "$PROMPT"]}
+        argv = build_command(defn, "hi", "prompt")
+        assert argv == [f"{SCRIPT_DIR}/dummy-cli", "hi"]
+
+    def test_does_not_mutate_original_argv(self):
+        defn = {"invokePrompt": ["claude", "-p", "$PROMPT"]}
+        original = list(defn["invokePrompt"])
+        build_command(defn, "hello", "prompt")
+        assert defn["invokePrompt"] == original
+
+
+class TestExpandArgv:
+    def test_no_placeholders(self):
+        assert _expand_argv(["claude", "-p", "literal"], "ignored") == [
+            "claude",
+            "-p",
+            "literal",
+        ]
+
+    def test_prompt_substitution(self):
+        assert _expand_argv(["x", "$PROMPT", "y"], "hello") == ["x", "hello", "y"]
+
+    def test_prompt_in_concatenated_arg(self):
+        assert _expand_argv(["wrap=$PROMPT-end"], "X") == ["wrap=X-end"]
+
+    def test_a8s_dir_substitution(self):
+        from core import SCRIPT_DIR
+        assert _expand_argv(["$A8S_DIR/x"], "") == [f"{SCRIPT_DIR}/x"]
+
+
+# ---------- _autodiscover_definition ----------
+
+class TestAutodiscoverDefinition:
+    def test_single_marker_uses_matching_builtin(self, tmp_path):
+        (tmp_path / "CLAUDE.md").write_text("# X\n")
+        path, note = _autodiscover_definition(tmp_path)
+        assert path == str(default_definition_path("claude"))
+        assert "auto-detected via CLAUDE.md" in note
+
+    def test_no_marker_uses_default(self, tmp_path):
+        path, note = _autodiscover_definition(tmp_path)
+        assert path == str(default_definition_path("default"))
+        assert "no marker file" in note
+
+    def test_multiple_markers_uses_default(self, tmp_path):
+        (tmp_path / "CLAUDE.md").write_text("# X\n")
+        (tmp_path / "GEMINI.md").write_text("# Y\n")
+        path, note = _autodiscover_definition(tmp_path)
+        assert path == str(default_definition_path("default"))
+        assert "multiple markers" in note
+        assert "CLAUDE.md" in note and "GEMINI.md" in note
+
+    def test_codex_marker(self, tmp_path):
+        (tmp_path / "CODEX.md").write_text("# C\n")
+        path, note = _autodiscover_definition(tmp_path)
+        assert path == str(default_definition_path("codex"))
+
+
+# ---------- load_definition ----------
+
+class TestLoadDefinition:
+    def test_loads_explicit_definition(self, fake_home, tmp_path, monkeypatch):
+        # Write a custom definition.
+        defn_path = tmp_path / "custom.json"
+        defn_path.write_text('{"invokePrompt": ["echo", "$PROMPT"]}')
+
+        # Add an agent that points at it.
+        import registry
+        registry.save_registry({"X": {"root": str(tmp_path), "definition": str(defn_path)}})
+
+        loaded = load_definition("X")
+        assert loaded == {"invokePrompt": ["echo", "$PROMPT"]}
+
+    def test_falls_back_to_default(self, fake_home):
+        # Agent registered with NO definition field — load_definition falls
+        # back to the bundled default.json.
+        import registry
+        registry.save_registry({"X": {"root": "/tmp"}})
+
+        loaded = load_definition("X")
+        # default.json has all four invoke verbs.
+        assert "invokePrompt" in loaded
+        assert "invokeClear" in loaded
+
+    def test_missing_file_raises(self, fake_home):
+        import registry
+        registry.save_registry({"X": {"root": "/tmp", "definition": "/nonexistent.json"}})
+        with pytest.raises(FileNotFoundError):
+            load_definition("X")

--- a/apps/a8s/tests/test_mailbox.py
+++ b/apps/a8s/tests/test_mailbox.py
@@ -1,0 +1,272 @@
+"""Tests for mailbox.py — routing fan-out, queue helpers, content/file split."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core import Participant, inbox_dir, outbox_dir, trash_dir
+from mailbox import (
+    _queue_clear_sentinel,
+    _queue_prompt,
+    _split_content_and_files,
+    _write_outbox,
+    ensure_mailboxes,
+    next_inbox_message,
+    route_outboxes,
+)
+from registry import save_aliases, save_registry
+
+
+# ---------- _split_content_and_files ----------
+
+class TestSplitContentAndFiles:
+    def test_no_files(self):
+        body, files = _split_content_and_files("hello world")
+        assert body == "hello world"
+        assert files == []
+
+    def test_single_file(self):
+        raw = "see attached\nFILE: /tmp/build.log"
+        body, files = _split_content_and_files(raw)
+        assert body == "see attached"
+        assert files == [{"filename": "build.log", "path": "/tmp/build.log"}]
+
+    def test_multiple_files_preserve_order(self):
+        raw = "two attachments\nFILE: /a/b.log\nFILE: /c/d.log"
+        body, files = _split_content_and_files(raw)
+        assert body == "two attachments"
+        assert files == [
+            {"filename": "b.log", "path": "/a/b.log"},
+            {"filename": "d.log", "path": "/c/d.log"},
+        ]
+
+    def test_files_must_be_at_end(self):
+        # FILE: lines in the middle are NOT extracted (only trailing ones).
+        raw = "FILE: /not-extracted\nbody"
+        body, files = _split_content_and_files(raw)
+        assert body == "FILE: /not-extracted\nbody"
+        assert files == []
+
+    def test_empty_input(self):
+        body, files = _split_content_and_files("")
+        assert body == ""
+        assert files == []
+
+
+# ---------- ensure_mailboxes ----------
+
+class TestEnsureMailboxes:
+    def test_creates_inbox_trash_outbox(self, fake_home, tmp_path):
+        agent_root = tmp_path / "agent"
+        agent_root.mkdir()
+        p = Participant("X", agent_root)
+        ensure_mailboxes(p)
+        assert inbox_dir("X").is_dir()
+        assert trash_dir("X").is_dir()
+        assert outbox_dir(agent_root).is_dir()
+
+
+# ---------- _write_outbox / _queue_prompt / _queue_clear_sentinel ----------
+
+class TestWriteOutbox:
+    def test_writes_message_json(self, fake_home, tmp_path):
+        path = _write_outbox(
+            sender_name="A",
+            sender_root=tmp_path,
+            to="B",
+            content="hi",
+            files=[],
+        )
+        assert path.is_file()
+        msg = json.loads(path.read_text())
+        assert msg["from"] == "A"
+        assert msg["to"] == "B"
+        assert msg["content"] == "hi"
+        assert msg["files"] == []
+        assert "date" in msg
+
+
+class TestQueuePrompt:
+    def test_writes_senderless_to_inbox(self, fake_home, tmp_path):
+        agent_root = tmp_path / "x"
+        agent_root.mkdir()
+        p = Participant("X", agent_root)
+        path = _queue_prompt(p, "do the thing")
+        assert path.parent == inbox_dir("X")
+        msg = json.loads(path.read_text())
+        assert msg["from"] == ""
+        assert msg["to"] == "X"
+        assert msg["content"] == "do the thing"
+
+
+class TestQueueClearSentinel:
+    def test_writes_clear_sentinel(self, fake_home, tmp_path):
+        agent_root = tmp_path / "x"
+        agent_root.mkdir()
+        p = Participant("X", agent_root)
+        path = _queue_clear_sentinel(p)
+        msg = json.loads(path.read_text())
+        assert msg["clear"] is True
+        assert msg["from"] == ""
+
+    def test_write_time_wipe_trashes_existing(self, fake_home, tmp_path):
+        agent_root = tmp_path / "x"
+        agent_root.mkdir()
+        p = Participant("X", agent_root)
+        # Pre-existing inbox messages.
+        _queue_prompt(p, "msg1")
+        _queue_prompt(p, "msg2")
+        _queue_prompt(p, "msg3")
+        assert len(list(inbox_dir("X").iterdir())) == 3
+
+        _queue_clear_sentinel(p)
+        # Inbox should now contain ONLY the CLEAR sentinel.
+        files = list(inbox_dir("X").iterdir())
+        assert len(files) == 1
+        assert "_CLEAR" in files[0].name
+        # The 3 prior messages are in trash.
+        assert len(list(trash_dir("X").iterdir())) == 3
+
+
+# ---------- route_outboxes ----------
+
+@pytest.fixture
+def two_agents(fake_home, tmp_path):
+    """Set up two agents, return their Participants."""
+    a_root = tmp_path / "a"; a_root.mkdir()
+    b_root = tmp_path / "b"; b_root.mkdir()
+    save_registry({"A": {"root": str(a_root)}, "B": {"root": str(b_root)}})
+    a = Participant("A", a_root)
+    b = Participant("B", b_root)
+    ensure_mailboxes(a)
+    ensure_mailboxes(b)
+    return a, b
+
+
+@pytest.fixture
+def three_agents(fake_home, tmp_path):
+    """Three agents A, B, C with an alias `devs` -> [A, B, C]."""
+    parts = []
+    for n in ("A", "B", "C"):
+        root = tmp_path / n
+        root.mkdir()
+        parts.append(Participant(n, root))
+    save_registry({p.name: {"root": str(p.root)} for p in parts})
+    save_aliases({"devs": ["A", "B", "C"]})
+    for p in parts:
+        ensure_mailboxes(p)
+    return parts
+
+
+class TestRouteOutboxes:
+    def test_single_agent_delivery(self, two_agents):
+        a, b = two_agents
+        # A writes to B
+        _write_outbox("A", a.root, "B", "hi", [])
+        n = route_outboxes([a, b], all_agents=[a, b])
+        assert n == 1
+        # B's inbox has one message
+        files = list(inbox_dir("B").iterdir())
+        assert len(files) == 1
+        msg = json.loads(files[0].read_text())
+        assert msg["from"] == "A"
+        assert msg["to"] == "B"
+        assert msg["content"] == "hi"
+        # A's outbox is empty
+        assert list(outbox_dir(a.root).iterdir()) == []
+
+    def test_alias_fanout_excludes_sender(self, three_agents):
+        a, b, c = three_agents
+        # A writes to alias devs (which contains [A, B, C]).
+        _write_outbox("A", a.root, "devs", "team meeting", [])
+        n = route_outboxes([a, b, c], all_agents=[a, b, c])
+        # Sender excluded → 2 recipients (B, C).
+        assert n == 2
+        assert list(inbox_dir("A").iterdir()) == []
+        b_msg = json.loads(next(inbox_dir("B").iterdir()).read_text())
+        assert b_msg["alias"] == "devs"
+        assert b_msg["others_count"] == 1  # B sees 1 OTHER (C)
+        assert b_msg["to"] == "B"
+        assert b_msg["from"] == "A"
+
+    def test_alias_fanout_others_count_when_outsider_sends(self, three_agents):
+        a, b, c = three_agents
+        # An outsider (also A here, but pretending) sends to alias of all 3.
+        # If sender is NOT on the alias, all 3 get it. But our setup has
+        # A in the alias, so let's test by removing A from the alias.
+        save_aliases({"devs": ["B", "C"]})
+        _write_outbox("A", a.root, "devs", "msg", [])
+        n = route_outboxes([a, b, c], all_agents=[a, b, c])
+        # All members (B and C) get it.
+        assert n == 2
+        b_msg = json.loads(next(inbox_dir("B").iterdir()).read_text())
+        assert b_msg["alias"] == "devs"
+        assert b_msg["others_count"] == 1  # B sees 1 OTHER (C)
+
+    def test_empty_to_is_rejected_to_trash(self, two_agents):
+        a, b = two_agents
+        # Write a malformed outbox file with empty `to`.
+        outbox = outbox_dir(a.root)
+        bad = outbox / "20260101T000000_A.json"
+        bad.write_text(json.dumps({
+            "from": "A", "to": "", "content": "rogue", "files": [],
+        }))
+        n = route_outboxes([a, b], all_agents=[a, b])
+        assert n == 0
+        # Outbox file moved to A's trash.
+        assert not bad.is_file()
+        assert any("rogue" in f.read_text() for f in trash_dir("A").iterdir())
+
+    def test_unknown_recipient_left_in_outbox(self, two_agents):
+        a, b = two_agents
+        outbox = outbox_dir(a.root)
+        bad = outbox / "20260101T000000_A.json"
+        bad.write_text(json.dumps({
+            "from": "A", "to": "BOGUS", "content": "x", "files": [],
+        }))
+        n = route_outboxes([a, b], all_agents=[a, b])
+        assert n == 0
+        # Unknown-recipient messages are LEFT in the outbox (not trashed) so
+        # they can be picked up if the recipient is added later.
+        assert bad.is_file()
+
+    def test_from_is_force_overwritten(self, two_agents):
+        a, b = two_agents
+        # Hand-write an outbox JSON with a SPOOFED from.
+        outbox = outbox_dir(a.root)
+        f = outbox / "20260101T000000_A.json"
+        f.write_text(json.dumps({
+            "from": "VICTIM",  # spoofed; should be overwritten with sender
+            "to": "B",
+            "content": "spoof attempt",
+            "files": [],
+        }))
+        route_outboxes([a, b], all_agents=[a, b])
+        delivered = json.loads(next(inbox_dir("B").iterdir()).read_text())
+        # Routing forces from = sender's actual name, regardless of the JSON.
+        assert delivered["from"] == "A"
+
+
+class TestNextInboxMessage:
+    def test_returns_oldest(self, fake_home, tmp_path):
+        agent_root = tmp_path / "x"
+        agent_root.mkdir()
+        p = Participant("X", agent_root)
+        ensure_mailboxes(p)
+        first = _queue_prompt(p, "first")
+        second = _queue_prompt(p, "second")
+        result = next_inbox_message(p)
+        # Both filenames sort lexicographically; first written has earlier ts.
+        assert result.name in {first.name, second.name}
+        # The function returns the SORTED-FIRST file (lex order, which matches
+        # creation order due to timestamp prefixes).
+        assert result.name == sorted([first.name, second.name])[0]
+
+    def test_returns_none_when_empty(self, fake_home, tmp_path):
+        agent_root = tmp_path / "x"
+        agent_root.mkdir()
+        p = Participant("X", agent_root)
+        ensure_mailboxes(p)
+        assert next_inbox_message(p) is None

--- a/apps/a8s/tests/test_registry.py
+++ b/apps/a8s/tests/test_registry.py
@@ -1,0 +1,248 @@
+"""Tests for registry.py — schema I/O, alias resolution, sender lookup,
+marker-file scan."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from registry import (
+    _load_raw_registry,
+    _scan_for_markers,
+    find_participant,
+    load_aliases,
+    load_registry,
+    parse_name,
+    participants_from_registry,
+    resolve_name,
+    resolve_recipient,
+    save_aliases,
+    save_registry,
+    sender_from_cwd,
+)
+from core import Participant, registry_path
+
+
+# ---------- low-level I/O ----------
+
+class TestRegistryIO:
+    def test_empty_registry_returns_zero_sections(self, fake_home):
+        raw = _load_raw_registry()
+        assert raw == {"agents": {}, "aliases": {}}
+
+    def test_save_and_load_agents(self, fake_home):
+        save_registry({"CLAUDE": {"root": "/tmp/x", "definition": "/tmp/d.json"}})
+        assert load_registry() == {"CLAUDE": {"root": "/tmp/x", "definition": "/tmp/d.json"}}
+
+    def test_save_agents_preserves_aliases(self, fake_home):
+        save_aliases({"devs": ["A", "B"]})
+        save_registry({"X": {"root": "/r"}})
+        assert load_aliases() == {"devs": ["A", "B"]}
+        assert load_registry() == {"X": {"root": "/r"}}
+
+    def test_save_aliases_preserves_agents(self, fake_home):
+        save_registry({"X": {"root": "/r"}})
+        save_aliases({"devs": ["X"]})
+        assert load_registry() == {"X": {"root": "/r"}}
+        assert load_aliases() == {"devs": ["X"]}
+
+    def test_corrupt_file_returns_empty(self, fake_home):
+        registry_path().write_text("not json")
+        assert _load_raw_registry() == {"agents": {}, "aliases": {}}
+
+    def test_non_dict_top_level_returns_empty(self, fake_home):
+        registry_path().write_text("[1, 2, 3]")
+        assert _load_raw_registry() == {"agents": {}, "aliases": {}}
+
+    def test_missing_sections_default_empty(self, fake_home):
+        registry_path().write_text(json.dumps({"agents": {"X": {"root": "/r"}}}))
+        raw = _load_raw_registry()
+        assert raw["agents"] == {"X": {"root": "/r"}}
+        assert raw["aliases"] == {}
+
+
+# ---------- resolve_name ----------
+
+class TestResolveName:
+    def test_agent_name_resolves_to_self(self, fake_home):
+        save_registry({"CLAUDE": {"root": "/r"}})
+        kind, members = resolve_name("CLAUDE")
+        assert kind == "agent"
+        assert members == ["CLAUDE"]
+
+    def test_case_insensitive(self, fake_home):
+        save_registry({"CLAUDE": {"root": "/r"}})
+        kind, members = resolve_name("claude")
+        assert kind == "agent"
+        assert members == ["CLAUDE"]  # canonical casing
+
+    def test_unknown_raises(self, fake_home):
+        with pytest.raises(KeyError):
+            resolve_name("BOGUS")
+
+    def test_alias_expands(self, fake_home):
+        save_registry({"A": {"root": "/a"}, "B": {"root": "/b"}})
+        save_aliases({"devs": ["A", "B"]})
+        kind, members = resolve_name("devs")
+        assert kind == "alias"
+        assert members == ["A", "B"]
+
+    def test_nested_alias(self, fake_home):
+        save_registry({"A": {"root": "/a"}, "B": {"root": "/b"}, "C": {"root": "/c"}})
+        save_aliases({"inner": ["A", "B"], "outer": ["inner", "C"]})
+        kind, members = resolve_name("outer")
+        assert kind == "alias"
+        assert members == ["A", "B", "C"]
+
+    def test_nested_alias_dedupes(self, fake_home):
+        save_registry({"A": {"root": "/a"}, "B": {"root": "/b"}})
+        save_aliases({"x": ["A"], "y": ["A", "B"], "z": ["x", "y"]})
+        kind, members = resolve_name("z")
+        # A appears via both x and y; should be listed only once.
+        assert members == ["A", "B"]
+
+    def test_cycle_raises(self, fake_home):
+        save_registry({"A": {"root": "/a"}})
+        # x -> y -> x
+        save_aliases({"x": ["y"], "y": ["x"]})
+        with pytest.raises(ValueError, match="alias cycle"):
+            resolve_name("x")
+
+    def test_dangling_reference_raises(self, fake_home):
+        # alias points at an agent that doesn't exist
+        save_aliases({"devs": ["MISSING"]})
+        with pytest.raises(KeyError):
+            resolve_name("devs")
+
+
+# ---------- find_participant + sender_from_cwd ----------
+
+class TestFindParticipant:
+    def test_finds_by_exact_name(self):
+        parts = [Participant("CLAUDE", Path("/r")), Participant("GEMINI", Path("/r2"))]
+        assert find_participant(parts, "CLAUDE").name == "CLAUDE"
+
+    def test_case_insensitive(self):
+        parts = [Participant("CLAUDE", Path("/r"))]
+        assert find_participant(parts, "claude").name == "CLAUDE"
+
+    def test_unknown_returns_none(self):
+        assert find_participant([], "X") is None
+
+
+class TestSenderFromCwd:
+    def test_finds_agent_from_inside_root(self, fake_home, tmp_path, monkeypatch):
+        agent_dir = tmp_path / "myagent"
+        agent_dir.mkdir()
+        save_registry({"X": {"root": str(agent_dir)}})
+        monkeypatch.chdir(agent_dir)
+        result = sender_from_cwd()
+        assert result is not None
+        name, info = result
+        assert name == "X"
+
+    def test_finds_agent_from_subdir(self, fake_home, tmp_path, monkeypatch):
+        agent_dir = tmp_path / "myagent"
+        sub = agent_dir / "sub" / "deeper"
+        sub.mkdir(parents=True)
+        save_registry({"X": {"root": str(agent_dir)}})
+        monkeypatch.chdir(sub)
+        name, _ = sender_from_cwd()
+        assert name == "X"
+
+    def test_outside_any_agent_returns_none(self, fake_home, tmp_path, monkeypatch):
+        agent_dir = tmp_path / "myagent"
+        agent_dir.mkdir()
+        save_registry({"X": {"root": str(agent_dir)}})
+        outside = tmp_path / "elsewhere"
+        outside.mkdir()
+        monkeypatch.chdir(outside)
+        assert sender_from_cwd() is None
+
+
+class TestResolveRecipient:
+    def test_finds_agent(self, fake_home):
+        save_registry({"CLAUDE": {"root": "/r"}})
+        result = resolve_recipient("claude")
+        assert result is not None
+        name, info = result
+        assert name == "CLAUDE"
+
+    def test_does_not_resolve_aliases(self, fake_home):
+        # resolve_recipient is exact-agent only; alias expansion is resolve_name.
+        save_aliases({"devs": ["X"]})
+        assert resolve_recipient("devs") is None
+
+
+# ---------- participants_from_registry ----------
+
+class TestParticipantsFromRegistry:
+    def test_empty(self, fake_home):
+        assert participants_from_registry() == []
+
+    def test_builds_participants(self, fake_home, tmp_path):
+        d1 = tmp_path / "a"; d1.mkdir()
+        d2 = tmp_path / "b"; d2.mkdir()
+        save_registry({"A": {"root": str(d1)}, "B": {"root": str(d2)}})
+        parts = participants_from_registry()
+        names = sorted(p.name for p in parts)
+        assert names == ["A", "B"]
+
+    def test_skips_entries_with_no_root(self, fake_home):
+        save_registry({"A": {"root": "/tmp"}, "B": {}})
+        parts = participants_from_registry()
+        assert {p.name for p in parts} == {"A"}
+
+
+# ---------- parse_name + _scan_for_markers ----------
+
+class TestParseName:
+    def test_first_hash_line(self, tmp_path):
+        f = tmp_path / "CLAUDE.md"
+        f.write_text("# CLAUDE: code review\n\nbody\n")
+        assert parse_name(f) == "CLAUDE"
+
+    def test_skips_blank_then_finds(self, tmp_path):
+        f = tmp_path / "CLAUDE.md"
+        f.write_text("\n\n# Llama: local\n")
+        assert parse_name(f) == "Llama"
+
+    def test_no_hash_line_returns_none(self, tmp_path):
+        f = tmp_path / "CLAUDE.md"
+        f.write_text("plain text\nno headings\n")
+        assert parse_name(f) is None
+
+    def test_missing_file_returns_none(self, tmp_path):
+        assert parse_name(tmp_path / "nope.md") is None
+
+
+class TestScanForMarkers:
+    def test_finds_marker_in_immediate_child(self, tmp_path):
+        d = tmp_path / "agent1"; d.mkdir()
+        (d / "CLAUDE.md").write_text("# A: x\n")
+        found = _scan_for_markers(tmp_path)
+        assert len(found) == 1
+        name, kind, dirpath = found[0]
+        assert name == "A"
+        assert kind == "claude"
+        assert dirpath == d.resolve()
+
+    def test_finds_marker_in_root_itself(self, tmp_path):
+        (tmp_path / "GEMINI.md").write_text("# G: y\n")
+        found = _scan_for_markers(tmp_path)
+        assert len(found) == 1
+        assert found[0][1] == "gemini"
+
+    def test_no_markers(self, tmp_path):
+        assert _scan_for_markers(tmp_path) == []
+
+    def test_one_marker_per_dir(self, tmp_path):
+        # If both CLAUDE.md and GEMINI.md exist, _scan_for_markers picks the
+        # FIRST marker iteration finds (per MARKER_FILES order).
+        d = tmp_path / "x"; d.mkdir()
+        (d / "CLAUDE.md").write_text("# A: x\n")
+        (d / "GEMINI.md").write_text("# B: y\n")
+        found = _scan_for_markers(tmp_path)
+        # Only one entry per directory (the break in _scan_for_markers).
+        assert len(found) == 1


### PR DESCRIPTION
## Summary

Adds a 98-test pytest suite covering all four extracted modules plus end-to-end wake_once runs against a deterministic mock CLI. **Stacks on #60** (the modular split) — depends on those modules existing.

### Coverage by module
| File | Tests | Focus |
|---|---:|---|
| `test_definitions.py` | 33 | `select_verb`, `build_prompt` (templates + file lines + date prefix), `build_command` ($PROMPT + $A8S_DIR expansion), `_autodiscover_definition`, `load_definition` |
| `test_registry.py`    | 34 | I/O round-trips, schema preservation on partial save, corrupt-file recovery, `resolve_name` (single / alias / nested / **diamond dedup** / cycle / dangling), `find_participant`, `sender_from_cwd`, `parse_name`, `_scan_for_markers` |
| `test_mailbox.py`     | 18 | `_split_content_and_files`, queue helpers, write-time wipe, `route_outboxes` (single delivery, alias fan-out with sender exclusion, `others_count`, empty-`to` rejection, FROM force-overwrite) |
| `test_daemon.py`      | 13 | pid-file atomic claim + dead-pid GC, `acquire`/`release`, end-to-end `wake_once` for **all four verbs** via the mock CLI, CLEAR sentinel read-time wipe, multi-agent handler shares one PID |
| **Total**             | **98** | runs in <100ms |

### Real bug found by the tests: diamond-alias false cycle

`resolve_name` was treating diamonds as cycles. Setup:
```
agents:  A, B
aliases: x = [A], y = [A, B], z = [x, y]
```
Walking `z` visited `A` via both `x` and `y`. The old global-`seen` set treated the second visit as a cycle and raised `ValueError`. Fix: split path tracking from completion tracking.
- `path`: aliases currently on the recursion stack — true cycle
- `seen_aliases`: aliases already fully expanded — diamond short-circuit
- `out_names`: dedupes agent leaves at append time

Both the diamond case (`test_nested_alias_dedupes`) and the true cycle case (`test_cycle_raises`) are covered.

### Test scaffolding
- `conftest.py`: prepends `apps/a8s/` to `sys.path`; `fake_home` fixture monkey-patches `HOME` to `tmp_path` so tests can't touch the real `~/.a8s/`; resets `core.PRINT_LOCK` between tests.
- `tests/fixtures/mock-cli` (bash): deterministic — prints each argv element on its own line with a `MOCK-CLI:` prefix. Tests grep the per-agent log to assert which argv the wake subprocess actually received.
- `tests/fixtures/mock.json`: a definition that routes all four verbs through `mock-cli` with deterministic prompt templates (e.g. `FROM:{sender}|TO:{recipient}|MSG:{message}` so log assertions are stable).

### Run

```
python3 -m pytest apps/a8s/tests/
```

```
98 passed in 0.10s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)