### PR TITLE
fix(a8s): reap stale rendezvous files from dead requesters

### DIFF
--- a/apps/a8s/daemon.py
+++ b/apps/a8s/daemon.py
@@ -201,8 +201,10 @@ def _write_detach_request(name: str, requester_pid: int) -> None:
 
 def _read_detach_request(name: str) -> int | None:
     """Return the requester pid in the detach-request file for `name`, or None.
-    Reaps malformed contents (empty / non-int / non-positive) like the pid
-    file does."""
+    Reaps malformed contents (empty / non-int / non-positive) and stale
+    requests from dead requesters — without the liveness check, an
+    `acquire()` caller that crashes after writing the request would cause
+    the holder's next iteration to release the agent to nobody (issue #71)."""
     p = detach_request_path(name)
     if not p.is_file():
         return None
@@ -210,13 +212,19 @@ def _read_detach_request(name: str) -> int | None:
         pid = int(p.read_text().strip())
         if pid <= 0:
             raise ValueError("non-positive pid")
-        return pid
     except (OSError, ValueError):
         try:
             p.unlink()
         except OSError:
             pass
         return None
+    if _pid_alive(pid):
+        return pid
+    try:
+        p.unlink()
+    except OSError:
+        pass
+    return None
 
 
 def _clear_detach_request(name: str) -> None:
@@ -234,7 +242,8 @@ def _write_kill_request(name: str, requester_pid: int) -> None:
 
 
 def _read_kill_request(name: str) -> int | None:
-    """Same parse-and-reap discipline as `_read_detach_request`."""
+    """Same parse-and-reap discipline as `_read_detach_request`, including
+    the dead-requester reap (issue #71)."""
     p = kill_request_path(name)
     if not p.is_file():
         return None
@@ -242,13 +251,19 @@ def _read_kill_request(name: str) -> int | None:
         pid = int(p.read_text().strip())
         if pid <= 0:
             raise ValueError("non-positive pid")
-        return pid
     except (OSError, ValueError):
         try:
             p.unlink()
         except OSError:
             pass
         return None
+    if _pid_alive(pid):
+        return pid
+    try:
+        p.unlink()
+    except OSError:
+        pass
+    return None
 
 
 def _clear_kill_request(name: str) -> None:

--- a/apps/a8s/tests/test_daemon.py
+++ b/apps/a8s/tests/test_daemon.py
@@ -104,6 +104,72 @@ class TestReadHandlerPid:
         assert not pid_path("X").is_file()
 
 
+class TestRequestFileLiveness:
+    """Issue #71: stale rendezvous files from dead requesters must not be
+    honored. Without this reap, an `acquire()` caller (or `cmd_kill`) that
+    crashes after writing the request would cause the holder's next
+    iteration to release the agent to nobody."""
+
+    def test_detach_request_dead_requester_reaped(self, fake_home):
+        dead_pid = 2**31 - 1
+        detach_request_path("X").parent.mkdir(parents=True, exist_ok=True)
+        detach_request_path("X").write_text(str(dead_pid))
+        assert _read_detach_request("X") is None
+        assert not detach_request_path("X").is_file()
+
+    def test_detach_request_live_requester_returned(self, fake_home):
+        detach_request_path("X").parent.mkdir(parents=True, exist_ok=True)
+        detach_request_path("X").write_text(str(os.getpid()))
+        assert _read_detach_request("X") == os.getpid()
+        assert detach_request_path("X").is_file()
+
+    def test_kill_request_dead_requester_reaped(self, fake_home):
+        dead_pid = 2**31 - 1
+        kill_request_path("X").parent.mkdir(parents=True, exist_ok=True)
+        kill_request_path("X").write_text(str(dead_pid))
+        assert _read_kill_request("X") is None
+        assert not kill_request_path("X").is_file()
+
+    def test_kill_request_live_requester_returned(self, fake_home):
+        kill_request_path("X").parent.mkdir(parents=True, exist_ok=True)
+        kill_request_path("X").write_text(str(os.getpid()))
+        assert _read_kill_request("X") == os.getpid()
+        assert kill_request_path("X").is_file()
+
+    def test_attached_loop_ignores_dead_requester_detach(self, fake_home, tmp_path, fixtures_dir):
+        # Without the liveness check, this dead-pid request would cause the
+        # iteration top to spuriously release X.
+        from registry import save_registry
+        d = tmp_path / "x"; d.mkdir()
+        save_registry({
+            "X": {"root": str(d), "definition": str(fixtures_dir / "mock.json")},
+        })
+        ensure_mailboxes(Participant("X", d))
+        detach_request_path("X").parent.mkdir(parents=True, exist_ok=True)
+        detach_request_path("X").write_text(str(2**31 - 1))
+
+        rc = attached_loop(["X"], 0.1, single_pass=True)
+        assert rc == 0
+        assert "releasing to PID" not in _read_log("X")
+        # Stale request file reaped.
+        assert not detach_request_path("X").is_file()
+
+    def test_attached_loop_ignores_dead_requester_kill(self, fake_home, tmp_path, fixtures_dir):
+        from registry import save_registry
+        d = tmp_path / "x"; d.mkdir()
+        save_registry({
+            "X": {"root": str(d), "definition": str(fixtures_dir / "mock.json")},
+        })
+        ensure_mailboxes(Participant("X", d))
+        kill_request_path("X").parent.mkdir(parents=True, exist_ok=True)
+        kill_request_path("X").write_text(str(2**31 - 1))
+
+        rc = attached_loop(["X"], 0.1, single_pass=True)
+        assert rc == 0
+        assert "killed by" not in _read_log("X")
+        assert not kill_request_path("X").is_file()
+
+
 class TestAtomicClaimDurability:
     def test_claim_after_partial_write_cleanup(self, fake_home):
         # Issue #66: if a prior writer died after O_CREAT but before the byte


### PR DESCRIPTION
Closes #71.

## Summary

- `_read_detach_request` and `_read_kill_request` now check `_pid_alive(pid)` and reap the file if the requester is dead — same discipline `_read_handler_pid` already follows.
- Without this, a requester that crashes after writing the request file (cron timeout, Ctrl+C, OOM) leaves a lingering request that the holder's next iteration honors — releases the agent to nobody until the next `a8s start` from cron.
- 6 new tests: 4 unit tests on the readers (live + dead × detach + kill), 2 end-to-end through `attached_loop` confirming a dead-requester request file does NOT cause spurious release and is reaped.

## Why this is the v1 fix

Per the discussion in #71: a8s in v1 is a thin transport, not a supervisor. Cron-based `a8s start` is the natural restart mechanism. That model only works if the rendezvous protocol is robust against requester death — otherwise transient cron job failures convert into agent-idle windows. This patch closes that hole.

The two-stage SIGTERM machinery and the `DETACH_TIMEOUT_S` polling raised by Position A in the issue are not bugs: the second-signal kill path is now load-bearing for `a8s kill`'s SIGUSR1 mechanism (PR #75), and the detach polling timeout is the only fallback when an LLM wake holds the iteration top.

## Test plan
- [x] `python3 -m pytest apps/a8s/tests/` → 148 passed (was 142)
- [x] New tests fail without the daemon.py change, pass with it (sanity-checked locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)