### PR TITLE
feat(a8s): `a8s ask` request/response + outbox-routing allowlist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,13 +128,14 @@ Key invariants:
 | `apps/a8s/a8s.py` | thin entry shim (~30 lines) | `cli.main` invocation only |
 | `apps/a8s/core.py` | paths, logging, helpers, `Participant`, mutable `PRINT_LOCK`, path constants (`SCRIPT_DIR`, `DEFINITIONS_DIR`, `ENTRYPOINT`) | leaf module — no a8s imports |
 | `apps/a8s/registry.py` | `~/.a8s/a8s.json` I/O, `resolve_name` (alias resolution with diamond/cycle detection), `sender_from_cwd`, `_scan_for_markers` | depends on `core` |
-| `apps/a8s/mailbox.py` | `route_outboxes` (two-phase: ingest → process), `ensure_mailboxes`, `_queue_prompt`, `_queue_clear_sentinel`, `_split_content_and_files`, `_write_outbox`. Per-message `.retry` sidecars live in `pending/` and drive backoff retries via `BACKOFF_SCHEDULE`. | depends on `core`, `registry`, `ulid` |
+| `apps/a8s/mailbox.py` | `route_outboxes` (two-phase: ingest → process), `ensure_mailboxes`, `_queue_prompt`, `_queue_clear_sentinel`, `_split_content_and_files`, `_write_outbox`. Per-message `.retry` sidecars live in `pending/` and drive backoff retries via `BACKOFF_SCHEDULE`. `_build_routed_message` filters outbox JSON through `ALLOWED_OUTBOX_FIELDS` (anti-spoof: system sentinels like `ask` / `clear` set only by system paths, never copied through agent-written JSON). | depends on `core`, `registry`, `ulid` |
 | `apps/a8s/definitions.py` | `select_verb`, `build_command`, `_expand_argv` (`$SENDER`/`$RECIPIENT`/`$MESSAGE`/`$A8S_DIR`), `load_definition`, `_autodiscover_definition` | depends on `core`, `registry` |
 | `apps/a8s/ulid.py` | `new()` / `parse()` / `is_ulid()` — pure-stdlib Crockford-base32 ULIDs. Mailbox messages are named `<ulid>.json` and carry the same id in the body's `id` field for receive-side dedup. | leaf module |
+| `apps/a8s/transient.py` | `register(name)` / `cleanup(name)` / `is_live(name)` / `prune_stale(...)` — per-process transient agent dirs at `~/.a8s/transient/<NAME>/`. Used by `a8s ask` to mint `ASK_<ulid>` so two terminals' replies don't conflate. `network.receive_envelope` checks `is_live` before the registry filter. | depends on `core` |
 | `apps/a8s/network.py` | `~/.a8s/network.json` IO, `load_remotes` (forwards every key past `transport`/`broker`/`topic` to the transport as `**opts` — each transport handles its own option vocabulary), `make_publish_remotes` (warn-and-continue per-remote publish), `receive_envelope` (decode → ULID dedup → registry filter → atomic inbox write), `start_remotes` / `stop_remotes`. Transport modules imported lazily. | depends on `core`, `registry`, `transports`, `ulid` |
 | `apps/a8s/transports/__init__.py` | `Transport` ABC + `TransportError`. The publish/subscribe/start/stop contract every remote transport implements. | leaf module |
 | `apps/a8s/transports/mqtt.py` | `MqttTransport` — MQTT 3.1.1 with `clean_session=False`, QoS 1, hash-derived stable `client_id` so the broker recognizes the same persistent session across restarts. Today's implementation is paho-mqtt; mini-MQTT pure-stdlib fallback lands as a follow-up and the user-facing config kind stays `mqtt`. The constructor takes a `**opts` bag, aliases `user`/`pass` → `username`/`password`, and rejects unknown keys so a typo in `network.json` fails loud. | depends on `transports`, `paho-mqtt` (soft) |
-| `apps/a8s/daemon.py` | `acquire`/`release` (pid files), `attached_loop` (also spawns subscriber threads via `start_remotes` and stops them on detach), signal handling (`_make_signal_handler`, `_kill_wake_subprocess_group`), `run_with_prefix`, `wake_once`. Mutable globals `_STOP_EVENT`/`_SIGNAL_COUNT`/`_CURRENT_WAKE_PROC` live here. Sets `core.PRINT_LOCK`. | depends on everything above |
+| `apps/a8s/daemon.py` | `acquire`/`release` (pid files), `attached_loop` (also spawns subscriber threads via `start_remotes` and stops them on detach), signal handling (`_make_signal_handler`, `_kill_wake_subprocess_group`), `run_with_prefix` (optional `capture` param for `ask` messages), `wake_once` (writes `<recipient>/.responses/<msg_id>.txt` and dispatches a transient reply when the message is `ask: true`). Mutable globals `_STOP_EVENT`/`_SIGNAL_COUNT`/`_CURRENT_WAKE_PROC` live here. Sets `core.PRINT_LOCK`. | depends on everything above |
 | `apps/a8s/commands.py` | every `cmd_*`, including `cmd_remote add/remove/ls`, `_install_skill_*` for Claude/Gemini/Codex, `_expand_to_agents` | depends on everything above |
 | `apps/a8s/cli.py` | `COMMANDS` table (the source of truth for help text), `dispatch`, `main` | depends on `commands` only |
 
@@ -204,6 +205,31 @@ Key invariants:
   → 24h). After `MAX_ATTEMPTS` failures the message moves to trash with a
   "discarded after backoff exhausted" log. Don't introduce per-pass
   unconditional retries — they generate excess log noise and broker traffic.
+- **Outbox-routing allowlist.** `_build_routed_message` only copies the
+  fields in `ALLOWED_OUTBOX_FIELDS` (`id`, `date`, `to`, `content`,
+  `files`) plus a force-stamped `from`. System sentinels — today `ask`
+  (set by `cmd_ask` to mark request/response messages) and `clear` (set
+  by `cmd_clear` for the inbox-wipe sentinel) — are dropped at routing.
+  Reasoning: an agent's `.outbox/` is agent-writable JSON, so any field
+  that triggers system behavior must be unforgeable. System paths
+  (`cmd_ask`, `cmd_clear`, `cmd_prompt`, the daemon's ask-reply
+  dispatch) bypass `route_outboxes` entirely — they write directly to
+  inbox or publish supervisor envelopes. When introducing a new system
+  sentinel, add it nowhere except the system path that produces it; the
+  allowlist is the wall that prevents agents from inventing it.
+- **`a8s ask` is single-recipient request/response.** `tell` and
+  `prompt` accept aliases and fan out; `ask` rejects aliases (there's
+  exactly one response slot). Local recipients: `wake_once` captures
+  the wake subprocess output (via `run_with_prefix`'s optional
+  `capture` parameter, only enabled when the message has `ask: true`)
+  and writes `~/.a8s/agents/<recipient>/.responses/<msg_id>.txt`. The
+  asker polls that file. Remote recipients: `cmd_ask` mints
+  `ASK_<ulid>` via `transient.register`, spawns its own subscribers on
+  every configured remote so two terminals don't conflate replies, and
+  `_deliver_ask_response` publishes the reply envelope back through
+  `publish_once_to_remotes`. Don't repurpose the `.responses/` channel
+  for non-ask messages — TTL cleanup runs at the top of every routing
+  pass and would clobber anything left there.
 
 ### Surface
 
@@ -225,6 +251,7 @@ exit                         SIGTERM every running handler
 ls                           list only running agents + their handler PIDs
 prompt <name> <message>      senderless supervisor message (raw delivery)
 tell <name> <message>        routed message (sender = agent enclosing CWD)
+ask <name> <message> [--timeout <s>]   send a prompt and print the captured response (single recipient; no aliases)
 clear <name>                 queue CLEAR sentinel (write-time + read-time inbox wipe)
 logs <name>... [--tail N] [-f]   merge-sorted per-agent logs
 remote                                  list all configured remotes
@@ -246,6 +273,11 @@ install                      install canonical skills
 ├── network.json              configured remotes (absent → local-only)
 ├── seen-ids                  cluster-wide ULID ring (receive-side dedup)
 ├── log.txt                   process-scoped supervisor log
+├── transient/                per-process transient agent dirs (a8s ask uses
+│   └── ASK_<ulid>/           ASK_<ulid> as its private reply inbox)
+│       ├── inbox/
+│       ├── inbox.tmp/
+│       └── pid               liveness check for receive_envelope's transient fallback
 └── agents/
     └── <NAME>/
         ├── inbox/            JSON messages waiting for wake_once
@@ -254,6 +286,9 @@ install                      install canonical skills
         │                     awaiting full delivery; <ulid>.json plus
         │                     optional <ulid>.json.retry sidecar tracking
         │                     attempts and per-remote success
+        ├── .responses/       captured wake stdout for `ask: true` messages,
+        │                     keyed by <msg_id>.txt; consumer reads + unlinks,
+        │                     handler-side TTL prunes orphans
         ├── trash/             processed / discarded messages
         ├── log.txt            agent-scoped log
         └── pid                handler attachment (one or more agents may share a PID)

--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -126,6 +126,7 @@ That's the full loop. Members don't know they're "in a8s" — they just see a `t
 |---|---|
 | `a8s tell <name> <msg>` | Routed message. `<name>` may be an agent or alias (fans out at routing time). Sender = agent enclosing CWD. |
 | `a8s prompt <name> <msg>` | Senderless supervisor message — delivered raw, no template wrapping. |
+| `a8s ask <name> <msg> [--timeout <s>]` | Send a prompt and print the recipient's captured response on stdout. Single-recipient only — aliases are rejected. Local recipient: handler writes the captured wake stdout to a per-message response file; ask polls it. Remote recipient: ask spawns a transient subscriber so two terminals don't conflate replies. Default timeout 60s. |
 | `a8s clear <name>` | Queue a CLEAR sentinel. Inbox is wiped at write time and at read time; the next wake runs `invokeClear`. Aliases iterate. |
 | `a8s logs <name>... [--tail N] [-f]` | Read per-agent log files; merge-sort by ISO timestamp across multiple agents. `-f` follows. |
 
@@ -218,6 +219,11 @@ The default definitions follow the opacity rule — `$SENDER tells $RECIPIENT: $
 ├── network.json              configured remotes (absent → local-only)
 ├── seen-ids                  cluster-wide ULID ring for receive-side dedup
 ├── log.txt                   process-scoped supervisor log
+├── transient/                per-process transient agent dirs (used by `a8s ask`
+│   └── ASK_<ulid>/           to mint a private reply inbox; cleaned on exit)
+│       ├── inbox/
+│       ├── inbox.tmp/
+│       └── pid
 └── agents/
     └── <NAME>/
         ├── inbox/            pending JSON messages (drained by wake_once)
@@ -226,6 +232,8 @@ The default definitions follow the opacity rule — `$SENDER tells $RECIPIENT: $
         │                     awaiting full delivery — `<ulid>.json` plus
         │                     optional `<ulid>.json.retry` sidecar tracking
         │                     attempts + per-remote success
+        ├── .responses/       captured wake stdout for `ask: true` messages,
+        │                     keyed by message id; consumer reads + unlinks
         ├── trash/             processed messages
         ├── log.txt            per-agent log (wakes, routing, subprocess output)
         └── pid                handler attachment

--- a/apps/a8s/cli.py
+++ b/apps/a8s/cli.py
@@ -9,6 +9,7 @@ from commands import (
     cmd_agents,
     cmd_alias,
     cmd_aliases,
+    cmd_ask,
     cmd_clear,
     cmd_define,
     cmd_discover,
@@ -48,6 +49,7 @@ COMMANDS: list[tuple[str, str, str]] = [
     ("ls",       "",                          "List running agents."),
     ("tell",     "<name> <message>",          "Send a message to an agent or alias."),
     ("prompt",   "<name> <message>",          "Send a message with no sender."),
+    ("ask",      "<name> <message> [--timeout <s>]", "Send a message and print the response."),
     ("clear",    "<name>",                    "Start a fresh session for an agent."),
     ("logs",     "<name>... [--tail N] [-f]", "Show per-agent logs."),
     ("remote",   "[<name> [<broker> <topic> [--<k> <v> ...]]]", "List, show, or set a cross-machine remote."),
@@ -107,6 +109,8 @@ def dispatch(cmd: str, args: list[str], interval: float) -> int:
         return cmd_tell(args)
     if cmd == "clear":
         return cmd_clear(args)
+    if cmd == "ask":
+        return cmd_ask(args)
     if cmd == "install":
         return cmd_install()
     if cmd == "logs":

--- a/apps/a8s/commands.py
+++ b/apps/a8s/commands.py
@@ -20,9 +20,12 @@ import signal
 import subprocess
 import sys
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 from core import (
+    ASK_PREFIX,
+    ASK_TIMEOUT_DEFAULT_S,
     ENTRYPOINT,
     SKILLS_DIR,
     BIN_ROOT,
@@ -31,9 +34,13 @@ from core import (
     agent_dir,
     agent_log_path,
     canonical_name,
+    inbox_dir,
+    inbox_tmp_dir,
     out,
     out_agent,
     pid_path,
+    response_path,
+    transient_inbox_dir,
 )
 from definitions import _autodiscover_definition, default_definition_path
 from daemon import (
@@ -51,9 +58,15 @@ from mailbox import (
 from network import (
     configured_remote_ids,
     load_network_config,
+    load_remotes,
+    make_receive_callback,
     publish_once_to_remotes,
     save_network_config,
+    start_remotes,
+    stop_remotes,
 )
+import transient as transient_dirs
+from ulid import new as new_ulid
 from registry import (
     _scan_for_markers,
     find_participant,
@@ -879,6 +892,231 @@ def cmd_clear(args: list[str]) -> int:
         queued += 1
     print(f"queued clear for {queued} agent(s)")
     return 0
+
+
+# ---------- ask ----------
+
+def _parse_ask_args(args: list[str]) -> tuple[str, str, float] | int:
+    """Pull `--timeout <seconds>` out of the argv tail. Returns
+    (recipient, message, timeout_s) or an int exit code on usage error."""
+    timeout = float(ASK_TIMEOUT_DEFAULT_S)
+    rest: list[str] = []
+    i = 0
+    while i < len(args):
+        if args[i] == "--timeout" and i + 1 < len(args):
+            try:
+                timeout = float(args[i + 1])
+            except ValueError:
+                print("ask: --timeout requires a number of seconds", file=sys.stderr)
+                return 2
+            i += 2
+            continue
+        rest.append(args[i])
+        i += 1
+    if len(rest) < 2:
+        print("usage: a8s ask <name> <message> [--timeout <seconds>]", file=sys.stderr)
+        return 2
+    recipient, *body = rest
+    return recipient, " ".join(body), timeout
+
+
+def _ask_local(recipient_name: str, content: str, timeout: float) -> int:
+    """Local recipient path. Write directly to the recipient's inbox with
+    `ask: true`, then poll `~/.a8s/agents/<recipient>/.responses/<id>.txt`
+    for the captured wake output. No transient name needed — the response
+    file is keyed by message id."""
+    parts = participants_from_registry()
+    target = find_participant(parts, recipient_name)
+    if target is None:
+        print(f"ask: registry inconsistency — {recipient_name!r} not found", file=sys.stderr)
+        return 1
+
+    msg_id = new_ulid()
+    now = datetime.now(timezone.utc)
+    msg = {
+        "id": msg_id,
+        "date": now.isoformat().replace("+00:00", "Z"),
+        "from": "",
+        "to": target.name,
+        "content": content,
+        "files": [],
+        "ask": True,
+    }
+    inbox_dir(target.name).mkdir(parents=True, exist_ok=True)
+    inbox_tmp_dir(target.name).mkdir(parents=True, exist_ok=True)
+    staging = inbox_tmp_dir(target.name) / f"{msg_id}.json"
+    final = inbox_dir(target.name) / f"{msg_id}.json"
+    with staging.open("w", encoding="utf-8") as f:
+        json.dump(msg, f, indent=2)
+    os.replace(str(staging), str(final))
+
+    deadline = time.time() + timeout
+    rpath = response_path(target.name, msg_id)
+    while time.time() < deadline:
+        if rpath.is_file():
+            try:
+                text = rpath.read_text(encoding="utf-8")
+            except OSError as e:
+                print(f"ask: failed to read response: {e}", file=sys.stderr)
+                return 1
+            try:
+                rpath.unlink()
+            except OSError:
+                pass
+            sys.stdout.write(text)
+            if not text.endswith("\n"):
+                sys.stdout.write("\n")
+            return 0
+        time.sleep(0.2)
+    print(f"ask: timed out after {timeout:g}s waiting for {target.name}", file=sys.stderr)
+    return 1
+
+
+def _ask_remote(recipient_name: str, content: str, timeout: float) -> int:
+    """Remote recipient path. Mint a transient `ASK_<ulid>` so two terminals
+    can each run `ask` without conflating replies. Spawn this process's
+    own subscribers on every configured remote (the seen-ids ring + the
+    `transient.is_live` check make `receive_envelope` deliver matching
+    replies into our transient inbox), publish the ask envelope, poll the
+    transient inbox for the first reply."""
+    transient_name = f"{ASK_PREFIX}{new_ulid()}"
+    transient_dirs.prune_stale()
+    transient_dirs.register(transient_name)
+    inbox = transient_inbox_dir(transient_name)
+    started: list = []
+    cleaned = {"done": False}
+
+    def cleanup() -> None:
+        if cleaned["done"]:
+            return
+        cleaned["done"] = True
+        try:
+            stop_remotes(started)
+        except Exception:
+            pass
+        transient_dirs.cleanup(transient_name)
+
+    def on_signal(_signum, _frame):
+        cleanup()
+        sys.exit(130)
+
+    signal.signal(signal.SIGINT, on_signal)
+    signal.signal(signal.SIGTERM, on_signal)
+
+    remotes = load_remotes()
+    if not remotes:
+        cleanup()
+        print(
+            f"ask: no agent or alias named {recipient_name!r} and no remotes configured",
+            file=sys.stderr,
+        )
+        return 1
+    started = start_remotes(remotes, lambda: [])
+
+    msg_id = new_ulid()
+    now = datetime.now(timezone.utc)
+    envelope = {
+        "id": msg_id,
+        "date": now.isoformat().replace("+00:00", "Z"),
+        "from": transient_name,
+        "to": recipient_name,
+        "content": content,
+        "files": [],
+        "ask": True,
+    }
+    try:
+        # The supervisor publish path (publish_once_to_remotes) starts and
+        # stops its own short-lived transports, so we use the started
+        # transports directly for the publish here. That keeps our
+        # subscribers running for the response window without juggling
+        # two transport sets.
+        from transports import TransportError as _TransportError
+
+        envelope_bytes = json.dumps(envelope).encode("utf-8")
+        publish_deadline = time.time() + min(timeout, 30.0)
+        publish_succeeded: list[str] = []
+        last_errors: dict[str, str] = {}
+        pending = list(started)
+        while pending and time.time() < publish_deadline:
+            still: list = []
+            for r in pending:
+                try:
+                    r.publish(envelope_bytes)
+                    publish_succeeded.append(r.id)
+                except _TransportError as e:
+                    last_errors[r.id] = str(e)
+                    still.append(r)
+                except Exception as e:
+                    last_errors[r.id] = f"{type(e).__name__}: {e}"
+                    still.append(r)
+            pending = still
+            if pending:
+                time.sleep(0.25)
+        if not publish_succeeded:
+            print(
+                "ask: publish failed on every remote: "
+                + ", ".join(f"{rid}: {last_errors.get(rid, '?')}" for rid in last_errors),
+                file=sys.stderr,
+            )
+            return 1
+
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            replies = sorted(inbox.iterdir()) if inbox.is_dir() else []
+            for entry in replies:
+                if not entry.is_file():
+                    continue
+                try:
+                    with entry.open("r", encoding="utf-8") as f:
+                        reply = json.load(f)
+                except (OSError, json.JSONDecodeError) as e:
+                    print(f"ask: malformed reply: {e}", file=sys.stderr)
+                    return 1
+                text = reply.get("content", "")
+                sys.stdout.write(text)
+                if not text.endswith("\n"):
+                    sys.stdout.write("\n")
+                return 0
+            time.sleep(0.25)
+        print(f"ask: timed out after {timeout:g}s waiting for reply from {recipient_name}", file=sys.stderr)
+        return 1
+    finally:
+        cleanup()
+
+
+def cmd_ask(args: list[str]) -> int:
+    """`a8s ask <name> <message> [--timeout <s>]` — send a prompt to a single
+    agent and print its captured response on stdout. Unlike `tell` and
+    `prompt`, ask is single-recipient: aliases are rejected (there's only
+    one response slot)."""
+    parsed = _parse_ask_args(args)
+    if isinstance(parsed, int):
+        return parsed
+    recipient_query, content, timeout = parsed
+
+    try:
+        kind, members = resolve_name(recipient_query)
+    except KeyError:
+        # Unknown locally — treat as remote if any remotes configured.
+        if not configured_remote_ids():
+            print(f"ask: no agent or alias named {recipient_query!r}", file=sys.stderr)
+            return 1
+        return _ask_remote(recipient_query, content, timeout)
+    except ValueError as e:
+        print(f"ask: {e}", file=sys.stderr)
+        return 1
+
+    if kind == "alias":
+        print(
+            f"ask: {recipient_query!r} is an alias; ask is single-recipient only",
+            file=sys.stderr,
+        )
+        print("hint: use `a8s tell` for fan-out, or ask a specific member by name", file=sys.stderr)
+        return 1
+    if not members:
+        print(f"ask: {recipient_query!r} resolves to no agents", file=sys.stderr)
+        return 1
+    return _ask_local(members[0], content, timeout)
 
 
 # ---------- logs ----------

--- a/apps/a8s/core.py
+++ b/apps/a8s/core.py
@@ -178,6 +178,41 @@ def network_config_path() -> Path:
     return _a8s_dir() / "network.json"
 
 
+def transient_dir(name: str) -> Path:
+    """Per-process transient agent directory under ~/.a8s/transient/. Lives
+    only for the duration of a single CLI invocation (today: `a8s ask` mints
+    `ASK_<ulid>` so two terminals don't conflate replies). Each transient
+    has its own inbox/inbox.tmp; a pid file marks it as live."""
+    return _a8s_dir() / "transient" / _safe_name(name)
+
+
+def transient_inbox_dir(name: str) -> Path:
+    return transient_dir(name) / "inbox"
+
+
+def transient_inbox_tmp_dir(name: str) -> Path:
+    return transient_dir(name) / "inbox.tmp"
+
+
+def responses_dir(name: str) -> Path:
+    """Per-agent ask-response staging area. The handler writes captured wake
+    output for an `ask` message to `<msg_id>.txt` here so a local asker can
+    poll for a single file rather than spinning up a transient subscriber.
+    Cleaned up by both consumer (cmd_ask reads + unlinks) and producer-side
+    TTL (`prune_stale_responses`)."""
+    return agent_dir(name) / ".responses"
+
+
+def response_path(name: str, msg_id: str) -> Path:
+    return responses_dir(name) / f"{_safe_name(msg_id)}.txt"
+
+
+# `ask` lifetime constants.
+ASK_PREFIX = "ASK_"
+ASK_TIMEOUT_DEFAULT_S = 60
+RESPONSE_TTL_S = 3600  # 1 hour — handler-side cleanup of orphaned response files
+
+
 def seen_ids_path() -> Path:
     """Single cluster-wide ring file holding the last MAX_SEEN_IDS message
     IDs the receive loops have written into local inboxes. Receive-side dedup

--- a/apps/a8s/daemon.py
+++ b/apps/a8s/daemon.py
@@ -29,6 +29,7 @@ from pathlib import Path
 
 import core
 from core import (
+    ASK_PREFIX,
     Participant,
     _pid_alive,
     _preview,
@@ -38,18 +39,25 @@ from core import (
     kill_request_path,
     out_agent,
     pid_path,
+    response_path,
+    responses_dir,
     trash_dir,
     unique_path,
 )
+from datetime import datetime, timezone
 from definitions import build_command, load_definition, select_verb
 from mailbox import ensure_mailboxes, next_inbox_message, route_outboxes
 from network import (
+    _deliver_to_transient,
     load_remotes,
     make_publish_remotes,
+    publish_once_to_remotes,
     start_remotes,
     stop_remotes,
 )
 from registry import participants_from_registry
+import transient as transient_dirs
+from ulid import new as new_ulid
 
 
 # ---------- subprocess execution ----------
@@ -62,11 +70,21 @@ _CURRENT_WAKE_PROC: subprocess.Popen | None = None
 _CURRENT_WAKE_NAME: str | None = None
 
 
-def run_with_prefix(name: str, cmd: list[str], cwd: Path) -> int:
+def run_with_prefix(
+    name: str,
+    cmd: list[str],
+    cwd: Path,
+    capture: list[str] | None = None,
+) -> int:
     """Run the wake subprocess in its own session so SIGKILL can target the
     whole process group (LLM CLI + any helpers it spawns). Tracks the live
     process in `_CURRENT_WAKE_PROC` and the agent in `_CURRENT_WAKE_NAME` so
-    signal handlers can identify which agent's wake is in-flight."""
+    signal handlers can identify which agent's wake is in-flight.
+
+    When `capture` is given, every output line is appended to it (the raw
+    line, no prefix) in addition to the per-agent log write. `wake_once`
+    enables capture only for `ask: true` messages so the response can be
+    sent back to the asker — non-ask wakes pay no extra cost."""
     global _CURRENT_WAKE_PROC, _CURRENT_WAKE_NAME
     prefix = f"{name}> "
     try:
@@ -88,7 +106,10 @@ def run_with_prefix(name: str, cmd: list[str], cwd: Path) -> int:
     try:
         assert proc.stdout is not None
         for line in proc.stdout:
-            out_agent(name, prefix + line.rstrip("\n"))
+            stripped = line.rstrip("\n")
+            out_agent(name, prefix + stripped)
+            if capture is not None:
+                capture.append(stripped)
         proc.wait()
         if proc.returncode != 0:
             out_agent(name, f"{prefix}(exit {proc.returncode})")
@@ -135,7 +156,66 @@ def wake_once(p: Participant, msg_path: Path) -> None:
         out_agent(p.name, f"[{p.name}] waking ({verb}) from {trashed.name}: {_preview(msg.get('content', ''))}")
     cmd = build_command(definition, msg, verb)
     out_agent(p.name, f"[{p.name}] exec: {shlex.join(cmd)}")
-    run_with_prefix(p.name, cmd, p.root)
+    is_ask = msg.get("ask") is True
+    capture: list[str] | None = [] if is_ask else None
+    run_with_prefix(p.name, cmd, p.root, capture=capture)
+    if is_ask:
+        response_text = "\n".join(capture or []).rstrip()
+        _deliver_ask_response(p, msg, response_text)
+
+
+def _deliver_ask_response(p: Participant, msg: dict, text: str) -> None:
+    """Two delivery channels for an ask response:
+
+    1. Always write the captured text to
+       `~/.a8s/agents/<recipient>/.responses/<msg_id>.txt` (atomic
+       stage→rename). A local asker polls this path; this is the only
+       channel the local case needs and avoids a transient subscriber.
+
+    2. If the message's `from` looks like a transient asker name
+       (`ASK_<ulid>`), also dispatch a reply envelope to that name. Local
+       transient → write directly to its inbox. Remote asker → publish
+       to all configured remotes (the asker's cluster's subscribers
+       deliver into its transient inbox)."""
+    msg_id = msg.get("id") or ""
+    if not msg_id:
+        out_agent(p.name, f"[{p.name}] ask response dropped — message had no id")
+        return
+    final = response_path(p.name, msg_id)
+    final.parent.mkdir(parents=True, exist_ok=True)
+    staging = final.with_suffix(final.suffix + ".tmp")
+    try:
+        with staging.open("w", encoding="utf-8") as f:
+            f.write(text)
+        os.replace(str(staging), str(final))
+    except OSError as e:
+        out_agent(p.name, f"[{p.name}] WARN failed to write ask response: {e}")
+
+    asker = (msg.get("from") or "").strip()
+    if not asker.startswith(ASK_PREFIX):
+        return
+    reply = {
+        "id": new_ulid(),
+        "date": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "from": p.name,
+        "to": asker,
+        "content": text,
+        "files": [],
+    }
+    if transient_dirs.is_live(asker):
+        # Asker is on this same cluster — short-circuit straight into its
+        # transient inbox without going through MQTT.
+        _deliver_to_transient(asker, reply["id"], reply)
+        out_agent(p.name, f"[{p.name}] ask reply delivered locally to {asker}")
+        return
+    # Asker lives on a remote cluster. Publish synchronously; warn-and-
+    # continue if every remote fails (the asker times out and the user
+    # re-runs the CLI command).
+    succeeded, failed = publish_once_to_remotes(reply)
+    if succeeded:
+        out_agent(p.name, f"[{p.name}] ask reply published to {','.join(succeeded)}")
+    if failed:
+        out_agent(p.name, f"[{p.name}] WARN ask reply failed on {','.join(failed)}")
 
 
 # ---------- per-agent attachment ----------

--- a/apps/a8s/mailbox.py
+++ b/apps/a8s/mailbox.py
@@ -52,6 +52,7 @@ from core import (
     BACKOFF_SCHEDULE,
     MAX_ATTEMPTS,
     MAX_FILE_BYTES,
+    RESPONSE_TTL_S,
     Participant,
     _preview,
     files_dir,
@@ -60,6 +61,7 @@ from core import (
     outbox_dir,
     out_agent,
     pending_dir,
+    responses_dir,
     retry_sidecar_path,
     trash_dir,
     unique_path,
@@ -72,6 +74,15 @@ from ulid import new as new_ulid
 # `succeeded_remotes` list. Daemon wires this up at startup; passing None
 # keeps the path purely local (no remotes configured).
 PublishRemotes = Callable[[dict, str, list[str], int], list[str]]
+
+
+# Outbox messages are agent-writable: an agent can put any JSON it likes in
+# `<root>/.outbox/<f>.json`. Routing copies only these fields through to the
+# delivered envelope. System-only fields (today: `ask`, `clear`) get dropped
+# so an agent can't manufacture a system sentinel by spoofing JSON it wrote.
+# `from` is force-stamped at process_pending — never copied through the
+# allowlist — so it's not in this set.
+ALLOWED_OUTBOX_FIELDS = {"id", "date", "to", "content", "files"}
 
 
 # ---------- mailboxes ----------
@@ -170,8 +181,16 @@ def _build_routed_message(
 
     Strict opacity (#69, #70): the `to` field is left at whatever the sender
     wrote — alias for fanned messages, agent name for direct ones — same as
-    a public mailing list's `To:` header."""
-    routed = dict(base_msg)
+    a public mailing list's `To:` header.
+
+    Anti-spoofing: the routed copy is built from an allowlist
+    (`ALLOWED_OUTBOX_FIELDS`). System sentinels like `ask` and `clear` are
+    set only on system-path messages (cmd_ask, cmd_clear, daemon-side
+    replies) that bypass this routing — so even if an agent JSON-injects
+    `"ask": true` into its outbox, the field is dropped here. `from` is
+    force-stamped to the (trusted) sender name so it survives the filter."""
+    routed = {k: v for k, v in base_msg.items() if k in ALLOWED_OUTBOX_FIELDS}
+    routed["from"] = sender_name
     src_files = base_msg.get("files") or []
     if src_files:
         new_files: list[dict] = []
@@ -452,6 +471,24 @@ def _process_pending(
     return routed
 
 
+def _prune_stale_responses(agents: list[Participant], ttl_s: int) -> None:
+    """Best-effort TTL cleanup of `.responses/<id>.txt` files. A local ask
+    consumer reads-and-unlinks its own response; this catches the orphan
+    case where an asker died after the handler wrote the response but
+    before the asker could read it."""
+    cutoff = datetime.now(timezone.utc).timestamp() - ttl_s
+    for p in agents:
+        d = responses_dir(p.name)
+        if not d.is_dir():
+            continue
+        for entry in d.iterdir():
+            try:
+                if entry.is_file() and entry.stat().st_mtime < cutoff:
+                    entry.unlink()
+            except OSError:
+                pass
+
+
 def route_outboxes(
     senders: list[Participant],
     all_agents: list[Participant] | None = None,
@@ -477,6 +514,7 @@ def route_outboxes(
     by_name = {p.name.lower(): p for p in all_agents}
     if configured_remote_ids is None:
         configured_remote_ids = []
+    _prune_stale_responses(all_agents, RESPONSE_TTL_S)
     _ingest_outboxes(senders)
     routed = 0
     for sender in senders:

--- a/apps/a8s/network.py
+++ b/apps/a8s/network.py
@@ -38,8 +38,11 @@ from core import (
     out,
     out_agent,
     seen_ids_path,
+    transient_inbox_dir,
+    transient_inbox_tmp_dir,
 )
 from registry import resolve_name
+import transient as transient_dirs
 from transports import OnMessage, Transport, TransportError
 from ulid import is_ulid
 
@@ -211,6 +214,25 @@ def make_publish_remotes(remotes: list[Transport]) -> Callable:
 
 # ---------- receive ----------
 
+def _deliver_to_transient(name: str, msg_id: str, msg: dict) -> None:
+    """Atomic stage→commit into a live transient's inbox. Used by both the
+    daemon's subscribers (so a remote reply to `ASK_<ulid>` finds its way
+    home even when the asker isn't running its own subscriber) and by
+    `a8s ask` itself when its self-spawned subscriber receives the reply."""
+    transient_inbox_dir(name).mkdir(parents=True, exist_ok=True)
+    transient_inbox_tmp_dir(name).mkdir(parents=True, exist_ok=True)
+    final = transient_inbox_dir(name) / f"{msg_id}.json"
+    if final.is_file():
+        return
+    staging = transient_inbox_tmp_dir(name) / f"{msg_id}.json"
+    try:
+        with staging.open("w", encoding="utf-8") as f:
+            json.dump(msg, f, indent=2)
+        os.replace(str(staging), str(final))
+    except OSError as e:
+        out(f"WARN failed to write transient envelope id={msg_id} to {name}: {e}")
+
+
 def receive_envelope(envelope: bytes, all_agents: list[Participant]) -> None:
     """Decode an incoming envelope, dedupe, filter against the local
     registry, and atomically write into each matched local recipient's
@@ -233,6 +255,17 @@ def receive_envelope(envelope: bytes, all_agents: list[Participant]) -> None:
     recipient_name = (msg.get("to") or "").strip()
     if not recipient_name:
         return  # malformed; nothing to filter on
+    # Transient recipients (today: `ASK_<ulid>` minted by `a8s ask`) bypass the
+    # registry. The asker process registers a live transient dir; subscribers
+    # check it before the registry filter and deliver into its private inbox
+    # so a remote reply lands where the asker is polling.
+    if transient_dirs.is_live(recipient_name):
+        if msg.get("files"):
+            msg = dict(msg)
+            msg["files"] = []
+        _deliver_to_transient(recipient_name, msg_id, msg)
+        seen_id_append(msg_id)
+        return
     by_name = {p.name.lower(): p for p in all_agents}
     try:
         kind, member_names = resolve_name(recipient_name)

--- a/apps/a8s/tests/test_commands.py
+++ b/apps/a8s/tests/test_commands.py
@@ -13,6 +13,7 @@ import pytest
 from commands import (
     cmd_add,
     cmd_alias,
+    cmd_ask,
     cmd_clear,
     cmd_kill,
     cmd_prompt,
@@ -474,3 +475,75 @@ class TestCmdClearRemoteRecipient:
         rc = cmd_clear(["GHOST"])
         assert rc == 1
         assert "failed to publish" in capsys.readouterr().err
+
+
+class TestCmdAsk:
+    """`a8s ask` is single-recipient request/response. Local path writes the
+    ask to the recipient's inbox with `ask: true`, polls a per-message
+    response file. Aliases are rejected — there's only one response slot."""
+
+    def test_alias_rejected(self, fake_home, tmp_path, capsys):
+        d = tmp_path / "a"
+        d.mkdir()
+        save_registry({"A": {"root": str(d), "definition": ""}})
+        cmd_alias(["TEAM", "A"])
+        rc = cmd_ask(["TEAM", "hello"])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "alias" in err and "single-recipient" in err
+
+    def test_unknown_no_remotes_rejected(self, fake_home, capsys):
+        rc = cmd_ask(["GHOST", "hello"])
+        assert rc == 1
+        assert "no agent or alias" in capsys.readouterr().err
+
+    def test_local_writes_ask_to_inbox_and_times_out(self, fake_home, tmp_path, capsys):
+        # No handler is running, so the ask never gets a response — it
+        # should time out promptly and exit non-zero.
+        from core import inbox_dir
+        import json as _json
+        d = tmp_path / "a"
+        d.mkdir()
+        save_registry({"A": {"root": str(d), "definition": ""}})
+        rc = cmd_ask(["A", "hello", "--timeout", "0.5"])
+        assert rc == 1
+        # The ask envelope did land in the inbox so a real handler would
+        # have something to wake on.
+        files = list(inbox_dir("A").iterdir())
+        assert len(files) == 1
+        body = _json.loads(files[0].read_text())
+        assert body["ask"] is True
+        assert body["from"] == ""
+        assert body["to"] == "A"
+        assert body["content"] == "hello"
+        err = capsys.readouterr().err
+        assert "timed out" in err
+
+    def test_local_returns_response_when_file_appears(self, fake_home, tmp_path, monkeypatch, capsys):
+        # Simulate the handler by writing the response file ourselves between
+        # ask invocation and timeout. Easiest: monkeypatch time.sleep in the
+        # poll loop to drop the file in.
+        from core import inbox_dir, response_path
+        import commands as _commands
+        import json as _json
+        d = tmp_path / "a"
+        d.mkdir()
+        save_registry({"A": {"root": str(d), "definition": ""}})
+
+        # Capture the message id by intercepting the inbox write.
+        original_sleep = _commands.time.sleep
+
+        def fake_sleep(seconds):
+            files = list(inbox_dir("A").iterdir())
+            if files:
+                msg = _json.loads(files[0].read_text())
+                rpath = response_path("A", msg["id"])
+                rpath.parent.mkdir(parents=True, exist_ok=True)
+                rpath.write_text("the answer is 42")
+            original_sleep(0)  # don't actually sleep — just return immediately
+
+        monkeypatch.setattr(_commands.time, "sleep", fake_sleep)
+        rc = cmd_ask(["A", "what's the answer", "--timeout", "5"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "the answer is 42" in out

--- a/apps/a8s/tests/test_daemon.py
+++ b/apps/a8s/tests/test_daemon.py
@@ -391,6 +391,44 @@ class TestWakeOnceVerbs:
         assert any(b.get("content") == "stale" for b in trashed_bodies)
 
 
+class TestAskWakeCapture:
+    """`ask: true` messages cause `wake_once` to capture the wake subprocess
+    stdout into `<agent>/.responses/<msg_id>.txt`. Local askers poll that
+    file rather than spawning their own subscribers."""
+
+    def test_captures_ask_response_locally(self, mock_agent):
+        from core import response_path
+        from ulid import new as new_ulid
+        msg_id = new_ulid()
+        msg = {
+            "id": msg_id,
+            "date": "2026-04-28T00:00:00Z",
+            "from": "",
+            "to": "MOCK",
+            "content": "what's up",
+            "files": [],
+            "ask": True,
+        }
+        (inbox_dir("MOCK") / f"{msg_id}.json").write_text(json.dumps(msg))
+        rc = attached_loop(["MOCK"], 0.1, single_pass=True)
+        assert rc == 0
+        rpath = response_path("MOCK", msg_id)
+        assert rpath.is_file(), "ask response file should be created"
+        body = rpath.read_text()
+        # Mock CLI prints `MOCK-CLI: <arg>` per argv element. Captured stdout
+        # has those raw lines (no per-agent prefix).
+        assert "MOCK-CLI: verb=prompt" in body
+
+    def test_non_ask_does_not_create_response_file(self, mock_agent):
+        from core import responses_dir
+        _queue_prompt(mock_agent, "regular")
+        rc = attached_loop(["MOCK"], 0.1, single_pass=True)
+        assert rc == 0
+        # Non-ask wake never writes a response file.
+        d = responses_dir("MOCK")
+        assert not d.is_dir() or not list(d.iterdir())
+
+
 class TestAttachedLoopLifecycle:
     def test_attaches_and_detaches(self, mock_agent):
         # No messages — single_pass attaches, sees nothing, detaches.

--- a/apps/a8s/tests/test_mailbox.py
+++ b/apps/a8s/tests/test_mailbox.py
@@ -282,6 +282,65 @@ class TestRouteOutboxes:
         assert delivered["from"] == "A"
 
 
+class TestOutboxAllowlist:
+    """Outbox routing only copies known-safe fields through to the delivered
+    envelope. System sentinels like `ask` (used by cmd_ask to mark messages
+    that should capture+reply) and `clear` (used by cmd_clear sentinels) get
+    dropped here so an agent can't manufacture them by hand-writing JSON to
+    its outbox."""
+
+    def test_ask_field_stripped(self, two_agents):
+        a, b = two_agents
+        outbox = outbox_dir(a.root)
+        f = outbox / "20260101T000000_A.json"
+        f.write_text(json.dumps({
+            "id": "01ABCDEFGHJKMNPQRSTVWXYZ12",
+            "date": "2026-04-28T00:00:00Z",
+            "from": "A",
+            "to": "B",
+            "content": "spoof",
+            "files": [],
+            "ask": True,
+        }))
+        route_outboxes([a, b], all_agents=[a, b])
+        delivered = json.loads(next(inbox_dir("B").iterdir()).read_text())
+        assert "ask" not in delivered
+
+    def test_clear_field_stripped(self, two_agents):
+        a, b = two_agents
+        outbox = outbox_dir(a.root)
+        f = outbox / "20260101T000001_A.json"
+        f.write_text(json.dumps({
+            "id": "01ABCDEFGHJKMNPQRSTVWXYZ13",
+            "date": "2026-04-28T00:00:00Z",
+            "from": "A",
+            "to": "B",
+            "content": "",
+            "files": [],
+            "clear": True,
+        }))
+        route_outboxes([a, b], all_agents=[a, b])
+        delivered = json.loads(next(inbox_dir("B").iterdir()).read_text())
+        assert "clear" not in delivered
+
+    def test_unknown_custom_field_stripped(self, two_agents):
+        a, b = two_agents
+        outbox = outbox_dir(a.root)
+        f = outbox / "20260101T000002_A.json"
+        f.write_text(json.dumps({
+            "id": "01ABCDEFGHJKMNPQRSTVWXYZ14",
+            "date": "2026-04-28T00:00:00Z",
+            "from": "A",
+            "to": "B",
+            "content": "hi",
+            "files": [],
+            "secret_internal_flag": "owned",
+        }))
+        route_outboxes([a, b], all_agents=[a, b])
+        delivered = json.loads(next(inbox_dir("B").iterdir()).read_text())
+        assert "secret_internal_flag" not in delivered
+
+
 class TestAtomicFanout:
     """Issue #67 — `route_outboxes` stages routed copies under each recipient's
     `inbox.tmp/<source-name>` and only renames them into `inbox/` after every

--- a/apps/a8s/tests/test_network.py
+++ b/apps/a8s/tests/test_network.py
@@ -302,6 +302,49 @@ class TestReceiveEnvelope:
         d = inbox_dir("B")
         assert not d.exists() or list(d.iterdir()) == []
 
+    def test_transient_recipient_delivered(self, fake_home):
+        # Live transient (e.g. ASK_<ulid> minted by `a8s ask`) should accept
+        # incoming envelopes addressed to it even though it isn't in the
+        # registry.
+        import transient as transient_dirs
+        from core import transient_inbox_dir
+        name = "ASK_TESTONLY"
+        transient_dirs.register(name)
+        try:
+            msg_id = new_ulid()
+            envelope = json.dumps({
+                "id": msg_id, "from": "GERRY", "to": name,
+                "content": "the answer", "files": [],
+            }).encode()
+            receive_envelope(envelope, [])
+            files = list(transient_inbox_dir(name).iterdir())
+            assert len(files) == 1
+            body = json.loads(files[0].read_text())
+            assert body["content"] == "the answer"
+        finally:
+            transient_dirs.cleanup(name)
+
+    def test_transient_dead_pid_does_not_match(self, fake_home):
+        # A transient dir whose pid file points at a dead process is not
+        # considered live; envelopes addressed to it fall through to the
+        # registry path (and get dropped if the name isn't in the registry).
+        import transient as transient_dirs
+        from core import transient_dir, transient_inbox_dir
+        name = "ASK_STALE"
+        transient_dirs.register(name)
+        try:
+            (transient_dir(name) / "pid").write_text("99999999")
+            assert not transient_dirs.is_live(name)
+            envelope = json.dumps({
+                "id": new_ulid(), "from": "X", "to": name,
+                "content": "ignored", "files": [],
+            }).encode()
+            receive_envelope(envelope, [])
+            d = transient_inbox_dir(name)
+            assert not d.exists() or list(d.iterdir()) == []
+        finally:
+            transient_dirs.cleanup(name)
+
 
 # ---------- start_remotes / stop_remotes ----------
 

--- a/apps/a8s/tests/test_remote_e2e.py
+++ b/apps/a8s/tests/test_remote_e2e.py
@@ -77,6 +77,77 @@ def _write_network_json(home: Path, port: int, topic: str, client_id: str) -> No
     }))
 
 
+def test_ask_reply_round_trip(tmp_path, mqtt_broker, monkeypatch):
+    """An ask reply (from recipient cluster's handler back to the asker's
+    transient name) rides MQTT just like any other envelope: the asker's
+    cluster has a subscriber registered for the topic and `receive_envelope`
+    delivers into the live transient's inbox when `to` matches."""
+    topic = f"a8s/test-ask-{os.getpid()}-{int(time.time() * 1000)}"
+    cluster_a_home = tmp_path / "askA"
+    cluster_a_home.mkdir()
+    cluster_b_home = tmp_path / "respB"
+    cluster_b_home.mkdir()
+    _write_network_json(cluster_a_home, mqtt_broker, topic, "a8s-test-askA")
+    _write_network_json(cluster_b_home, mqtt_broker, topic, "a8s-test-respB")
+
+    import core
+    core.PRINT_LOCK = None
+
+    # Cluster A registers its transient ASK_<ulid> first so the subscriber
+    # we spin up will accept envelopes addressed to it. Pre-warm the
+    # persistent session so the broker holds messages while B publishes.
+    monkeypatch.setenv("HOME", str(cluster_a_home))
+    monkeypatch.delenv("USERPROFILE", raising=False)
+    import transient as transient_dirs
+    from core import transient_inbox_dir
+    from network import load_remotes, start_remotes, stop_remotes
+    transient_name = "ASK_E2ETESTONLY"
+    transient_dirs.register(transient_name)
+    warmup = start_remotes(load_remotes(), lambda: [])
+    stop_remotes(warmup)
+
+    # Cluster B publishes the ask reply envelope through the supervisor
+    # publish helper (same path the daemon's _deliver_ask_response uses for
+    # remote askers).
+    monkeypatch.setenv("HOME", str(cluster_b_home))
+    core.PRINT_LOCK = None
+    from network import publish_once_to_remotes
+    from ulid import new as new_ulid
+    reply = {
+        "id": new_ulid(),
+        "date": "2026-04-28T00:00:00Z",
+        "from": "TARGET",
+        "to": transient_name,
+        "content": "the answer is 42",
+        "files": [],
+    }
+    succeeded, failed = publish_once_to_remotes(reply)
+    assert succeeded, f"publish failed: {failed}"
+
+    # Cluster A reconnects its subscriber; broker replays the held message.
+    monkeypatch.setenv("HOME", str(cluster_a_home))
+    core.PRINT_LOCK = None
+    rx_remotes = start_remotes(load_remotes(), lambda: [])
+    try:
+        deadline = time.time() + 5.0
+        files: list[Path] = []
+        while time.time() < deadline:
+            inbox = transient_inbox_dir(transient_name)
+            if inbox.is_dir():
+                files = list(inbox.iterdir())
+            if files:
+                break
+            time.sleep(0.1)
+        assert files, "ask reply did not arrive at the transient inbox"
+        body = json.loads(files[0].read_text())
+        assert body["from"] == "TARGET"
+        assert body["to"] == transient_name
+        assert body["content"] == "the answer is 42"
+    finally:
+        stop_remotes(rx_remotes)
+        transient_dirs.cleanup(transient_name)
+
+
 def test_remote_round_trip(tmp_path, mqtt_broker, monkeypatch):
     """Sender publishes via attached_loop's remote-routing wiring; a
     receiver running start_remotes on the same broker writes the envelope

--- a/apps/a8s/transient.py
+++ b/apps/a8s/transient.py
@@ -1,0 +1,86 @@
+"""Transient agent directories under `~/.a8s/transient/`.
+
+Used today by `a8s ask` to mint a per-CLI-invocation `ASK_<ulid>` name that
+acts as the asker's pseudo-recipient. The asker registers a transient dir,
+publishes the ask envelope with `from = ASK_<ulid>`, and either spawns its
+own subscribers (remote case) or polls a per-message response file
+(local case). When the reply arrives, it lands in
+`~/.a8s/transient/ASK_<ulid>/inbox/`, the asker reads it, and cleanup
+removes the dir.
+
+A transient is "live" if its pid file points at a running process. Stale
+dirs (process gone, mtime older than `max_age_s`) are pruned best-effort
+on every new registration.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import time
+from pathlib import Path
+
+from core import (
+    _pid_alive,
+    transient_dir,
+    transient_inbox_dir,
+    transient_inbox_tmp_dir,
+)
+
+
+def register(name: str) -> Path:
+    """Create the transient dir for `name`, write the pid file, return the
+    transient root. Idempotent — re-registering the same name no-ops on the
+    dirs but rewrites the pid file."""
+    root = transient_dir(name)
+    transient_inbox_dir(name).mkdir(parents=True, exist_ok=True)
+    transient_inbox_tmp_dir(name).mkdir(parents=True, exist_ok=True)
+    (root / "pid").write_text(str(os.getpid()), encoding="utf-8")
+    return root
+
+
+def cleanup(name: str) -> None:
+    """Remove the transient dir entirely. Safe to call multiple times."""
+    shutil.rmtree(str(transient_dir(name)), ignore_errors=True)
+
+
+def is_live(name: str) -> bool:
+    """True iff a transient dir for `name` exists AND its pid file points at
+    a running process. Used by `network.receive_envelope` to decide whether
+    to deliver an envelope addressed to a transient name."""
+    root = transient_dir(name)
+    if not root.is_dir():
+        return False
+    pid_file = root / "pid"
+    try:
+        pid = int(pid_file.read_text(encoding="utf-8").strip())
+    except (OSError, ValueError):
+        return False
+    return _pid_alive(pid)
+
+
+def prune_stale(max_age_s: int = 3600) -> None:
+    """Best-effort cleanup of transient dirs whose pid is gone or whose mtime
+    is older than `max_age_s`. Called on every `register` so leftover dirs
+    from crashed asks don't accumulate."""
+    # Derive the transient base from a known-name path so we don't hardcode it.
+    base = transient_dir("placeholder").parent
+    if not base.is_dir():
+        return
+    cutoff = time.time() - max_age_s
+    for child in base.iterdir():
+        if not child.is_dir():
+            continue
+        pid_file = child / "pid"
+        alive = False
+        try:
+            pid = int(pid_file.read_text(encoding="utf-8").strip())
+            alive = _pid_alive(pid)
+        except (OSError, ValueError):
+            alive = False
+        try:
+            mtime = child.stat().st_mtime
+        except OSError:
+            mtime = 0
+        if alive and mtime > cutoff:
+            continue
+        shutil.rmtree(str(child), ignore_errors=True)


### PR DESCRIPTION
## Summary
- New `a8s ask <name> <msg> [--timeout <s>]` — send a prompt, capture the recipient's wake stdout, print it. Single recipient (no aliases).
- Local recipients: handler writes `<recipient>/.responses/<msg_id>.txt`; ask polls. No subscriber, no broker — works without remotes.
- Remote recipients: ask mints `ASK_<ulid>` (per-process transient agent at `~/.a8s/transient/`), spawns its own subscribers so two terminals' replies don't conflate, publishes the envelope, polls its private inbox. Recipient cluster's `_deliver_ask_response` publishes captured stdout back via `publish_once_to_remotes`; `receive_envelope` checks the transient dir before the registry filter.
- Outbox routing now uses an allowlist (`ALLOWED_OUTBOX_FIELDS = {id, date, to, content, files}` + force-stamped `from`). System sentinels (`ask`, `clear`, future flags) get stripped at routing — closes the new ask spoof surface and the latent `clear: true` spoof.

## Architecture notes
- `run_with_prefix` gained an optional `capture: list[str] | None` param; `wake_once` enables it only for `ask: true` messages so non-ask wakes pay no cost.
- New `transient.py` (~50 LOC): `register/cleanup/is_live/prune_stale`. Stale dirs (dead pid or older than 1h) get pruned on next `register`.
- `.responses/` files have a 1h TTL pruned at the top of every routing pass — handler-side cleanup of orphans where the asker died after the handler wrote the response.
- The local-ask path requires the recipient's handler to be running so wake fires. Cross-cluster ask additionally requires the recipient cluster's handler to be running. The asker's cluster does NOT need a daemon — `cmd_ask` runs its own subscriber for the wait window.

## Test plan
- [x] Unit: 12 new tests across mailbox sanitization, daemon capture, cmd_ask local, network transient receive
- [x] E2E: new `test_ask_reply_round_trip` exercises the full publish → receive into transient inbox path through a real mosquitto broker
- [x] Full suite: **271 passed**
- [x] CLI smoke: `a8s` help shows `ask` row; `a8s ask GHOST "hi"` against a configured remote connects, publishes, times out cleanly with stderr message and exit 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)