### PR TITLE
fix(a8s): per-agent take-over via detach-request — never orphan an agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,15 @@ Key invariants:
   in `acquire`: that's what created the orphan-collateral bug. The 60s
   `DETACH_TIMEOUT_S` is the only fallback if the holder is mid-wake on a
   slow LLM call; `a8s kill` breaks the deadlock.
+- **Per-agent kill via kill-request + SIGUSR1.** `cmd_kill` writes
+  `~/.a8s/agents/<NAME>/kill-request` and SIGUSR1s the holder. The handler's
+  `_on_kill_signal` checks the kill-request for `_CURRENT_WAKE_NAME` (the
+  agent being woken right now); if present, it kills the wake subprocess
+  group so `run_with_prefix.wait()` returns immediately. The actual release
+  of the agent happens at the next iteration top via the kill-request check
+  — same shape as detach-request, but logs as "killed by" and takes
+  precedence. Whole-process SIGTERM is the last-resort escalation only
+  when the holder doesn't honor the request within 10s.
 
 ### Surface
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,14 @@ Key invariants:
 - **`run_with_prefix` uses `start_new_session=True`** so SIGKILL targets the
   whole subprocess group (claude/gemini/codex CLI plus any helpers it spawned).
   Don't drop this — it's the only way the second-signal kill path works.
+- **Per-agent take-over via detach-request (no orphans).** When `acquire`
+  hits a live conflict, it writes `~/.a8s/agents/<NAME>/detach-request` with
+  its pid and polls. The holder's `attached_loop` checks for that file at
+  the top of each iteration and releases just that one agent — its sibling
+  attachments stay running. Don't reintroduce process-level SIGTERM-and-wait
+  in `acquire`: that's what created the orphan-collateral bug. The 60s
+  `DETACH_TIMEOUT_S` is the only fallback if the holder is mid-wake on a
+  slow LLM call; `a8s kill` breaks the deadlock.
 
 ### Surface
 
@@ -269,12 +277,7 @@ The locked-design refactor (#52) is closed. The following are open:
 | # | State | Topic |
 |---|---|---|
 | #39 | open enhancement | Copilot CLI as 4th tool kind. Trivial after the refactor: write `copilot.json`, add `COPILOT.md` → `copilot` to `core.MARKER_FILES`. |
-| #62 | open enhancement | File transfer: `FILE:` payloads must be staged into `<recipient>/.files/`. Path-validation defense is critical (post-#62 without it = sandbox escape). |
 | #63 | open enhancement | Transparent multi-cluster routing (peer mesh). MQTT + ephemeral payload host as initial transports. Spec is implementation-agnostic. Armstrong's 5-item retrofit list (UUIDs, expiry, priority, dedup, acks) lands locally first. |
-| #65 | open bug | Agent name case-collision (`claude` vs `Claude` produces two dirs but lookups conflate them). Canonicalize at registration. |
-| #66 | open bug | pid file integrity — `os.fsync` after write + validate parsed pid. |
-| #67 | open bug | Atomic alias fan-out — adopt maildir-style `tmp/` → `new/` rename. Crash mid-fan-out leaves inconsistent state today. |
-| #68 | open enhancement | Per-agent attachment (replace process-level pid). Fixes "take-over collateral" footgun. Multiple reviewers flagged this. |
 | #69–72 | open question | Design discussions surfaced by the review panel: verb-scheme collapse vs eliminate; opacity strictness; supervision model; mailbox file format. Resolve before #63 hardens. |
 
 ### What I tried that didn't work (concrete)

--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -116,7 +116,7 @@ That's the full loop. Members don't know they're "in a8s" — they just see a `t
 | `a8s run <name>` | Foreground attached loop. Aliases produce one process with interleaved output. Ctrl+C: graceful detach. 2nd Ctrl+C: kill the wake subprocess group. |
 | `a8s step <name>` | Attach, do one route+drain pass, release. Heavyweight: detaches the current handler if any. |
 | `a8s stop <name>` | SIGTERM the handler. Aliases dedupe by PID — one signal per multi-agent handler. Graceful detach. |
-| `a8s kill <name>` | Etiquette-then-force: SIGTERM, brief grace, SIGTERM again (kills the wake subprocess group), SIGKILL fallback. |
+| `a8s kill <name>` | Per-agent force-detach: writes a kill-request, SIGUSR1s the holder. Holder kills the in-flight wake subprocess iff it's for that agent and releases the attachment; siblings keep running. Falls back to whole-process SIGTERM only if the holder doesn't honor the request in 10s. |
 | `a8s exit` | SIGTERM every running handler. |
 | `a8s ls` | List only running agents and their handler PIDs. |
 
@@ -141,7 +141,9 @@ That's the full loop. Members don't know they're "in a8s" — they just see a `t
 
 Concretely: P1 is `a8s start devs` (handling `[CLAUDE, GEMINI, FOO]`). You run `a8s run CLAUDE` in another window. CLAUDE moves to your foreground process; P1 keeps handling `[GEMINI, FOO]`. If you then `a8s run GEMINI` in a third window, GEMINI moves there; P1 keeps `[FOO]`. If P1's last agent gets pulled out, P1 exits cleanly with nothing left to handle.
 
-Take-over has a 60-second timeout. If the holder is wedged on a long LLM wake and doesn't honor the request in time, `acquire` errors out — `a8s kill <name>` breaks the deadlock.
+`a8s kill <name>` works the same way but force: it writes a `kill-request` file and SIGUSR1s the holder, which kills the in-flight wake subprocess (if any) for just that agent and releases the attachment. P1 keeps its other agents either way.
+
+Take-over has a 60-second timeout (kill is 10s). If the holder is wedged on a long LLM wake and doesn't honor the request in time, the requester errors out (or, for `kill`, escalates to a whole-process SIGTERM as a last resort).
 
 ## Definitions
 

--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -135,9 +135,13 @@ That's the full loop. Members don't know they're "in a8s" — they just see a `t
 
 `a8s` with no command prints help. There is no auto-discovery of agents from CWD — registration is always explicit.
 
-### Take-over collateral
+### Per-agent take-over
 
-`start`/`run`/`step` always win. If another handler holds the agent, the new caller SIGTERMs it, waits for it to detach, then atomically claims the pid file. If the prior handler was multi-agent (handling an alias), it detaches **all** its agents — the new caller takes only what it asked for. Other agents in the prior set become orphaned. Documented footgun; restart them explicitly.
+`start`/`run`/`step` against an agent that's already attached to another live process performs a **per-agent** hand-off. The new caller drops a `detach-request` file under `~/.a8s/agents/<NAME>/`; the existing handler reads it at the top of its next iteration and releases just that one agent — its other handled agents keep running. Then the new caller atomically claims the pid file. There is never an orphan: at every moment, an agent is either attached to exactly one live process or it isn't running at all.
+
+Concretely: P1 is `a8s start devs` (handling `[CLAUDE, GEMINI, FOO]`). You run `a8s run CLAUDE` in another window. CLAUDE moves to your foreground process; P1 keeps handling `[GEMINI, FOO]`. If you then `a8s run GEMINI` in a third window, GEMINI moves there; P1 keeps `[FOO]`. If P1's last agent gets pulled out, P1 exits cleanly with nothing left to handle.
+
+Take-over has a 60-second timeout. If the holder is wedged on a long LLM wake and doesn't honor the request in time, `acquire` errors out — `a8s kill <name>` breaks the deadlock.
 
 ## Definitions
 

--- a/apps/a8s/commands.py
+++ b/apps/a8s/commands.py
@@ -35,7 +35,12 @@ from core import (
     pid_path,
 )
 from definitions import _autodiscover_definition, default_definition_path
-from daemon import _read_handler_pid, attached_loop
+from daemon import (
+    _clear_kill_request,
+    _read_handler_pid,
+    _write_kill_request,
+    attached_loop,
+)
 from mailbox import (
     _queue_clear_sentinel,
     _queue_prompt,
@@ -552,53 +557,57 @@ def cmd_stop(args: list[str]) -> int:
     return 0
 
 
+KILL_TIMEOUT_S = 10.0
+KILL_POLL_S = 0.1
+
+
 def cmd_kill(args: list[str]) -> int:
-    """`a8s kill <name>` — etiquette-then-force per unique handler PID."""
+    """`a8s kill <name>` — per-agent force-detach. For each member, write
+    a kill-request file and SIGUSR1 the holder; the holder's iteration top
+    releases just that agent (and its SIGUSR1 handler kills any in-flight
+    wake subprocess group iff the current wake target matches), so siblings
+    keep running. Falls back to whole-process SIGTERM if the holder doesn't
+    honor the request within KILL_TIMEOUT_S — that's the only path that
+    still creates collateral, and it's the user's explicit force escalation."""
     if len(args) != 1:
         print("usage: a8s kill <name>", file=sys.stderr)
         return 2
     members = _expand_to_agents(args[0])
     if members is None:
         return 1
-    seen_pids: dict[int, str] = {}
+    rc = 0
     for name in members:
-        pid = _read_handler_pid(name)
-        if pid is not None and pid not in seen_pids:
-            seen_pids[pid] = name
-    if not seen_pids:
-        for name in members:
-            print(f"{name}: not running", file=sys.stderr)
-        return 1
-    for pid, label in seen_pids.items():
-        print(f"{label}: SIGTERM PID {pid} (graceful)")
-        try:
-            os.kill(pid, signal.SIGTERM)
-        except ProcessLookupError:
+        holder = _read_handler_pid(name)
+        if holder is None:
+            print(f"{name}: not running")
             continue
-        time.sleep(0.5)
-        if _pid_alive(pid):
-            print(f"{label}: still alive — second SIGTERM (forces subprocess group kill)")
+        _write_kill_request(name, os.getpid())
+        print(f"{name}: kill request → PID {holder}")
+        try:
+            os.kill(holder, signal.SIGUSR1)
+        except ProcessLookupError:
+            _clear_kill_request(name)
+            continue
+        deadline = time.time() + KILL_TIMEOUT_S
+        released = False
+        while time.time() < deadline:
+            if not pid_path(name).is_file():
+                released = True
+                break
+            time.sleep(KILL_POLL_S)
+        if not released:
+            print(
+                f"{name}: holder PID {holder} did not honor kill within {KILL_TIMEOUT_S}s — "
+                f"escalating to whole-process SIGTERM",
+                file=sys.stderr,
+            )
             try:
-                os.kill(pid, signal.SIGTERM)
-            except ProcessLookupError:
-                continue
-            time.sleep(0.5)
-        if _pid_alive(pid):
-            print(f"{label}: still alive — SIGKILL")
-            try:
-                os.kill(pid, signal.SIGKILL)
+                os.kill(holder, signal.SIGTERM)
             except ProcessLookupError:
                 pass
-        # Clean up any pid files still pointing at this dead PID.
-        for name in members:
-            p = pid_path(name)
-            if p.is_file():
-                try:
-                    if int(p.read_text().strip()) == pid:
-                        p.unlink()
-                except (OSError, ValueError):
-                    pass
-    return 0
+            rc = 1
+        _clear_kill_request(name)
+    return rc
 
 
 def cmd_exit() -> int:

--- a/apps/a8s/core.py
+++ b/apps/a8s/core.py
@@ -118,6 +118,15 @@ def detach_request_path(name: str) -> Path:
     return agent_dir(name) / "detach-request"
 
 
+def kill_request_path(name: str) -> Path:
+    """Per-agent kill-request file. `a8s kill <name>` writes its pid here and
+    SIGUSR1s the holder. The holder's iteration top releases just <name>;
+    its SIGUSR1 handler additionally kills the in-flight wake subprocess
+    group iff the current wake target matches — so a long-running LLM call
+    for <name> dies immediately while siblings keep running."""
+    return agent_dir(name) / "kill-request"
+
+
 def outbox_dir(root: Path) -> Path:
     """Outbox lives **inside the agent's own dir** so the agent can write to it
     even under a strict workspace sandbox (codex --full-auto). Inbox and trash

--- a/apps/a8s/core.py
+++ b/apps/a8s/core.py
@@ -108,6 +108,16 @@ def pid_path(name: str) -> Path:
     return agent_dir(name) / "pid"
 
 
+def detach_request_path(name: str) -> Path:
+    """Per-agent detach-request file. A process that wants to take over <name>
+    writes its own pid here, then polls for the holder to release. The holder's
+    `attached_loop` checks this file at the top of each iteration and, when the
+    request is from a different pid, releases ONLY <name> (not its other handled
+    agents) and clears the request. This is how take-over moves a single agent
+    between processes without orphaning the holder's siblings."""
+    return agent_dir(name) / "detach-request"
+
+
 def outbox_dir(root: Path) -> Path:
     """Outbox lives **inside the agent's own dir** so the agent can write to it
     even under a strict workspace sandbox (codex --full-auto). Inbox and trash

--- a/apps/a8s/daemon.py
+++ b/apps/a8s/daemon.py
@@ -32,6 +32,7 @@ from core import (
     _pid_alive,
     _preview,
     agent_dir,
+    detach_request_path,
     inbox_dir,
     out_agent,
     pid_path,
@@ -174,64 +175,110 @@ def _try_atomic_claim(name: str, pid: int) -> bool:
     return True
 
 
-# Wait up to this long for an existing handler to release after SIGTERM.
-ACQUIRE_TIMEOUT_S = 30.0
-ACQUIRE_POLL_S = 0.1
+# How long to wait for the holder to honor a detach-request before giving up.
+# Long enough to cover an in-flight LLM wake (the holder only checks the
+# request between iterations, so an active subprocess delays response).
+DETACH_TIMEOUT_S = 60.0
+DETACH_POLL_S = 0.2
+
+
+def _write_detach_request(name: str, requester_pid: int) -> None:
+    """Write `requester_pid` into the detach-request file for `name` (overwrites
+    any prior request — last writer wins, which is fine since whichever
+    requester is the most recent will get the agent next)."""
+    p = detach_request_path(name)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(str(requester_pid))
+
+
+def _read_detach_request(name: str) -> int | None:
+    """Return the requester pid in the detach-request file for `name`, or None.
+    Reaps malformed contents (empty / non-int / non-positive) like the pid
+    file does."""
+    p = detach_request_path(name)
+    if not p.is_file():
+        return None
+    try:
+        pid = int(p.read_text().strip())
+        if pid <= 0:
+            raise ValueError("non-positive pid")
+        return pid
+    except (OSError, ValueError):
+        try:
+            p.unlink()
+        except OSError:
+            pass
+        return None
+
+
+def _clear_detach_request(name: str) -> None:
+    """Best-effort unlink of the detach-request file."""
+    try:
+        detach_request_path(name).unlink()
+    except OSError:
+        pass
 
 
 def acquire(name: str) -> None:
-    """Attach this process as the handler of <name>. If another live process
-    is currently handling it, send SIGTERM (graceful detach) and wait for
-    release. Always wins (per locked design). Raises TimeoutError if the prior
-    handler doesn't release within ACQUIRE_TIMEOUT_S."""
+    """Attach this process as the handler of <name>.
+
+    If another live process holds <name>, write a detach-request file and
+    poll for it to release. The holder's `attached_loop` checks the request
+    at the top of each iteration and releases just <name> (not its other
+    handled agents) — so a multi-agent handler losing one member keeps
+    serving the rest. Raises `TimeoutError` if the holder doesn't honor
+    the request within `DETACH_TIMEOUT_S` (typically because an in-flight
+    LLM wake is taking a long time; `a8s kill <name>` breaks the deadlock).
+
+    Stale pid files (writer dead) are reaped by `_read_handler_pid` and
+    the claim retried."""
     me = os.getpid()
+    requested = False
+    deadline: float | None = None
     while True:
         if _try_atomic_claim(name, me):
+            # If the pending request was OURS (we placed it earlier in this
+            # call), clear it — it's been satisfied. Leave foreign requests
+            # alone: those belong to whichever process placed them, and our
+            # next iteration as the new holder will honor them.
+            if _read_detach_request(name) == me:
+                _clear_detach_request(name)
             return
         existing = _read_handler_pid(name)
         if existing is None:
-            continue  # stale or freed; retry
+            continue  # stale; retry the claim
         if existing == me:
             return
-        sys.stderr.write(f"[a8s] detach in progress: {name} from PID {existing}\n")
-        sys.stderr.flush()
-        try:
-            os.kill(existing, signal.SIGTERM)
-        except ProcessLookupError:
-            try:
-                pid_path(name).unlink()
-            except OSError:
-                pass
-            continue
-        deadline = _time.time() + ACQUIRE_TIMEOUT_S
-        while _time.time() < deadline:
-            if not pid_path(name).is_file():
-                break
-            if not _pid_alive(existing):
-                try:
-                    pid_path(name).unlink()
-                except OSError:
-                    pass
-                break
-            _time.sleep(ACQUIRE_POLL_S)
-        else:
+        if not requested:
+            _write_detach_request(name, me)
+            sys.stderr.write(
+                f"[a8s] {name}: requesting release from PID {existing}...\n"
+            )
+            sys.stderr.flush()
+            requested = True
+            deadline = _time.time() + DETACH_TIMEOUT_S
+        if deadline is not None and _time.time() >= deadline:
+            _clear_detach_request(name)
             raise TimeoutError(
-                f"PID {existing} did not release {name} within {ACQUIRE_TIMEOUT_S}s — "
+                f"PID {existing} did not release {name} within {DETACH_TIMEOUT_S}s — "
                 f"try `a8s kill {name}`"
             )
+        _time.sleep(DETACH_POLL_S)
 
 
 def release(name: str) -> None:
-    """Unlink the pid file iff it points at our pid. Safe to call repeatedly."""
+    """Unlink the pid file iff it points at our pid. Safe to call repeatedly.
+    Also clears any pending detach-request for `name` since the request was
+    aimed at the now-released attachment."""
     p = pid_path(name)
     try:
-        if not p.is_file():
-            return
-        pid = int(p.read_text().strip())
-        if pid == os.getpid():
-            p.unlink()
+        if p.is_file():
+            pid = int(p.read_text().strip())
+            if pid == os.getpid():
+                p.unlink()
     except (OSError, ValueError):
         pass
+    _clear_detach_request(name)
 
 
 # ---------- attached loop (daemon body for 1+ agents) ----------
@@ -285,23 +332,22 @@ def _make_signal_handler(label: str):
 
 def attached_loop(names: list[str], interval: float, *, single_pass: bool = False) -> int:
     """Body of `a8s run` / `a8s start` / `a8s step`. ONE process handles every
-    name in `names` (multiple agents share the same handler PID, recorded in
-    each agent's `~/.a8s/agents/<NAME>/pid`).
+    name in `names`; multi-agent handlers share a PID across each member's
+    pid file.
 
     Per iteration:
+      - honor any detach-requests for our handled agents (per-agent take-over,
+        issue #68): release just the requested agent and keep serving the rest
       - reload registry (so newly-added agents become routable recipients)
-      - check each handled agent's pid file is still ours (drop if taken over)
-      - route each handled agent's outbox to recipients
-      - drain each handled agent's inbox
+      - drop any agent whose pid file no longer points at us (defense)
+      - route each handled agent's outbox; drain each handled agent's inbox
 
     On 1st signal: detach all currently-handled agents (graceful — finish the
     in-flight wake first). On 2nd signal: SIGTERM-then-SIGKILL the wake
-    subprocess group.
-
-    Take-over collateral: SIGTERM is process-level, so when one of our handled
-    agents is targeted by another `a8s start`, this whole handler detaches
-    everything. Other agents in our set become orphaned. The user's footgun;
-    documented in #52."""
+    subprocess group. The whole-process detach is the path for explicit
+    `a8s stop` / `a8s kill`; per-agent take-over for `a8s start`/`run`/`step`
+    against an already-attached agent goes through the detach-request file
+    instead, leaving siblings handled — no orphans."""
     global _STOP_EVENT, _SIGNAL_COUNT
     core.PRINT_LOCK = threading.Lock()
     _STOP_EVENT = threading.Event()
@@ -311,7 +357,8 @@ def attached_loop(names: list[str], interval: float, *, single_pass: bool = Fals
         print("attached_loop: empty names list", file=sys.stderr)
         return 2
 
-    # Acquire each pid file. If any fails (timeout), release whatever we got.
+    # Acquire each pid file. If any fails (holder didn't honor the
+    # detach-request in time), release whatever we got.
     acquired: list[str] = []
     try:
         for name in names:
@@ -334,8 +381,17 @@ def attached_loop(names: list[str], interval: float, *, single_pass: bool = Fals
     try:
         while not _STOP_EVENT.is_set():
             try:
+                # Honor detach-requests first. Another process wrote its pid
+                # into <NAME>/detach-request; release just that agent and let
+                # the requester's atomic_claim succeed on its next poll.
+                for name in list(names):
+                    requester = _read_detach_request(name)
+                    if requester is not None and requester != pid:
+                        out_agent(name, f"[a8s] {name}: releasing to PID {requester}")
+                        release(name)
+                        names.remove(name)
+
                 all_agents = participants_from_registry()
-                # Filter to agents we still hold and that still exist.
                 handled: list[Participant] = []
                 for name in list(names):
                     p = next((q for q in all_agents if q.name == name), None)
@@ -345,7 +401,9 @@ def attached_loop(names: list[str], interval: float, *, single_pass: bool = Fals
                         continue
                     holder = _read_handler_pid(name)
                     if holder is not None and holder != pid:
-                        out_agent(name, f"[a8s] {name}: detaching (taken over by PID {holder})")
+                        # Defense: someone manually overwrote the pid file
+                        # outside of the detach-request handshake.
+                        out_agent(name, f"[a8s] {name}: pid file diverged (now PID {holder}); dropping")
                         names.remove(name)
                         continue
                     handled.append(p)

--- a/apps/a8s/daemon.py
+++ b/apps/a8s/daemon.py
@@ -34,6 +34,7 @@ from core import (
     agent_dir,
     detach_request_path,
     inbox_dir,
+    kill_request_path,
     out_agent,
     pid_path,
     trash_dir,
@@ -46,15 +47,20 @@ from registry import participants_from_registry
 
 # ---------- subprocess execution ----------
 
-# Set by run_with_prefix; read by _kill_wake_subprocess_group via the signal handler.
+# Set by run_with_prefix; read by _kill_wake_subprocess_group via the signal
+# handler. _CURRENT_WAKE_NAME pairs with _CURRENT_WAKE_PROC so the SIGUSR1
+# kill-request handler can decide whether the in-flight wake is the one
+# being killed (per-agent kill, issue #68 follow-up).
 _CURRENT_WAKE_PROC: subprocess.Popen | None = None
+_CURRENT_WAKE_NAME: str | None = None
 
 
 def run_with_prefix(name: str, cmd: list[str], cwd: Path) -> int:
     """Run the wake subprocess in its own session so SIGKILL can target the
     whole process group (LLM CLI + any helpers it spawns). Tracks the live
-    process in `_CURRENT_WAKE_PROC` so the second-signal handler can find it."""
-    global _CURRENT_WAKE_PROC
+    process in `_CURRENT_WAKE_PROC` and the agent in `_CURRENT_WAKE_NAME` so
+    signal handlers can identify which agent's wake is in-flight."""
+    global _CURRENT_WAKE_PROC, _CURRENT_WAKE_NAME
     prefix = f"{name}> "
     try:
         proc = subprocess.Popen(
@@ -71,6 +77,7 @@ def run_with_prefix(name: str, cmd: list[str], cwd: Path) -> int:
         out_agent(name, f"{prefix}command not found: {cmd[0]}")
         return 127
     _CURRENT_WAKE_PROC = proc
+    _CURRENT_WAKE_NAME = name
     try:
         assert proc.stdout is not None
         for line in proc.stdout:
@@ -81,6 +88,7 @@ def run_with_prefix(name: str, cmd: list[str], cwd: Path) -> int:
         return proc.returncode
     finally:
         _CURRENT_WAKE_PROC = None
+        _CURRENT_WAKE_NAME = None
 
 
 def wake_once(p: Participant, msg_path: Path) -> None:
@@ -219,6 +227,37 @@ def _clear_detach_request(name: str) -> None:
         pass
 
 
+def _write_kill_request(name: str, requester_pid: int) -> None:
+    p = kill_request_path(name)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(str(requester_pid))
+
+
+def _read_kill_request(name: str) -> int | None:
+    """Same parse-and-reap discipline as `_read_detach_request`."""
+    p = kill_request_path(name)
+    if not p.is_file():
+        return None
+    try:
+        pid = int(p.read_text().strip())
+        if pid <= 0:
+            raise ValueError("non-positive pid")
+        return pid
+    except (OSError, ValueError):
+        try:
+            p.unlink()
+        except OSError:
+            pass
+        return None
+
+
+def _clear_kill_request(name: str) -> None:
+    try:
+        kill_request_path(name).unlink()
+    except OSError:
+        pass
+
+
 def acquire(name: str) -> None:
     """Attach this process as the handler of <name>.
 
@@ -330,6 +369,21 @@ def _make_signal_handler(label: str):
     return handle
 
 
+def _on_kill_signal(_signum, _frame):
+    """SIGUSR1 from `cmd_kill`. If the in-flight wake's target agent has a
+    foreign kill-request, kill the subprocess group so `run_with_prefix`'s
+    `wait()` returns immediately. The actual release of the agent (and any
+    others with a kill-request, even when no wake is in flight) happens at
+    the next iteration top via `_read_kill_request`."""
+    name = _CURRENT_WAKE_NAME
+    if name is None:
+        return
+    req = _read_kill_request(name)
+    if req is None or req == os.getpid():
+        return
+    _kill_wake_subprocess_group()
+
+
 def attached_loop(names: list[str], interval: float, *, single_pass: bool = False) -> int:
     """Body of `a8s run` / `a8s start` / `a8s step`. ONE process handles every
     name in `names`; multi-agent handlers share a PID across each member's
@@ -374,6 +428,7 @@ def attached_loop(names: list[str], interval: float, *, single_pass: bool = Fals
     handler = _make_signal_handler(label)
     prev_sigterm = signal.signal(signal.SIGTERM, handler)
     prev_sigint = signal.signal(signal.SIGINT, handler)
+    prev_sigusr1 = signal.signal(signal.SIGUSR1, _on_kill_signal)
 
     pid = os.getpid()
     for n in names:
@@ -381,10 +436,18 @@ def attached_loop(names: list[str], interval: float, *, single_pass: bool = Fals
     try:
         while not _STOP_EVENT.is_set():
             try:
-                # Honor detach-requests first. Another process wrote its pid
-                # into <NAME>/detach-request; release just that agent and let
-                # the requester's atomic_claim succeed on its next poll.
+                # Honor kill-requests and detach-requests at the iteration
+                # top. Kill takes precedence (SIGUSR1 may have already killed
+                # the subprocess group, but the release happens here so the
+                # iteration body skips that agent for the rest of the pass).
                 for name in list(names):
+                    kill_req = _read_kill_request(name)
+                    if kill_req is not None and kill_req != pid:
+                        out_agent(name, f"[a8s] {name}: killed by PID {kill_req}")
+                        release(name)
+                        _clear_kill_request(name)
+                        names.remove(name)
+                        continue
                     requester = _read_detach_request(name)
                     if requester is not None and requester != pid:
                         out_agent(name, f"[a8s] {name}: releasing to PID {requester}")
@@ -433,5 +496,6 @@ def attached_loop(names: list[str], interval: float, *, single_pass: bool = Fals
                 out_agent(n, f"[a8s] {n}: detached")
         signal.signal(signal.SIGTERM, prev_sigterm)
         signal.signal(signal.SIGINT, prev_sigint)
+        signal.signal(signal.SIGUSR1, prev_sigusr1)
         _STOP_EVENT = None
     return 0

--- a/apps/a8s/tests/test_commands.py
+++ b/apps/a8s/tests/test_commands.py
@@ -1,15 +1,18 @@
 """Tests for commands.py — focused on the canonicalization invariant added
 for issue #65 (lowercase canonical key at registration time, regardless of
-the casing the user typed)."""
+the casing the user typed) and the per-agent kill / no-orphan rule from
+issue #68."""
 from __future__ import annotations
 
+import os
+import signal
 from pathlib import Path
 
 import pytest
 
-from commands import cmd_add, cmd_alias, cmd_unalias
-from core import agent_dir
-from registry import load_aliases, load_registry
+from commands import cmd_add, cmd_alias, cmd_kill, cmd_unalias
+from core import agent_dir, kill_request_path, pid_path
+from registry import load_aliases, load_registry, save_registry
 
 
 @pytest.fixture
@@ -106,3 +109,70 @@ class TestCmdUnaliasCaseInsensitive:
         rc = cmd_unalias(["DEVS"])
         assert rc == 0
         assert load_aliases() == {}
+
+
+class TestCmdKillPerAgent:
+    """`a8s kill <name>` writes a kill-request file and SIGUSR1s the holder.
+    Tests stub `os.kill` so we don't actually signal a real process; we
+    verify the file mechanics + that the SIGUSR1 was directed at the
+    holder pid."""
+
+    def test_writes_kill_request_and_signals_holder(self, fake_home, tmp_path, monkeypatch, capsys):
+        d = tmp_path / "x"; d.mkdir()
+        save_registry({"claude": {"root": str(d)}})
+        # Pre-attach claude to a foreign live pid.
+        pid_path("claude").parent.mkdir(parents=True, exist_ok=True)
+        pid_path("claude").write_text(str(os.getppid()))
+
+        signaled = []
+        def fake_kill(pid, sig):
+            signaled.append((pid, sig))
+            # Simulate the holder honoring the request: unlink the pid file.
+            if sig == signal.SIGUSR1:
+                pid_path("claude").unlink()
+        monkeypatch.setattr("commands.os.kill", fake_kill)
+
+        rc = cmd_kill(["claude"])
+        assert rc == 0
+        # SIGUSR1 went to the holder.
+        assert (os.getppid(), signal.SIGUSR1) in signaled
+        # No SIGTERM escalation (holder responded).
+        assert not any(s == signal.SIGTERM for _, s in signaled)
+        # Kill-request file was cleared at the end.
+        assert not kill_request_path("claude").is_file()
+        # Output includes the request notice.
+        out = capsys.readouterr().out
+        assert "kill request" in out
+
+    def test_escalates_to_sigterm_on_unresponsive_holder(self, fake_home, tmp_path, monkeypatch, capsys):
+        d = tmp_path / "x"; d.mkdir()
+        save_registry({"claude": {"root": str(d)}})
+        pid_path("claude").parent.mkdir(parents=True, exist_ok=True)
+        pid_path("claude").write_text(str(os.getppid()))
+
+        signaled = []
+        def fake_kill(pid, sig):
+            signaled.append((pid, sig))
+            # DON'T release — simulate a wedged holder.
+        monkeypatch.setattr("commands.os.kill", fake_kill)
+        # Tighten the timeout so the test isn't slow.
+        monkeypatch.setattr("commands.KILL_TIMEOUT_S", 0.3)
+        monkeypatch.setattr("commands.KILL_POLL_S", 0.05)
+
+        rc = cmd_kill(["claude"])
+        assert rc == 1
+        # Both SIGUSR1 and the SIGTERM escalation got delivered.
+        sigs = {s for _, s in signaled}
+        assert signal.SIGUSR1 in sigs
+        assert signal.SIGTERM in sigs
+        err = capsys.readouterr().err
+        assert "did not honor kill" in err
+
+    def test_not_running_is_no_op(self, fake_home, tmp_path, capsys):
+        d = tmp_path / "x"; d.mkdir()
+        save_registry({"claude": {"root": str(d)}})
+        # No pid file → not running.
+        rc = cmd_kill(["claude"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "not running" in out

--- a/apps/a8s/tests/test_daemon.py
+++ b/apps/a8s/tests/test_daemon.py
@@ -21,15 +21,19 @@ from core import (
     agent_log_path,
     detach_request_path,
     inbox_dir,
+    kill_request_path,
     pid_path,
     trash_dir,
 )
 from daemon import (
     _clear_detach_request,
+    _clear_kill_request,
     _read_detach_request,
     _read_handler_pid,
+    _read_kill_request,
     _try_atomic_claim,
     _write_detach_request,
+    _write_kill_request,
     acquire,
     attached_loop,
     release,
@@ -366,6 +370,63 @@ class TestAttachedLoopDetachRequest:
         # Normal attached + detached.
         assert "attached (PID" in _read_log("X")
         assert "detached" in _read_log("X")
+
+
+class TestAttachedLoopKillRequest:
+    """Per-agent kill via kill-request file. Same shape as detach-request,
+    but logs as 'killed by' and the SIGUSR1 handler interrupts an in-flight
+    wake whose target matches."""
+
+    def test_releases_only_killed_agent(self, fake_home, tmp_path, fixtures_dir):
+        for n in ("A", "B"):
+            (tmp_path / n).mkdir()
+        save_registry({
+            "A": {"root": str(tmp_path / "a"), "definition": str(fixtures_dir / "mock.json")},
+            "B": {"root": str(tmp_path / "b"), "definition": str(fixtures_dir / "mock.json")},
+        })
+        for n in ("A", "B"):
+            ensure_mailboxes(Participant(n, tmp_path / n))
+
+        # Pre-place kill-request for A from a foreign pid.
+        _write_kill_request("A", os.getppid())
+        rc = attached_loop(["A", "B"], 0.1, single_pass=True)
+        assert rc == 0
+        # A's log shows 'killed by'; B's does not.
+        assert f"killed by PID {os.getppid()}" in _read_log("A")
+        assert "killed by" not in _read_log("B")
+        # B attached normally.
+        assert "B: attached" in _read_log("B")
+        # Kill-request file was cleared.
+        assert not kill_request_path("A").is_file()
+
+    def test_kill_takes_precedence_over_detach(self, fake_home, tmp_path, fixtures_dir):
+        # If both files exist for the same agent, kill wins.
+        d = tmp_path / "x"; d.mkdir()
+        save_registry({
+            "X": {"root": str(d), "definition": str(fixtures_dir / "mock.json")},
+        })
+        ensure_mailboxes(Participant("X", d))
+
+        _write_detach_request("X", os.getppid())
+        _write_kill_request("X", os.getppid())
+
+        rc = attached_loop(["X"], 0.1, single_pass=True)
+        assert rc == 0
+        log = _read_log("X")
+        assert "killed by" in log
+        assert "releasing to PID" not in log
+
+    def test_self_kill_request_is_ignored(self, fake_home, tmp_path, fixtures_dir):
+        d = tmp_path / "x"; d.mkdir()
+        save_registry({
+            "X": {"root": str(d), "definition": str(fixtures_dir / "mock.json")},
+        })
+        ensure_mailboxes(Participant("X", d))
+
+        _write_kill_request("X", os.getpid())
+        rc = attached_loop(["X"], 0.1, single_pass=True)
+        assert rc == 0
+        assert "killed by" not in _read_log("X")
 
     def test_multi_agent_share_one_pid(self, fake_home, tmp_path, fixtures_dir):
         # Two agents, one process — both pid files point at this pytest process.

--- a/apps/a8s/tests/test_daemon.py
+++ b/apps/a8s/tests/test_daemon.py
@@ -19,13 +19,17 @@ import pytest
 from core import (
     Participant,
     agent_log_path,
+    detach_request_path,
     inbox_dir,
     pid_path,
     trash_dir,
 )
 from daemon import (
+    _clear_detach_request,
+    _read_detach_request,
     _read_handler_pid,
     _try_atomic_claim,
+    _write_detach_request,
     acquire,
     attached_loop,
     release,
@@ -118,6 +122,63 @@ class TestAcquireRelease:
         assert pid_path("X").read_text() == str(os.getpid())
         release("X")
         assert not pid_path("X").is_file()
+
+    def test_acquire_reaps_stale_pid_and_succeeds(self, fake_home):
+        # Pid file points at a dead pid → _read_handler_pid unlinks it →
+        # acquire's loop retries the claim and succeeds.
+        dead_pid = 2**31 - 1
+        pid_path("X").parent.mkdir(parents=True, exist_ok=True)
+        pid_path("X").write_text(str(dead_pid))
+        acquire("X")
+        assert pid_path("X").read_text() == str(os.getpid())
+        release("X")
+
+    def test_acquire_against_live_holder_times_out(self, fake_home, monkeypatch):
+        # Issue #68: acquire writes a detach-request and polls; if the holder
+        # never honors it, raise TimeoutError. Use a tiny timeout so the test
+        # finishes quickly.
+        monkeypatch.setattr("daemon.DETACH_TIMEOUT_S", 0.5)
+        monkeypatch.setattr("daemon.DETACH_POLL_S", 0.05)
+        # Hold the pid file with the parent shell's pid (live, foreign).
+        pid_path("X").parent.mkdir(parents=True, exist_ok=True)
+        pid_path("X").write_text(str(os.getppid()))
+        with pytest.raises(TimeoutError, match="did not release X"):
+            acquire("X")
+        # Holder pid file untouched.
+        assert pid_path("X").read_text() == str(os.getppid())
+        # Detach-request cleared on timeout.
+        assert not detach_request_path("X").is_file()
+
+    def test_acquire_writes_detach_request_for_live_holder(self, fake_home, monkeypatch):
+        # Verify the request file is written before the timeout fires.
+        monkeypatch.setattr("daemon.DETACH_TIMEOUT_S", 0.3)
+        monkeypatch.setattr("daemon.DETACH_POLL_S", 0.05)
+        pid_path("X").parent.mkdir(parents=True, exist_ok=True)
+        pid_path("X").write_text(str(os.getppid()))
+        # During acquire's poll loop, the request file should be present.
+        # Easiest assertion: after timeout, the file is gone (cleared on
+        # timeout) — but during the polling window it WAS written. Use a
+        # spy on _write_detach_request.
+        called = {}
+        orig = _write_detach_request
+        def spy(name, pid):
+            called["name"] = name
+            called["pid"] = pid
+            orig(name, pid)
+        monkeypatch.setattr("daemon._write_detach_request", spy)
+        with pytest.raises(TimeoutError):
+            acquire("X")
+        assert called == {"name": "X", "pid": os.getpid()}
+
+    def test_release_clears_detach_request(self, fake_home):
+        # release(name) also clears any pending detach-request — once we
+        # release, there's nothing to ask for.
+        acquire("X")
+        _write_detach_request("X", os.getppid())
+        assert detach_request_path("X").is_file()
+        release("X")
+        assert not pid_path("X").is_file()
+        assert not detach_request_path("X").is_file()
 
     def test_release_other_pid_is_noop(self, fake_home):
         # Another (dead) pid in the file — release shouldn't unlink it because
@@ -247,6 +308,64 @@ class TestAttachedLoopLifecycle:
         assert "[a8s] MOCK: detached" in log
         # Pid file released.
         assert not pid_path("MOCK").is_file()
+
+
+class TestAttachedLoopDetachRequest:
+    """Issue #68 — per-agent take-over. A detach-request file under one of
+    our handled agents causes that agent (and only that agent) to be
+    released; siblings keep running."""
+
+    def test_releases_only_requested_agent(self, fake_home, tmp_path, fixtures_dir):
+        # Two agents A, B. We acquire both, then drop a detach-request for
+        # A (from a foreign pid), run one iteration, and verify A is gone
+        # while B is still ours.
+        for n in ("A", "B"):
+            (tmp_path / n).mkdir()
+        save_registry({
+            "A": {"root": str(tmp_path / "a"), "definition": str(fixtures_dir / "mock.json")},
+            "B": {"root": str(tmp_path / "b"), "definition": str(fixtures_dir / "mock.json")},
+        })
+        for n in ("A", "B"):
+            ensure_mailboxes(Participant(n, tmp_path / n))
+
+        # Place the detach-request BEFORE running attached_loop. The first
+        # iteration will pick it up, release A, and continue with B.
+        detach_request_path("A").parent.mkdir(parents=True, exist_ok=True)
+        detach_request_path("A").write_text(str(os.getppid()))
+
+        rc = attached_loop(["A", "B"], 0.1, single_pass=True)
+        assert rc == 0
+        # A's log captured the release notice.
+        assert f"releasing to PID {os.getppid()}" in _read_log("A")
+        # B's log shows attached + detached normally.
+        assert f"[a8s] B: attached (PID {os.getpid()}" in _read_log("B")
+        assert "[a8s] B: detached" in _read_log("B")
+        # Both pid files cleaned up at end (B by the finally block, A by the
+        # detach-request handling mid-iteration).
+        assert not pid_path("A").is_file()
+        assert not pid_path("B").is_file()
+        # Detach-request file removed too.
+        assert not detach_request_path("A").is_file()
+
+    def test_self_request_is_ignored(self, fake_home, tmp_path, fixtures_dir):
+        # If our OWN pid is in the detach-request (shouldn't happen, but
+        # defense), we don't release ourselves.
+        d = tmp_path / "x"; d.mkdir()
+        save_registry({
+            "X": {"root": str(d), "definition": str(fixtures_dir / "mock.json")},
+        })
+        ensure_mailboxes(Participant("X", d))
+
+        detach_request_path("X").parent.mkdir(parents=True, exist_ok=True)
+        detach_request_path("X").write_text(str(os.getpid()))
+
+        rc = attached_loop(["X"], 0.1, single_pass=True)
+        assert rc == 0
+        # Did NOT log a release.
+        assert "releasing to PID" not in _read_log("X")
+        # Normal attached + detached.
+        assert "attached (PID" in _read_log("X")
+        assert "detached" in _read_log("X")
 
     def test_multi_agent_share_one_pid(self, fake_home, tmp_path, fixtures_dir):
         # Two agents, one process — both pid files point at this pytest process.


### PR DESCRIPTION
## Summary

Replaces both the implicit take-over AND the whole-process kill with per-agent rendezvous mechanisms, so a multi-agent handler losing one of its agents (to `start`/`run`/`step` taking it over, or to `kill <name>` force-detaching it) keeps serving the rest. **No-orphan invariant**: at every moment, an agent is attached to exactly one live process or it isn't running.

### Take-over (`start`/`run`/`step`) — `detach-request`

`acquire` writes `~/.a8s/agents/<NAME>/detach-request` with its pid and polls. The holder's `attached_loop` checks the file at the top of each iteration and releases just that one agent — siblings keep running. 60s timeout; on timeout `acquire` raises `TimeoutError` and the operator can `a8s kill <name>` to break the deadlock.

```
P1: a8s start devs        → P1 handles [CLAUDE, GEMINI, FOO]
P2: a8s run CLAUDE        → CLAUDE moves to P2; P1 keeps [GEMINI, FOO]
P3: a8s run GEMINI        → GEMINI moves to P3; P1 keeps [FOO]
P4: a8s run FOO           → FOO moves to P4; P1 has nothing left, exits
```

### Force-detach (`kill`) — `kill-request` + SIGUSR1

`cmd_kill <name>` writes `~/.a8s/agents/<NAME>/kill-request` and SIGUSR1s the holder. The holder's `_on_kill_signal` kills the in-flight wake subprocess group iff `_CURRENT_WAKE_NAME` matches (so a slow LLM call for that agent dies immediately while siblings stay attached). The release happens at the iteration top via the kill-request check, identical to detach-request flow but logs as "killed by" and takes precedence.

Whole-process SIGTERM remains as the **last-resort escalation only** when the holder doesn't honor the kill-request within 10s. That's the only path that still creates collateral on siblings, and it's gated behind a wedged-holder timeout rather than the default.

### Detail bits
- `acquire` only clears its OWN request on successful claim; foreign requests stay so the new holder honors them next iteration.
- `release` clears any pending request for the released name (the request was aimed at the now-released attachment).
- The two-signal SIGTERM → SIGKILL kill-subprocess-group machinery still exists for direct shell signals to the handler.

## Doc updates
- `CLAUDE.md` — added "Per-agent take-over" + "Per-agent kill" hard-constraint bullets; removed #62/#65/#66/#67/#68 from the active-threads table.
- `apps/a8s/README.md` — replaced "Take-over collateral" footgun section with "Per-agent take-over" describing the no-orphan model + how `kill` works.

## Test plan
- [x] `python3 -m pytest apps/a8s/tests/` — 142 pass (12 new across `test_daemon.py` + `test_commands.py`)
- [x] **Take-over**: acquire reaps stale + succeeds, times out against live foreign holder, writes detach-request, release clears request, attached_loop releases only the requested agent and keeps siblings, self-request ignored
- [x] **Kill**: attached_loop releases on foreign kill-request, kill takes precedence over co-pending detach, self-kill-request ignored, cmd_kill writes request and signals holder, escalates to SIGTERM on unresponsive holder, no-op on not-running

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)