### PR TITLE
feat(a8s): A8S_HOME env var for state-dir override

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,8 +244,13 @@ install                      install canonical skills
 
 ### State on disk
 
+The state directory is `$HOME/.a8s` by default and can be relocated with the
+`A8S_HOME` env var — useful for sandboxed test runs that mustn't touch the
+real configuration. All paths below are relative to whichever `A8S_HOME` (or
+default) is in effect.
+
 ```
-~/.a8s/
+~/.a8s/                       (or wherever A8S_HOME points)
 ├── a8s.json                  registry: { agents: {...}, aliases: {...} }
 ├── network.json              configured remotes (absent → local-only)
 ├── seen-ids                  cluster-wide ULID ring (receive-side dedup)

--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -202,8 +202,10 @@ The default definitions follow the opacity rule — `$SENDER tells $RECIPIENT: $
 
 ## State on disk
 
+The state root is `$HOME/.a8s` by default; set `A8S_HOME` to relocate it. This is the only relocation knob — everything below is relative to whichever path `A8S_HOME` points at (or the default). Useful for sandboxed end-to-end tests that mustn't touch the operator's real configuration.
+
 ```
-~/.a8s/
+~/.a8s/                       (or wherever A8S_HOME points)
 ├── a8s.json                  registry: { agents: {...}, aliases: {...} }
 ├── network.json              configured remotes (absent → local-only)
 ├── seen-ids                  cluster-wide ULID ring for receive-side dedup

--- a/apps/a8s/core.py
+++ b/apps/a8s/core.py
@@ -51,7 +51,11 @@ PRINT_LOCK: threading.Lock | None = None
 # ---------- ~/.a8s/ paths ----------
 
 def _a8s_dir() -> Path:
-    base = Path.home() / ".a8s"
+    """State directory for the registry, mailboxes, and process logs. Defaults
+    to `$HOME/.a8s` and can be overridden by setting `A8S_HOME` — useful for
+    sandboxed test runs that must not touch the real configuration."""
+    override = os.environ.get("A8S_HOME")
+    base = Path(override) if override else Path.home() / ".a8s"
     base.mkdir(parents=True, exist_ok=True)
     return base
 
@@ -167,9 +171,7 @@ def files_dir(root: Path) -> Path:
 
 
 def registry_path() -> Path:
-    base = Path.home() / ".a8s"
-    base.mkdir(parents=True, exist_ok=True)
-    return base / "a8s.json"
+    return _a8s_dir() / "a8s.json"
 
 
 def network_config_path() -> Path:

--- a/apps/a8s/tests/conftest.py
+++ b/apps/a8s/tests/conftest.py
@@ -27,6 +27,8 @@ def fake_home(tmp_path, monkeypatch):
     # Some platforms also honor USERPROFILE / HOMEPATH. Set HOME and clear
     # the others to be safe.
     monkeypatch.delenv("USERPROFILE", raising=False)
+    # Don't let a globally-set A8S_HOME leak into tests.
+    monkeypatch.delenv("A8S_HOME", raising=False)
 
     import core
     # Make sure no prior test left a Lock attached.

--- a/apps/a8s/tests/test_core.py
+++ b/apps/a8s/tests/test_core.py
@@ -7,9 +7,11 @@ from core import (
     BACKOFF_SCHEDULE,
     MAX_ATTEMPTS,
     MAX_SEEN_IDS,
+    _a8s_dir,
     agent_dir,
     network_config_path,
     pending_dir,
+    registry_path,
     retry_sidecar_path,
     seen_ids_path,
 )
@@ -63,3 +65,24 @@ class TestSeenIdsCap:
         # 26-char ULID + newline = 27 bytes per row; 10k rows ≈ 270 KiB.
         # Sanity: not zero, not absurd.
         assert 1000 <= MAX_SEEN_IDS <= 1_000_000
+
+
+class TestA8sHomeOverride:
+    def test_default_under_home(self, fake_home):
+        assert _a8s_dir() == fake_home / ".a8s"
+
+    def test_env_var_overrides(self, fake_home, tmp_path, monkeypatch):
+        sandbox = tmp_path / "sandbox-a8s"
+        monkeypatch.setenv("A8S_HOME", str(sandbox))
+        assert _a8s_dir() == sandbox
+        assert sandbox.is_dir()
+
+    def test_registry_path_honors_override(self, fake_home, tmp_path, monkeypatch):
+        sandbox = tmp_path / "sandbox-a8s"
+        monkeypatch.setenv("A8S_HOME", str(sandbox))
+        assert registry_path() == sandbox / "a8s.json"
+
+    def test_agent_dir_honors_override(self, fake_home, tmp_path, monkeypatch):
+        sandbox = tmp_path / "sandbox-a8s"
+        monkeypatch.setenv("A8S_HOME", str(sandbox))
+        assert agent_dir("claude") == sandbox / "agents" / "claude"


### PR DESCRIPTION
## Why

The `~/.a8s/` state directory has been hardcoded to `$HOME/.a8s`. End-to-end testing a connector (e.g. PR #85's gmail connector) against the live bridge requires a sandboxed registry that doesn't clobber the operator's real configuration. Until now there was no way to relocate the state dir without overriding `$HOME` (which ripples into every other tool).

## What

- `_a8s_dir()` honors `A8S_HOME` env var; defaults to `$HOME/.a8s`.
- All derived paths (`registry_path`, `agent_dir`, `inbox_dir`, `pending_dir`, `network_config_path`, etc.) inherit the override automatically.
- `fake_home` test fixture clears `A8S_HOME` so a globally-set override doesn't leak into the suite.
- 4 new tests on `_a8s_dir` / `registry_path` / `agent_dir` covering the default and override paths.
- CLAUDE.md and apps/a8s/README.md state-on-disk diagrams updated.

## Verification

- [x] Full a8s suite: 242 / 242 pass.
- [x] Default behavior unchanged (no env var → `$HOME/.a8s`).
- [x] With `A8S_HOME=/tmp/sandbox`, every derived path lands under `/tmp/sandbox/`.
- [x] Live e2e exercise of PR #85's gmail connector against `knobesq@gmail.com` ran cleanly under `A8S_HOME=/tmp/test-a8s` without touching the operator's real `~/.a8s/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)