### PR TITLE
fix(a8s): MQTT publish waits briefly for reconnect before raising

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,6 +221,14 @@ in the message envelope.
   `clean_session=False` + QoS 1, with a stable hash-derived `client_id`. The
   broker holds messages for an offline subscriber until reconnect — that's
   how a Cloud-Shell-style listener catches up after coming online.
+- **`publish` waits for the readiness event before raising.** `_on_connect`
+  sets `self._connected`; `_on_disconnect` clears it. When `publish()`
+  finds `is_connected()` False, it `wait()`s up to `connect_timeout_s` for
+  the next CONNACK before raising `broker not connected`. Without this,
+  every NAT timeout / brief broker flap surfaced as a routing-layer warning
+  with backoff, even though paho's loop reconnects within ~1s. Don't drop
+  the disconnect handler — without it the readiness event would stay set
+  forever and the `wait()` would be a no-op on a flap.
 - **Per-message backoff retry.** When a remote publish fails, the
   `<file>.json.retry` sidecar tracks attempts and `next_attempt`. The
   schedule is `BACKOFF_SCHEDULE` (30s → 1m → 2m → 5m → 15m → 30m → 1h → 6h

--- a/apps/a8s/tests/test_transport_mqtt.py
+++ b/apps/a8s/tests/test_transport_mqtt.py
@@ -124,6 +124,64 @@ def test_unreachable_broker_publish_raises():
         t.stop()
 
 
+def test_on_disconnect_clears_ready_event(mqtt_broker):
+    """The disconnect callback must clear the readiness event so a
+    subsequent `publish` knows to wait for the next CONNACK."""
+    t = MqttTransport(
+        remote_id="t",
+        broker=mqtt_broker,
+        topic="a8s/test-disconnect-event",
+        client_id="a8s-test-disconnect-event",
+    )
+    t.start(lambda _b: None)
+    try:
+        assert t._connected.is_set(), "should be connected after start()"
+        # Invoke the callback directly — the v2 signature is
+        # (client, userdata, disconnect_flags, reason_code, properties).
+        t._on_disconnect(t._client, None, None, 0, None)
+        assert not t._connected.is_set()
+    finally:
+        t.stop()
+
+
+def test_publish_waits_for_reconnect_before_raising(mqtt_broker):
+    """When `is_connected()` returns False (transient blip / NAT timeout
+    / mid-reconnect), `publish` must wait up to `connect_timeout_s` for
+    paho's background loop to come back. Without the wait we'd surface a
+    `broker not connected` warning at the routing layer for every blip;
+    with it, only durable disconnects cause the warn-and-retry."""
+    t = MqttTransport(
+        remote_id="t",
+        broker=mqtt_broker,
+        topic="a8s/test-wait-reconnect",
+        client_id="a8s-test-wait-reconnect",
+        connect_timeout_s=0.5,
+    )
+    t.start(lambda _b: None)
+    try:
+        # Simulate a disconnected state without actually disconnecting paho's
+        # socket: clear the event and force is_connected() to lie. This is the
+        # tightest reproduction — we want to verify the wait happens.
+        t._connected.clear()
+        original_is_connected = t._client.is_connected
+        t._client.is_connected = lambda: False  # type: ignore[method-assign]
+        try:
+            start_time = time.monotonic()
+            with pytest.raises(TransportError, match="broker not connected"):
+                t.publish(b"x")
+            elapsed = time.monotonic() - start_time
+            # publish should have waited the full connect_timeout_s before
+            # giving up. Allow a little slack on the lower bound.
+            assert elapsed >= 0.4, (
+                f"publish returned in {elapsed:.3f}s — should have waited "
+                f"~{t._connect_timeout_s}s for the readiness event"
+            )
+        finally:
+            t._client.is_connected = original_is_connected  # type: ignore[method-assign]
+    finally:
+        t.stop()
+
+
 def test_persistent_session_replays_on_reconnect(mqtt_broker):
     """The whole point of clean_session=False + QoS 1: an offline subscriber
     catches up when it reconnects under the same client_id. We simulate by

--- a/apps/a8s/transports/mqtt.py
+++ b/apps/a8s/transports/mqtt.py
@@ -131,6 +131,12 @@ class MqttTransport(Transport):
             client.subscribe(self._topic, qos=1)
             self._connected.set()
 
+    def _on_disconnect(self, client, userdata, disconnect_flags, reason_code, properties):
+        # Clear the readiness event so `publish()` can wait for the next
+        # CONNACK before declaring failure. paho's loop auto-reconnects in
+        # the background while `loop_start()` is running.
+        self._connected.clear()
+
     def _on_message_cb(self, client, userdata, msg):
         cb = self._on_message
         if cb is not None:
@@ -147,6 +153,7 @@ class MqttTransport(Transport):
             raise TransportError(f"{self._remote_id}: already started")
         self._on_message = on_message
         self._client.on_connect = self._on_connect
+        self._client.on_disconnect = self._on_disconnect
         self._client.on_message = self._on_message_cb
         try:
             self._client.connect_async(self._host, self._port, keepalive=self._keepalive)
@@ -177,6 +184,12 @@ class MqttTransport(Transport):
     def publish(self, envelope: bytes) -> None:
         if not self._started:
             raise TransportError(f"{self._remote_id}: publish before start")
+        if not self._client.is_connected():
+            # Transient blip — paho's background loop auto-reconnects.
+            # Wait briefly for the next CONNACK before declaring failure
+            # so a normal NAT-timeout / broker-flap doesn't trigger a
+            # warn-and-backoff at the routing layer.
+            self._connected.wait(timeout=self._connect_timeout_s)
         if not self._client.is_connected():
             raise TransportError(f"{self._remote_id}: broker not connected")
         info = self._client.publish(self._topic, payload=envelope, qos=1)


### PR DESCRIPTION
## Symptom

User report — running agents against HiveMQ Cloud:

```
WARN remote hivemq publish failed (attempt 2): hivemq: broker not connected
```

…appearing regularly, with the per-message backoff (30s → 1m → 2m...) kicking in for what should be transient connection blips.

## Root cause

paho-mqtt's auto-reconnect runs in the background loop. When a connection drops (NAT timeout, broker flap, network blip), `is_connected()` returns False until paho's next CONNACK lands — typically ~1s after the disconnect. Our `publish()` was raising the moment it saw `is_connected() == False`, so every transient blip surfaced as a routing-layer WARN.

## Fix

Add an `_on_disconnect` callback that clears the readiness `Event`, and have `publish()` `wait()` on the event for up to `connect_timeout_s` (default 5s) before raising. Durable failures still surface — the wait just times out — but a normal reconnect completes well inside the window so the publish succeeds without a warning.

## Test coverage (292 → 294)

- `test_on_disconnect_clears_ready_event`: invoke the callback directly; assert the event clears.
- `test_publish_waits_for_reconnect_before_raising`: simulate a disconnected state (clear the event and force `is_connected() = False`); assert `publish` waits ≥ 0.4s (`connect_timeout_s=0.5`) before raising.

## CLAUDE.md

New hard-constraint note explaining the mechanic so a future contributor doesn't accidentally remove the disconnect handler (which would leave the event permanently set, defeating the wait).

## Test plan

- [x] Full a8s suite: 294 / 294 pass.
- [ ] Live verify against HiveMQ — should see far fewer (ideally zero) `broker not connected` warnings during normal operation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)