### PR TITLE
feat(a8s): log full wake argv before exec

### DIFF
--- a/apps/a8s/daemon.py
+++ b/apps/a8s/daemon.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import signal
 import subprocess
 import sys
@@ -127,6 +128,7 @@ def wake_once(p: Participant, msg_path: Path) -> None:
     else:
         out_agent(p.name, f"[{p.name}] waking ({verb}) from {trashed.name}: {_preview(msg.get('content', ''))}")
     cmd = build_command(definition, msg, verb)
+    out_agent(p.name, f"[{p.name}] exec: {shlex.join(cmd)}")
     run_with_prefix(p.name, cmd, p.root)
 
 

--- a/apps/a8s/tests/test_daemon.py
+++ b/apps/a8s/tests/test_daemon.py
@@ -306,6 +306,11 @@ class TestWakeOnceVerbs:
         assert "FROM:|TO:MOCK|TS:" in log
         assert "|MSG:show capabilities" in log
         assert "AGE:0 seconds ago" in log or "AGE:1 seconds ago" in log
+        # The full argv is logged before invocation so operators can see the
+        # real prompt that was sent to the wake subprocess.
+        assert "[MOCK] exec: " in log
+        assert "verb=prompt" in log
+        assert "MSG:show capabilities" in log
 
     def test_message_verb_argv_via_routing(self, fake_home, tmp_path, fixtures_dir):
         # Two agents, both using mock.json.


### PR DESCRIPTION
## Summary

- `wake_once` now logs the full argv (`shlex.join`'d) to the per-agent log right before invoking the wake subprocess.
- The existing "waking" line previewed `msg.content`, but the actual interpolated argv — what the LLM CLI was *really* called with — wasn't logged anywhere.
- New log line: `[<NAME>] exec: <shlex-joined argv>`. Copy-pasteable for repro.

## Test plan

- [x] `python3 -m pytest apps/a8s/tests/` — 161 passing
- [x] `test_prompt_verb_argv` extended to assert `[MOCK] exec: ` line, verb arg, and rendered `$MESSAGE`
- [ ] Manual: tail `~/.a8s/agents/<NAME>/log.txt` during a real `tell` and confirm the `exec:` line shows the rendered prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)