### PR TITLE
fix(a8s): canonical names + pid integrity + atomic fan-out + FILE: transfer

### DIFF
--- a/apps/a8s/commands.py
+++ b/apps/a8s/commands.py
@@ -24,12 +24,12 @@ from pathlib import Path
 
 from core import (
     ENTRYPOINT,
-    NAME_RE,
     SKILLS_DIR,
     BIN_ROOT,
     _pid_alive,
     _preview,
     agent_log_path,
+    canonical_name,
     out,
     out_agent,
     pid_path,
@@ -121,6 +121,11 @@ def _install_skill_codex(skill_dir: Path) -> str:
 def cmd_add(args: list[str]) -> int:
     """`a8s add <name> <dir> [<definition>]` — register a new agent.
 
+    The name is canonicalized (lowercase, alphanumeric) at registration so
+    `a8s add CLAUDE` and `a8s add claude` collapse to the same agent — closes
+    the case-collision footgun where independent registry entries each got
+    their own dir but lookups conflated them (issue #65).
+
     Without `<definition>`, `<dir>` is scanned for a marker file
     (CLAUDE.md/GEMINI.md/CODEX.md) and the matching built-in definition is
     auto-linked. Multiple or zero markers fall back to the bundled default.
@@ -132,10 +137,12 @@ def cmd_add(args: list[str]) -> int:
     if len(args) < 2 or len(args) > 3:
         print("usage: a8s add <name> <dir> [<definition>]", file=sys.stderr)
         return 2
-    name, dir_str = args[0], args[1]
+    raw_name, dir_str = args[0], args[1]
     definition_arg = args[2] if len(args) == 3 else None
-    if not NAME_RE.fullmatch(name):
-        print(f"name must be alphanumeric: {name!r}", file=sys.stderr)
+    try:
+        name = canonical_name(raw_name)
+    except ValueError as e:
+        print(str(e), file=sys.stderr)
         return 2
     root = Path(dir_str).expanduser()
     if not root.is_dir():
@@ -144,12 +151,12 @@ def cmd_add(args: list[str]) -> int:
     root = root.resolve()
     reg = load_registry()
     for k in reg:
-        if k.lower() == name.lower():
+        if k.lower() == name:
             print(f"agent already exists with name: {k}", file=sys.stderr)
             return 1
     aliases = load_aliases()
     for k in aliases:
-        if k.lower() == name.lower():
+        if k.lower() == name:
             print(f"alias already exists with name: {k} — pick a different agent name", file=sys.stderr)
             return 1
 
@@ -302,42 +309,51 @@ def cmd_alias(args: list[str]) -> int:
     """`a8s alias <alias> <member>` — add member to alias, creating the alias
     if new. Members may be agent names OR existing alias names (nesting OK,
     cycles rejected at resolve time). The alias name must not collide with
-    an existing agent name."""
+    an existing agent name. Both alias name and member are canonicalized
+    (lowercase) so `a8s alias Devs CLAUDE` and `a8s alias devs claude` are
+    the same operation (issue #65)."""
     if len(args) == 0:
         return cmd_aliases()
     if len(args) != 2:
         print("usage: a8s alias <alias> <member>     # add or create", file=sys.stderr)
         print("       a8s alias                      # list", file=sys.stderr)
         return 2
-    alias_name, member = args
-    if not NAME_RE.fullmatch(alias_name):
-        print(f"alias name must be alphanumeric: {alias_name!r}", file=sys.stderr)
+    raw_alias, raw_member = args
+    try:
+        alias_name = canonical_name(raw_alias)
+    except ValueError as e:
+        print(str(e), file=sys.stderr)
+        return 2
+    try:
+        member = canonical_name(raw_member)
+    except ValueError as e:
+        print(str(e), file=sys.stderr)
         return 2
     agents = load_registry()
     aliases = load_aliases()
     for k in agents:
-        if k.lower() == alias_name.lower():
+        if k.lower() == alias_name:
             print(f"agent already exists with name: {k} — pick a different alias", file=sys.stderr)
             return 1
     member_resolved: str | None = None
     for k in agents:
-        if k.lower() == member.lower():
+        if k.lower() == member:
             member_resolved = k
             break
     if member_resolved is None:
         for k in aliases:
-            if k.lower() == member.lower():
+            if k.lower() == member:
                 member_resolved = k
                 break
     if member_resolved is None:
-        print(f"unknown member {member!r} (not an agent or alias)", file=sys.stderr)
+        print(f"unknown member {raw_member!r} (not an agent or alias)", file=sys.stderr)
         return 1
-    if member_resolved.lower() == alias_name.lower():
+    if member_resolved.lower() == alias_name:
         print(f"cannot add alias {alias_name!r} to itself", file=sys.stderr)
         return 1
     canonical_alias = alias_name
     for k in aliases:
-        if k.lower() == alias_name.lower():
+        if k.lower() == alias_name:
             canonical_alias = k
             break
     members = aliases.get(canonical_alias) or []
@@ -365,14 +381,15 @@ def cmd_alias(args: list[str]) -> int:
 
 def cmd_unalias(args: list[str]) -> int:
     """`a8s unalias <alias> [<member>]` — remove a single member, or the whole
-    alias if no member given."""
+    alias if no member given. Both names are case-insensitive."""
     if not args or len(args) > 2:
         print("usage: a8s unalias <alias> [<member>]", file=sys.stderr)
         return 2
+    target = args[0].strip().lower()
     aliases = load_aliases()
     canonical: str | None = None
     for k in aliases:
-        if k.lower() == args[0].lower():
+        if k.lower() == target:
             canonical = k
             break
     if canonical is None:
@@ -384,8 +401,9 @@ def cmd_unalias(args: list[str]) -> int:
         print(f"removed alias {canonical}")
         return 0
     member = args[1]
+    member_lc = member.strip().lower()
     members = aliases[canonical]
-    new_members = [m for m in members if m.lower() != member.lower()]
+    new_members = [m for m in members if m.lower() != member_lc]
     if len(new_members) == len(members):
         print(f"{canonical}: not a member: {member!r}", file=sys.stderr)
         return 1

--- a/apps/a8s/core.py
+++ b/apps/a8s/core.py
@@ -29,6 +29,11 @@ MARKER_FILES = {
 
 NAME_RE = re.compile(r"[A-Za-z0-9]+")
 
+# File-transfer cap for FILE: payloads. Larger sources are dropped at routing
+# time with a log line; agents needing larger payloads should use a side-
+# channel (see issue #63 — TempFile.org-style staging supports 100 MiB).
+MAX_FILE_BYTES = 50 * 1024 * 1024  # 50 MiB
+
 # Path constants — computed once at module load.
 SCRIPT_DIR = Path(__file__).resolve().parent
 SKILLS_DIR = SCRIPT_DIR / "skills"
@@ -61,6 +66,18 @@ def _safe_name(name: str) -> str:
     return re.sub(r"[^A-Za-z0-9_-]", "_", name)
 
 
+def canonical_name(name: str) -> str:
+    """Canonical form of an agent or alias name: stripped, lowercase, validated
+    against NAME_RE. Raises ValueError on invalid input. Used at registration
+    boundaries (`a8s add`, `a8s alias`) so the on-disk directory key is the
+    same regardless of input casing — eliminates the case-collision footgun
+    where `claude` and `Claude` produced two separate agent dirs."""
+    s = (name or "").strip().lower()
+    if not s or not NAME_RE.fullmatch(s):
+        raise ValueError(f"name must be alphanumeric: {name!r}")
+    return s
+
+
 def agent_dir(name: str) -> Path:
     """Per-agent internal directory under ~/.a8s/. Holds inbox/, trash/,
     log.txt, and the pid file."""
@@ -69,6 +86,14 @@ def agent_dir(name: str) -> Path:
 
 def inbox_dir(name: str) -> Path:
     return agent_dir(name) / "inbox"
+
+
+def inbox_tmp_dir(name: str) -> Path:
+    """Maildir-style staging dir. `route_outboxes` writes routed copies here
+    first and renames them into `inbox/` only after every recipient's stage
+    succeeds — so a crash mid-fan-out leaves no partial state to be re-routed
+    as duplicates."""
+    return agent_dir(name) / "inbox.tmp"
 
 
 def trash_dir(name: str) -> Path:
@@ -93,6 +118,14 @@ def outbox_dir(root: Path) -> Path:
     a JSON with `from: ""`.
     """
     return root / ".outbox"
+
+
+def files_dir(root: Path) -> Path:
+    """Recipient-side staging dir for `FILE:` payloads. Sender's `FILE:` paths
+    point inside the sender's root; routing copies the bytes here so the
+    recipient can read them under their own sandbox (codex --full-auto, etc.)
+    without knowing the sender's filesystem layout."""
+    return root / ".files"
 
 
 def registry_path() -> Path:

--- a/apps/a8s/daemon.py
+++ b/apps/a8s/daemon.py
@@ -126,12 +126,17 @@ def wake_once(p: Participant, msg_path: Path) -> None:
 
 def _read_handler_pid(name: str) -> int | None:
     """Return the live PID currently handling <name>, or None. Cleans up stale
-    pid files."""
+    pid files. Treats empty / non-int / non-positive contents as stale (the
+    O_CREAT|O_EXCL window allows a partial-write to leave an empty pid file
+    if the writer dies before `os.write`; non-positive values don't refer to
+    any real process — `os.kill(0, ...)` would target the whole process group)."""
     p = pid_path(name)
     if not p.is_file():
         return None
     try:
         pid = int(p.read_text().strip())
+        if pid <= 0:
+            raise ValueError("non-positive pid")
     except (OSError, ValueError):
         try:
             p.unlink()
@@ -149,7 +154,12 @@ def _read_handler_pid(name: str) -> int | None:
 
 def _try_atomic_claim(name: str, pid: int) -> bool:
     """Attempt to write `pid` into `pid_path(name)` using O_CREAT|O_EXCL.
-    Returns True iff this process now holds the handler attachment."""
+    Returns True iff this process now holds the handler attachment.
+
+    `os.fsync` after the write makes the pid bytes durable before the fd
+    closes — without it, a kernel-level crash window between create and write
+    could leave readers parsing an empty file (which `_read_handler_pid` now
+    treats as stale and cleans up)."""
     p = pid_path(name)
     p.parent.mkdir(parents=True, exist_ok=True)
     try:
@@ -158,6 +168,7 @@ def _try_atomic_claim(name: str, pid: int) -> bool:
         return False
     try:
         os.write(fd, str(pid).encode())
+        os.fsync(fd)
     finally:
         os.close(fd)
     return True

--- a/apps/a8s/mailbox.py
+++ b/apps/a8s/mailbox.py
@@ -3,18 +3,37 @@
 Mailbox routing is process-agnostic: a per-agent daemon may write into any
 other agent's inbox even though it isn't handling them. Only `wake_once` (in
 daemon.py) requires the handler attachment.
+
+Atomic alias fan-out (issue #67): `route_outboxes` writes each routed copy
+into `<recipient>/inbox.tmp/<source-fname>` first, then renames the staged
+files into `<recipient>/inbox/` only after every recipient has staged
+successfully — so a process killed mid-fan-out leaves no half-routed state
+that would deliver duplicates on retry. Source filename is preserved (not
+uniquified) so retries are idempotent: a recipient whose final-inbox copy
+already exists is skipped.
+
+FILE: payload transfer (issue #62): each `FILE:` entry's bytes are copied
+into `<recipient>/.files/<filename>` and the routed message's path rewritten
+to the recipient-local copy. Sender paths are validated to live inside the
+sender's own root before copy — the outbox is agent-writable, so an
+unvalidated path could be a probe for files outside the sandbox.
 """
 from __future__ import annotations
 
 import json
+import os
+import shutil
 from datetime import datetime, timezone
 from pathlib import Path
 
 from core import (
+    MAX_FILE_BYTES,
     Participant,
     _preview,
     _safe_name,
+    files_dir,
     inbox_dir,
+    inbox_tmp_dir,
     outbox_dir,
     out_agent,
     trash_dir,
@@ -26,12 +45,115 @@ from registry import resolve_name
 # ---------- mailboxes ----------
 
 def ensure_mailboxes(p: Participant) -> None:
-    """Create mailbox dirs for `p`. Inbox and trash live under ~/.a8s/ (hidden
-    from the agent); outbox lives in the agent's own root (so the agent can
-    actually write to it under a workspace sandbox)."""
-    for d in (inbox_dir(p.name), trash_dir(p.name)):
+    """Create mailbox dirs for `p`. Inbox, inbox.tmp, and trash live under
+    ~/.a8s/ (hidden from the agent); outbox and .files live in the agent's
+    own root (so the agent can write to outbox and read from .files under a
+    workspace sandbox)."""
+    for d in (inbox_dir(p.name), inbox_tmp_dir(p.name), trash_dir(p.name)):
         d.mkdir(parents=True, exist_ok=True)
     outbox_dir(p.root).mkdir(parents=True, exist_ok=True)
+    files_dir(p.root).mkdir(parents=True, exist_ok=True)
+
+
+def _transfer_file_to_recipient(
+    sender_name: str,
+    sender_root: Path,
+    recipient_root: Path,
+    entry: dict,
+) -> dict | None:
+    """Copy one `FILE:` payload from sender to `<recipient_root>/.files/`.
+    Returns the rewritten file entry (recipient-local path) or None if the
+    file was rejected (logged to sender's per-agent log).
+
+    Defenses:
+      - source must resolve INSIDE `sender_root` (the outbox is
+        agent-writable, so an unvalidated path could be a probe for files
+        outside the sandbox)
+      - source must exist and be a regular file
+      - source size must be <= MAX_FILE_BYTES (large payloads belong on a
+        side-channel; see issue #63)
+
+    On collision in `.files/`, `unique_path` appends `.1`, `.2`, ... — the
+    routed message's `files[i].path` is updated to match.
+    """
+    src_path = Path(entry.get("path") or "").expanduser()
+    sender_root_resolved = sender_root.resolve()
+    try:
+        if src_path.is_absolute():
+            src_resolved = src_path.resolve()
+        else:
+            src_resolved = (sender_root_resolved / src_path).resolve()
+    except (OSError, RuntimeError) as e:
+        out_agent(sender_name, f"FILE: cannot resolve {src_path!s}: {e}")
+        return None
+    try:
+        src_resolved.relative_to(sender_root_resolved)
+    except ValueError:
+        out_agent(
+            sender_name,
+            f"FILE: rejected — path outside sender root: {src_resolved}",
+        )
+        return None
+    if not src_resolved.is_file():
+        out_agent(sender_name, f"FILE: source missing or not a regular file: {src_resolved}")
+        return None
+    try:
+        size = src_resolved.stat().st_size
+    except OSError as e:
+        out_agent(sender_name, f"FILE: stat failed for {src_resolved}: {e}")
+        return None
+    if size > MAX_FILE_BYTES:
+        out_agent(
+            sender_name,
+            f"FILE: too large ({size} > {MAX_FILE_BYTES}): {src_resolved}",
+        )
+        return None
+    dest_dir = files_dir(recipient_root)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest = unique_path(dest_dir / src_resolved.name)
+    try:
+        shutil.copyfile(src_resolved, dest)
+        os.chmod(dest, 0o644)
+    except OSError as e:
+        out_agent(sender_name, f"FILE: copy failed {src_resolved} -> {dest}: {e}")
+        return None
+    return {"filename": dest.name, "path": str(dest)}
+
+
+def _build_routed_message(
+    base_msg: dict,
+    sender_name: str,
+    sender_root: Path,
+    recipient: Participant,
+) -> dict:
+    """Construct the routed copy of `base_msg` for `recipient` — copies any
+    `FILE:` payloads into the recipient's `.files/` and rewrites the file
+    paths in the returned message. Files that fail validation are dropped
+    (logged); the message is delivered with the surviving files."""
+    routed = dict(base_msg)
+    routed["to"] = recipient.name
+    src_files = base_msg.get("files") or []
+    if src_files:
+        new_files: list[dict] = []
+        for entry in src_files:
+            rewritten = _transfer_file_to_recipient(
+                sender_name, sender_root, recipient.root, entry
+            )
+            if rewritten is not None:
+                new_files.append(rewritten)
+        routed["files"] = new_files
+    return routed
+
+
+def _commit_staged_inboxes(staged: list[tuple[Path, Path]]) -> None:
+    """Atomically promote each `(staging, final)` pair from `inbox.tmp/` into
+    `inbox/`. Uses `os.replace` so the rename is atomic on POSIX even if the
+    final already exists (re-route after partial crash). Skips entries whose
+    staging file is already gone (already promoted by a prior partial commit)."""
+    for staging, final in staged:
+        if not staging.is_file():
+            continue
+        os.replace(str(staging), str(final))
 
 
 # ---------- routing ----------
@@ -42,7 +164,14 @@ def route_outboxes(senders: list[Participant], all_agents: list[Participant] | N
     `all_agents` is the recipient lookup pool (defaults to senders for
     self-contained calls). Aliases fan out at routing time; sender is excluded
     from delivery (no self-echo). Each routed copy carries `alias` and
-    `others_count` fields for the recipient's prompt template."""
+    `others_count` fields for the recipient's prompt template.
+
+    Atomicity (issue #67): each outbox file is staged into every recipient's
+    `inbox.tmp/` first, then promoted into `inbox/` via `os.replace`, then
+    the source outbox file is unlinked. The staging filename mirrors the
+    source filename (no `unique_path` randomization), so a recipient whose
+    `inbox/<source-name>` already exists is skipped on retry — the routing
+    pass becomes idempotent across crashes."""
     if all_agents is None:
         all_agents = senders
     by_name = {p.name.lower(): p for p in all_agents}
@@ -89,31 +218,62 @@ def route_outboxes(senders: list[Participant], all_agents: list[Participant] | N
             if kind == "alias":
                 msg["alias"] = recipient_name
                 msg["others_count"] = max(0, len(recipients) - 1)
-                out_agent(sender.name, f"routed: {sender.name} -> {recipient_name} (alias of {len(recipients)}): {preview}")
-                for recipient in recipients:
-                    ensure_mailboxes(recipient)
-                    copy = dict(msg)
-                    copy["to"] = recipient.name
-                    dest = unique_path(inbox_dir(recipient.name) / f.name)
-                    with dest.open("w", encoding="utf-8") as out_f:
-                        json.dump(copy, out_f, indent=2)
-                    out_agent(recipient.name, f"received from {sender.name} (via {recipient_name} alias): {preview}")
-                f.unlink()
-                routed += len(recipients)
             else:
-                # Single agent recipient.
                 if not recipients:
                     out_agent(sender.name, f"[{sender.name}] {recipient_name!r} resolved to no agents in {f.name}")
                     continue
+
+            # Stage every recipient's copy into inbox.tmp/<source-name>. Skip
+            # any recipient whose final inbox already has the file (prior
+            # partial run already promoted that recipient's copy).
+            staged: list[tuple[Path, Path]] = []
+            try:
+                for recipient in recipients:
+                    ensure_mailboxes(recipient)
+                    final = inbox_dir(recipient.name) / f.name
+                    if final.is_file():
+                        continue  # already delivered on a prior pass
+                    staging = inbox_tmp_dir(recipient.name) / f.name
+                    routed_msg = _build_routed_message(msg, sender.name, sender.root, recipient)
+                    with staging.open("w", encoding="utf-8") as out_f:
+                        json.dump(routed_msg, out_f, indent=2)
+                    staged.append((staging, final))
+            except OSError as e:
+                # Stage failed — leave the outbox file in place for retry. Best-
+                # effort gc of any partially-staged copies; they'll be replaced
+                # on the next pass anyway (overwritten under the same name).
+                out_agent(sender.name, f"[{sender.name}] stage failed on {f.name}: {e}")
+                for staging, _ in staged:
+                    try:
+                        staging.unlink()
+                    except OSError:
+                        pass
+                continue
+
+            # All copies staged — atomic commit phase. `os.replace` is atomic
+            # on POSIX; even if we crash between iterations, the next pass
+            # detects already-promoted recipients via the `final.is_file()`
+            # skip above and finishes the rest.
+            try:
+                _commit_staged_inboxes(staged)
+            except OSError as e:
+                out_agent(sender.name, f"[{sender.name}] commit failed on {f.name}: {e}")
+                continue
+
+            if kind == "alias":
+                out_agent(sender.name, f"routed: {sender.name} -> {recipient_name} (alias of {len(recipients)}): {preview}")
+                for recipient in recipients:
+                    out_agent(recipient.name, f"received from {sender.name} (via {recipient_name} alias): {preview}")
+                routed += len(recipients)
+            else:
                 recipient = recipients[0]
-                ensure_mailboxes(recipient)
-                dest = unique_path(inbox_dir(recipient.name) / f.name)
-                with dest.open("w", encoding="utf-8") as out_f:
-                    json.dump(msg, out_f, indent=2)
-                f.unlink()
                 out_agent(sender.name, f"routed: {sender.name} -> {recipient.name}: {preview}")
                 out_agent(recipient.name, f"received from {sender.name}: {preview}")
                 routed += 1
+            try:
+                f.unlink()
+            except OSError:
+                pass
     return routed
 
 

--- a/apps/a8s/tests/test_commands.py
+++ b/apps/a8s/tests/test_commands.py
@@ -1,0 +1,108 @@
+"""Tests for commands.py — focused on the canonicalization invariant added
+for issue #65 (lowercase canonical key at registration time, regardless of
+the casing the user typed)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from commands import cmd_add, cmd_alias, cmd_unalias
+from core import agent_dir
+from registry import load_aliases, load_registry
+
+
+@pytest.fixture
+def agent_root(fake_home, tmp_path):
+    d = tmp_path / "x"
+    d.mkdir()
+    return d
+
+
+class TestCmdAddCanonicalization:
+    def test_uppercase_input_stored_lowercase(self, agent_root):
+        rc = cmd_add(["CLAUDE", str(agent_root)])
+        assert rc == 0
+        reg = load_registry()
+        assert "claude" in reg
+        assert "CLAUDE" not in reg
+
+    def test_mixed_case_collision_rejected(self, agent_root, tmp_path, capsys):
+        assert cmd_add(["claude", str(agent_root)]) == 0
+        other = tmp_path / "y"
+        other.mkdir()
+        # Re-add under a different casing — should be rejected as duplicate
+        # rather than producing a second registry entry.
+        rc = cmd_add(["Claude", str(other)])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "already exists" in err
+        # Registry still has exactly one entry.
+        assert list(load_registry().keys()) == ["claude"]
+
+    def test_directory_path_uses_canonical_key(self, agent_root):
+        cmd_add(["CLAUDE", str(agent_root)])
+        # Directory derived from canonical (lowercase) key.
+        assert agent_dir("claude").exists() or not agent_dir("CLAUDE").exists()
+        # The actual on-disk dir is materialized lazily by ensure_mailboxes,
+        # so just check that resolution paths agree.
+        assert agent_dir("claude") == agent_dir("CLAUDE".lower())
+
+    def test_invalid_name_rejected(self, agent_root, capsys):
+        rc = cmd_add(["foo-bar", str(agent_root)])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "alphanumeric" in err
+
+    def test_empty_name_rejected(self, agent_root, capsys):
+        rc = cmd_add(["", str(agent_root)])
+        assert rc == 2
+
+
+class TestCmdAddAliasCollision:
+    def test_alias_then_agent_with_same_name_rejected(self, fake_home, tmp_path, agent_root, capsys):
+        # First agent registered.
+        other = tmp_path / "other"; other.mkdir()
+        cmd_add(["claude", str(other)])
+        # Create an alias.
+        assert cmd_alias(["devs", "claude"]) == 0
+        # Try to register a new agent named "DEVS" — must collide with the
+        # alias namespace, rejected.
+        rc = cmd_add(["DEVS", str(agent_root)])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "alias" in err.lower()
+
+
+class TestCmdAliasCanonicalization:
+    def test_alias_name_canonicalized(self, fake_home, agent_root):
+        cmd_add(["claude", str(agent_root)])
+        rc = cmd_alias(["DEVS", "Claude"])
+        assert rc == 0
+        aliases = load_aliases()
+        assert "devs" in aliases
+        assert aliases["devs"] == ["claude"]
+
+    def test_alias_collides_with_agent_name(self, fake_home, agent_root, capsys):
+        cmd_add(["claude", str(agent_root)])
+        # Try to create an alias whose name (lowercased) matches an agent.
+        rc = cmd_alias(["CLAUDE", "claude"])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "agent already exists" in err
+
+    def test_unknown_member_rejected(self, fake_home, capsys):
+        rc = cmd_alias(["devs", "nobody"])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "unknown member" in err
+
+
+class TestCmdUnaliasCaseInsensitive:
+    def test_unalias_with_different_case(self, fake_home, agent_root):
+        cmd_add(["claude", str(agent_root)])
+        cmd_alias(["devs", "claude"])
+        # Use uppercase to remove — should match canonical lowercase entry.
+        rc = cmd_unalias(["DEVS"])
+        assert rc == 0
+        assert load_aliases() == {}

--- a/apps/a8s/tests/test_daemon.py
+++ b/apps/a8s/tests/test_daemon.py
@@ -66,6 +66,51 @@ class TestReadHandlerPid:
         pid_path("X").write_text(str(os.getpid()))
         assert _read_handler_pid("X") == os.getpid()
 
+    def test_empty_pid_file_is_cleaned_up(self, fake_home):
+        # Issue #66: a partial-write window between O_CREAT|O_EXCL and os.write
+        # can leave an empty pid file. Treat as stale and unlink.
+        pid_path("X").parent.mkdir(parents=True, exist_ok=True)
+        pid_path("X").write_text("")
+        assert _read_handler_pid("X") is None
+        assert not pid_path("X").is_file()
+
+    def test_negative_pid_is_cleaned_up(self, fake_home):
+        # Issue #66: a non-positive pid doesn't refer to any real process —
+        # pid 0 / negative pids would target the whole process group via
+        # os.kill, which is unsafe.
+        pid_path("X").parent.mkdir(parents=True, exist_ok=True)
+        pid_path("X").write_text("-1")
+        assert _read_handler_pid("X") is None
+        assert not pid_path("X").is_file()
+
+    def test_zero_pid_is_cleaned_up(self, fake_home):
+        pid_path("X").parent.mkdir(parents=True, exist_ok=True)
+        pid_path("X").write_text("0")
+        assert _read_handler_pid("X") is None
+        assert not pid_path("X").is_file()
+
+    def test_garbage_pid_is_cleaned_up(self, fake_home):
+        pid_path("X").parent.mkdir(parents=True, exist_ok=True)
+        pid_path("X").write_text("not-an-int")
+        assert _read_handler_pid("X") is None
+        assert not pid_path("X").is_file()
+
+
+class TestAtomicClaimDurability:
+    def test_claim_after_partial_write_cleanup(self, fake_home):
+        # Issue #66: if a prior writer died after O_CREAT but before the byte
+        # write, the file exists but is empty. _read_handler_pid cleans it up;
+        # the next _try_atomic_claim must then succeed.
+        pid_path("X").parent.mkdir(parents=True, exist_ok=True)
+        pid_path("X").write_text("")  # simulate partial-write death
+        # Direct re-claim fails because the file still exists.
+        assert _try_atomic_claim("X", os.getpid()) is False
+        # _read_handler_pid reaps the empty file.
+        assert _read_handler_pid("X") is None
+        # Now _try_atomic_claim succeeds.
+        assert _try_atomic_claim("X", os.getpid()) is True
+        assert pid_path("X").read_text() == str(os.getpid())
+
 
 class TestAcquireRelease:
     def test_acquire_when_free_then_release(self, fake_home):

--- a/apps/a8s/tests/test_mailbox.py
+++ b/apps/a8s/tests/test_mailbox.py
@@ -6,7 +6,15 @@ from pathlib import Path
 
 import pytest
 
-from core import Participant, inbox_dir, outbox_dir, trash_dir
+from core import (
+    MAX_FILE_BYTES,
+    Participant,
+    files_dir,
+    inbox_dir,
+    inbox_tmp_dir,
+    outbox_dir,
+    trash_dir,
+)
 from mailbox import (
     _queue_clear_sentinel,
     _queue_prompt,
@@ -247,6 +255,185 @@ class TestRouteOutboxes:
         delivered = json.loads(next(inbox_dir("B").iterdir()).read_text())
         # Routing forces from = sender's actual name, regardless of the JSON.
         assert delivered["from"] == "A"
+
+
+class TestAtomicFanout:
+    """Issue #67 — `route_outboxes` stages routed copies under each recipient's
+    `inbox.tmp/<source-name>` and only renames them into `inbox/` after every
+    recipient has staged. A crash mid-fan-out should not produce duplicates
+    on retry: recipients whose final `inbox/<source-name>` already exists are
+    skipped."""
+
+    def test_uses_source_filename_in_inbox(self, three_agents):
+        a, b, c = three_agents
+        out_path = _write_outbox("A", a.root, "devs", "team msg", [])
+        save_aliases({"devs": ["A", "B", "C"]})
+        route_outboxes([a, b, c], all_agents=[a, b, c])
+        # Recipients receive a file named exactly like the source outbox file.
+        b_files = list(inbox_dir("B").iterdir())
+        assert len(b_files) == 1
+        assert b_files[0].name == out_path.name
+        c_files = list(inbox_dir("C").iterdir())
+        assert c_files[0].name == out_path.name
+
+    def test_inbox_tmp_is_empty_after_clean_run(self, three_agents):
+        a, b, c = three_agents
+        save_aliases({"devs": ["A", "B", "C"]})
+        _write_outbox("A", a.root, "devs", "team msg", [])
+        route_outboxes([a, b, c], all_agents=[a, b, c])
+        for p in (a, b, c):
+            assert list(inbox_tmp_dir(p.name).iterdir()) == []
+
+    def test_retry_skips_already_delivered_recipient(self, three_agents):
+        # Simulate "process died after delivering to B but before unlinking
+        # A's outbox." Pre-populate B's inbox with the source filename and
+        # leave A's outbox file in place. Re-routing should NOT re-deliver
+        # to B, only fill in C; the outbox file is then unlinked.
+        a, b, c = three_agents
+        save_aliases({"devs": ["A", "B", "C"]})
+        out_path = _write_outbox("A", a.root, "devs", "team msg", [])
+        # Pre-populate B's inbox with a copy of the message under the same
+        # filename — represents a successful prior staging that promoted to
+        # inbox/ before the process died.
+        with out_path.open("r", encoding="utf-8") as f:
+            base_msg = json.load(f)
+        base_msg["from"] = "A"  # routing force-overwrites this anyway
+        base_msg["to"] = "B"
+        base_msg["alias"] = "devs"
+        base_msg["others_count"] = 1
+        b_pre = inbox_dir("B") / out_path.name
+        with b_pre.open("w", encoding="utf-8") as f:
+            json.dump(base_msg, f)
+
+        route_outboxes([a, b, c], all_agents=[a, b, c])
+
+        # B still has exactly one copy (no duplicate via .1 suffix).
+        b_files = list(inbox_dir("B").iterdir())
+        assert len(b_files) == 1
+        assert b_files[0].name == out_path.name
+        # C now has the message.
+        c_files = list(inbox_dir("C").iterdir())
+        assert len(c_files) == 1
+        # Source outbox unlinked after the routing pass committed.
+        assert not out_path.is_file()
+
+
+class TestFileTransfer:
+    """Issue #62 — `FILE:` payloads are copied into each recipient's `.files/`
+    at routing time. The routed message's `files[i].path` is rewritten to the
+    recipient-local copy so the recipient's wake prompt emits a path it can
+    actually open under its own sandbox."""
+
+    @pytest.fixture
+    def file_agents(self, fake_home, tmp_path):
+        a_root = tmp_path / "a"; a_root.mkdir()
+        b_root = tmp_path / "b"; b_root.mkdir()
+        save_registry({"A": {"root": str(a_root)}, "B": {"root": str(b_root)}})
+        a = Participant("A", a_root)
+        b = Participant("B", b_root)
+        ensure_mailboxes(a)
+        ensure_mailboxes(b)
+        return a, b
+
+    def test_copies_file_to_recipient_files_dir(self, file_agents):
+        a, b = file_agents
+        # Sender prepares a payload under its OWN root.
+        payload = a.root / "report.txt"
+        payload.write_text("hello payload")
+        _write_outbox("A", a.root, "B", "see attached", [
+            {"filename": "report.txt", "path": str(payload)},
+        ])
+        route_outboxes([a, b], all_agents=[a, b])
+        # File arrived in B's .files/ and content matches.
+        b_files = list(files_dir(b.root).iterdir())
+        assert len(b_files) == 1
+        assert b_files[0].name == "report.txt"
+        assert b_files[0].read_text() == "hello payload"
+        # Routed message's path points at B's local copy.
+        delivered = json.loads(next(inbox_dir("B").iterdir()).read_text())
+        assert len(delivered["files"]) == 1
+        assert delivered["files"][0]["path"] == str(b_files[0])
+        assert delivered["files"][0]["filename"] == "report.txt"
+
+    def test_alias_fanout_copies_to_each_recipient(self, fake_home, tmp_path):
+        # A sends to alias devs=[B, C] with a FILE; each recipient gets its
+        # own copy under its own .files/.
+        agents = {}
+        for n in ("A", "B", "C"):
+            d = tmp_path / n; d.mkdir()
+            agents[n] = Participant(n, d)
+        save_registry({n: {"root": str(p.root)} for n, p in agents.items()})
+        save_aliases({"devs": ["B", "C"]})
+        for p in agents.values():
+            ensure_mailboxes(p)
+        a = agents["A"]
+        payload = a.root / "data.csv"
+        payload.write_text("col1,col2\n1,2\n")
+        _write_outbox("A", a.root, "devs", "team data", [
+            {"filename": "data.csv", "path": str(payload)},
+        ])
+        route_outboxes(list(agents.values()), all_agents=list(agents.values()))
+        for n in ("B", "C"):
+            recipient_files = list(files_dir(agents[n].root).iterdir())
+            assert len(recipient_files) == 1
+            assert recipient_files[0].read_text() == "col1,col2\n1,2\n"
+
+    def test_path_outside_sender_root_is_rejected(self, fake_home, tmp_path, file_agents):
+        a, b = file_agents
+        # Attacker writes a FILE: pointing OUTSIDE A's root (e.g., system
+        # secrets). Routing must drop the file rather than copy it.
+        outside = tmp_path / "secrets.txt"
+        outside.write_text("PASSWORD=hunter2")
+        _write_outbox("A", a.root, "B", "leaking", [
+            {"filename": "secrets.txt", "path": str(outside)},
+        ])
+        route_outboxes([a, b], all_agents=[a, b])
+        # File NOT copied into B's .files/.
+        assert list(files_dir(b.root).iterdir()) == []
+        # Message still delivered (with the file dropped).
+        delivered = json.loads(next(inbox_dir("B").iterdir()).read_text())
+        assert delivered["files"] == []
+        assert delivered["content"] == "leaking"
+
+    def test_missing_source_is_dropped(self, file_agents):
+        a, b = file_agents
+        # FILE: points at a path that doesn't exist (sender promised something
+        # they didn't write). Routing drops the file silently into the log.
+        _write_outbox("A", a.root, "B", "ghost", [
+            {"filename": "ghost.txt", "path": str(a.root / "ghost.txt")},
+        ])
+        route_outboxes([a, b], all_agents=[a, b])
+        assert list(files_dir(b.root).iterdir()) == []
+        delivered = json.loads(next(inbox_dir("B").iterdir()).read_text())
+        assert delivered["files"] == []
+
+    def test_oversized_source_is_dropped(self, file_agents):
+        a, b = file_agents
+        big = a.root / "big.bin"
+        # 1 byte over the cap.
+        big.write_bytes(b"x" * (MAX_FILE_BYTES + 1))
+        _write_outbox("A", a.root, "B", "huge", [
+            {"filename": "big.bin", "path": str(big)},
+        ])
+        route_outboxes([a, b], all_agents=[a, b])
+        assert list(files_dir(b.root).iterdir()) == []
+
+    def test_collision_uniquifies(self, file_agents):
+        a, b = file_agents
+        # Two messages, each carrying a FILE with the same basename.
+        for i in range(2):
+            payload = a.root / f"p{i}.txt"
+            payload.write_text(f"contents {i}")
+            # Force same destination filename via shared "doc.txt" name.
+            entry_path = a.root / "doc.txt"
+            entry_path.write_text(f"v{i}")
+            _write_outbox("A", a.root, "B", f"msg {i}", [
+                {"filename": "doc.txt", "path": str(entry_path)},
+            ])
+            route_outboxes([a, b], all_agents=[a, b])
+        # Two distinct copies in B's .files/ thanks to unique_path uniquify.
+        names = {p.name for p in files_dir(b.root).iterdir()}
+        assert names == {"doc.txt", "doc.1.txt"}
 
 
 class TestNextInboxMessage:

--- a/apps/a8s/tests/test_registry.py
+++ b/apps/a8s/tests/test_registry.py
@@ -21,7 +21,45 @@ from registry import (
     save_registry,
     sender_from_cwd,
 )
-from core import Participant, registry_path
+from core import Participant, canonical_name, registry_path
+
+
+# ---------- canonical_name ----------
+
+class TestCanonicalName:
+    """Issue #65 — names canonicalize to lowercase at registration boundaries
+    (`a8s add`, `a8s alias`) so directory keys collapse and the case-collision
+    footgun (two distinct `~/.a8s/agents/<NAME>/` dirs for `claude` vs
+    `Claude`) goes away."""
+
+    def test_lowercases(self):
+        assert canonical_name("CLAUDE") == "claude"
+
+    def test_strips(self):
+        assert canonical_name("  claude  ") == "claude"
+
+    def test_mixed_case(self):
+        assert canonical_name("Claude") == "claude"
+
+    def test_alphanumeric_passes(self):
+        assert canonical_name("agent42") == "agent42"
+
+    def test_empty_rejected(self):
+        with pytest.raises(ValueError):
+            canonical_name("")
+
+    def test_whitespace_only_rejected(self):
+        with pytest.raises(ValueError):
+            canonical_name("   ")
+
+    def test_hyphen_rejected(self):
+        # NAME_RE is [A-Za-z0-9]+ — no separators allowed.
+        with pytest.raises(ValueError):
+            canonical_name("foo-bar")
+
+    def test_space_rejected(self):
+        with pytest.raises(ValueError):
+            canonical_name("foo bar")
 
 
 # ---------- low-level I/O ----------


### PR DESCRIPTION
## Summary

Four hardening fixes bundled (each surfaced by the review panel last week):

- **#65** — `a8s add` / `a8s alias` canonicalize names to lowercase via `core.canonical_name`. `add CLAUDE` and `add claude` collapse to one entry / one on-disk dir; the case-collision footgun is gone.
- **#66** — `_try_atomic_claim` `os.fsync`s after the pid write so contents are durable before the fd closes. `_read_handler_pid` validates `pid > 0` and reaps empty / non-positive / unparseable files as stale.
- **#67** — `route_outboxes` adopts maildir-style staging (`inbox.tmp/<src-name>` → `inbox/<src-name>` via `os.replace`), unlinks the outbox only after the commit phase, and skips recipients whose final inbox already has the source filename. A crash mid-fan-out can no longer produce duplicates on retry.
- **#62** — `FILE:` payloads are copied into each recipient's `<root>/.files/<filename>` at routing time; the routed message's `files[i].path` is rewritten so the wake prompt points at the recipient's local copy. Source paths are validated to be inside the sender's root (the outbox is agent-writable — unvalidated paths probe the sandbox). Size cap: 50 MiB; over-cap files are dropped with a log line. Side-channel #63 will replace this for very large payloads.

## Test plan
- [x] `python3 -m pytest apps/a8s/tests/` — 130 tests pass (32 new across `test_commands.py` (new), `test_daemon.py`, `test_mailbox.py`, `test_registry.py`)
- [x] Smoke-tested via the entry script: `a8s add CLAUDE` then `a8s add Claude` → second rejected; registry stores `claude`; alias-vs-agent collisions blocked both directions
- [x] `a8s --help` renders cleanly through the new code paths

## Notes
- `MAX_FILE_BYTES = 50 * 1024 * 1024` lives in `core.py`; bumped from the issue's tentative 1 MiB after a v1-realism check.
- No back-compat for prior pid files / inbox layouts — pre-v1 scorch-the-earth (per CLAUDE.md). Existing on-disk state needs `rm -rf ~/.a8s/agents` after pulling this.

Closes #62
Closes #65
Closes #66
Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)