### PR TITLE
refactor(a8s): strict opacity + verb collapse (#69, #70)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,9 +106,12 @@ read it first.
 
 Key invariants:
 
-- **Recipient opacity** — sender doesn't know whether the recipient is a
-  Claude session, a script, or a human. Never leak this through skill
-  descriptions, prompt templates, or routing metadata.
+- **Recipient opacity (strict, mailing-list style)** — sender doesn't know
+  whether the recipient is a Claude session, a script, or a human; recipient
+  doesn't know who else got the message. A direct tell and an alias-fanned
+  tell produce identical message shapes — only `to` differs (alias vs agent
+  name). Never re-introduce `alias` / `others_count` fields or a separate
+  alias verb. (Settled in issues #69 / #70.)
 - **Members don't know about a8s** — drop in any project unchanged.
   An agent just sees a `tell` shell command and wakes to messages.
 - **The filesystem is the IPC, the outbox location is the unforgeable identity.**
@@ -126,7 +129,7 @@ Key invariants:
 | `apps/a8s/core.py` | paths, logging, helpers, `Participant`, mutable `PRINT_LOCK`, path constants (`SCRIPT_DIR`, `DEFINITIONS_DIR`, `ENTRYPOINT`) | leaf module — no a8s imports |
 | `apps/a8s/registry.py` | `~/.a8s/a8s.json` I/O, `resolve_name` (alias resolution with diamond/cycle detection), `sender_from_cwd`, `_scan_for_markers` | depends on `core` |
 | `apps/a8s/mailbox.py` | `route_outboxes`, `ensure_mailboxes`, `_queue_prompt`, `_queue_clear_sentinel`, `_split_content_and_files`, `_write_outbox` | depends on `core`, `registry` |
-| `apps/a8s/definitions.py` | `select_verb`, `build_prompt`, `build_command`, `_expand_argv` ($PROMPT/$A8S_DIR), `load_definition`, `_autodiscover_definition` | depends on `core`, `registry` |
+| `apps/a8s/definitions.py` | `select_verb`, `build_command`, `_expand_argv` (`$SENDER`/`$RECIPIENT`/`$MESSAGE`/`$A8S_DIR`), `load_definition`, `_autodiscover_definition` | depends on `core`, `registry` |
 | `apps/a8s/daemon.py` | `acquire`/`release` (pid files), `attached_loop`, signal handling (`_make_signal_handler`, `_kill_wake_subprocess_group`), `run_with_prefix`, `wake_once`. Mutable globals `_STOP_EVENT`/`_SIGNAL_COUNT`/`_CURRENT_WAKE_PROC` live here. Sets `core.PRINT_LOCK`. | depends on everything above |
 | `apps/a8s/commands.py` | every `cmd_*`, `_install_skill_*` for Claude/Gemini/Codex, `_expand_to_agents` | depends on everything above |
 | `apps/a8s/cli.py` | `COMMANDS` table (the source of truth for help text), `dispatch`, `main` | depends on `commands` only |
@@ -136,10 +139,10 @@ Key invariants:
 - **`cmd_start` re-execs via `core.ENTRYPOINT`**, not `__file__`. After the
   modular split, `__file__` inside `commands.py` resolves to the wrong path.
   `core.ENTRYPOINT = SCRIPT_DIR / "a8s.py"` is the canonical re-exec target.
-- **`$A8S_DIR` placeholder** in definition argv expands via
-  `definitions._expand_argv`. Used by `default.json` to point at the bundled
-  `dummy-cli`. Don't introduce more placeholders without checking they make
-  sense across all four `invoke*` verbs.
+- **Argv interpolation** (`$SENDER`, `$RECIPIENT`, `$MESSAGE`, `$A8S_DIR`)
+  expands via `definitions._expand_argv`. `invokeClear` always gets empty
+  strings for the message-shaped vars. Don't introduce more placeholders
+  without checking they make sense across all three `invoke*` verbs.
 - **`core.PRINT_LOCK` is the cross-module log lock.** It's `None` at module
   load and only set when `daemon.attached_loop` starts. Threading is intentional:
   multi-agent handlers may interleave wake events. If you write a new code path
@@ -209,19 +212,25 @@ install                      install canonical skills
 └── .outbox/                  agent writes here; route_outboxes re-stamps `from`
 ```
 
-### The four invoke verbs
+### The three invoke verbs
 
 `select_verb(msg)` picks one based on the message's shape:
 
-| Verb | Trigger | Body |
+| Verb | Trigger | Argv vars typically used |
 |---|---|---|
-| `invokePrompt` | `from` is empty (queued by `a8s prompt`) | raw `content`, no template |
-| `invokeMessage` | `from` set, no `alias` field | `promptMessage` template formatted |
-| `invokeMessageAlias` | `from` set, `alias` field set | `promptMessageAlias` template (with `{others_count}`, `{alias}`) |
-| `invokeClear` | `clear: true` field set | no prompt; runs the CLI fresh |
+| `invokePrompt` | `from` is empty (queued by `a8s prompt`) | `$MESSAGE` only |
+| `invokeMessage` | `from` set | `$SENDER`, `$RECIPIENT`, `$MESSAGE` |
+| `invokeClear` | `clear: true` field set | none — argv is literal |
 
-`build_command(definition, prompt, verb)` reads the matching `invoke*` argv
-from the definition JSON and substitutes `$PROMPT` and `$A8S_DIR`.
+There's no separate alias verb. Strict opacity (#69, #70) makes a direct
+tell and an alias-fanned tell indistinguishable in shape; `$RECIPIENT`
+preserves whatever the sender wrote (alias name for fanned, agent name for
+direct) — mailing-list semantics.
+
+`build_command(definition, msg, verb)` reads the matching `invoke*` argv
+and substitutes `$SENDER` / `$RECIPIENT` / `$MESSAGE` (content + any
+`FILE:` lines) / `$A8S_DIR`. There is no `$PROMPT` and no separate
+`promptMessage` template — argv interpolation does the whole job.
 
 ### Definition fallback
 
@@ -271,9 +280,9 @@ python3 -m pytest apps/a8s/tests/
   end-to-end daemon tests. Each argv element printed on its own line with
   `MOCK-CLI:` prefix; tests grep the per-agent log to assert what the wake
   subprocess actually received.
-- `apps/a8s/tests/fixtures/mock.json` — definition that routes all four
-  verbs through `mock-cli` with deterministic templates like
-  `FROM:{sender}|TO:{recipient}|MSG:{message}` so log assertions are stable.
+- `apps/a8s/tests/fixtures/mock.json` — definition that routes all three
+  verbs through `mock-cli` with a deterministic argv template
+  `FROM:$SENDER|TO:$RECIPIENT|MSG:$MESSAGE` so log assertions are stable.
 
 When you change behavior in `core` / `registry` / `mailbox` / `definitions` /
 `daemon`, add or modify the corresponding `test_*.py`. The pytest suite is
@@ -287,7 +296,7 @@ The locked-design refactor (#52) is closed. The following are open:
 |---|---|---|
 | #39 | open enhancement | Copilot CLI as 4th tool kind. Trivial after the refactor: write `copilot.json`, add `COPILOT.md` → `copilot` to `core.MARKER_FILES`. |
 | #63 | open enhancement | Transparent multi-cluster routing (peer mesh). MQTT + ephemeral payload host as initial transports. Spec is implementation-agnostic. Armstrong's 5-item retrofit list (UUIDs, expiry, priority, dedup, acks) lands locally first. |
-| #69–72 | open question | Design discussions surfaced by the review panel: verb-scheme collapse vs eliminate; opacity strictness; supervision model; mailbox file format. Resolve before #63 hardens. |
+| #72 | open question | Design discussion surfaced by the review panel: mailbox file format. Resolve before #63 hardens. (#69, #70 closed by strict opacity + verb collapse; #71 closed by v1 thin-wrapper stance + stale-rendezvous-file fix.) |
 
 ### What I tried that didn't work (concrete)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,10 +139,13 @@ Key invariants:
 - **`cmd_start` re-execs via `core.ENTRYPOINT`**, not `__file__`. After the
   modular split, `__file__` inside `commands.py` resolves to the wrong path.
   `core.ENTRYPOINT = SCRIPT_DIR / "a8s.py"` is the canonical re-exec target.
-- **Argv interpolation** (`$SENDER`, `$RECIPIENT`, `$MESSAGE`, `$A8S_DIR`)
-  expands via `definitions._expand_argv`. `invokeClear` always gets empty
-  strings for the message-shaped vars. Don't introduce more placeholders
-  without checking they make sense across all three `invoke*` verbs.
+- **Argv interpolation** (`$SENDER`, `$RECIPIENT`, `$MESSAGE`, `$TIMESTAMP`,
+  `$AGE`, `$A8S_DIR`) expands via `definitions._expand_argv`. `$TIMESTAMP`
+  is the ISO date the message was queued; `$AGE` is the human-readable
+  delta from now (computed each wake, so backlogs get accurate per-message
+  ages). `invokeClear` always gets empty strings for the message-shaped
+  vars. Don't introduce more placeholders without checking they make
+  sense across all three `invoke*` verbs.
 - **`core.PRINT_LOCK` is the cross-module log lock.** It's `None` at module
   load and only set when `daemon.attached_loop` starts. Threading is intentional:
   multi-agent handlers may interleave wake events. If you write a new code path
@@ -218,8 +221,8 @@ install                      install canonical skills
 
 | Verb | Trigger | Argv vars typically used |
 |---|---|---|
-| `invokePrompt` | `from` is empty (queued by `a8s prompt`) | `$MESSAGE` only |
-| `invokeMessage` | `from` set | `$SENDER`, `$RECIPIENT`, `$MESSAGE` |
+| `invokePrompt` | `from` is empty (queued by `a8s prompt`) | `$MESSAGE` (and optionally `$AGE`/`$TIMESTAMP`) |
+| `invokeMessage` | `from` set | `$SENDER`, `$RECIPIENT`, `$AGE` or `$TIMESTAMP`, `$MESSAGE` |
 | `invokeClear` | `clear: true` field set | none — argv is literal |
 
 There's no separate alias verb. Strict opacity (#69, #70) makes a direct

--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -147,7 +147,7 @@ Take-over has a 60-second timeout (kill is 10s). If the holder is wedged on a lo
 
 ## Definitions
 
-Each agent has a definition file: a JSON document describing how to invoke its CLI for each verb, plus prompt templates. Built-in defaults ship in `apps/a8s/definitions/`:
+Each agent has a definition file: a JSON document describing how to invoke its CLI for each verb. Built-in defaults ship in `apps/a8s/definitions/`:
 
 | File | Purpose |
 |---|---|
@@ -156,40 +156,40 @@ Each agent has a definition file: a JSON document describing how to invoke its C
 | `codex.json` | Codex CLI with `--full-auto` workspace-write sandbox + `resume --last` |
 | `default.json` | Fallback — runs `dummy-cli` and prints "no real CLI configured" |
 
-### The four verbs
+### The three verbs
 
 The wake routine reads the message and selects one of:
 
 | Verb | Trigger | Body |
 |---|---|---|
-| `invokePrompt` | `from` is empty (queued by `a8s prompt`) | Raw `content`, delivered as-is |
-| `invokeMessage` | `from` is set, no alias context | `promptMessage` template formatted |
-| `invokeMessageAlias` | `from` is set, message arrived via alias | `promptMessageAlias` template (sees alias name + others-count, NOT the other recipients' names — opacity rule) |
+| `invokePrompt` | `from` is empty (queued by `a8s prompt`) | `$MESSAGE` only — raw content, no sender header |
+| `invokeMessage` | `from` is set | `$SENDER`/`$RECIPIENT`/`$MESSAGE` interpolated into argv directly |
 | `invokeClear` | `clear: true` sentinel | No prompt; runs the CLI fresh to start a new conversation |
+
+There is no separate alias verb. Strict opacity (issues #69, #70): a routed message looks identical whether it arrived directly or via alias fan-out — `$RECIPIENT` resolves to whatever the sender wrote in `to` (the alias name for fanned messages, the agent name for direct ones). The recipient knows it came via the list; not who else got it. Mailing-list semantics.
 
 ### Schema
 
 ```json
 {
   "description": "...",
-  "invokePrompt":       ["claude", "...", "--continue", "-p", "$PROMPT"],
-  "invokeMessage":      ["claude", "...", "--continue", "-p", "$PROMPT"],
-  "invokeMessageAlias": ["claude", "...", "--continue", "-p", "$PROMPT"],
-  "invokeClear":        ["claude", "-p", "Conversation cleared. New conversation starts now."],
-  "promptMessage":      "{sender} tells you ({recipient}): {message}",
-  "promptMessageAlias": "{sender} tells you ({recipient}) and {others_count} others on the {alias} alias: {message}"
+  "invokePrompt":  ["claude", "...", "--continue", "-p", "$MESSAGE"],
+  "invokeMessage": ["claude", "...", "--continue", "-p", "$SENDER tells $RECIPIENT: $MESSAGE"],
+  "invokeClear":   ["claude", "-p", "Conversation cleared. New conversation starts now."]
 }
 ```
 
-Argv elements run through two substitutions:
-- `$PROMPT` → the wake's prompt body (formatted via the matching template, or raw for `invokePrompt`).
+Argv elements run through four substitutions:
+- `$SENDER` → sender's canonical name (empty for senderless prompts).
+- `$RECIPIENT` → what the sender wrote in `to` (alias name for fanned messages, agent name for direct ones).
+- `$MESSAGE` → the message body (`content`, with any `FILE: <path>` lines appended).
 - `$A8S_DIR` → `apps/a8s/` itself, so definitions can point at bundled scripts (`default.json` uses this for `dummy-cli`).
 
 Override per-agent with `a8s define <name> <path>` — point at any JSON. The file isn't moved or copied; the registry stores the path.
 
 ### Recipient transparency
 
-Templates SHOULD NOT leak whether the recipient is a Claude session, a script, or a human via SMS. The four built-in defaults follow this — `{sender} tells you ({recipient})` works equally well for any backend. Customize at your own risk.
+The default definitions follow the opacity rule — `$SENDER tells $RECIPIENT: $MESSAGE` works equally well whether `$RECIPIENT` is an LLM session, a Python script, or (someday) an SMS gateway. Customize at your own risk.
 
 ## State on disk
 

--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -174,16 +174,20 @@ There is no separate alias verb. Strict opacity (issues #69, #70): a routed mess
 {
   "description": "...",
   "invokePrompt":  ["claude", "...", "--continue", "-p", "$MESSAGE"],
-  "invokeMessage": ["claude", "...", "--continue", "-p", "$SENDER tells $RECIPIENT: $MESSAGE"],
+  "invokeMessage": ["claude", "...", "--continue", "-p", "$SENDER tells $RECIPIENT ($AGE): $MESSAGE"],
   "invokeClear":   ["claude", "-p", "Conversation cleared. New conversation starts now."]
 }
 ```
 
-Argv elements run through four substitutions:
+Argv elements run through six substitutions:
 - `$SENDER` → sender's canonical name (empty for senderless prompts).
 - `$RECIPIENT` → what the sender wrote in `to` (alias name for fanned messages, agent name for direct ones).
 - `$MESSAGE` → the message body (`content`, with any `FILE: <path>` lines appended).
+- `$TIMESTAMP` → ISO 8601 UTC timestamp the message was queued (e.g. `2026-04-28T14:30:00.123456Z`). Useful when you want a stable machine-readable time.
+- `$AGE` → human-readable age relative to now (e.g. `5 minutes ago`). Computed at wake time, so a long backlog gets accurate values per message. Pick this OR `$TIMESTAMP` per definition based on which the LLM will read more naturally.
 - `$A8S_DIR` → `apps/a8s/` itself, so definitions can point at bundled scripts (`default.json` uses this for `dummy-cli`).
+
+`$TIMESTAMP` and `$AGE` are empty for `invokeClear` and for any message without a `date` field.
 
 Override per-agent with `a8s define <name> <path>` — point at any JSON. The file isn't moved or copied; the registry stores the path.
 

--- a/apps/a8s/commands.py
+++ b/apps/a8s/commands.py
@@ -651,9 +651,9 @@ def cmd_ls() -> int:
 
 def cmd_tell(args: list[str]) -> int:
     """`a8s tell <name> <msg>` — write a single outbox message; `name` may be
-    an agent or alias. Fan-out to alias members happens at routing time so the
-    `to` field stays the original alias name (recipients can see it via
-    `promptMessageAlias`)."""
+    an agent or alias. Fan-out to alias members happens at routing time and
+    preserves the original `to` (alias name) — strict opacity, mailing-list
+    style: the recipient knows it came via the list, not who else got it."""
     if len(args) < 2:
         print("usage: tell <name> <message>", file=sys.stderr)
         return 2

--- a/apps/a8s/daemon.py
+++ b/apps/a8s/daemon.py
@@ -40,7 +40,7 @@ from core import (
     trash_dir,
     unique_path,
 )
-from definitions import build_command, build_prompt, load_definition, select_verb
+from definitions import build_command, load_definition, select_verb
 from mailbox import ensure_mailboxes, next_inbox_message, route_outboxes
 from registry import participants_from_registry
 
@@ -120,14 +120,13 @@ def wake_once(p: Participant, msg_path: Path) -> None:
                 trashed = unique_path(trash_dir(p.name) / f.name)
                 f.rename(trashed)
 
-    prompt = build_prompt(msg, definition, verb)
     trashed = unique_path(trash_dir(p.name) / msg_path.name)
     msg_path.rename(trashed)
     if verb == "clear":
         out_agent(p.name, f"[{p.name}] waking ({verb}) from {trashed.name}")
     else:
         out_agent(p.name, f"[{p.name}] waking ({verb}) from {trashed.name}: {_preview(msg.get('content', ''))}")
-    cmd = build_command(definition, prompt, verb)
+    cmd = build_command(definition, msg, verb)
     run_with_prefix(p.name, cmd, p.root)
 
 

--- a/apps/a8s/definitions.py
+++ b/apps/a8s/definitions.py
@@ -2,8 +2,8 @@
 
 Each agent has a definition JSON (built-in or custom) that encodes argv for
 three verbs. `select_verb` picks the verb from the queued message;
-`build_command` substitutes `$SENDER` / `$RECIPIENT` / `$MESSAGE` / `$A8S_DIR`
-into the chosen argv.
+`build_command` substitutes `$SENDER` / `$RECIPIENT` / `$MESSAGE` /
+`$TIMESTAMP` / `$AGE` / `$A8S_DIR` into the chosen argv.
 
 Strict opacity (issues #69, #70): the recipient sees only sender + message
 content — no `alias` or `others_count` leak. A direct tell and an
@@ -15,6 +15,7 @@ mailing list: you know it came via the list, you don't know who else got it).
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 
 from core import (
@@ -93,11 +94,59 @@ def _message_body(msg: dict) -> str:
     return "\n".join([content, *lines])
 
 
-def _expand_argv(argv: list[str], sender: str, recipient: str, message: str) -> list[str]:
+def _parse_iso(date_str: str) -> datetime | None:
+    """Parse the ISO timestamp we write into messages (`...Z` UTC). Returns
+    None for empty / unparseable input."""
+    if not date_str:
+        return None
+    try:
+        if date_str.endswith("Z"):
+            return datetime.fromisoformat(date_str[:-1] + "+00:00")
+        return datetime.fromisoformat(date_str)
+    except ValueError:
+        return None
+
+
+def _format_age(date_str: str, *, now: datetime | None = None) -> str:
+    """Convert an ISO timestamp into a human-readable 'N units ago' string.
+    Empty for missing/unparseable input. `now` is injectable for tests."""
+    ts = _parse_iso(date_str)
+    if ts is None:
+        return ""
+    if now is None:
+        now = datetime.now(timezone.utc)
+    seconds = max(0, int((now - ts).total_seconds()))
+    if seconds < 60:
+        n, unit = seconds, "second"
+    elif seconds < 3600:
+        n, unit = seconds // 60, "minute"
+    elif seconds < 86400:
+        n, unit = seconds // 3600, "hour"
+    elif seconds < 7 * 86400:
+        n, unit = seconds // 86400, "day"
+    else:
+        n, unit = seconds // (7 * 86400), "week"
+    plural = "" if n == 1 else "s"
+    return f"{n} {unit}{plural} ago"
+
+
+def _expand_argv(
+    argv: list[str],
+    sender: str,
+    recipient: str,
+    message: str,
+    timestamp: str = "",
+    age: str = "",
+) -> list[str]:
     """Expand placeholders in argv:
       - `$SENDER`     sender's canonical name (empty for senderless prompts)
       - `$RECIPIENT`  what the sender wrote in `to` (alias for fanned, agent for direct)
       - `$MESSAGE`    content + any FILE: lines
+      - `$TIMESTAMP`  ISO 8601 UTC time the message was queued (e.g.,
+                      `2026-04-28T14:30:00.123456Z`); empty for invokeClear
+                      and for messages without a `date` field
+      - `$AGE`        human-readable age relative to now (e.g.,
+                      `5 minutes ago`); same emptiness rules as $TIMESTAMP
       - `$A8S_DIR`    the apps/a8s/ directory (so default.json can reference
                       bundled scripts like dummy-cli without hardcoding paths)
     """
@@ -107,6 +156,8 @@ def _expand_argv(argv: list[str], sender: str, recipient: str, message: str) -> 
         a = a.replace("$SENDER", sender)
         a = a.replace("$RECIPIENT", recipient)
         a = a.replace("$MESSAGE", message)
+        a = a.replace("$TIMESTAMP", timestamp)
+        a = a.replace("$AGE", age)
         a = a.replace("$A8S_DIR", a8s_dir)
         out.append(a)
     return out
@@ -120,6 +171,10 @@ def build_command(definition: dict, msg: dict, verb: str) -> list[str]:
       prompt   invokePrompt   senderless supervisor-direct (raw content)
       message  invokeMessage  routed tell (sender + recipient + content)
       clear    invokeClear    start a fresh conversation (no message)
+
+    `$TIMESTAMP` and `$AGE` come from `msg["date"]`; both empty for clear
+    and for messages that somehow lack a date field (defensive, shouldn't
+    happen since `_write_outbox` / `_queue_*` always stamp one).
     """
     key = VERB_KEY.get(verb)
     if key is None:
@@ -132,7 +187,9 @@ def build_command(definition: dict, msg: dict, verb: str) -> list[str]:
     sender = (msg.get("from") or "").strip()
     recipient = (msg.get("to") or "").strip()
     body = _message_body(msg)
-    return _expand_argv(list(argv), sender, recipient, body)
+    date_str = (msg.get("date") or "").strip()
+    age = _format_age(date_str)
+    return _expand_argv(list(argv), sender, recipient, body, date_str, age)
 
 
 def _autodiscover_definition(root: Path) -> tuple[str, str]:

--- a/apps/a8s/definitions.py
+++ b/apps/a8s/definitions.py
@@ -1,9 +1,16 @@
-"""a8s definitions — invoke* verbs, prompt formatting, definition loading.
+"""a8s definitions — invoke* verbs and argv interpolation.
 
 Each agent has a definition JSON (built-in or custom) that encodes argv for
-four verbs and message templates. `select_verb` picks the verb from the
-queued message, `build_prompt` formats the body, `build_command` expands
-$PROMPT/$A8S_DIR placeholders into the final argv.
+three verbs. `select_verb` picks the verb from the queued message;
+`build_command` substitutes `$SENDER` / `$RECIPIENT` / `$MESSAGE` / `$A8S_DIR`
+into the chosen argv.
+
+Strict opacity (issues #69, #70): the recipient sees only sender + message
+content — no `alias` or `others_count` leak. A direct tell and an
+alias-fanned tell produce the same prompt shape, distinguished only by what
+`$RECIPIENT` resolves to (the original `to` field, which is the alias name
+for fanned messages and the agent name for direct ones — same as a public
+mailing list: you know it came via the list, you don't know who else got it).
 """
 from __future__ import annotations
 
@@ -21,7 +28,6 @@ from registry import load_registry
 VERB_KEY = {
     "prompt": "invokePrompt",
     "message": "invokeMessage",
-    "messageAlias": "invokeMessageAlias",
     "clear": "invokeClear",
 }
 
@@ -36,8 +42,8 @@ def load_definition(name: str) -> dict:
     bundled `apps/a8s/definitions/default.json` (a dummy CLI that prints
     'not configured' and the received prompt).
 
-    Definitions encode argv (with `$PROMPT` and `$A8S_DIR` placeholders),
-    message templates, and per-tool quirks. See apps/a8s/definitions/*.json.
+    Definitions encode argv with `$SENDER`, `$RECIPIENT`, `$MESSAGE`, and
+    `$A8S_DIR` placeholders. See apps/a8s/definitions/*.json.
     """
     reg = load_registry()
     info = reg.get(name) or {}
@@ -68,74 +74,52 @@ def select_verb(msg: dict) -> str:
     """Determine the wake verb from a queued message JSON.
 
     Order matters: clear first (so the sentinel takes precedence), then
-    senderless prompt, then alias, then plain message."""
+    senderless prompt, then plain message. Alias-routed messages take
+    `message` like direct ones — strict opacity collapses the dispatch."""
     if msg.get("clear") is True:
         return "clear"
     sender = (msg.get("from") or "").strip()
     if not sender:
         return "prompt"
-    if (msg.get("alias") or "").strip():
-        return "messageAlias"
     return "message"
 
 
-def build_prompt(msg: dict, definition: dict, verb: str) -> str:
-    """Format a queued message into the prompt string for the agent CLI.
-
-    `verb` selects how the body is built:
-      - `prompt`        — raw `content` delivery (no template wrapping)
-      - `message`       — `promptMessage` template
-      - `messageAlias`  — `promptMessageAlias` template (alias + others_count)
-      - `clear`         — invokeClear takes no prompt; returns empty string
-    """
-    if verb == "clear":
-        return ""
+def _message_body(msg: dict) -> str:
+    """Compose the `$MESSAGE` body: content plus any FILE: lines."""
     content = msg.get("content", "")
-    if verb == "prompt":
-        return "\n".join([content, *_file_lines(msg)])
-
-    sender = (msg.get("from") or "").strip()
-    date = msg.get("date", "")
-    recipient = (msg.get("to") or "").strip()
-    alias = (msg.get("alias") or "").strip()
-    others_count = msg.get("others_count", 0)
-    if verb == "messageAlias":
-        tmpl = definition.get("promptMessageAlias") or (
-            "{sender} tells you ({recipient}) and {others_count} others on the {alias} alias: {message}"
-        )
-    else:  # "message"
-        tmpl = definition.get("promptMessage") or "{sender} tells you ({recipient}): {message}"
-    header = tmpl.format(
-        sender=sender,
-        recipient=recipient,
-        message=content,
-        date=date,
-        alias=alias,
-        others_count=others_count,
-    )
-    if date and "{date}" not in tmpl:
-        header = f"[{date}] {header}"
-    return "\n".join([header, *_file_lines(msg)])
+    lines = _file_lines(msg)
+    if not lines:
+        return content
+    return "\n".join([content, *lines])
 
 
-def _expand_argv(argv: list[str], prompt: str) -> list[str]:
+def _expand_argv(argv: list[str], sender: str, recipient: str, message: str) -> list[str]:
     """Expand placeholders in argv:
-      - `$PROMPT`   the wake prompt (raw or template-formatted)
-      - `$A8S_DIR`  the apps/a8s/ directory (so default.json can reference
-                    bundled scripts like dummy-cli without hardcoding paths)
-    invokeClear ignores prompt entirely; its argv should not contain $PROMPT."""
+      - `$SENDER`     sender's canonical name (empty for senderless prompts)
+      - `$RECIPIENT`  what the sender wrote in `to` (alias for fanned, agent for direct)
+      - `$MESSAGE`    content + any FILE: lines
+      - `$A8S_DIR`    the apps/a8s/ directory (so default.json can reference
+                      bundled scripts like dummy-cli without hardcoding paths)
+    """
     a8s_dir = str(SCRIPT_DIR)
-    return [a.replace("$PROMPT", prompt).replace("$A8S_DIR", a8s_dir) for a in argv]
+    out: list[str] = []
+    for a in argv:
+        a = a.replace("$SENDER", sender)
+        a = a.replace("$RECIPIENT", recipient)
+        a = a.replace("$MESSAGE", message)
+        a = a.replace("$A8S_DIR", a8s_dir)
+        out.append(a)
+    return out
 
 
-def build_command(definition: dict, prompt: str, verb: str) -> list[str]:
-    """Pick the `invoke*` argv from `definition` for this verb and expand $PROMPT.
+def build_command(definition: dict, msg: dict, verb: str) -> list[str]:
+    """Pick the `invoke*` argv from `definition` for this verb and expand
+    interpolation variables.
 
     Verbs:
-      prompt        invokePrompt        senderless supervisor-direct (raw)
-      message       invokeMessage       direct tell from one agent to another
-      messageAlias  invokeMessageAlias  alias-routed tell (with opacity vars)
-      clear         invokeClear         start a fresh conversation (no prompt)
+      prompt   invokePrompt   senderless supervisor-direct (raw content)
+      message  invokeMessage  routed tell (sender + recipient + content)
+      clear    invokeClear    start a fresh conversation (no message)
     """
     key = VERB_KEY.get(verb)
     if key is None:
@@ -143,7 +127,12 @@ def build_command(definition: dict, prompt: str, verb: str) -> list[str]:
     argv = definition.get(key)
     if not argv:
         raise ValueError(f"definition missing {key!r}")
-    return _expand_argv(list(argv), prompt)
+    if verb == "clear":
+        return _expand_argv(list(argv), "", "", "")
+    sender = (msg.get("from") or "").strip()
+    recipient = (msg.get("to") or "").strip()
+    body = _message_body(msg)
+    return _expand_argv(list(argv), sender, recipient, body)
 
 
 def _autodiscover_definition(root: Path) -> tuple[str, str]:

--- a/apps/a8s/definitions/claude.json
+++ b/apps/a8s/definitions/claude.json
@@ -5,27 +5,18 @@
     "--permission-mode", "dontAsk",
     "--allowedTools", "Bash(tell:*) Read Edit Write Glob Grep WebFetch WebSearch TodoWrite",
     "--continue",
-    "-p", "$PROMPT"
+    "-p", "$MESSAGE"
   ],
   "invokeMessage": [
     "claude",
     "--permission-mode", "dontAsk",
     "--allowedTools", "Bash(tell:*) Read Edit Write Glob Grep WebFetch WebSearch TodoWrite",
     "--continue",
-    "-p", "$PROMPT"
-  ],
-  "invokeMessageAlias": [
-    "claude",
-    "--permission-mode", "dontAsk",
-    "--allowedTools", "Bash(tell:*) Read Edit Write Glob Grep WebFetch WebSearch TodoWrite",
-    "--continue",
-    "-p", "$PROMPT"
+    "-p", "$SENDER tells $RECIPIENT: $MESSAGE"
   ],
   "invokeClear": [
     "claude",
     "--permission-mode", "dontAsk",
     "-p", "Conversation cleared. New conversation starts now."
-  ],
-  "promptMessage": "{sender} tells you ({recipient}): {message}",
-  "promptMessageAlias": "{sender} tells you ({recipient}) and {others_count} others on the {alias} alias: {message}"
+  ]
 }

--- a/apps/a8s/definitions/claude.json
+++ b/apps/a8s/definitions/claude.json
@@ -12,7 +12,7 @@
     "--permission-mode", "dontAsk",
     "--allowedTools", "Bash(tell:*) Read Edit Write Glob Grep WebFetch WebSearch TodoWrite",
     "--continue",
-    "-p", "$SENDER tells $RECIPIENT: $MESSAGE"
+    "-p", "$SENDER tells $RECIPIENT ($AGE): $MESSAGE"
   ],
   "invokeClear": [
     "claude",

--- a/apps/a8s/definitions/codex.json
+++ b/apps/a8s/definitions/codex.json
@@ -12,7 +12,7 @@
     "resume", "--last",
     "--full-auto",
     "--skip-git-repo-check",
-    "$SENDER tells $RECIPIENT: $MESSAGE"
+    "$SENDER tells $RECIPIENT ($AGE): $MESSAGE"
   ],
   "invokeClear": [
     "codex", "exec",

--- a/apps/a8s/definitions/codex.json
+++ b/apps/a8s/definitions/codex.json
@@ -5,28 +5,19 @@
     "resume", "--last",
     "--full-auto",
     "--skip-git-repo-check",
-    "$PROMPT"
+    "$MESSAGE"
   ],
   "invokeMessage": [
     "codex", "exec",
     "resume", "--last",
     "--full-auto",
     "--skip-git-repo-check",
-    "$PROMPT"
-  ],
-  "invokeMessageAlias": [
-    "codex", "exec",
-    "resume", "--last",
-    "--full-auto",
-    "--skip-git-repo-check",
-    "$PROMPT"
+    "$SENDER tells $RECIPIENT: $MESSAGE"
   ],
   "invokeClear": [
     "codex", "exec",
     "--full-auto",
     "--skip-git-repo-check",
     "Conversation cleared. New conversation starts now."
-  ],
-  "promptMessage": "{sender} tells you ({recipient}): {message}",
-  "promptMessageAlias": "{sender} tells you ({recipient}) and {others_count} others on the {alias} alias: {message}"
+  ]
 }

--- a/apps/a8s/definitions/default.json
+++ b/apps/a8s/definitions/default.json
@@ -1,6 +1,6 @@
 {
   "description": "Fallback default — no real CLI is configured. Routes every verb to apps/a8s/dummy-cli, which prints a 'not configured' notice and the received prompt. Configure a real CLI with `a8s define <name> <path-to-definition.json>`.",
   "invokePrompt":  ["$A8S_DIR/dummy-cli", "$MESSAGE"],
-  "invokeMessage": ["$A8S_DIR/dummy-cli", "$SENDER tells $RECIPIENT: $MESSAGE"],
+  "invokeMessage": ["$A8S_DIR/dummy-cli", "$SENDER tells $RECIPIENT ($AGE): $MESSAGE"],
   "invokeClear":   ["$A8S_DIR/dummy-cli", "(conversation cleared)"]
 }

--- a/apps/a8s/definitions/default.json
+++ b/apps/a8s/definitions/default.json
@@ -1,9 +1,6 @@
 {
   "description": "Fallback default — no real CLI is configured. Routes every verb to apps/a8s/dummy-cli, which prints a 'not configured' notice and the received prompt. Configure a real CLI with `a8s define <name> <path-to-definition.json>`.",
-  "invokePrompt":       ["$A8S_DIR/dummy-cli", "$PROMPT"],
-  "invokeMessage":      ["$A8S_DIR/dummy-cli", "$PROMPT"],
-  "invokeMessageAlias": ["$A8S_DIR/dummy-cli", "$PROMPT"],
-  "invokeClear":        ["$A8S_DIR/dummy-cli", "(conversation cleared)"],
-  "promptMessage": "{sender} tells you ({recipient}): {message}",
-  "promptMessageAlias": "{sender} tells you ({recipient}) and {others_count} others on the {alias} alias: {message}"
+  "invokePrompt":  ["$A8S_DIR/dummy-cli", "$MESSAGE"],
+  "invokeMessage": ["$A8S_DIR/dummy-cli", "$SENDER tells $RECIPIENT: $MESSAGE"],
+  "invokeClear":   ["$A8S_DIR/dummy-cli", "(conversation cleared)"]
 }

--- a/apps/a8s/definitions/gemini.json
+++ b/apps/a8s/definitions/gemini.json
@@ -10,7 +10,7 @@
     "gemini",
     "--yolo",
     "--resume", "latest",
-    "--prompt", "$SENDER tells $RECIPIENT: $MESSAGE"
+    "--prompt", "$SENDER tells $RECIPIENT ($AGE): $MESSAGE"
   ],
   "invokeClear": [
     "gemini",

--- a/apps/a8s/definitions/gemini.json
+++ b/apps/a8s/definitions/gemini.json
@@ -4,25 +4,17 @@
     "gemini",
     "--yolo",
     "--resume", "latest",
-    "--prompt", "$PROMPT"
+    "--prompt", "$MESSAGE"
   ],
   "invokeMessage": [
     "gemini",
     "--yolo",
     "--resume", "latest",
-    "--prompt", "$PROMPT"
-  ],
-  "invokeMessageAlias": [
-    "gemini",
-    "--yolo",
-    "--resume", "latest",
-    "--prompt", "$PROMPT"
+    "--prompt", "$SENDER tells $RECIPIENT: $MESSAGE"
   ],
   "invokeClear": [
     "gemini",
     "--yolo",
     "--prompt", "Conversation cleared. New conversation starts now."
-  ],
-  "promptMessage": "{sender} tells you ({recipient}): {message}",
-  "promptMessageAlias": "{sender} tells you ({recipient}) and {others_count} others on the {alias} alias: {message}"
+  ]
 }

--- a/apps/a8s/mailbox.py
+++ b/apps/a8s/mailbox.py
@@ -129,9 +129,12 @@ def _build_routed_message(
     """Construct the routed copy of `base_msg` for `recipient` — copies any
     `FILE:` payloads into the recipient's `.files/` and rewrites the file
     paths in the returned message. Files that fail validation are dropped
-    (logged); the message is delivered with the surviving files."""
+    (logged); the message is delivered with the surviving files.
+
+    Strict opacity (#69, #70): the `to` field is left at whatever the sender
+    wrote — alias for fanned messages, agent name for direct ones — same as
+    a public mailing list's `To:` header."""
     routed = dict(base_msg)
-    routed["to"] = recipient.name
     src_files = base_msg.get("files") or []
     if src_files:
         new_files: list[dict] = []
@@ -163,8 +166,9 @@ def route_outboxes(senders: list[Participant], all_agents: list[Participant] | N
 
     `all_agents` is the recipient lookup pool (defaults to senders for
     self-contained calls). Aliases fan out at routing time; sender is excluded
-    from delivery (no self-echo). Each routed copy carries `alias` and
-    `others_count` fields for the recipient's prompt template.
+    from delivery (no self-echo). Routed copies preserve the original `to`
+    field — for an alias-fanned message that's the alias name, opaque about
+    the other recipients (issues #69, #70).
 
     Atomicity (issue #67): each outbox file is staged into every recipient's
     `inbox.tmp/` first, then promoted into `inbox/` via `os.replace`, then
@@ -215,13 +219,9 @@ def route_outboxes(senders: list[Participant], all_agents: list[Participant] | N
                     # Skip self-copy: an alias that includes the sender doesn't
                     # echo the message back to them.
                     recipients.append(rp)
-            if kind == "alias":
-                msg["alias"] = recipient_name
-                msg["others_count"] = max(0, len(recipients) - 1)
-            else:
-                if not recipients:
-                    out_agent(sender.name, f"[{sender.name}] {recipient_name!r} resolved to no agents in {f.name}")
-                    continue
+            if kind != "alias" and not recipients:
+                out_agent(sender.name, f"[{sender.name}] {recipient_name!r} resolved to no agents in {f.name}")
+                continue
 
             # Stage every recipient's copy into inbox.tmp/<source-name>. Skip
             # any recipient whose final inbox already has the file (prior
@@ -319,9 +319,9 @@ def _write_outbox(sender_name: str, sender_root: Path, to: str, content: str, fi
 def _queue_prompt(p: Participant, content: str) -> Path:
     """Drop a senderless message JSON directly into <p>/inbox/.
 
-    The empty `from` is the signal to `build_prompt` to deliver the raw
-    content (no `tells you` template wrapping). The next inbox-drain wakes
-    the agent."""
+    The empty `from` is the signal to `select_verb` to dispatch via
+    `invokePrompt` (raw content, no sender header). The next inbox-drain
+    wakes the agent."""
     ensure_mailboxes(p)
     now = datetime.now(timezone.utc)
     msg = {

--- a/apps/a8s/skills/tell/SKILL.md
+++ b/apps/a8s/skills/tell/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "tell"
-description: "Send a message to a recipient by name using the `tell` shell command. Delivery is asynchronous and may take seconds, minutes, or longer to reach the recipient and be processed; do not wait for or expect an immediate reply. Optional file attachments via trailing FILE lines."
+description: "Send a message to a recipient by name using the `tell` shell command. Delivery is asynchronous and may take seconds, minutes, or longer for the recipient to receive and act on the message; do not wait for or expect an immediate reply. Optional file attachments via trailing FILE lines."
 ---
 
 # /tell — send a message to a recipient by name
@@ -14,7 +14,7 @@ tell <name> <message>
 - `<name>` is the recipient's name. Treat it as opaque — do not assume whether the recipient is a person or another assistant, and do not change your tone based on a guess.
 - `<message>` is the body. To attach files, append one or more `FILE: <absolute-path>` lines at the end. Lines starting with `FILE: ` are stripped from the body and added as attachments.
 
-The command returns immediately. Delivery is asynchronous: the recipient may pick up the message seconds, minutes, or longer after you send it (depending on how long their handler is taking to process prior messages and any in-flight work). Reading and acting on the message is also asynchronous on their side. Do not block waiting for a reply; if you need a response, send the message and continue with other work. If a reply is essential, ask the user how to proceed rather than polling.
+The command returns immediately. Delivery and processing are asynchronous: the recipient may receive the message seconds, minutes, hours, or longer after you send it, and may take additional time to read and act on it. Don't make assumptions about what causes the delay — it isn't necessarily mechanical. Do not block waiting for a reply; if you need a response, send the message and continue with other work. If a reply is essential, ask the user how to proceed rather than polling.
 
 ## Examples
 

--- a/apps/a8s/skills/tell/SKILL.md
+++ b/apps/a8s/skills/tell/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "tell"
-description: "Send a message to a recipient by name using the `tell` shell command. Optional file attachments via trailing FILE lines."
+description: "Send a message to a recipient by name using the `tell` shell command. Delivery is asynchronous and may take seconds, minutes, or longer to reach the recipient and be processed; do not wait for or expect an immediate reply. Optional file attachments via trailing FILE lines."
 ---
 
 # /tell — send a message to a recipient by name
@@ -14,7 +14,7 @@ tell <name> <message>
 - `<name>` is the recipient's name. Treat it as opaque — do not assume whether the recipient is a person or another assistant, and do not change your tone based on a guess.
 - `<message>` is the body. To attach files, append one or more `FILE: <absolute-path>` lines at the end. Lines starting with `FILE: ` are stripped from the body and added as attachments.
 
-The command returns immediately; delivery is asynchronous and you do not need to wait for a reply.
+The command returns immediately. Delivery is asynchronous: the recipient may pick up the message seconds, minutes, or longer after you send it (depending on how long their handler is taking to process prior messages and any in-flight work). Reading and acting on the message is also asynchronous on their side. Do not block waiting for a reply; if you need a response, send the message and continue with other work. If a reply is essential, ask the user how to proceed rather than polling.
 
 ## Examples
 

--- a/apps/a8s/tests/fixtures/mock.json
+++ b/apps/a8s/tests/fixtures/mock.json
@@ -1,9 +1,6 @@
 {
-  "description": "Test-only mock CLI definition. Each invoke* runs the bundled mock-cli script which echoes its argv.",
-  "invokePrompt":       ["$A8S_DIR/tests/fixtures/mock-cli", "verb=prompt", "$PROMPT"],
-  "invokeMessage":      ["$A8S_DIR/tests/fixtures/mock-cli", "verb=message", "$PROMPT"],
-  "invokeMessageAlias": ["$A8S_DIR/tests/fixtures/mock-cli", "verb=messageAlias", "$PROMPT"],
-  "invokeClear":        ["$A8S_DIR/tests/fixtures/mock-cli", "verb=clear"],
-  "promptMessage": "FROM:{sender}|TO:{recipient}|MSG:{message}",
-  "promptMessageAlias": "FROM:{sender}|TO:{recipient}|ALIAS:{alias}|OTHERS:{others_count}|MSG:{message}"
+  "description": "Test-only mock CLI definition. Each invoke* runs the bundled mock-cli script which echoes its argv. Single-arg payloads use the FROM:|TO:|MSG: format so daemon tests can grep stable strings.",
+  "invokePrompt":  ["$A8S_DIR/tests/fixtures/mock-cli", "verb=prompt", "FROM:$SENDER|TO:$RECIPIENT|MSG:$MESSAGE"],
+  "invokeMessage": ["$A8S_DIR/tests/fixtures/mock-cli", "verb=message", "FROM:$SENDER|TO:$RECIPIENT|MSG:$MESSAGE"],
+  "invokeClear":   ["$A8S_DIR/tests/fixtures/mock-cli", "verb=clear"]
 }

--- a/apps/a8s/tests/fixtures/mock.json
+++ b/apps/a8s/tests/fixtures/mock.json
@@ -1,6 +1,6 @@
 {
   "description": "Test-only mock CLI definition. Each invoke* runs the bundled mock-cli script which echoes its argv. Single-arg payloads use the FROM:|TO:|MSG: format so daemon tests can grep stable strings.",
-  "invokePrompt":  ["$A8S_DIR/tests/fixtures/mock-cli", "verb=prompt", "FROM:$SENDER|TO:$RECIPIENT|MSG:$MESSAGE"],
-  "invokeMessage": ["$A8S_DIR/tests/fixtures/mock-cli", "verb=message", "FROM:$SENDER|TO:$RECIPIENT|MSG:$MESSAGE"],
+  "invokePrompt":  ["$A8S_DIR/tests/fixtures/mock-cli", "verb=prompt", "FROM:$SENDER|TO:$RECIPIENT|TS:$TIMESTAMP|AGE:$AGE|MSG:$MESSAGE"],
+  "invokeMessage": ["$A8S_DIR/tests/fixtures/mock-cli", "verb=message", "FROM:$SENDER|TO:$RECIPIENT|TS:$TIMESTAMP|AGE:$AGE|MSG:$MESSAGE"],
   "invokeClear":   ["$A8S_DIR/tests/fixtures/mock-cli", "verb=clear"]
 }

--- a/apps/a8s/tests/test_daemon.py
+++ b/apps/a8s/tests/test_daemon.py
@@ -300,8 +300,12 @@ class TestWakeOnceVerbs:
         # mock-cli echoes each argv element prefixed with "MOCK-CLI:"
         assert "MOCK> MOCK-CLI: verb=prompt" in log
         # Senderless prompt: $SENDER is empty, $RECIPIENT is the agent's own
-        # name, $MESSAGE is the raw content.
-        assert "MOCK> MOCK-CLI: FROM:|TO:MOCK|MSG:show capabilities" in log
+        # name, $MESSAGE is the raw content. $TIMESTAMP / $AGE are populated
+        # from msg["date"]; assert the surrounding structure rather than the
+        # exact dynamic values.
+        assert "FROM:|TO:MOCK|TS:" in log
+        assert "|MSG:show capabilities" in log
+        assert "AGE:0 seconds ago" in log or "AGE:1 seconds ago" in log
 
     def test_message_verb_argv_via_routing(self, fake_home, tmp_path, fixtures_dir):
         # Two agents, both using mock.json.
@@ -321,9 +325,11 @@ class TestWakeOnceVerbs:
         rc = attached_loop(["A", "B"], 0.1, single_pass=True)
         assert rc == 0
         log_b = _read_log("B")
-        # invokeMessage interpolates $SENDER, $RECIPIENT, $MESSAGE directly.
+        # invokeMessage interpolates $SENDER, $RECIPIENT, $TIMESTAMP, $AGE,
+        # $MESSAGE directly.
         assert "MOCK-CLI: verb=message" in log_b
-        assert "FROM:A|TO:B|MSG:design review" in log_b
+        assert "FROM:A|TO:B|TS:" in log_b
+        assert "|MSG:design review" in log_b
 
     def test_alias_routed_message_uses_message_verb(self, fake_home, tmp_path, fixtures_dir):
         # Strict opacity (#69, #70): alias-routed messages dispatch to
@@ -349,12 +355,14 @@ class TestWakeOnceVerbs:
         # No "messageAlias" verb, no others_count leak — just the regular
         # message verb with $RECIPIENT preserving the alias name.
         assert "MOCK-CLI: verb=message" in log_b
-        assert "FROM:A|TO:devs|MSG:all-hands" in log_b
+        assert "FROM:A|TO:devs|TS:" in log_b
+        assert "|MSG:all-hands" in log_b
         assert "OTHERS:" not in log_b
         assert "ALIAS:" not in log_b
         # C sees the same shape — both recipients are indistinguishable.
         log_c = _read_log("C")
-        assert "FROM:A|TO:devs|MSG:all-hands" in log_c
+        assert "FROM:A|TO:devs|TS:" in log_c
+        assert "|MSG:all-hands" in log_c
 
     def test_clear_verb_via_sentinel(self, mock_agent):
         # Pre-queue a normal prompt + then a clear; the clear should wipe

--- a/apps/a8s/tests/test_daemon.py
+++ b/apps/a8s/tests/test_daemon.py
@@ -299,7 +299,9 @@ class TestWakeOnceVerbs:
         log = _read_log("MOCK")
         # mock-cli echoes each argv element prefixed with "MOCK-CLI:"
         assert "MOCK> MOCK-CLI: verb=prompt" in log
-        assert "MOCK> MOCK-CLI: show capabilities" in log
+        # Senderless prompt: $SENDER is empty, $RECIPIENT is the agent's own
+        # name, $MESSAGE is the raw content.
+        assert "MOCK> MOCK-CLI: FROM:|TO:MOCK|MSG:show capabilities" in log
 
     def test_message_verb_argv_via_routing(self, fake_home, tmp_path, fixtures_dir):
         # Two agents, both using mock.json.
@@ -313,23 +315,20 @@ class TestWakeOnceVerbs:
         b = Participant("B", tmp_path / "b")
         ensure_mailboxes(a)
         ensure_mailboxes(b)
-        # A writes to B's outbox path... no, A's outbox.
         from mailbox import _write_outbox
         _write_outbox("A", a.root, "B", "design review", [])
 
-        # Run B's loop — its outbox is empty but B will receive A's routed msg.
-        # attached_loop routes ALL agents' outboxes via route_outboxes(handled).
-        # We need A's outbox to be routed too. Pass [A, B].
         rc = attached_loop(["A", "B"], 0.1, single_pass=True)
         assert rc == 0
         log_b = _read_log("B")
-        # B's invokeMessage runs with the formatted promptMessage template
-        # containing "FROM:A|TO:B|MSG:design review".
+        # invokeMessage interpolates $SENDER, $RECIPIENT, $MESSAGE directly.
         assert "MOCK-CLI: verb=message" in log_b
         assert "FROM:A|TO:B|MSG:design review" in log_b
 
-    def test_messageAlias_verb_with_others_count(self, fake_home, tmp_path, fixtures_dir):
-        # A, B, C all using mock.json. devs alias = [A, B, C]. A sends to devs.
+    def test_alias_routed_message_uses_message_verb(self, fake_home, tmp_path, fixtures_dir):
+        # Strict opacity (#69, #70): alias-routed messages dispatch to
+        # invokeMessage just like direct ones. The only difference visible to
+        # the recipient is that $RECIPIENT resolves to the alias name.
         from mailbox import _write_outbox
         agents = {}
         for n in ("A", "B", "C"):
@@ -347,9 +346,15 @@ class TestWakeOnceVerbs:
         rc = attached_loop(["A", "B", "C"], 0.1, single_pass=True)
         assert rc == 0
         log_b = _read_log("B")
-        # Sender excluded → recipients = [B, C] → B sees others_count=1.
-        assert "MOCK-CLI: verb=messageAlias" in log_b
-        assert "FROM:A|TO:B|ALIAS:devs|OTHERS:1|MSG:all-hands" in log_b
+        # No "messageAlias" verb, no others_count leak — just the regular
+        # message verb with $RECIPIENT preserving the alias name.
+        assert "MOCK-CLI: verb=message" in log_b
+        assert "FROM:A|TO:devs|MSG:all-hands" in log_b
+        assert "OTHERS:" not in log_b
+        assert "ALIAS:" not in log_b
+        # C sees the same shape — both recipients are indistinguishable.
+        log_c = _read_log("C")
+        assert "FROM:A|TO:devs|MSG:all-hands" in log_c
 
     def test_clear_verb_via_sentinel(self, mock_agent):
         # Pre-queue a normal prompt + then a clear; the clear should wipe

--- a/apps/a8s/tests/test_definitions.py
+++ b/apps/a8s/tests/test_definitions.py
@@ -1,4 +1,4 @@
-"""Tests for definitions.py — verb selection, prompt formatting, argv expansion,
+"""Tests for definitions.py — verb selection, argv interpolation,
 and auto-discovery."""
 from __future__ import annotations
 
@@ -9,8 +9,8 @@ import pytest
 from definitions import (
     _autodiscover_definition,
     _expand_argv,
+    _message_body,
     build_command,
-    build_prompt,
     default_definition_path,
     load_definition,
     select_verb,
@@ -21,8 +21,8 @@ from definitions import (
 
 class TestSelectVerb:
     def test_clear_takes_precedence(self):
-        # Even with a sender + alias, clear:true wins.
-        msg = {"from": "GERRY", "to": "CLAUDE", "alias": "devs", "clear": True}
+        # Even with a sender + alias-style `to`, clear:true wins.
+        msg = {"from": "GERRY", "to": "devs", "clear": True}
         assert select_verb(msg) == "clear"
 
     def test_senderless_is_prompt(self):
@@ -33,144 +33,119 @@ class TestSelectVerb:
         msg = {"to": "CLAUDE", "content": "hi"}
         assert select_verb(msg) == "prompt"
 
-    def test_with_alias_is_messageAlias(self):
-        msg = {"from": "GERRY", "to": "CLAUDE", "alias": "devs", "content": "hi"}
-        assert select_verb(msg) == "messageAlias"
-
-    def test_with_sender_no_alias_is_message(self):
+    def test_with_sender_is_message(self):
         msg = {"from": "GERRY", "to": "CLAUDE", "content": "hi"}
         assert select_verb(msg) == "message"
 
-    def test_empty_alias_string_is_message(self):
-        msg = {"from": "GERRY", "to": "CLAUDE", "alias": "", "content": "hi"}
+    def test_alias_routed_is_still_message(self):
+        # Strict opacity: alias-routed messages dispatch via the same verb
+        # as direct ones — the only difference is what `to` resolves to.
+        msg = {"from": "GERRY", "to": "devs", "content": "hi"}
         assert select_verb(msg) == "message"
 
 
-# ---------- build_prompt ----------
+# ---------- _message_body ----------
 
-DEFINITION = {
-    "promptMessage": "{sender} tells you ({recipient}): {message}",
-    "promptMessageAlias": "{sender} tells you ({recipient}) and {others_count} others on the {alias} alias: {message}",
-}
+class TestMessageBody:
+    def test_content_only(self):
+        assert _message_body({"content": "hello"}) == "hello"
 
-
-class TestBuildPrompt:
-    def test_clear_returns_empty(self):
-        assert build_prompt({}, DEFINITION, "clear") == ""
-
-    def test_prompt_is_raw_content(self):
-        msg = {"from": "", "to": "CLAUDE", "content": "show capabilities"}
-        assert build_prompt(msg, DEFINITION, "prompt") == "show capabilities"
-
-    def test_prompt_appends_file_lines(self):
+    def test_content_with_files(self):
         msg = {
-            "from": "",
             "content": "see attached",
             "files": [{"path": "/tmp/build.log"}, {"path": "/tmp/data.csv"}],
         }
-        out = build_prompt(msg, DEFINITION, "prompt")
-        assert out == "see attached\n\nFILE: /tmp/build.log\nFILE: /tmp/data.csv"
+        assert _message_body(msg) == "see attached\n\nFILE: /tmp/build.log\nFILE: /tmp/data.csv"
 
-    def test_message_uses_promptMessage(self):
-        msg = {"from": "GERRY", "to": "CLAUDE", "content": "fix this"}
-        assert build_prompt(msg, DEFINITION, "message") == "GERRY tells you (CLAUDE): fix this"
-
-    def test_messageAlias_uses_promptMessageAlias(self):
-        msg = {
-            "from": "GERRY",
-            "to": "CLAUDE",
-            "content": "standup",
-            "alias": "devs",
-            "others_count": 1,
-        }
-        out = build_prompt(msg, DEFINITION, "messageAlias")
-        assert out == "GERRY tells you (CLAUDE) and 1 others on the devs alias: standup"
-
-    def test_message_with_date_prefix(self):
-        msg = {"from": "GERRY", "to": "CLAUDE", "content": "hi", "date": "2026-04-27T15:30:00Z"}
-        out = build_prompt(msg, DEFINITION, "message")
-        # Template doesn't include {date}, so it's prefixed.
-        assert out == "[2026-04-27T15:30:00Z] GERRY tells you (CLAUDE): hi"
-
-    def test_template_with_date_placeholder_no_prefix(self):
-        defn = {"promptMessage": "[{date}] {sender}: {message}"}
-        msg = {"from": "GERRY", "to": "CLAUDE", "content": "hi", "date": "X"}
-        out = build_prompt(msg, defn, "message")
-        # Prefix is suppressed because the template already includes {date}.
-        assert out == "[X] GERRY: hi"
-
-    def test_message_with_files(self):
-        msg = {
-            "from": "GERRY",
-            "to": "CLAUDE",
-            "content": "review",
-            "files": [{"path": "/x"}],
-        }
-        out = build_prompt(msg, DEFINITION, "message")
-        assert out == "GERRY tells you (CLAUDE): review\n\nFILE: /x"
+    def test_empty(self):
+        assert _message_body({}) == ""
 
 
 # ---------- build_command + _expand_argv ----------
 
 class TestBuildCommand:
     def test_dispatches_to_invokePrompt(self):
-        defn = {"invokePrompt": ["claude", "-p", "$PROMPT"]}
-        argv = build_command(defn, "hello", "prompt")
+        defn = {"invokePrompt": ["claude", "-p", "$MESSAGE"]}
+        msg = {"from": "", "to": "CLAUDE", "content": "hello"}
+        argv = build_command(defn, msg, "prompt")
         assert argv == ["claude", "-p", "hello"]
 
     def test_dispatches_to_invokeMessage(self):
-        defn = {"invokeMessage": ["claude", "--continue", "-p", "$PROMPT"]}
-        argv = build_command(defn, "x", "message")
-        assert argv == ["claude", "--continue", "-p", "x"]
+        defn = {"invokeMessage": ["claude", "--continue", "-p", "$SENDER tells $RECIPIENT: $MESSAGE"]}
+        msg = {"from": "GERRY", "to": "CLAUDE", "content": "fix this"}
+        argv = build_command(defn, msg, "message")
+        assert argv == ["claude", "--continue", "-p", "GERRY tells CLAUDE: fix this"]
 
-    def test_dispatches_to_invokeMessageAlias(self):
-        defn = {"invokeMessageAlias": ["claude", "-p", "$PROMPT"]}
-        argv = build_command(defn, "y", "messageAlias")
-        assert argv == ["claude", "-p", "y"]
+    def test_alias_routed_message_keeps_alias_in_recipient(self):
+        # Strict opacity / mailing-list semantics: when the sender wrote
+        # `to: devs`, the recipient's $RECIPIENT resolves to "devs" — they
+        # know it came via the list, but not who else got it.
+        defn = {"invokeMessage": ["claude", "-p", "$SENDER tells $RECIPIENT: $MESSAGE"]}
+        msg = {"from": "GERRY", "to": "devs", "content": "standup"}
+        argv = build_command(defn, msg, "message")
+        assert argv == ["claude", "-p", "GERRY tells devs: standup"]
 
     def test_dispatches_to_invokeClear(self):
         defn = {"invokeClear": ["claude", "-p", "/clear"]}
-        argv = build_command(defn, "", "clear")
+        argv = build_command(defn, {"clear": True}, "clear")
         assert argv == ["claude", "-p", "/clear"]
+
+    def test_clear_ignores_message_fields(self):
+        # invokeClear shouldn't leak prior content into argv even if the
+        # sentinel msg happens to carry stale fields.
+        defn = {"invokeClear": ["x", "$SENDER", "$RECIPIENT", "$MESSAGE"]}
+        msg = {"from": "GERRY", "to": "CLAUDE", "content": "stale", "clear": True}
+        argv = build_command(defn, msg, "clear")
+        assert argv == ["x", "", "", ""]
 
     def test_unknown_verb_raises(self):
         with pytest.raises(ValueError, match="unknown verb"):
-            build_command({}, "x", "bogus")
+            build_command({}, {}, "bogus")
 
     def test_missing_invoke_raises(self):
         with pytest.raises(ValueError, match="invokeMessage"):
-            build_command({"invokePrompt": ["x"]}, "p", "message")
+            build_command({"invokePrompt": ["x"]}, {"from": "G", "to": "C"}, "message")
 
     def test_a8s_dir_substitution(self):
         from core import SCRIPT_DIR
-        defn = {"invokePrompt": ["$A8S_DIR/dummy-cli", "$PROMPT"]}
-        argv = build_command(defn, "hi", "prompt")
+        defn = {"invokePrompt": ["$A8S_DIR/dummy-cli", "$MESSAGE"]}
+        msg = {"from": "", "to": "X", "content": "hi"}
+        argv = build_command(defn, msg, "prompt")
         assert argv == [f"{SCRIPT_DIR}/dummy-cli", "hi"]
 
     def test_does_not_mutate_original_argv(self):
-        defn = {"invokePrompt": ["claude", "-p", "$PROMPT"]}
+        defn = {"invokePrompt": ["claude", "-p", "$MESSAGE"]}
         original = list(defn["invokePrompt"])
-        build_command(defn, "hello", "prompt")
+        build_command(defn, {"from": "", "content": "hello"}, "prompt")
         assert defn["invokePrompt"] == original
+
+    def test_message_body_includes_files(self):
+        defn = {"invokeMessage": ["x", "$MESSAGE"]}
+        msg = {
+            "from": "GERRY",
+            "to": "CLAUDE",
+            "content": "review",
+            "files": [{"path": "/tmp/x"}],
+        }
+        argv = build_command(defn, msg, "message")
+        assert argv == ["x", "review\n\nFILE: /tmp/x"]
 
 
 class TestExpandArgv:
     def test_no_placeholders(self):
-        assert _expand_argv(["claude", "-p", "literal"], "ignored") == [
-            "claude",
-            "-p",
-            "literal",
+        assert _expand_argv(["claude", "-p", "literal"], "S", "R", "M") == [
+            "claude", "-p", "literal",
         ]
 
-    def test_prompt_substitution(self):
-        assert _expand_argv(["x", "$PROMPT", "y"], "hello") == ["x", "hello", "y"]
+    def test_message_substitution(self):
+        assert _expand_argv(["x", "$MESSAGE", "y"], "", "", "hello") == ["x", "hello", "y"]
 
-    def test_prompt_in_concatenated_arg(self):
-        assert _expand_argv(["wrap=$PROMPT-end"], "X") == ["wrap=X-end"]
+    def test_sender_recipient_message_in_one_arg(self):
+        assert _expand_argv(["$SENDER->$RECIPIENT: $MESSAGE"], "A", "B", "hi") == ["A->B: hi"]
 
     def test_a8s_dir_substitution(self):
         from core import SCRIPT_DIR
-        assert _expand_argv(["$A8S_DIR/x"], "") == [f"{SCRIPT_DIR}/x"]
+        assert _expand_argv(["$A8S_DIR/x"], "", "", "") == [f"{SCRIPT_DIR}/x"]
 
 
 # ---------- _autodiscover_definition ----------
@@ -205,16 +180,14 @@ class TestAutodiscoverDefinition:
 
 class TestLoadDefinition:
     def test_loads_explicit_definition(self, fake_home, tmp_path, monkeypatch):
-        # Write a custom definition.
         defn_path = tmp_path / "custom.json"
-        defn_path.write_text('{"invokePrompt": ["echo", "$PROMPT"]}')
+        defn_path.write_text('{"invokePrompt": ["echo", "$MESSAGE"]}')
 
-        # Add an agent that points at it.
         import registry
         registry.save_registry({"X": {"root": str(tmp_path), "definition": str(defn_path)}})
 
         loaded = load_definition("X")
-        assert loaded == {"invokePrompt": ["echo", "$PROMPT"]}
+        assert loaded == {"invokePrompt": ["echo", "$MESSAGE"]}
 
     def test_falls_back_to_default(self, fake_home):
         # Agent registered with NO definition field — load_definition falls
@@ -223,7 +196,6 @@ class TestLoadDefinition:
         registry.save_registry({"X": {"root": "/tmp"}})
 
         loaded = load_definition("X")
-        # default.json has all four invoke verbs.
         assert "invokePrompt" in loaded
         assert "invokeClear" in loaded
 

--- a/apps/a8s/tests/test_definitions.py
+++ b/apps/a8s/tests/test_definitions.py
@@ -6,9 +6,12 @@ from pathlib import Path
 
 import pytest
 
+from datetime import datetime, timezone
+
 from definitions import (
     _autodiscover_definition,
     _expand_argv,
+    _format_age,
     _message_body,
     build_command,
     default_definition_path,
@@ -42,6 +45,57 @@ class TestSelectVerb:
         # as direct ones — the only difference is what `to` resolves to.
         msg = {"from": "GERRY", "to": "devs", "content": "hi"}
         assert select_verb(msg) == "message"
+
+
+# ---------- _format_age ----------
+
+class TestFormatAge:
+    NOW = datetime(2026, 4, 28, 14, 30, 0, tzinfo=timezone.utc)
+
+    def _ago(self, **kwargs):
+        from datetime import timedelta
+        return (self.NOW - timedelta(**kwargs)).isoformat().replace("+00:00", "Z")
+
+    def test_seconds(self):
+        assert _format_age(self._ago(seconds=5), now=self.NOW) == "5 seconds ago"
+
+    def test_singular_second(self):
+        assert _format_age(self._ago(seconds=1), now=self.NOW) == "1 second ago"
+
+    def test_zero_seconds(self):
+        assert _format_age(self._ago(seconds=0), now=self.NOW) == "0 seconds ago"
+
+    def test_minutes(self):
+        assert _format_age(self._ago(minutes=5), now=self.NOW) == "5 minutes ago"
+
+    def test_singular_minute(self):
+        assert _format_age(self._ago(minutes=1), now=self.NOW) == "1 minute ago"
+
+    def test_hours(self):
+        assert _format_age(self._ago(hours=3), now=self.NOW) == "3 hours ago"
+
+    def test_days(self):
+        assert _format_age(self._ago(days=2), now=self.NOW) == "2 days ago"
+
+    def test_weeks(self):
+        assert _format_age(self._ago(days=14), now=self.NOW) == "2 weeks ago"
+
+    def test_future_clamps_to_zero(self):
+        # Clock skew shouldn't produce negative ages.
+        from datetime import timedelta
+        future = (self.NOW + timedelta(seconds=10)).isoformat().replace("+00:00", "Z")
+        assert _format_age(future, now=self.NOW) == "0 seconds ago"
+
+    def test_empty_string(self):
+        assert _format_age("", now=self.NOW) == ""
+
+    def test_unparseable(self):
+        assert _format_age("not-a-date", now=self.NOW) == ""
+
+    def test_iso_without_z_suffix(self):
+        # `_write_outbox` writes `Z` but accept timezone-aware ISO too.
+        ts = "2026-04-28T14:25:00+00:00"
+        assert _format_age(ts, now=self.NOW) == "5 minutes ago"
 
 
 # ---------- _message_body ----------
@@ -130,6 +184,53 @@ class TestBuildCommand:
         argv = build_command(defn, msg, "message")
         assert argv == ["x", "review\n\nFILE: /tmp/x"]
 
+    def test_timestamp_substitution_from_msg_date(self):
+        # $TIMESTAMP comes from msg["date"] verbatim — useful for backlog
+        # context when an agent finally drains a long-queued message.
+        defn = {"invokeMessage": ["x", "[$TIMESTAMP] $SENDER: $MESSAGE"]}
+        msg = {
+            "from": "GERRY",
+            "to": "CLAUDE",
+            "date": "2026-04-28T14:30:00.000000Z",
+            "content": "hi",
+        }
+        argv = build_command(defn, msg, "message")
+        assert argv == ["x", "[2026-04-28T14:30:00.000000Z] GERRY: hi"]
+
+    def test_age_substitution_relative_to_now(self, monkeypatch):
+        # Freeze the clock by monkeypatching `datetime` in definitions module.
+        from datetime import timedelta
+        import definitions as dmod
+        frozen = datetime(2026, 4, 28, 14, 35, 0, tzinfo=timezone.utc)
+        msg_date = (frozen - timedelta(minutes=5)).isoformat().replace("+00:00", "Z")
+
+        class FakeDT(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                return frozen
+        monkeypatch.setattr(dmod, "datetime", FakeDT)
+
+        defn = {"invokeMessage": ["x", "($AGE) $MESSAGE"]}
+        msg = {"from": "G", "to": "C", "date": msg_date, "content": "hi"}
+        argv = build_command(defn, msg, "message")
+        assert argv == ["x", "(5 minutes ago) hi"]
+
+    def test_clear_does_not_substitute_timestamp_or_age(self):
+        # invokeClear deliberately gets empty strings for all message-shaped
+        # vars, including $TIMESTAMP and $AGE — there's no message to age.
+        defn = {"invokeClear": ["x", "TS:$TIMESTAMP", "AGE:$AGE"]}
+        msg = {"clear": True, "date": "2026-04-28T14:30:00Z"}
+        argv = build_command(defn, msg, "clear")
+        assert argv == ["x", "TS:", "AGE:"]
+
+    def test_missing_date_yields_empty_age_and_timestamp(self):
+        # Defensive: a message without `date` (shouldn't normally happen)
+        # gets empty $TIMESTAMP / $AGE rather than crashing.
+        defn = {"invokeMessage": ["x", "TS:$TIMESTAMP", "AGE:$AGE", "$MESSAGE"]}
+        msg = {"from": "G", "to": "C", "content": "hi"}
+        argv = build_command(defn, msg, "message")
+        assert argv == ["x", "TS:", "AGE:", "hi"]
+
 
 class TestExpandArgv:
     def test_no_placeholders(self):
@@ -142,6 +243,15 @@ class TestExpandArgv:
 
     def test_sender_recipient_message_in_one_arg(self):
         assert _expand_argv(["$SENDER->$RECIPIENT: $MESSAGE"], "A", "B", "hi") == ["A->B: hi"]
+
+    def test_timestamp_and_age(self):
+        argv = _expand_argv(
+            ["[$TIMESTAMP][$AGE] $MESSAGE"],
+            "A", "B", "hi",
+            timestamp="2026-04-28T14:30:00Z",
+            age="5 minutes ago",
+        )
+        assert argv == ["[2026-04-28T14:30:00Z][5 minutes ago] hi"]
 
     def test_a8s_dir_substitution(self):
         from core import SCRIPT_DIR

--- a/apps/a8s/tests/test_mailbox.py
+++ b/apps/a8s/tests/test_mailbox.py
@@ -194,24 +194,25 @@ class TestRouteOutboxes:
         assert n == 2
         assert list(inbox_dir("A").iterdir()) == []
         b_msg = json.loads(next(inbox_dir("B").iterdir()).read_text())
-        assert b_msg["alias"] == "devs"
-        assert b_msg["others_count"] == 1  # B sees 1 OTHER (C)
-        assert b_msg["to"] == "B"
+        # Strict opacity (#69, #70): no `alias` / `others_count` fields, and
+        # `to` preserves the alias name (mailing-list semantics).
+        assert "alias" not in b_msg
+        assert "others_count" not in b_msg
+        assert b_msg["to"] == "devs"
         assert b_msg["from"] == "A"
 
-    def test_alias_fanout_others_count_when_outsider_sends(self, three_agents):
+    def test_alias_fanout_preserves_to_for_all_recipients(self, three_agents):
+        # Both fanout recipients see `to: devs`; the message shape is
+        # identical for them (no individual "you got this" leak).
         a, b, c = three_agents
-        # An outsider (also A here, but pretending) sends to alias of all 3.
-        # If sender is NOT on the alias, all 3 get it. But our setup has
-        # A in the alias, so let's test by removing A from the alias.
         save_aliases({"devs": ["B", "C"]})
         _write_outbox("A", a.root, "devs", "msg", [])
-        n = route_outboxes([a, b, c], all_agents=[a, b, c])
-        # All members (B and C) get it.
-        assert n == 2
-        b_msg = json.loads(next(inbox_dir("B").iterdir()).read_text())
-        assert b_msg["alias"] == "devs"
-        assert b_msg["others_count"] == 1  # B sees 1 OTHER (C)
+        route_outboxes([a, b, c], all_agents=[a, b, c])
+        for n in ("B", "C"):
+            m = json.loads(next(inbox_dir(n).iterdir()).read_text())
+            assert m["to"] == "devs"
+            assert "alias" not in m
+            assert "others_count" not in m
 
     def test_empty_to_is_rejected_to_trash(self, two_agents):
         a, b = two_agents
@@ -298,9 +299,7 @@ class TestAtomicFanout:
         with out_path.open("r", encoding="utf-8") as f:
             base_msg = json.load(f)
         base_msg["from"] = "A"  # routing force-overwrites this anyway
-        base_msg["to"] = "B"
-        base_msg["alias"] = "devs"
-        base_msg["others_count"] = 1
+        # `to` stays at "devs" — strict opacity preserves the original target.
         b_pre = inbox_dir("B") / out_path.name
         with b_pre.open("w", encoding="utf-8") as f:
             json.dump(base_msg, f)


### PR DESCRIPTION
Closes #69, closes #70.

## Summary

Mailing-list semantics for routed messages: recipient sees sender + what was written in `to`, but not who else got it. A direct tell and an alias-fanned tell produce the same prompt shape — only `$RECIPIENT` differs.

Three simplifications collapsed into one change:

1. **Drop `alias` / `others_count` from routed messages.** `route_outboxes` no longer overwrites `to` and no longer adds alias-context fields. The recipient's view of a fanned message is indistinguishable from a direct one in shape; the only signal that it came via the list is the alias name preserved in `to`.

2. **`invokeMessageAlias` verb goes away.** `select_verb` returns one of `prompt` / `message` / `clear`. Three verbs, not four.

3. **`promptMessage` / `promptMessageAlias` templates go away.** Argv interpolation handles the whole job. New vars: `$SENDER`, `$RECIPIENT`, `$MESSAGE` (content + any `FILE:` lines), `$TIMESTAMP` (ISO date the message was queued), `$AGE` (human-readable "N units ago" computed at wake time so a long backlog gets accurate per-message ages), plus the existing `$A8S_DIR`. No `$PROMPT`, no separate template stage. `build_prompt` is deleted; `build_command(definition, msg, verb)` does it all.

## Definition shape: before → after

```diff
 {
   "description": "Claude Code default — granular permissions, continues prior session.",
-  "invokePrompt":       ["claude", "...", "--continue", "-p", "$PROMPT"],
-  "invokeMessage":      ["claude", "...", "--continue", "-p", "$PROMPT"],
-  "invokeMessageAlias": ["claude", "...", "--continue", "-p", "$PROMPT"],
-  "invokeClear":        ["claude", "-p", "Conversation cleared. New conversation starts now."],
-  "promptMessage":      "{sender} tells you ({recipient}): {message}",
-  "promptMessageAlias": "{sender} tells you ({recipient}) and {others_count} others on the {alias} alias: {message}"
+  "invokePrompt":  ["claude", "...", "--continue", "-p", "$MESSAGE"],
+  "invokeMessage": ["claude", "...", "--continue", "-p", "$SENDER tells $RECIPIENT ($AGE): $MESSAGE"],
+  "invokeClear":   ["claude", "-p", "Conversation cleared. New conversation starts now."]
 }
```

6 fields → 3. The three identical invoke argvs collapse. Prompt format lives in argv directly. `$AGE` baked into the bundled `invokeMessage` so backlogged messages carry context (e.g. `"GERRY tells CLAUDE (5 minutes ago): fix this"`).

## Tell skill — async delivery is now explicit

`apps/a8s/skills/tell/SKILL.md` description and body now state plainly that delivery is asynchronous and recipients may take seconds, minutes, or longer to pick up and process a message. Senders should not block waiting for a reply; if a response is essential, ask the user how to proceed.

## Pre-v1 scorch-the-earth

Existing custom definitions break and need rewriting (same shape swap as the bundled ones). No migration code per the project's pre-v1 stance — users wipe `~/.a8s/` and re-add.

## Test plan
- [x] `python3 -m pytest apps/a8s/tests/` → 161 passed (was 148; net +13 from new `TestFormatAge` + `$TIMESTAMP`/`$AGE` integration tests, minus deleted `build_prompt` / messageAlias tests)
- [x] No stale references to `build_prompt` / `invokeMessageAlias` / `promptMessageAlias` / `others_count` / `$PROMPT` outside intentional 'no longer present' assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)