### PR TITLE
feat(a8s): add remove command + slim CLI help text

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,7 @@ Key invariants:
 
 ```
 add <name> <dir> [<def>]    register an agent (auto-detects definition from marker)
+remove <name>                unregister an agent; wipes its mailbox dir and prunes aliases. Refuses if a handler is running.
 agents                       list all registered
 discover <path>              read-only scan; suggests add+define commands
 define <name> [<path>]       show or set definition

--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -98,6 +98,7 @@ That's the full loop. Members don't know they're "in a8s" — they just see a `t
 | | |
 |---|---|
 | `a8s add <name> <dir> [<def>]` | Register an agent. Auto-detects definition from `<dir>`'s marker file unless `<def>` is given. |
+| `a8s remove <name>` | Unregister an agent. Wipes `~/.a8s/agents/<NAME>/` and prunes the agent from any alias's member list (deletes empty aliases). Refuses if a handler is running. |
 | `a8s define <name> [<path>]` | Show or set the agent's definition file. |
 | `a8s discover <path>` | Walk a path for marker files; print suggested `add`+`define` commands. Read-only. |
 | `a8s agents` | List every registered agent and its definition. |

--- a/apps/a8s/cli.py
+++ b/apps/a8s/cli.py
@@ -18,6 +18,7 @@ from commands import (
     cmd_logs,
     cmd_ls,
     cmd_prompt,
+    cmd_remove,
     cmd_run,
     cmd_start,
     cmd_step,
@@ -28,25 +29,26 @@ from commands import (
 
 
 COMMANDS: list[tuple[str, str, str]] = [
-    ("add",      "<name> <dir> [<def>]", "Register a new agent. Without <def>, scans <dir> for marker files (CLAUDE.md/GEMINI.md/CODEX.md) and auto-links the matching built-in definition."),
-    ("agents",   "",                     "List every registered agent and definition status."),
-    ("discover", "<path>",               "Walk <path> for marker files; print suggested `a8s add`/`a8s define` commands. Read-only."),
-    ("define",   "<name> [<path>]",      "Show or set <name>'s definition JSON. Without <path>, prints the effective definition."),
-    ("alias",    "[<alias> <member>]",   "Add member to alias (creates if new). Bare lists all aliases. Members may be agents or other aliases."),
-    ("unalias",  "<alias> [<member>]",   "Remove a member from alias, or remove the whole alias."),
-    ("aliases",  "",                     "List every alias and its members."),
-    ("start",    "<name>",               "Detached background process handling <name>. Aliases produce ONE process handling all members (each member's pid file points at it)."),
-    ("run",      "<name>",               "Foreground attached loop. Aliases produce one process handling all members (interleaved output). Ctrl+C: graceful detach. 2nd Ctrl+C: kill subprocess group."),
-    ("step",     "<name>",               "Attach as handler, one route+drain pass across all members, release. Heavyweight: detaches current handler."),
-    ("stop",     "<name>",               "SIGTERM each unique handler PID (one signal per multi-agent handler). Graceful detach — collateral on other members of the same handler."),
-    ("kill",     "<name>",               "Per unique handler PID: SIGTERM, brief grace, 2nd SIGTERM (kills subprocess group), SIGKILL fallback."),
-    ("exit",     "",                     "SIGTERM every running handler. Each detaches gracefully on its own."),
-    ("ls",       "",                     "List only running agents and their handler PIDs."),
-    ("prompt",   "<name> <message>",     "Queue a senderless message. <name> may be an agent or alias (queues per member)."),
-    ("tell",     "<name> <message>",     "Routed message to <name>. <name> may be an agent or alias (fans out at routing time). Sender = agent enclosing CWD."),
-    ("clear",    "<name>",               "Queue a CLEAR sentinel (wipes inbox first; next wake runs invokeClear). Aliases iterate."),
-    ("install",  "",                     "Install canonical skills into each supported tool's user scope."),
-    ("logs",     "<name>... [--tail N] [-f]", "Read per-agent log files; merge-sort multiple by timestamp. Names may include aliases."),
+    ("add",      "<name> <dir> [<def>]",      "Register an agent."),
+    ("remove",   "<name>",                    "Unregister an agent and delete its mailbox."),
+    ("agents",   "",                          "List registered agents."),
+    ("discover", "<path>",                    "Scan a path for agents and suggest `add` commands."),
+    ("define",   "<name> [<path>]",           "Show or set an agent's command definition."),
+    ("alias",    "[<alias> <member>]",        "Group agents under an alias name."),
+    ("unalias",  "<alias> [<member>]",        "Remove a member from an alias, or the whole alias."),
+    ("aliases",  "",                          "List aliases and their members."),
+    ("start",    "<name>",                    "Run an agent in the background."),
+    ("run",      "<name>",                    "Run an agent in the foreground."),
+    ("step",     "<name>",                    "Run an agent for one pass and exit."),
+    ("stop",     "<name>",                    "Stop a running agent."),
+    ("kill",     "<name>",                    "Force-stop a running agent."),
+    ("exit",     "",                          "Stop every running agent."),
+    ("ls",       "",                          "List running agents."),
+    ("tell",     "<name> <message>",          "Send a message to an agent or alias."),
+    ("prompt",   "<name> <message>",          "Send a message with no sender."),
+    ("clear",    "<name>",                    "Start a fresh session for an agent."),
+    ("logs",     "<name>... [--tail N] [-f]", "Show per-agent logs."),
+    ("install",  "",                          "Install the `tell` skill into supported tools."),
 ]
 
 KNOWN_COMMANDS = {name for name, _, _ in COMMANDS}
@@ -67,6 +69,8 @@ CLI_EPILOG = "Commands:\n" + _format_commands(COMMANDS)
 def dispatch(cmd: str, args: list[str], interval: float) -> int:
     if cmd == "add":
         return cmd_add(args)
+    if cmd == "remove":
+        return cmd_remove(args)
     if cmd == "agents":
         return cmd_agents()
     if cmd == "discover":

--- a/apps/a8s/commands.py
+++ b/apps/a8s/commands.py
@@ -28,6 +28,7 @@ from core import (
     BIN_ROOT,
     _pid_alive,
     _preview,
+    agent_dir,
     agent_log_path,
     canonical_name,
     out,
@@ -185,6 +186,58 @@ def cmd_add(args: list[str]) -> int:
     save_registry(reg)
     print(f"added {name} -> {root}")
     print(f"definition: {definition_path}  ({note})")
+    return 0
+
+
+def cmd_remove(args: list[str]) -> int:
+    """`a8s remove <name>` — unregister an agent. Refuses if a handler is
+    running (the user must `a8s stop` it first). Cascades into aliases:
+    drops <name> from any alias's member list, and deletes any alias that
+    becomes empty as a result. Wipes the on-disk per-agent dir
+    (~/.a8s/agents/<NAME>/) — inbox, trash, log, pid file all gone."""
+    if len(args) != 1:
+        print("usage: a8s remove <name>", file=sys.stderr)
+        return 2
+    raw = args[0]
+    try:
+        name = canonical_name(raw)
+    except ValueError as e:
+        print(str(e), file=sys.stderr)
+        return 2
+    reg = load_registry()
+    if name not in reg:
+        print(f"no agent named {raw!r}", file=sys.stderr)
+        return 1
+    holder = _read_handler_pid(name)
+    if holder is not None:
+        print(f"{name} is running (PID {holder}); stop it first: `a8s stop {name}`", file=sys.stderr)
+        return 1
+    aliases = load_aliases()
+    pruned: list[str] = []
+    dropped: list[str] = []
+    for alias_name in list(aliases.keys()):
+        members = aliases[alias_name]
+        kept = [m for m in members if m.lower() != name]
+        if len(kept) == len(members):
+            continue
+        if kept:
+            aliases[alias_name] = kept
+            pruned.append(alias_name)
+        else:
+            del aliases[alias_name]
+            dropped.append(alias_name)
+    if pruned or dropped:
+        save_aliases(aliases)
+    d = agent_dir(name)
+    if d.exists():
+        shutil.rmtree(d, ignore_errors=True)
+    del reg[name]
+    save_registry(reg)
+    print(f"removed {name}")
+    if pruned:
+        print(f"  pruned from aliases: {', '.join(sorted(pruned))}")
+    if dropped:
+        print(f"  dropped now-empty aliases: {', '.join(sorted(dropped))}")
     return 0
 
 

--- a/apps/a8s/tests/test_commands.py
+++ b/apps/a8s/tests/test_commands.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import pytest
 
-from commands import cmd_add, cmd_alias, cmd_kill, cmd_unalias
+from commands import cmd_add, cmd_alias, cmd_kill, cmd_remove, cmd_unalias
 from core import agent_dir, kill_request_path, pid_path
 from registry import load_aliases, load_registry, save_registry
 
@@ -99,6 +99,72 @@ class TestCmdAliasCanonicalization:
         assert rc == 1
         err = capsys.readouterr().err
         assert "unknown member" in err
+
+
+class TestCmdRemove:
+    def test_unknown_agent_rejected(self, fake_home, capsys):
+        rc = cmd_remove(["nobody"])
+        assert rc == 1
+        assert "no agent" in capsys.readouterr().err
+
+    def test_invalid_name_rejected(self, fake_home, capsys):
+        rc = cmd_remove(["foo-bar"])
+        assert rc == 2
+        assert "alphanumeric" in capsys.readouterr().err
+
+    def test_usage_on_wrong_arity(self, fake_home, capsys):
+        assert cmd_remove([]) == 2
+        assert cmd_remove(["a", "b"]) == 2
+
+    def test_running_handler_blocks_removal(self, fake_home, agent_root, capsys):
+        cmd_add(["claude", str(agent_root)])
+        # Claim claude under our own (live) pid.
+        pid_path("claude").parent.mkdir(parents=True, exist_ok=True)
+        pid_path("claude").write_text(str(os.getpid()))
+        rc = cmd_remove(["claude"])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "running" in err
+        # Registry untouched.
+        assert "claude" in load_registry()
+
+    def test_basic_removal_wipes_dir_and_registry(self, fake_home, agent_root):
+        cmd_add(["claude", str(agent_root)])
+        # Materialize the agent dir so we can verify it's wiped.
+        agent_dir("claude").mkdir(parents=True, exist_ok=True)
+        (agent_dir("claude") / "log.txt").write_text("hi")
+        rc = cmd_remove(["claude"])
+        assert rc == 0
+        assert "claude" not in load_registry()
+        assert not agent_dir("claude").exists()
+
+    def test_case_insensitive(self, fake_home, agent_root):
+        cmd_add(["claude", str(agent_root)])
+        rc = cmd_remove(["Claude"])
+        assert rc == 0
+        assert load_registry() == {}
+
+    def test_cascade_prunes_alias_member(self, fake_home, tmp_path, agent_root, capsys):
+        cmd_add(["claude", str(agent_root)])
+        other = tmp_path / "g"; other.mkdir()
+        cmd_add(["gemini", str(other)])
+        cmd_alias(["devs", "claude"])
+        cmd_alias(["devs", "gemini"])
+        rc = cmd_remove(["claude"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "pruned from aliases" in out
+        # Alias remains with just gemini.
+        assert load_aliases() == {"devs": ["gemini"]}
+
+    def test_cascade_drops_now_empty_alias(self, fake_home, agent_root, capsys):
+        cmd_add(["claude", str(agent_root)])
+        cmd_alias(["devs", "claude"])
+        rc = cmd_remove(["claude"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "dropped now-empty aliases" in out
+        assert load_aliases() == {}
 
 
 class TestCmdUnaliasCaseInsensitive:


### PR DESCRIPTION
## Summary

- **`a8s remove <name>`** — unregisters an agent. Wipes `~/.a8s/agents/<NAME>/` (inbox, trash, log, pid), removes the registry entry, and prunes the agent from any alias's member list (deletes empty aliases). Refuses if a handler is running.
- **Slimmed CLI help** — every row in the `Commands:` block was a dense paragraph leaking implementation (`SIGTERM each unique handler PID`, `subprocess group`, `queues per member`, etc). Rewrote each as one short user-facing sentence. README and per-command docstrings still carry the operational detail.

## Test plan

- [x] `python3 -m pytest apps/a8s/tests/` — 169 passing (8 new)
- [x] `python3 apps/a8s/a8s.py` prints the new compact help block
- [ ] Manual: `a8s add X /tmp/x && a8s remove X` — registry cleared, dir wiped
- [ ] Manual: `a8s start X && a8s remove X` — refused with `stop it first`

🤖 Generated with [Claude Code](https://claude.com/claude-code)