### PR TITLE
fix(a8s): dedup local-route round-trip + add idle invoke

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,6 +227,16 @@ in the message envelope.
   → 24h). After `MAX_ATTEMPTS` failures the message moves to trash with a
   "discarded after backoff exhausted" log. Don't introduce per-pass
   unconditional retries — they generate excess log noise and broker traffic.
+- **Local routing claims the ULID in `seen-ids`.** When `_process_pending`
+  commits a local delivery, it appends the message's ULID to the
+  cluster-wide ring at `~/.a8s/seen-ids` — same ring the receive path
+  consults. Without this, our own MQTT round-trip (we publish to the
+  broker; the broker pushes back to our subscriber) would write the
+  envelope a second time once the local handler has trashed the first
+  copy from the inbox. The bug surfaced in #85's live test as a
+  connector emailing every routed message twice (`<ulid>.json` and
+  `<ulid>.1.json` both landed in trash). One append per envelope, after
+  the staged batch commits.
 
 ### Surface
 
@@ -282,12 +292,48 @@ default) is in effect.
         │                     attempts and per-remote success
         ├── trash/             processed / discarded messages
         ├── log.txt            agent-scoped log
+        ├── last-active        ISO timestamp; touched at wake start/end and
+        │                     after every idle invoke. `attached_loop` reads
+        │                     it to gate `definition.idle.invoke` firing.
         └── pid                handler attachment (one or more agents may share a PID)
 
 <agent-root>/
 └── .outbox/                  agent writes here; a8s renames out — never
                               read-modify-writes — to ~/.a8s/agents/<NAME>/pending/
 ```
+
+### Idle invoke
+
+Definitions can opt into a periodic-while-quiet wake via:
+
+```json
+{
+  "invoke":  ["claude", "..."],
+  "idle":    { "timeout": 1800, "invoke": ["claude", "-p", "summarize the day"] }
+}
+```
+
+Semantics:
+
+- The handler tracks per-agent `last-active` (ISO timestamp at
+  `~/.a8s/agents/<NAME>/last-active`).
+- `wake_once` touches it at start and end of every real wake, so a
+  long-running LLM call doesn't leave it stale.
+- After draining the inbox each iteration, `attached_loop` calls
+  `maybe_run_idle(p)`. If `now - last_active >= idle.timeout`, it runs
+  `idle.invoke` via the same `run_with_prefix` path as a real wake, then
+  refreshes `last-active`.
+- A wake in flight blocks idle naturally — `attached_loop` is
+  single-threaded for its handled agents, and the inbox drain happens
+  before the idle check.
+- `timeout: 0` (or negative / non-numeric) disables idle.
+- Argv expansion: `$SENDER`/`$MESSAGE`/`$TIMESTAMP`/`$AGE` are empty
+  (no incoming message); `$RECIPIENT` is the agent's own name;
+  `$A8S_DIR` works as usual.
+
+Idle subsumes the retired `clear` use-case: write a definition whose
+idle invoke runs `claude -p "/clear" --new-session` (or whatever your
+chosen tool needs to reset session state).
 
 ### The single invoke verb
 

--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -180,7 +180,8 @@ Strict opacity (issues #69, #70) still holds: a routed message looks identical w
 ```json
 {
   "description": "...",
-  "invoke": ["claude", "...", "--continue", "-p", "$SENDER tells $RECIPIENT ($AGE): $MESSAGE"]
+  "invoke": ["claude", "...", "--continue", "-p", "$SENDER tells $RECIPIENT ($AGE): $MESSAGE"],
+  "idle":   { "timeout": 1800, "invoke": ["claude", "-p", "summarize the day's tells"] }
 }
 ```
 
@@ -195,6 +196,18 @@ Argv elements run through six substitutions:
 `$TIMESTAMP` and `$AGE` are empty for any message without a `date` field (defensive — every `_write_outbox` stamps one).
 
 Override per-agent with `a8s define <name> <path>` — point at any JSON. The file isn't moved or copied; the registry stores the path.
+
+### Idle invoke (optional)
+
+A definition's `idle` block fires `idle.invoke` when the agent has gone `idle.timeout` seconds without any wake activity. Update mechanics:
+
+- `~/.a8s/agents/<NAME>/last-active` (ISO timestamp) is touched at every wake start, every wake end, and at the end of every idle invoke.
+- After draining the inbox each iteration, `attached_loop` checks each handled agent: if `now - last_active >= timeout`, run `idle.invoke` via the same `run_with_prefix` machinery that real wakes use.
+- A wake in flight blocks idle naturally — the loop is single-threaded for its handled agents and the inbox drain happens before the idle check.
+- `timeout: 0` (or negative / non-numeric) disables idle.
+- Argv expansion: `$SENDER`/`$MESSAGE`/`$TIMESTAMP`/`$AGE` are empty (no incoming message); `$RECIPIENT` is the agent's own name; `$A8S_DIR` resolves as usual.
+
+This subsumes the retired `clear` use-case: define an idle invoke that runs whatever your CLI needs to reset session state (e.g. `claude -p "/clear"`).
 
 ### Recipient transparency
 
@@ -220,6 +233,8 @@ The state root is `$HOME/.a8s` by default; set `A8S_HOME` to relocate it. This i
         │                     attempts + per-remote success
         ├── trash/             processed messages
         ├── log.txt            per-agent log (wakes, routing, subprocess output)
+        ├── last-active        ISO timestamp; touched at wake start/end and
+        │                     after every idle invoke (gates `idle.invoke`)
         └── pid                handler attachment
 
 <agent-root>/

--- a/apps/a8s/core.py
+++ b/apps/a8s/core.py
@@ -131,6 +131,47 @@ def kill_request_path(name: str) -> Path:
     return agent_dir(name) / "kill-request"
 
 
+def last_active_path(name: str) -> Path:
+    """Per-agent last-activity timestamp. Single-line ISO-8601 UTC string,
+    updated at the start of every wake and at the end of every idle-invoke
+    run. `attached_loop` reads it to decide whether the agent has been idle
+    long enough to fire `definition.idle.invoke`. Persists across handler
+    restarts so an idle that was about to fire still fires after a restart."""
+    return agent_dir(name) / "last-active"
+
+
+def read_last_active(name: str) -> datetime | None:
+    """Returns the parsed timestamp, or None if the file is missing /
+    unreadable / unparseable. None signals "no prior activity recorded";
+    callers typically fall back to "now" and write the file."""
+    p = last_active_path(name)
+    if not p.is_file():
+        return None
+    try:
+        s = p.read_text().strip()
+    except OSError:
+        return None
+    if not s:
+        return None
+    try:
+        return datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def touch_last_active(name: str, when: datetime | None = None) -> None:
+    """Write `when` (or now) into the agent's last-active file. Best-effort
+    — disk failures don't propagate (a missed write means the next idle
+    check might fire one cycle late)."""
+    ts = (when or datetime.now(timezone.utc)).isoformat().replace("+00:00", "Z")
+    p = last_active_path(name)
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(ts)
+    except OSError:
+        pass
+
+
 def pending_dir(name: str) -> Path:
     """Ingested-but-not-yet-fully-routed messages. `route_outboxes` atomically
     moves each new file from `<root>/.outbox/` into here on every pass before

--- a/apps/a8s/daemon.py
+++ b/apps/a8s/daemon.py
@@ -25,6 +25,7 @@ import subprocess
 import sys
 import threading
 import time as _time
+from datetime import datetime, timezone
 from pathlib import Path
 
 import core
@@ -38,10 +39,17 @@ from core import (
     kill_request_path,
     out_agent,
     pid_path,
+    read_last_active,
+    touch_last_active,
     trash_dir,
     unique_path,
 )
-from definitions import build_command, load_definition
+from definitions import (
+    build_command,
+    build_idle_command,
+    idle_timeout_seconds,
+    load_definition,
+)
 from mailbox import ensure_mailboxes, next_inbox_message, route_outboxes
 from network import (
     load_remotes,
@@ -99,6 +107,10 @@ def run_with_prefix(name: str, cmd: list[str], cwd: Path) -> int:
 
 
 def wake_once(p: Participant, msg_path: Path) -> None:
+    # Mark activity before any work — covers the parse-error / load-error
+    # exits below too. Without this, a bad inbox file in the only handled
+    # agent could let an idle invoke fire on the same iteration.
+    touch_last_active(p.name)
     try:
         with msg_path.open("r", encoding="utf-8") as f:
             msg = json.load(f)
@@ -122,6 +134,46 @@ def wake_once(p: Participant, msg_path: Path) -> None:
     cmd = build_command(definition, msg)
     out_agent(p.name, f"[{p.name}] exec: {shlex.join(cmd)}")
     run_with_prefix(p.name, cmd, p.root)
+    # And again after the wake returns — a long-running LLM call shouldn't
+    # leave last-active stuck at the pre-wake timestamp.
+    touch_last_active(p.name)
+
+
+def maybe_run_idle(p: Participant) -> bool:
+    """If the agent has `definition.idle.invoke` configured AND has been
+    idle for at least `definition.idle.timeout` seconds, run the configured
+    argv via `run_with_prefix` and refresh `last-active`. Returns True iff
+    an idle invoke fired this call. Errors loading the definition are
+    logged and swallowed — idle never crashes the loop."""
+    try:
+        definition = load_definition(p.name)
+    except (FileNotFoundError, RuntimeError):
+        return False
+    timeout = idle_timeout_seconds(definition)
+    if timeout is None:
+        return False
+    cmd = build_idle_command(definition, p.name)
+    if cmd is None:
+        return False
+    last = read_last_active(p.name)
+    if last is None:
+        # No prior activity recorded — initialize and let the next iteration
+        # start the clock fresh.
+        touch_last_active(p.name)
+        return False
+    elapsed = (datetime.now(timezone.utc) - last).total_seconds()
+    if elapsed < timeout:
+        return False
+    out_agent(
+        p.name,
+        f"[{p.name}] idle {int(elapsed)}s ≥ {int(timeout)}s — firing idle invoke",
+    )
+    out_agent(p.name, f"[{p.name}] idle exec: {shlex.join(cmd)}")
+    try:
+        run_with_prefix(p.name, cmd, p.root)
+    finally:
+        touch_last_active(p.name)
+    return True
 
 
 # ---------- per-agent attachment ----------
@@ -503,6 +555,17 @@ def attached_loop(names: list[str], interval: float, *, single_pass: bool = Fals
                         if msg is None:
                             break
                         wake_once(p, msg)
+                # Idle invoke: per-agent, only after the inbox has drained.
+                # Skipped while a wake is in flight automatically — the
+                # drain loop above is the only thing that calls
+                # `run_with_prefix`, so reaching this point means the
+                # agent is genuinely between wakes for this iteration.
+                if not _STOP_EVENT.is_set():
+                    for p in handled:
+                        try:
+                            maybe_run_idle(p)
+                        except Exception as e:
+                            out_agent(p.name, f"[{p.name}] idle check error: {e}")
             except Exception as e:
                 out_agent(label, f"[a8s] {label}: iteration error: {e}")
             if single_pass:

--- a/apps/a8s/definitions.py
+++ b/apps/a8s/definitions.py
@@ -160,6 +160,41 @@ def build_command(definition: dict, msg: dict) -> list[str]:
     return _expand_argv(list(argv), sender, recipient, body, date_str, age)
 
 
+def build_idle_command(definition: dict, agent_name: str) -> list[str] | None:
+    """Pick the `idle.invoke` argv from `definition` and expand the same
+    interpolation variables `build_command` does. Returns None if the agent
+    has no idle config, or if its `invoke` argv is missing/empty.
+
+    Idle invocations have no incoming message, so $SENDER, $MESSAGE,
+    $TIMESTAMP, and $AGE expand to empty strings. $RECIPIENT is set to the
+    agent's own name so a definition like `["claude", "--continue", "-p",
+    "$RECIPIENT idle wake"]` reads naturally."""
+    idle = definition.get("idle")
+    if not isinstance(idle, dict):
+        return None
+    argv = idle.get("invoke")
+    if not argv:
+        return None
+    return _expand_argv(list(argv), "", agent_name, "", "", "")
+
+
+def idle_timeout_seconds(definition: dict) -> float | None:
+    """Returns `definition.idle.timeout` as a positive float, or None if
+    not configured / not a positive number. Loose typing tolerated:
+    `"60"` strings parse the same as `60`."""
+    idle = definition.get("idle")
+    if not isinstance(idle, dict):
+        return None
+    raw = idle.get("timeout")
+    if raw is None:
+        return None
+    try:
+        v = float(raw)
+    except (TypeError, ValueError):
+        return None
+    return v if v > 0 else None
+
+
 def _autodiscover_definition(root: Path) -> tuple[str, str]:
     """Look for marker files (CLAUDE.md/GEMINI.md/CODEX.md) directly in `root`
     and pick the matching built-in definition. Always returns a usable path:

--- a/apps/a8s/mailbox.py
+++ b/apps/a8s/mailbox.py
@@ -64,6 +64,7 @@ from core import (
     trash_dir,
     unique_path,
 )
+from network import seen_id_append
 from registry import resolve_name
 from ulid import new as new_ulid
 
@@ -388,6 +389,15 @@ def _process_pending(
                         try:
                             _commit_staged_inboxes(staged)
                             sidecar["local_delivered"] = True
+                            # Claim the ULID in the cluster-wide seen-ids ring
+                            # so a remote round-trip (we publish to MQTT below;
+                            # the broker pushes back to our own subscriber)
+                            # gets deduped instead of writing a second inbox
+                            # entry. Whichever recipient(s) accepted the local
+                            # write counts — one append per envelope.
+                            local_msg_id = msg.get("id", "")
+                            if local_msg_id:
+                                seen_id_append(local_msg_id)
                             if kind == "alias":
                                 out_agent(sender.name, f"routed: {sender.name} -> {recipient_name} (alias of {len(recipients)}): {preview}")
                                 for recipient in recipients:

--- a/apps/a8s/tests/test_core.py
+++ b/apps/a8s/tests/test_core.py
@@ -1,6 +1,7 @@
 """Tests for core helpers added for the remote-routing PR (issue #63)."""
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from pathlib import Path
 
 from core import (
@@ -9,11 +10,14 @@ from core import (
     MAX_SEEN_IDS,
     _a8s_dir,
     agent_dir,
+    last_active_path,
     network_config_path,
     pending_dir,
+    read_last_active,
     registry_path,
     retry_sidecar_path,
     seen_ids_path,
+    touch_last_active,
 )
 
 
@@ -86,3 +90,32 @@ class TestA8sHomeOverride:
         sandbox = tmp_path / "sandbox-a8s"
         monkeypatch.setenv("A8S_HOME", str(sandbox))
         assert agent_dir("claude") == sandbox / "agents" / "claude"
+
+
+class TestLastActive:
+    def test_path_under_agent_dir(self, fake_home):
+        assert last_active_path("claude") == agent_dir("claude") / "last-active"
+
+    def test_read_returns_none_when_missing(self, fake_home):
+        assert read_last_active("claude") is None
+
+    def test_touch_then_read_round_trip(self, fake_home):
+        agent_dir("claude").mkdir(parents=True, exist_ok=True)
+        ts = datetime(2026, 4, 29, 12, 0, 0, tzinfo=timezone.utc)
+        touch_last_active("claude", ts)
+        assert read_last_active("claude") == ts
+
+    def test_touch_writes_now_by_default(self, fake_home):
+        agent_dir("claude").mkdir(parents=True, exist_ok=True)
+        before = datetime.now(timezone.utc)
+        touch_last_active("claude")
+        after = datetime.now(timezone.utc)
+        got = read_last_active("claude")
+        assert got is not None
+        assert before <= got <= after
+
+    def test_read_handles_unparseable_content(self, fake_home):
+        d = agent_dir("claude")
+        d.mkdir(parents=True, exist_ok=True)
+        last_active_path("claude").write_text("not-a-date")
+        assert read_last_active("claude") is None

--- a/apps/a8s/tests/test_daemon.py
+++ b/apps/a8s/tests/test_daemon.py
@@ -36,6 +36,7 @@ from daemon import (
     _write_kill_request,
     acquire,
     attached_loop,
+    maybe_run_idle,
     release,
 )
 from mailbox import _write_outbox, ensure_mailboxes
@@ -493,3 +494,149 @@ class TestAttachedLoopKillRequest:
         assert "shared" in _read_log("B")
         assert not pid_path("A").is_file()
         assert not pid_path("B").is_file()
+
+
+# ---------- idle invoke ----------
+
+def _write_idle_def(path: Path, fixtures_dir: Path, timeout: int) -> None:
+    """Write a definition that wakes via mock-cli on tells AND has an
+    idle.invoke that prints a distinguishable string. The idle command's
+    argv echoes 'IDLE-FIRED-FOR:$RECIPIENT' so we can grep the per-agent
+    log to assert it ran."""
+    path.write_text(json.dumps({
+        "invoke": [
+            f"{fixtures_dir}/mock-cli",
+            "FROM:$SENDER|TO:$RECIPIENT|TS:$TIMESTAMP|AGE:$AGE|MSG:$MESSAGE",
+        ],
+        "idle": {
+            "timeout": timeout,
+            "invoke": [
+                f"{fixtures_dir}/mock-cli",
+                "IDLE-FIRED-FOR:$RECIPIENT",
+            ],
+        },
+    }))
+
+
+class TestMaybeRunIdle:
+    """`maybe_run_idle` is the per-iteration check `attached_loop` calls
+    for each handled agent after draining the inbox. It reads
+    `last-active`, computes elapsed, and fires `idle.invoke` iff the
+    agent has been quiet long enough."""
+
+    def test_returns_false_when_no_idle_config(self, fake_home, tmp_path, fixtures_dir):
+        d = tmp_path / "X"; d.mkdir()
+        save_registry({"X": {"root": str(d), "definition": str(fixtures_dir / "mock.json")}})
+        ensure_mailboxes(Participant("X", d))
+        # mock.json has no `idle` block.
+        assert maybe_run_idle(Participant("X", d)) is False
+
+    def test_initializes_last_active_when_missing(self, fake_home, tmp_path, fixtures_dir):
+        from core import last_active_path, read_last_active
+        d = tmp_path / "X"; d.mkdir()
+        defp = tmp_path / "idle.json"
+        _write_idle_def(defp, fixtures_dir, timeout=60)
+        save_registry({"X": {"root": str(d), "definition": str(defp)}})
+        ensure_mailboxes(Participant("X", d))
+        # No last-active file yet — first call seeds it and does NOT fire.
+        assert not last_active_path("X").is_file()
+        fired = maybe_run_idle(Participant("X", d))
+        assert fired is False
+        assert read_last_active("X") is not None
+
+    def test_skips_when_not_yet_idle_long_enough(self, fake_home, tmp_path, fixtures_dir):
+        from core import touch_last_active
+        from datetime import datetime, timezone, timedelta
+        d = tmp_path / "X"; d.mkdir()
+        defp = tmp_path / "idle.json"
+        _write_idle_def(defp, fixtures_dir, timeout=300)
+        save_registry({"X": {"root": str(d), "definition": str(defp)}})
+        ensure_mailboxes(Participant("X", d))
+        # Last active 10 seconds ago; timeout is 300.
+        touch_last_active("X", datetime.now(timezone.utc) - timedelta(seconds=10))
+        assert maybe_run_idle(Participant("X", d)) is False
+
+    def test_fires_when_elapsed_exceeds_timeout(self, fake_home, tmp_path, fixtures_dir):
+        from core import touch_last_active, read_last_active
+        from datetime import datetime, timezone, timedelta
+        d = tmp_path / "X"; d.mkdir()
+        defp = tmp_path / "idle.json"
+        _write_idle_def(defp, fixtures_dir, timeout=1)
+        save_registry({"X": {"root": str(d), "definition": str(defp)}})
+        ensure_mailboxes(Participant("X", d))
+        before = datetime.now(timezone.utc)
+        touch_last_active("X", before - timedelta(seconds=60))
+        fired = maybe_run_idle(Participant("X", d))
+        assert fired is True
+        # Log must show the idle invoke ran.
+        log = _read_log("X")
+        assert "idle exec:" in log
+        assert "IDLE-FIRED-FOR:X" in log
+        # last-active was refreshed to ~now after the run.
+        got = read_last_active("X")
+        assert got is not None
+        assert got >= before
+
+    def test_zero_timeout_disables_idle(self, fake_home, tmp_path, fixtures_dir):
+        d = tmp_path / "X"; d.mkdir()
+        defp = tmp_path / "idle.json"
+        _write_idle_def(defp, fixtures_dir, timeout=0)
+        save_registry({"X": {"root": str(d), "definition": str(defp)}})
+        ensure_mailboxes(Participant("X", d))
+        # Even with no last-active, timeout<=0 means idle is off.
+        assert maybe_run_idle(Participant("X", d)) is False
+
+
+class TestAttachedLoopIdleIntegration:
+    """End-to-end: attached_loop's iteration must call maybe_run_idle for
+    every handled agent after the inbox drain. With single_pass=True we
+    can prep last-active to look "stale" and verify the idle invoke fires
+    on the very first iteration."""
+
+    def test_idle_fires_after_drain(self, fake_home, tmp_path, fixtures_dir):
+        from core import touch_last_active
+        from datetime import datetime, timezone, timedelta
+        d = tmp_path / "X"; d.mkdir()
+        defp = tmp_path / "idle.json"
+        _write_idle_def(defp, fixtures_dir, timeout=1)
+        save_registry({"X": {"root": str(d), "definition": str(defp)}})
+        ensure_mailboxes(Participant("X", d))
+        # Stale last-active so idle should fire this pass.
+        touch_last_active("X", datetime.now(timezone.utc) - timedelta(seconds=60))
+
+        rc = attached_loop(["X"], 0.1, single_pass=True)
+        assert rc == 0
+        log = _read_log("X")
+        assert "idle exec:" in log
+        assert "IDLE-FIRED-FOR:X" in log
+
+    def test_wake_refreshes_last_active_so_idle_doesnt_fire(self, fake_home, tmp_path, fixtures_dir):
+        # If a real wake happened this iteration, last-active was just
+        # touched at wake_once time — idle should NOT fire.
+        d = tmp_path / "X"; d.mkdir()
+        defp = tmp_path / "idle.json"
+        _write_idle_def(defp, fixtures_dir, timeout=1)
+        save_registry({"X": {"root": str(d), "definition": str(defp)}})
+        ensure_mailboxes(Participant("X", d))
+        # Drop a self-tell so there's an inbox message to drain. We can't
+        # tell ourselves through routing (sender exclusion), so write the
+        # routed message directly into the inbox.
+        from ulid import new as new_ulid
+        msg_id = new_ulid()
+        (inbox_dir("X") / f"{msg_id}.json").write_text(json.dumps({
+            "id": msg_id,
+            "date": "2026-04-29T12:00:00Z",
+            "from": "Y",
+            "to": "X",
+            "content": "wake-test",
+            "files": [],
+        }))
+
+        rc = attached_loop(["X"], 0.1, single_pass=True)
+        assert rc == 0
+        log = _read_log("X")
+        # Wake fired (mock-cli received the message).
+        assert "MSG:wake-test" in log
+        # Idle did NOT fire — wake_once just touched last-active.
+        assert "idle exec:" not in log
+        assert "IDLE-FIRED-FOR" not in log

--- a/apps/a8s/tests/test_definitions.py
+++ b/apps/a8s/tests/test_definitions.py
@@ -248,3 +248,61 @@ class TestLoadDefinition:
         registry.save_registry({"X": {"root": "/tmp", "definition": "/nonexistent.json"}})
         with pytest.raises(FileNotFoundError):
             load_definition("X")
+
+
+# ---------- build_idle_command + idle_timeout_seconds ----------
+
+class TestBuildIdleCommand:
+    def test_returns_none_when_no_idle(self):
+        from definitions import build_idle_command
+        assert build_idle_command({"invoke": ["x"]}, "neil") is None
+
+    def test_returns_none_when_idle_invoke_missing(self):
+        from definitions import build_idle_command
+        assert build_idle_command({"invoke": ["x"], "idle": {"timeout": 60}}, "neil") is None
+
+    def test_expands_recipient_to_agent_name(self):
+        from definitions import build_idle_command
+        defn = {"invoke": ["x"], "idle": {"timeout": 60, "invoke": ["claude", "$RECIPIENT idle"]}}
+        assert build_idle_command(defn, "neil") == ["claude", "neil idle"]
+
+    def test_message_fields_are_empty(self):
+        # Idle has no incoming message — sender/message/timestamp/age all blank.
+        from definitions import build_idle_command
+        defn = {"invoke": ["x"], "idle": {"timeout": 60, "invoke": [
+            "echo", "S=$SENDER", "M=$MESSAGE", "T=$TIMESTAMP", "A=$AGE",
+        ]}}
+        assert build_idle_command(defn, "neil") == [
+            "echo", "S=", "M=", "T=", "A=",
+        ]
+
+    def test_a8s_dir_substitution_works(self):
+        from core import SCRIPT_DIR
+        from definitions import build_idle_command
+        defn = {"invoke": ["x"], "idle": {"timeout": 60, "invoke": ["$A8S_DIR/check"]}}
+        assert build_idle_command(defn, "neil") == [f"{SCRIPT_DIR}/check"]
+
+
+class TestIdleTimeoutSeconds:
+    def test_none_when_no_idle(self):
+        from definitions import idle_timeout_seconds
+        assert idle_timeout_seconds({"invoke": ["x"]}) is None
+
+    def test_returns_float_when_set(self):
+        from definitions import idle_timeout_seconds
+        assert idle_timeout_seconds({"idle": {"timeout": 60}}) == 60.0
+
+    def test_string_numeric_parses(self):
+        from definitions import idle_timeout_seconds
+        assert idle_timeout_seconds({"idle": {"timeout": "120"}}) == 120.0
+
+    def test_zero_or_negative_returns_none(self):
+        # Treat 0 and negative as "disabled" — caller skips if None.
+        from definitions import idle_timeout_seconds
+        assert idle_timeout_seconds({"idle": {"timeout": 0}}) is None
+        assert idle_timeout_seconds({"idle": {"timeout": -10}}) is None
+
+    def test_garbage_returns_none(self):
+        from definitions import idle_timeout_seconds
+        assert idle_timeout_seconds({"idle": {"timeout": "soon"}}) is None
+        assert idle_timeout_seconds({"idle": {"timeout": None}}) is None

--- a/apps/a8s/tests/test_mailbox.py
+++ b/apps/a8s/tests/test_mailbox.py
@@ -234,6 +234,44 @@ class TestRouteOutboxes:
         # Routing forces from = sender's actual name, regardless of the JSON.
         assert delivered["from"] == "A"
 
+    def test_local_routing_appends_seen_ids(self, two_agents):
+        """When local routing commits, the message ULID enters the seen-ids
+        ring. Without this a remote round-trip — we publish to MQTT, the
+        broker pushes back to our own subscriber — would deliver the same
+        envelope a second time, and the handler would wake on it twice
+        (the bug seen in PR #85's live test where the connector emailed
+        every routed message twice)."""
+        from network import seen_id_contains
+        a, b = two_agents
+        path = _write_outbox("A", a.root, "B", "dedup-test", [])
+        msg_id = json.loads(path.read_text())["id"]
+        assert not seen_id_contains(msg_id)
+        route_outboxes([a, b], all_agents=[a, b])
+        assert seen_id_contains(msg_id), (
+            "Local routing must claim the ULID so an MQTT round-trip is deduped"
+        )
+
+    def test_local_route_then_receive_envelope_is_no_op(self, two_agents):
+        """End-to-end repro of the round-trip duplicate: local routing
+        delivers, then the same envelope arrives via the remote subscriber
+        (`receive_envelope`). The receive must dedupe — no second inbox
+        file."""
+        from network import receive_envelope
+        a, b = two_agents
+        path = _write_outbox("A", a.root, "B", "loopback", [])
+        envelope_bytes = path.read_text().encode("utf-8")
+        route_outboxes([a, b], all_agents=[a, b])
+        # Simulate MQTT round-trip: drain the inbox first, mimicking the
+        # local handler's wake (so the inbox-file-already-exists short-circuit
+        # in receive_envelope can't be the one catching the dup).
+        inbox_b = inbox_dir("B")
+        for f in list(inbox_b.iterdir()):
+            f.unlink()
+        receive_envelope(envelope_bytes, [a, b])
+        assert list(inbox_b.iterdir()) == [], (
+            "Round-trip must be deduped via seen-ids, not delivered again"
+        )
+
 
 class TestAtomicFanout:
     """Issue #67 — `route_outboxes` stages routed copies under each recipient's


### PR DESCRIPTION
Two changes landed together because the bug surfaced while testing the connector that the new feature targets.

## Bug fix — duplicate message delivery

Live test of #85's gmail connector emailed every `tell` twice:

```
[neil] waking from 01KQD....json: hello       ← first wake
[neil] waking from 01KQD....1.json: hello     ← duplicate
```

Trace:

1. `_process_pending` wrote the routed message to neil's inbox.
2. Same pass published to the configured MQTT broker.
3. Local handler drained inbox, trashed the file.
4. Broker pushed same envelope back to local subscriber.
5. `receive_envelope` saw the ULID was not in `seen-ids` (the local-routing path never claimed it) and the inbox no longer had the file (already trashed), so it staged a second copy.
6. Handler woke again; `unique_path` renamed the second trash entry to `<ulid>.1.json`.

Fix: in `mailbox._process_pending`, append the message ULID to the cluster-wide `seen-ids` ring the moment local delivery commits. The MQTT round-trip's `seen_id_contains` then catches it cleanly. Two new tests pin the append + the end-to-end "route locally → call `receive_envelope` with the same envelope" no-op.

## Feature — `definition.idle.invoke`

Periodic-while-quiet wake. Replaces external cron for connector-side work (gmail connector's reply check) and subsumes the retired `clear` use case.

```json
{
  "invoke": ["claude", "..."],
  "idle":   { "timeout": 1800, "invoke": ["claude", "-p", "summarize"] }
}
```

Mechanics:

- Per-agent `~/.a8s/agents/<NAME>/last-active` (ISO timestamp).
- `wake_once` touches it at start and end of every wake — long-running LLM calls don't leave it stale.
- `attached_loop` calls `maybe_run_idle(p)` after draining the inbox each iteration. If `now - last_active >= idle.timeout`, runs `idle.invoke` via the same `run_with_prefix` path as a real wake; refreshes `last-active` after.
- A wake in flight blocks idle naturally — the loop is single-threaded for its handled agents and drain happens first.
- `timeout: 0` (or negative / non-numeric) disables idle.
- Argv expansion: `$SENDER` / `$MESSAGE` / `$TIMESTAMP` / `$AGE` are empty (no incoming message); `$RECIPIENT` is the agent's own name; `$A8S_DIR` works as usual.

## Tests

24 new tests, full suite 268 → 292 pass in ~3s.

- `test_mailbox.py`: seen-ids appended on local commit; receive after route is a no-op.
- `test_core.py`: `last_active` read/touch round-trip + missing/garbage handling.
- `test_definitions.py`: `build_idle_command` + `idle_timeout_seconds`.
- `test_daemon.py`: `maybe_run_idle` skip-cases and fire-case; `attached_loop` integration showing idle fires after drain when stale and doesn't fire when wake just refreshed `last-active`.

## Docs

- `CLAUDE.md` — new `### Idle invoke` section, `last-active` row in state-on-disk diagram, hard-constraint note pinning the seen-ids local-route invariant (so a future contributor doesn't accidentally remove the append).
- `apps/a8s/README.md` — schema example with idle, new `### Idle invoke (optional)` subsection, state diagram updated.

## Test plan

- [x] Unit tests pass: `python3 -m pytest apps/a8s/tests/`
- [ ] Live verify: re-run the original reproduction from #85's smoke test (a8s + MQTT remote configured, `tell neil "hello"` from a sender on the same machine) — should now produce a single email instead of two.
- [ ] Live verify: definition with `idle.timeout: 60` and `idle.invoke: ["echo", "tick"]`; `a8s run NEIL`; observe one tick per minute of quiet, no ticks while wakes are firing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)