### PR TITLE
feat(a8s): cross-cluster FILE: payloads via storage services (#90)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,9 +131,11 @@ Key invariants:
 | `apps/a8s/mailbox.py` | `route_outboxes` (two-phase: ingest → process), `ensure_mailboxes`, `_split_content_and_files`, `_write_outbox`. Per-message `.retry` sidecars live in `pending/` and drive backoff retries via `BACKOFF_SCHEDULE`. | depends on `core`, `registry`, `ulid` |
 | `apps/a8s/definitions.py` | `build_command(definition, msg)` (single `invoke` field, no verb dispatch), `_expand_argv` (`$SENDER`/`$RECIPIENT`/`$MESSAGE`/`$TIMESTAMP`/`$AGE`/`$A8S_DIR`), `load_definition`, `_autodiscover_definition` | depends on `core`, `registry` |
 | `apps/a8s/ulid.py` | `new()` / `parse()` / `is_ulid()` — pure-stdlib Crockford-base32 ULIDs. Mailbox messages are named `<ulid>.json` and carry the same id in the body's `id` field for receive-side dedup. | leaf module |
-| `apps/a8s/network.py` | `~/.a8s/network.json` IO, `load_remotes` (forwards every key past `transport`/`broker`/`topic` to the transport as `**opts` — each transport handles its own option vocabulary), `make_publish_remotes` (warn-and-continue per-remote publish), `receive_envelope` (decode → ULID dedup → registry filter → atomic inbox write), `start_remotes` / `stop_remotes`. Transport modules imported lazily. | depends on `core`, `registry`, `transports`, `ulid` |
+| `apps/a8s/network.py` | `~/.a8s/network.json` IO (top-level `remotes` and `services` maps), `load_remotes` and `load_services` (each forwards keys past the dispatcher's reserved set as `**opts` — each transport/service handles its own option vocabulary), `_build_transport` / `_build_service` / `detect_service_kind`, `make_publish_remotes` (warn-and-continue per-remote publish), `receive_envelope` (decode → ULID dedup → registry filter → cross-cluster file download via configured services → atomic inbox write), `start_remotes` / `stop_remotes`. Transport and service modules imported lazily. | depends on `core`, `registry`, `transports`, `services`, `ulid` |
 | `apps/a8s/transports/__init__.py` | `Transport` ABC + `TransportError`. The publish/subscribe/start/stop contract every remote transport implements. | leaf module |
 | `apps/a8s/transports/mqtt.py` | `MqttTransport` — MQTT 3.1.1 with `clean_session=False`, QoS 1, hash-derived stable `client_id` so the broker recognizes the same persistent session across restarts. Today's implementation is paho-mqtt; mini-MQTT pure-stdlib fallback lands as a follow-up and the user-facing config kind stays `mqtt`. The constructor takes a `**opts` bag, aliases `user`/`pass` → `username`/`password`, and rejects unknown keys so a typo in `network.json` fails loud. | depends on `transports`, `paho-mqtt` (soft) |
+| `apps/a8s/services/__init__.py` | `StorageService` ABC + `StorageError`. The `store(src) -> url` / `retrieve(url, dest) -> bool` contract every cross-cluster file backend implements. Stateless — no start/stop. **"Service" disambiguates from "transport"**: messaging plugins are transports (MQTT, etc.), file plugins are services (TempFile.org, etc.). | leaf module |
+| `apps/a8s/services/tempfile_org.py` | `TempFileOrgService` — pure-stdlib `urllib`. POSTs `multipart/form-data` to `/api/upload/local`, GETs `<url>download` for retrieval. 100 MB per-file ceiling (the existing 50 MiB `MAX_FILE_BYTES` keeps us comfortably under). Constructor opts: `expiry_hours` (1, 6, 24, or 48; default 24), `timeout_s` (default 30). | depends on `services`, stdlib only |
 | `apps/a8s/daemon.py` | `acquire`/`release` (pid files), `attached_loop` (also spawns subscriber threads via `start_remotes` and stops them on detach), signal handling (`_make_signal_handler`, `_kill_wake_subprocess_group`), `run_with_prefix`, `wake_once`. Mutable globals `_STOP_EVENT`/`_SIGNAL_COUNT`/`_CURRENT_WAKE_PROC` live here. Sets `core.PRINT_LOCK`. | depends on everything above |
 | `apps/a8s/commands.py` | every `cmd_*`, including `cmd_remote add/remove/ls`, `_install_skill_*` for Claude/Gemini/Codex, `_expand_to_agents` | depends on everything above |
 | `apps/a8s/cli.py` | `COMMANDS` table (the source of truth for help text), `dispatch`, `main` | depends on `commands` only |
@@ -211,12 +213,33 @@ in the message envelope.
   Senders publish to all configured remotes; receivers dedupe by ULID. A
   message to an unknown-locally recipient publishes to all remotes (each
   receiving cluster decides locally whether to deliver based on its own
-  registry). File payloads (`FILE:`) are local-only in v1 —
-  `route_outboxes` marks all configured remotes as "succeeded" for
-  messages with files so they finalize after local delivery instead of
-  looping retries. Note: a8s only routes *messages* across remotes —
-  state queries like `a8s logs`, `a8s ls`, `a8s agents` are strictly
-  local. There is no cross-cluster state query path by design.
+  registry). Note: a8s only routes *messages* across remotes — state
+  queries like `a8s logs`, `a8s ls`, `a8s agents` are strictly local.
+  There is no cross-cluster state query path by design.
+- **Cross-cluster `FILE:` payloads ride storage services (#90).**
+  Configured under `network.json`'s `services` map — separate from the
+  `remotes` (messaging) map. When a sender's `_process_pending` finds a
+  message has files AND services are configured, it uploads each file to
+  every configured service and rewrites the wire envelope's `files[i]`
+  to `{"filename": ..., "storage": [url1, url2, ...]}` (dropping
+  `path` — sender-local). The receiver's `receive_envelope` iterates
+  the URLs × configured services until one accepts the download into
+  `<recipient>/.files/`. Per-file × per-service success is cached in
+  the `<f>.json.retry` sidecar's `uploaded` field so backoff retries
+  don't re-upload to services that already accepted. With NO services
+  configured, files stay local-only — `route_outboxes` marks all
+  remotes as "succeeded" for messages with files so they finalize on
+  local delivery alone. The receive side strips storage-bearing files
+  with a warning if the recipient cluster has no matching service.
+- **Storage services are stateless.** No start/stop lifecycle. One
+  instance per `~/.a8s/network.json` `services` entry, shared between
+  the sender's upload path and the receive callback's download path.
+  Services dispatch via `supports_config_url(url)` (class method) at
+  config-load time and via host match at retrieve time —
+  `retrieve()` returning False means "this URL isn't mine, try the
+  next service" (so a multi-service install can route mixed URLs).
+  Real failures raise `StorageError`. Don't add per-service start/stop
+  unless a future backend genuinely needs a connection pool.
 - **Persistent sessions.** The MQTT transport is configured with
   `clean_session=False` + QoS 1, with a stable hash-derived `client_id`. The
   broker holds messages for an offline subscriber until reconnect — that's
@@ -270,8 +293,10 @@ remote                                  list all configured remotes
 remote <name>                           show one remote's spec (passwords masked)
 remote <name> <broker> <topic> [--<k> <v> ...]   register or overwrite (extras forwarded to transport)
 unremote <name>                          forget a remote
-remote remove <name>         forget a remote
-remote ls                    list configured remotes
+storage                                 list all configured storage services
+storage <name>                          show one service's spec
+storage <name> <url> [--<k> <v> ...]    register or overwrite (kind auto-dispatched from URL; extras forwarded to service)
+unstorage <name>                        forget a storage service
 install                      install canonical skills
 ```
 
@@ -425,8 +450,8 @@ The locked-design refactor (#52) is closed. The following are open:
 | # | State | Topic |
 |---|---|---|
 | #39 | open enhancement | Copilot CLI as 4th tool kind. Trivial after the refactor: write `copilot.json`, add `COPILOT.md` → `copilot` to `core.MARKER_FILES`. |
-| #63 | partially landed | Transparent multi-cluster routing. MQTT transport (paho-mqtt impl) + layered remotes + per-message backoff + ULID dedup are in. Still open: mini-MQTT pure-stdlib fallback (auto-activates when paho isn't importable), HTTPS long-poll transport, peer-to-peer TCP transport, app-level envelope encryption (per-network PSK), cross-cluster `FILE:` payloads (rides #62). |
-| #62 | open enhancement | Cross-cluster file payload host (TempFile.org-style ephemeral storage with signed URLs and per-message symmetric keys). v1 strips `files` from incoming envelopes and skips remote publish for outgoing messages with files. |
+| #63 | partially landed | Transparent multi-cluster routing. MQTT transport (paho-mqtt impl) + layered remotes + per-message backoff + ULID dedup are in. Still open: mini-MQTT pure-stdlib fallback (auto-activates when paho isn't importable), HTTPS long-poll transport, peer-to-peer TCP transport, app-level envelope encryption (per-network PSK). |
+| #90 | landed | Cross-cluster `FILE:` payloads via pluggable storage services (`a8s storage`/`unstorage`). TempFile.org first impl (pure-stdlib HTTP). Per-file × per-service success cached in the retry sidecar; receive side downloads into recipient's `.files/`. App-level encryption / per-message symmetric keys (originally scoped under #62) deferred. |
 | #72 | open question | Design discussion surfaced by the review panel: mailbox file format. (#67's atomic fan-out and #63's ULID + ingest-to-pending split partially address this; revisit before mini-MQTT lands.) |
 
 ### What I tried that didn't work (concrete)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,6 +240,18 @@ in the message envelope.
   next service" (so a multi-service install can route mixed URLs).
   Real failures raise `StorageError`. Don't add per-service start/stop
   unless a future backend genuinely needs a connection pool.
+- **Recipient-CWD-relative `FILE:` paths.** The routed envelope's
+  `files[i].path` is always written as `./.files/<filename>` — never
+  the absolute host path. The wake subprocess runs with
+  `cwd=recipient.root`, so the agent finds the file under whatever
+  prefix its container has mapped that directory to (e.g. host
+  `/home/me/agents/clover/.files/x` mapped to in-container
+  `/home/me/.files/x`). Both the local-copy path
+  (`_transfer_file_to_recipient`) and the cross-cluster download path
+  (`_download_files_to_recipient`) emit through the
+  `_recipient_relative_path` helper. Don't reintroduce
+  `str(absolute_dest)` — it works locally but breaks any agent whose
+  root is bind-mounted at a different path.
 - **Persistent sessions.** The MQTT transport is configured with
   `clean_session=False` + QoS 1, with a stable hash-derived `client_id`. The
   broker holds messages for an offline subscriber until reconnect — that's

--- a/apps/a8s/cli.py
+++ b/apps/a8s/cli.py
@@ -22,9 +22,11 @@ from commands import (
     cmd_start,
     cmd_step,
     cmd_stop,
+    cmd_storage,
     cmd_tell,
     cmd_unalias,
     cmd_unremote,
+    cmd_unstorage,
 )
 
 
@@ -48,6 +50,8 @@ COMMANDS: list[tuple[str, str, str]] = [
     ("logs",     "<name>... [--tail N] [-f]", "Show per-agent logs."),
     ("remote",   "[<name> [<broker> <topic> [--<k> <v> ...]]]", "List, show, or set a cross-machine remote."),
     ("unremote", "<name>",                    "Remove a configured remote."),
+    ("storage",  "[<name> [<url> [--<k> <v> ...]]]",            "List, show, or set a cross-cluster file storage service."),
+    ("unstorage","<name>",                    "Remove a configured storage service."),
     ("install",  "",                          "Install the `tell` skill into supported tools."),
 ]
 
@@ -107,6 +111,10 @@ def dispatch(cmd: str, args: list[str], interval: float) -> int:
         return cmd_remote(args)
     if cmd == "unremote":
         return cmd_unremote(args)
+    if cmd == "storage":
+        return cmd_storage(args)
+    if cmd == "unstorage":
+        return cmd_unstorage(args)
     raise ValueError(f"unknown command: {cmd!r}")
 
 

--- a/apps/a8s/commands.py
+++ b/apps/a8s/commands.py
@@ -49,6 +49,7 @@ from mailbox import (
 )
 from network import (
     configured_remote_ids,
+    detect_service_kind,
     load_network_config,
     save_network_config,
 )
@@ -1009,4 +1010,132 @@ def cmd_unremote(args: list[str]) -> int:
     del cfg["remotes"][name]
     save_network_config(cfg)
     print(f"removed remote {name}")
+    return 0
+
+
+# ---------- storage services (issue #90) ----------
+
+
+def _storage_usage() -> int:
+    print(
+        "usage: a8s storage                                          # list all\n"
+        "       a8s storage <name>                                   # show one\n"
+        "       a8s storage <name> <url> [--<k> <v> ...]             # add or overwrite\n"
+        "       a8s unstorage <name>                                 # remove\n"
+        "\n"
+        "The service kind is auto-dispatched from the URL host. Any --<opt> <value>\n"
+        "pair past the URL is passed verbatim to the service (e.g. --expiry_hours\n"
+        "for tempfile.org). Unknown options are rejected by the service at load time.",
+        file=sys.stderr,
+    )
+    return 2
+
+
+def _format_storage_summary(spec: dict) -> str:
+    kind = spec.get("service", "?")
+    url = spec.get("url", "?")
+    extras = " ".join(
+        f"--{k}=***" if k in _SECRET_KEYS else f"--{k}={v}"
+        for k, v in spec.items()
+        if k not in {"service", "url"}
+    )
+    line = f"{kind} {url}"
+    if extras:
+        line += f" {extras}"
+    return line
+
+
+def cmd_storage(args: list[str]) -> int:
+    """`a8s storage` — manage cross-cluster file services declared in
+    `~/.a8s/network.json` (services map).
+
+    Forms (mirror `a8s remote`):
+      a8s storage                                 list all
+      a8s storage <name>                          show one
+      a8s storage <name> <url> [--<k> <v> ...]    add or overwrite
+      a8s unstorage <name>                        remove (see `cmd_unstorage`)
+    """
+    if len(args) == 0:
+        return _cmd_storage_list()
+    if len(args) == 1:
+        return _cmd_storage_show(args[0])
+    if len(args) >= 2:
+        return _cmd_storage_set(args[0], args[1], args[2:])
+    return _storage_usage()
+
+
+def _cmd_storage_list() -> int:
+    cfg = load_network_config()
+    services = cfg.get("services", {})
+    if not services:
+        print("(no storage services configured)")
+        return 0
+    name_w = max(len(n) for n in services)
+    for name, spec in services.items():
+        print(f"  {name.ljust(name_w)}  {_format_storage_summary(spec)}")
+    return 0
+
+
+def _cmd_storage_show(name: str) -> int:
+    cfg = load_network_config()
+    if name not in cfg["services"]:
+        print(f"no storage named {name!r}", file=sys.stderr)
+        return 1
+    print(f"{name}: {_format_storage_summary(cfg['services'][name])}")
+    return 0
+
+
+def _cmd_storage_set(name: str, url: str, opt_tokens: list[str]) -> int:
+    if not _REMOTE_NAME_RE.match(name):
+        print(f"storage name must be alphanumeric (with -, _, .): {name!r}", file=sys.stderr)
+        return 2
+    extras: dict = {}
+    i = 0
+    while i < len(opt_tokens):
+        tok = opt_tokens[i]
+        if not tok.startswith("--") or len(tok) <= 2:
+            print(f"expected --<opt> <value> pair, got: {tok!r}", file=sys.stderr)
+            return _storage_usage()
+        key = tok[2:]
+        i += 1
+        if i >= len(opt_tokens):
+            print(f"missing value for {tok}", file=sys.stderr)
+            return _storage_usage()
+        if key in extras:
+            print(f"duplicate option: {tok}", file=sys.stderr)
+            return _storage_usage()
+        extras[key] = opt_tokens[i]
+        i += 1
+    kind = detect_service_kind(url)
+    if kind is None:
+        print(
+            f"no storage service matches URL {url!r} (known kinds: tempfile_org)",
+            file=sys.stderr,
+        )
+        return 2
+    cfg = load_network_config()
+    overwriting = name in cfg["services"]
+    spec: dict = {"service": kind, "url": url, **extras}
+    cfg["services"][name] = spec
+    save_network_config(cfg)
+    verb = "updated" if overwriting else "added"
+    print(f"{verb} storage {name} ({_format_storage_summary(spec)})")
+    return 0
+
+
+def cmd_unstorage(args: list[str]) -> int:
+    """`a8s unstorage <name>` — remove a configured storage service. Mirrors
+    `unremote`'s shape so the surface stays uniform across configurable
+    cross-cluster primitives."""
+    if len(args) != 1:
+        print("usage: a8s unstorage <name>", file=sys.stderr)
+        return 2
+    name = args[0]
+    cfg = load_network_config()
+    if name not in cfg["services"]:
+        print(f"no storage named {name!r}", file=sys.stderr)
+        return 1
+    del cfg["services"][name]
+    save_network_config(cfg)
+    print(f"removed storage {name}")
     return 0

--- a/apps/a8s/commands.py
+++ b/apps/a8s/commands.py
@@ -707,6 +707,35 @@ def cmd_ls() -> int:
 
 # ---------- messaging commands ----------
 
+def _join_tell_args(rest: list[str]) -> str:
+    """Concatenate the message-body argv into a single string suitable for
+    `_split_content_and_files`.
+
+    Plain shell usage stays untouched: `tell alice hello world` joins with
+    spaces. But when an argv element starts with `FILE:` — which is what
+    happens when an LLM forgets to fold the FILE: line into the same
+    quoted string — promote it to its own line. `_split_content_and_files`
+    only recognizes trailing FILE: lines (newline-delimited), so without
+    this lift the FILE: tag would silently inline into the body and the
+    attachment would be dropped.
+
+    Examples:
+      ['hello', 'world']                         -> 'hello world'
+      ['msg', 'FILE: ./x']                       -> 'msg\\nFILE: ./x'
+      ['FILE: ./x']                              -> 'FILE: ./x'
+      ['msg', 'FILE: ./a', 'FILE: ./b']          -> 'msg\\nFILE: ./a\\nFILE: ./b'
+    """
+    parts: list[str] = []
+    for arg in rest:
+        if arg.lstrip().startswith("FILE:"):
+            parts.append("\n" + arg.lstrip())
+        else:
+            if parts:
+                parts.append(" ")
+            parts.append(arg)
+    return "".join(parts).strip()
+
+
 def cmd_tell(args: list[str]) -> int:
     """`a8s tell <name> <msg>` — write a single outbox message; `name` may be
     an agent or alias. Fan-out to alias members happens at routing time and
@@ -716,7 +745,7 @@ def cmd_tell(args: list[str]) -> int:
         print("usage: tell <name> <message>", file=sys.stderr)
         return 2
     target_query, *rest = args
-    content, files = _split_content_and_files(" ".join(rest))
+    content, files = _split_content_and_files(_join_tell_args(rest))
 
     sender = sender_from_cwd()
     if sender is None:

--- a/apps/a8s/daemon.py
+++ b/apps/a8s/daemon.py
@@ -53,6 +53,7 @@ from definitions import (
 from mailbox import ensure_mailboxes, next_inbox_message, route_outboxes
 from network import (
     load_remotes,
+    load_services,
     make_publish_remotes,
     start_remotes,
     stop_remotes,
@@ -498,7 +499,12 @@ def attached_loop(names: list[str], interval: float, *, single_pass: bool = Fals
     # remote. The receive callback always asks the registry for the current
     # participant list so agents added after startup become routable without
     # restarting the daemon.
-    started_remotes = start_remotes(load_remotes(), participants_from_registry)
+    # Storage services (#90) — stateless, no start/stop. Loaded once per
+    # daemon lifetime and shared between routing-side uploads and the
+    # receive callback's downloads. An empty list keeps the path
+    # local-files-only (pre-#90 behavior).
+    services = load_services()
+    started_remotes = start_remotes(load_remotes(), participants_from_registry, services=services)
     publish_remotes = make_publish_remotes(started_remotes) if started_remotes else None
     configured_remote_ids = [r.id for r in started_remotes]
     try:
@@ -548,6 +554,7 @@ def attached_loop(names: list[str], interval: float, *, single_pass: bool = Fals
                     all_agents=all_agents,
                     publish_remotes=publish_remotes,
                     configured_remote_ids=configured_remote_ids,
+                    services=services,
                 )
                 for p in handled:
                     while not _STOP_EVENT.is_set():

--- a/apps/a8s/mailbox.py
+++ b/apps/a8s/mailbox.py
@@ -94,6 +94,18 @@ def ensure_mailboxes(p: Participant) -> None:
     files_dir(p.root).mkdir(parents=True, exist_ok=True)
 
 
+def _recipient_relative_path(files_dir_path: Path, dest: Path) -> str:
+    """Build the path string surfaced into the recipient's `$MESSAGE` as
+    `FILE: <path>`. The wake subprocess runs with `cwd=recipient.root`, so
+    a CWD-relative path resolves correctly even when the agent runs in a
+    container that maps its root to a different host prefix. We never
+    serialize the absolute host path into the routed envelope.
+
+    Returned form: `./.files/<filename>` (POSIX separators, explicit `./`).
+    """
+    return f"./{files_dir_path.name}/{dest.name}"
+
+
 def _transfer_file_to_recipient(
     sender_name: str,
     sender_root: Path,
@@ -156,7 +168,11 @@ def _transfer_file_to_recipient(
     except OSError as e:
         out_agent(sender_name, f"FILE: copy failed {src_resolved} -> {dest}: {e}")
         return None
-    return {"filename": dest.name, "path": str(dest)}
+    # Recipient-CWD-relative path (e.g. "./.files/report.txt"). The agent's
+    # wake subprocess runs with cwd=recipient.root; an absolute host path
+    # wouldn't resolve inside a container that has the agent's directory
+    # mapped to a different prefix.
+    return {"filename": dest.name, "path": _recipient_relative_path(dest_dir, dest)}
 
 
 def _build_routed_message(
@@ -455,7 +471,7 @@ def _download_files_to_recipient(
             if delivered:
                 break
         if delivered:
-            new_files.append({"filename": dest.name, "path": str(dest)})
+            new_files.append({"filename": dest.name, "path": _recipient_relative_path(dest_dir, dest)})
         else:
             out_agent(
                 recipient.name,

--- a/apps/a8s/mailbox.py
+++ b/apps/a8s/mailbox.py
@@ -66,6 +66,7 @@ from core import (
 )
 from network import seen_id_append
 from registry import resolve_name
+from services import StorageError, StorageService
 from ulid import new as new_ulid
 
 # A function that publishes one routed-and-from-stamped message envelope to
@@ -242,6 +243,7 @@ def _load_or_init_sidecar(pending_file: Path) -> dict:
                 data.setdefault("next_attempt", "")
                 data.setdefault("succeeded_remotes", [])
                 data.setdefault("local_delivered", False)
+                data.setdefault("uploaded", {})
                 return data
         except (OSError, json.JSONDecodeError):
             pass  # corrupt sidecar — start fresh
@@ -250,6 +252,10 @@ def _load_or_init_sidecar(pending_file: Path) -> dict:
         "next_attempt": "",
         "succeeded_remotes": [],
         "local_delivered": False,
+        # Per-file × per-service upload cache for cross-cluster `FILE:`
+        # payloads. Shape: {"<filename>": {"<service_id>": "<download_url>"}}.
+        # A backoff retry only re-uploads to services still missing.
+        "uploaded": {},
     }
 
 
@@ -293,11 +299,178 @@ def _schedule_retry(pending_file: Path, sidecar: dict, sender: Participant) -> N
     _save_sidecar(pending_file, sidecar)
 
 
+def _resolve_file_source(sender_root: Path, entry: dict) -> Path | None:
+    """Validate and resolve a `FILE:` entry's source path, returning a
+    sandbox-safe absolute path or None if the path can't be used. Same
+    validation rules as `_transfer_file_to_recipient` (exists, regular file,
+    inside sender_root, under MAX_FILE_BYTES) — factored out so the upload
+    path can reuse the defenses without copying bytes."""
+    src_path = Path(entry.get("path") or "").expanduser()
+    sender_root_resolved = sender_root.resolve()
+    try:
+        if src_path.is_absolute():
+            src_resolved = src_path.resolve()
+        else:
+            src_resolved = (sender_root_resolved / src_path).resolve()
+    except (OSError, RuntimeError):
+        return None
+    try:
+        src_resolved.relative_to(sender_root_resolved)
+    except ValueError:
+        return None
+    if not src_resolved.is_file():
+        return None
+    try:
+        size = src_resolved.stat().st_size
+    except OSError:
+        return None
+    if size > MAX_FILE_BYTES:
+        return None
+    return src_resolved
+
+
+def _upload_files_for_remote(
+    msg: dict,
+    sender_name: str,
+    sender_root: Path,
+    services: list[StorageService],
+    sidecar: dict,
+) -> bool:
+    """Upload every file in `msg["files"]` to every configured storage
+    service that hasn't yet accepted it. Caches results in
+    `sidecar["uploaded"][filename][service_id] = url` so a backoff retry
+    only re-uploads to services still missing.
+
+    Side-effects:
+      - Mutates `sidecar["uploaded"]` with each successful upload.
+      - On full success (every file × every service covered), rewrites
+        `msg["files"]` in-place to the wire shape:
+        `[{"filename": ..., "storage": [url1, url2, ...]}]` (drops `path`).
+
+    Returns True if every file is now covered by every configured service
+    (caller proceeds to publish). Returns False if any upload failed
+    (caller schedules retry; msg["files"] stays in its on-disk shape)."""
+    files = msg.get("files") or []
+    if not files or not services:
+        return True  # no work to do
+
+    uploaded: dict = sidecar.setdefault("uploaded", {})
+    all_done = True
+    for entry in files:
+        filename = entry.get("filename") or ""
+        if not filename:
+            continue  # malformed entry — skip silently
+        per_file = uploaded.setdefault(filename, {})
+        # We need the source path each pass — even on retry. The sender's
+        # outbox bytes still live at the original location until the message
+        # finalizes (we don't move them).
+        src = _resolve_file_source(sender_root, entry)
+        if src is None and any(s.id not in per_file for s in services):
+            # Source unreadable / oversized / outside-root and at least one
+            # service still needs it. Treat as upload failure for those
+            # services so the message retries (the file may have appeared
+            # mid-pass, etc.). If every service already has its URL, we're
+            # fine even with the source gone.
+            out_agent(
+                sender_name,
+                f"FILE: cannot read source for upload (filename={filename!r}); will retry",
+            )
+            all_done = False
+            continue
+        for service in services:
+            if service.id in per_file:
+                continue
+            try:
+                url = service.store(src)  # type: ignore[arg-type]
+            except StorageError as e:
+                out_agent(
+                    sender_name,
+                    f"WARN storage {service.id} upload failed for {filename!r} (attempt {sidecar['attempts'] + 1}): {e}",
+                )
+                all_done = False
+                continue
+            except Exception as e:
+                out_agent(
+                    sender_name,
+                    f"WARN storage {service.id} upload raised for {filename!r} (attempt {sidecar['attempts'] + 1}): {e}",
+                )
+                all_done = False
+                continue
+            per_file[service.id] = url
+
+    if not all_done:
+        return False
+
+    # Every file is covered by every service — rewrite to the wire shape.
+    new_files: list[dict] = []
+    for entry in files:
+        filename = entry.get("filename") or ""
+        urls = list(uploaded.get(filename, {}).values())
+        new_files.append({"filename": filename, "storage": urls})
+    msg["files"] = new_files
+    return True
+
+
+def _download_files_to_recipient(
+    msg: dict,
+    recipient: Participant,
+    services: list[StorageService],
+) -> dict:
+    """Pull `msg["files"][i]["storage"]` URLs into the recipient's
+    `<root>/.files/`. Returns a NEW dict with `files` rewritten to
+    recipient-local shape `{filename, path}`. Files that no configured
+    service can download are dropped + logged on the recipient's per-agent
+    log; the message is delivered with the surviving files (matches local
+    delivery's "rejected file dropped, message survives" semantics).
+
+    Multiple `storage` URLs per file are tried in order until one service
+    successfully downloads — equivalent uploads from the sender's POV, so
+    first wins. Mismatched URLs (no configured service accepts) just fall
+    through; only an actual `StorageError` from a matched service counts
+    as failure for that URL."""
+    out_msg = dict(msg)
+    src_files = msg.get("files") or []
+    new_files: list[dict] = []
+    dest_dir = files_dir(recipient.root)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    for entry in src_files:
+        filename = entry.get("filename") or ""
+        urls = entry.get("storage") or []
+        if not filename or not urls:
+            continue  # malformed wire entry; drop
+        dest = unique_path(dest_dir / filename)
+        delivered = False
+        for url in urls:
+            for service in services:
+                try:
+                    if service.retrieve(url, dest):
+                        delivered = True
+                        break
+                except StorageError as e:
+                    out_agent(
+                        recipient.name,
+                        f"WARN storage {service.id} download failed for {filename!r}: {e}",
+                    )
+                    # Real failure on a matched URL — try next URL/service.
+            if delivered:
+                break
+        if delivered:
+            new_files.append({"filename": dest.name, "path": str(dest)})
+        else:
+            out_agent(
+                recipient.name,
+                f"WARN no configured storage service could download {filename!r} (urls={urls})",
+            )
+    out_msg["files"] = new_files
+    return out_msg
+
+
 def _process_pending(
     sender: Participant,
     by_name: dict[str, Participant],
     publish_remotes: Optional[PublishRemotes],
     configured_remote_ids: list[str],
+    services: Optional[list[StorageService]] = None,
 ) -> int:
     """Phase 2: iterate `~/.a8s/agents/<sender>/pending/`, deliver each
     pending file locally and/or publish to not-yet-succeeded remotes. The
@@ -417,20 +590,37 @@ def _process_pending(
                     # Nothing to deliver locally; mark done so we don't loop.
                     out_agent(sender.name, f"{recipient_name!r} has no local recipients (excluding self)")
                     sidecar["local_delivered"] = True
-        # ----- REMOTE ROUTING (placeholder hook; chunk 7 wires up) -----
+        # ----- REMOTE ROUTING -----
         has_files = bool(msg.get("files"))
-        if publish_remotes is not None and configured_remote_ids and not has_files:
-            sidecar["succeeded_remotes"] = publish_remotes(
-                msg, sender.name, list(sidecar["succeeded_remotes"]), sidecar["attempts"]
-            )
-        elif has_files and configured_remote_ids:
-            # v1 limitation (#62 deferred): file payloads stay local-only —
-            # the sender's path doesn't exist on the receiving cluster.
-            # Treat all configured remotes as "done" so the message finalizes
-            # after local delivery instead of looping on retries.
-            if sidecar["attempts"] == 0:
-                out_agent(sender.name, f"FILE: payloads in {f.name} not published to remotes (v1)")
-            sidecar["succeeded_remotes"] = list(configured_remote_ids)
+        if publish_remotes is not None and configured_remote_ids:
+            services_list = services or []
+            if has_files and not services_list:
+                # No storage services configured — file payloads can't make
+                # the trip. Mark all remotes "succeeded" so the message
+                # finalizes after local delivery instead of looping on
+                # retries (#62 v1 fallback: local-only with files when no
+                # services, full pipeline when services are configured).
+                if sidecar["attempts"] == 0:
+                    out_agent(sender.name, f"FILE: payloads in {f.name} not published to remotes (no storage configured)")
+                sidecar["succeeded_remotes"] = list(configured_remote_ids)
+            else:
+                # Upload any files first (per-file × per-service cache lives
+                # in the sidecar). On full success the in-memory msg gets
+                # rewritten to the wire shape; on partial failure we fall
+                # through to schedule a retry without publishing this pass.
+                publish_msg = dict(msg)
+                upload_ok = True
+                if has_files:
+                    publish_msg["files"] = list(msg.get("files") or [])
+                    upload_ok = _upload_files_for_remote(
+                        publish_msg, sender.name, sender.root, services_list, sidecar,
+                    )
+                if upload_ok:
+                    sidecar["succeeded_remotes"] = publish_remotes(
+                        publish_msg, sender.name, list(sidecar["succeeded_remotes"]), sidecar["attempts"]
+                    )
+                # else: leave succeeded_remotes alone; backoff retry will
+                # finish the uploads and try the publish next pass.
         # ----- OUTCOME -----
         remaining_remotes = [
             rid for rid in configured_remote_ids
@@ -467,6 +657,7 @@ def route_outboxes(
     all_agents: list[Participant] | None = None,
     publish_remotes: Optional[PublishRemotes] = None,
     configured_remote_ids: Optional[list[str]] = None,
+    services: Optional[list[StorageService]] = None,
 ) -> int:
     """Two-phase routing pass:
 
@@ -481,7 +672,12 @@ def route_outboxes(
     `publish_remotes` and `configured_remote_ids` are the daemon-wired
     hooks for cross-cluster routing; both default to None / [] so an
     install with no remotes configured behaves identically to pre-#63
-    except for the on-disk location of in-flight messages."""
+    except for the on-disk location of in-flight messages.
+
+    `services` is the storage-service hook (#90) for cross-cluster `FILE:`
+    payloads. When set and a message has files, each service uploads its
+    bytes and the wire envelope carries `files[i].storage = [...]`. None /
+    empty falls back to the v1 limitation (files local-only, remote skip)."""
     if all_agents is None:
         all_agents = senders
     by_name = {p.name.lower(): p for p in all_agents}
@@ -490,7 +686,9 @@ def route_outboxes(
     _ingest_outboxes(senders)
     routed = 0
     for sender in senders:
-        routed += _process_pending(sender, by_name, publish_remotes, configured_remote_ids)
+        routed += _process_pending(
+            sender, by_name, publish_remotes, configured_remote_ids, services,
+        )
     return routed
 
 

--- a/apps/a8s/network.py
+++ b/apps/a8s/network.py
@@ -41,6 +41,7 @@ from core import (
     seen_ids_path,
 )
 from registry import resolve_name
+from services import StorageService
 from transports import OnMessage, Transport, TransportError
 from ulid import is_ulid
 
@@ -56,18 +57,21 @@ _SEEN_IDS_LOCK = threading.Lock()
 def load_network_config() -> dict:
     p = network_config_path()
     if not p.is_file():
-        return {"remotes": {}}
+        return {"remotes": {}, "services": {}}
     try:
         with p.open("r", encoding="utf-8") as f:
             data = json.load(f)
     except (OSError, json.JSONDecodeError) as e:
         out(f"WARN: ~/.a8s/network.json malformed ({e}); treating as empty")
-        return {"remotes": {}}
+        return {"remotes": {}, "services": {}}
     if not isinstance(data, dict):
-        return {"remotes": {}}
+        return {"remotes": {}, "services": {}}
     data.setdefault("remotes", {})
     if not isinstance(data["remotes"], dict):
         data["remotes"] = {}
+    data.setdefault("services", {})
+    if not isinstance(data["services"], dict):
+        data["services"] = {}
     return data
 
 
@@ -125,6 +129,79 @@ def configured_remote_ids() -> list[str]:
     routing pass to know which remotes to wait on without paying the cost
     of building the full Transport instances."""
     return list(load_network_config()["remotes"].keys())
+
+
+# ---------- storage services (#90) ----------
+
+# Top-level keys in a network.json `services` entry that the dispatcher
+# consumes itself before forwarding the rest to the StorageService constructor.
+_RESERVED_SERVICE_SPEC_KEYS = {"service", "url"}
+
+
+def _build_service(name: str, spec: dict) -> StorageService:
+    """Instantiate one StorageService from a network.json `services` entry.
+
+    The persisted `service` field is the canonical kind name (e.g.
+    `tempfile_org`). The dispatcher imports each known service class
+    lazily so the import graph stays empty for installs without storage
+    configured. Any keys past `service` and `url` are forwarded as
+    `**opts`; each service class handles its own option vocabulary
+    and rejects unknowns at construction time."""
+    kind = (spec.get("service") or "").strip().lower()
+    url = spec.get("url")
+    if not url:
+        raise ValueError(f"storage {name!r}: every service requires `url`")
+    opts = {k: v for k, v in spec.items() if k not in _RESERVED_SERVICE_SPEC_KEYS}
+    if kind == "tempfile_org":
+        # Lazy import — keeps the storage modules out of the import graph
+        # for users without storage configured.
+        from services.tempfile_org import TempFileOrgService
+
+        return TempFileOrgService(name, url=url, **opts)
+    raise ValueError(f"storage {name!r}: unsupported service kind {kind!r}")
+
+
+def load_services() -> list[StorageService]:
+    """Return StorageService instances for every entry in
+    `network.json`'s `services` map. Failures (bad config, missing
+    module) are logged and skipped — never block a8s startup."""
+    cfg = load_network_config()
+    out_list: list[StorageService] = []
+    for name, spec in cfg["services"].items():
+        if not isinstance(spec, dict):
+            out(f"WARN: storage {name!r} config is not an object; skipping")
+            continue
+        try:
+            out_list.append(_build_service(name, spec))
+        except Exception as e:
+            out(f"WARN: storage {name!r} skipped: {e}")
+    return out_list
+
+
+def configured_service_ids() -> list[str]:
+    """Just the ordered list of service IDs from network.json. Used by the
+    routing pass to know which services need uploads before remote publish
+    can finalize."""
+    return list(load_network_config()["services"].keys())
+
+
+def detect_service_kind(url: str) -> str | None:
+    """Find the canonical service kind for an operator-typed URL by asking
+    each known StorageService subclass `supports_config_url`. Returns the
+    canonical kind string (e.g. `tempfile_org`) or None if no service
+    accepted the URL. Used by the `a8s storage` CLI to persist the right
+    `service` field at config-write time."""
+    # Lazy imports keep the storage modules out of the import graph for
+    # installs without storage configured.
+    from services.tempfile_org import TempFileOrgService
+
+    for kind, cls in (("tempfile_org", TempFileOrgService),):
+        try:
+            if cls.supports_config_url(url):
+                return kind
+        except Exception:
+            continue
+    return None
 
 
 # ---------- seen-ids ring ----------
@@ -212,12 +289,22 @@ def make_publish_remotes(remotes: list[Transport]) -> Callable:
 
 # ---------- receive ----------
 
-def receive_envelope(envelope: bytes, all_agents: list[Participant]) -> None:
+def receive_envelope(
+    envelope: bytes,
+    all_agents: list[Participant],
+    services: list[StorageService] | None = None,
+) -> None:
     """Decode an incoming envelope, dedupe, filter against the local
     registry, and atomically write into each matched local recipient's
     inbox. Drops silently if the recipient isn't ours, the envelope is
     malformed, or the ULID has been seen before — nothing should crash the
-    subscriber thread."""
+    subscriber thread.
+
+    `services`: configured storage services (#90). When set and the
+    envelope's `files[i].storage` URLs point at a service we know, the
+    helper downloads each file into the recipient's `<root>/.files/` and
+    rewrites the entry to local `{filename, path}` shape. None / empty
+    falls back to the v1 limitation (strip files; log warning)."""
     try:
         msg = json.loads(envelope)
         if not isinstance(msg, dict):
@@ -252,19 +339,30 @@ def receive_envelope(envelope: bytes, all_agents: list[Participant]) -> None:
             recipients.append(rp)
     if not recipients:
         return  # alias resolved to nothing locally
-    # v1 limitation: file payloads stay local-only — the FILE: paths point
-    # at the sender's filesystem and would just produce errors on the
-    # recipient side. Strip them before writing if any arrived via remote.
-    if msg.get("files"):
+    # File payloads (#90): when storage services are configured, download
+    # each file's bytes into the recipient's `.files/` and rewrite the
+    # envelope entry to local-path shape. Without storage services
+    # configured, fall back to the v1 limitation (strip + warn).
+    raw_files = msg.get("files") or []
+    files_have_storage = any((isinstance(e, dict) and e.get("storage")) for e in raw_files)
+    if raw_files and (not services or not files_have_storage):
         out(f"WARN: stripped FILE: payloads from incoming envelope id={msg_id}")
         msg = dict(msg)
         msg["files"] = []
     sender_label = msg.get("from") or "?"
     preview = _preview(msg.get("content", ""))
     for recipient in recipients:
+        # Per-recipient download: each recipient has its own `.files/`, so
+        # the bytes land in the right place even on alias fan-out. Imported
+        # lazily — `mailbox` imports `network`, so a top-level import here
+        # would form an import cycle.
+        msg_for_recipient = msg
+        if services and files_have_storage:
+            from mailbox import _download_files_to_recipient
+
+            msg_for_recipient = _download_files_to_recipient(msg, recipient, services)
         # ensure_mailboxes lives in mailbox.py; importing it here would form
-        # a cycle (mailbox imports from registry; network imports from
-        # mailbox would be fine but is unnecessary). Just create dirs.
+        # a cycle. Just create dirs.
         inbox_dir(recipient.name).mkdir(parents=True, exist_ok=True)
         inbox_tmp_dir(recipient.name).mkdir(parents=True, exist_ok=True)
         final = inbox_dir(recipient.name) / f"{msg_id}.json"
@@ -273,7 +371,7 @@ def receive_envelope(envelope: bytes, all_agents: list[Participant]) -> None:
         staging = inbox_tmp_dir(recipient.name) / f"{msg_id}.json"
         try:
             with staging.open("w", encoding="utf-8") as f:
-                json.dump(msg, f, indent=2)
+                json.dump(msg_for_recipient, f, indent=2)
             os.replace(str(staging), str(final))
         except OSError as e:
             out_agent(recipient.name, f"WARN failed to write incoming envelope id={msg_id}: {e}")
@@ -284,14 +382,17 @@ def receive_envelope(envelope: bytes, all_agents: list[Participant]) -> None:
 
 def make_receive_callback(
     get_participants: Callable[[], list[Participant]],
+    services: list[StorageService] | None = None,
 ) -> OnMessage:
     """Wrap `receive_envelope` so the subscriber thread always passes the
     CURRENT participant list — agents added via `a8s add` after the
-    subscriber started are picked up without restarting the loop."""
+    subscriber started are picked up without restarting the loop. Storage
+    services (#90) are passed in once at startup; the receive helper uses
+    them to download cross-cluster `FILE:` payloads."""
 
     def callback(envelope: bytes) -> None:
         try:
-            receive_envelope(envelope, get_participants())
+            receive_envelope(envelope, get_participants(), services=services)
         except Exception as e:
             out(f"WARN: receive_envelope raised: {e}")
 
@@ -303,12 +404,18 @@ def make_receive_callback(
 def start_remotes(
     remotes: list[Transport],
     get_participants: Callable[[], list[Participant]],
+    services: list[StorageService] | None = None,
 ) -> list[Transport]:
     """Start every remote's subscriber loop. A failure to start one remote
     logs a warning and continues with the others — no remote is allowed to
-    block a8s startup. Returns the list of successfully-started remotes."""
+    block a8s startup. Returns the list of successfully-started remotes.
+
+    `services` is passed through to the receive callback so cross-cluster
+    `FILE:` payloads (#90) can be downloaded into each recipient's
+    `.files/` as envelopes arrive. None / empty preserves pre-#90
+    behavior (incoming files are stripped + warned)."""
     started: list[Transport] = []
-    cb = make_receive_callback(get_participants)
+    cb = make_receive_callback(get_participants, services=services)
     for r in remotes:
         try:
             r.start(cb)

--- a/apps/a8s/services/__init__.py
+++ b/apps/a8s/services/__init__.py
@@ -1,0 +1,66 @@
+"""Storage service plugin interface for a8s cross-cluster file transfer (#90).
+
+A "service" is the file-side analogue of a "transport". Where the messaging
+layer publishes/subscribes JSON envelopes, the file layer uploads bytes and
+hands back URLs that travel inside those envelopes. Different words on
+purpose: `a8s remote` configures messaging transports, `a8s storage`
+configures file services, and the two are independently composable.
+
+Lifecycle: services are stateless HTTP clients, so there's no start/stop.
+The dispatcher in `network._build_service` instantiates one per
+configured `~/.a8s/network.json` `services` entry and hands the same
+instance to both the upload path (sender's `_process_pending`) and the
+download path (receiver's `_download_files_to_recipient`).
+
+Contract:
+- `supports_config_url(url)` is a class method that the dispatcher uses
+  to pick the right `StorageService` subclass for an operator-typed URL.
+- `store(src)` uploads bytes and returns a download URL string. Raises
+  `StorageError` on failure (network down, auth, oversized payload).
+- `retrieve(url, dest)` returns False if the URL doesn't belong to this
+  service (so the caller falls through to the next configured service).
+  Returns True after writing the bytes to `dest`. Raises `StorageError`
+  on a real download failure (the URL was ours but the server refused).
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+
+class StorageError(Exception):
+    """Raised by `store` / `retrieve` when an upload or download genuinely
+    failed (network, auth, oversize, server 5xx). Callers warn-and-continue
+    and rely on the per-message retry sidecar to drive backoff."""
+
+
+class StorageService(ABC):
+    """A single configured storage backend."""
+
+    @property
+    @abstractmethod
+    def id(self) -> str:
+        """Stable identifier matching the user's `network.json` entry name.
+        Used as the cache key in the per-message `uploaded` sidecar so two
+        passes against the same service don't double-upload."""
+
+    @classmethod
+    @abstractmethod
+    def supports_config_url(cls, url: str) -> bool:
+        """Return True if this subclass can handle the operator-typed URL.
+        Used by `network._build_service` at config-load time to dispatch
+        to the right implementation. Should not raise — anything funny
+        about the URL is just "not for me"."""
+
+    @abstractmethod
+    def store(self, src: Path) -> str:
+        """Upload the bytes at `src` and return a download URL. Raises
+        `StorageError` on failure. The returned URL is opaque to the
+        caller; the receiver round-trips it through `retrieve`."""
+
+    @abstractmethod
+    def retrieve(self, url: str, dest: Path) -> bool:
+        """Download `url` into `dest`. Returns False if the URL doesn't
+        belong to this service (caller should try the next configured
+        service). Returns True after a successful write. Raises
+        `StorageError` if the URL was ours but the download itself failed."""

--- a/apps/a8s/services/tempfile_org.py
+++ b/apps/a8s/services/tempfile_org.py
@@ -1,0 +1,203 @@
+"""TempFile.org storage service.
+
+Wire format (https://tempfile.org/api):
+
+  POST <base>/api/upload/local     multipart/form-data
+    fields: files=<binary>, expiryHours=<1|6|24|48>
+    response: {"files": [{"id", "name", "size", "url", "expiryTime"}, ...]}
+              where "url" is e.g. "https://tempfile.org/<id>/"
+
+  GET <returned-url>download       streams the bytes
+
+The service is stateless — instances hold the operator-configured base URL
+plus an `expiry_hours` knob, and that's it. One instance per `a8s storage`
+entry; both `store` and `retrieve` are called on the same instance.
+
+Dispatch: `supports_config_url` matches by host (default `tempfile.org`).
+Operators can point this implementation at a self-hosted clone by giving
+a different URL — `retrieve` accepts URLs whose host matches the
+configured base, so the same code path serves both.
+
+Construction is option-bag-shaped, mirroring `MqttTransport`: anything past
+`name` and `url` arrives as `**opts` and unknown keys raise so a typo in
+`network.json` fails loud at load time.
+"""
+from __future__ import annotations
+
+import io
+import json
+import mimetypes
+import os
+import secrets
+import shutil
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+from services import StorageError, StorageService
+
+
+# Recognized opts (post-aliasing). Anything else raises.
+_KNOWN_OPTS: set[str] = {
+    "expiry_hours",
+    "timeout_s",
+}
+
+_VALID_EXPIRY_HOURS = {1, 6, 24, 48}
+
+_DEFAULT_HOSTS = ("tempfile.org", "www.tempfile.org")
+
+
+def _build_multipart(filename: str, content_type: str, body: bytes, expiry_hours: int) -> tuple[bytes, str]:
+    """Hand-rolled multipart/form-data — stdlib has no helper that handles
+    binary file fields cleanly. Returns (encoded_body, content_type_header)."""
+    boundary = "----a8s" + secrets.token_hex(16)
+    parts: list[bytes] = []
+    # files field
+    parts.append(f"--{boundary}\r\n".encode())
+    parts.append(
+        (
+            f'Content-Disposition: form-data; name="files"; filename="{filename}"\r\n'
+            f"Content-Type: {content_type}\r\n\r\n"
+        ).encode()
+    )
+    parts.append(body)
+    parts.append(b"\r\n")
+    # expiryHours field
+    parts.append(f"--{boundary}\r\n".encode())
+    parts.append(b'Content-Disposition: form-data; name="expiryHours"\r\n\r\n')
+    parts.append(str(expiry_hours).encode())
+    parts.append(b"\r\n")
+    parts.append(f"--{boundary}--\r\n".encode())
+    return b"".join(parts), f"multipart/form-data; boundary={boundary}"
+
+
+class TempFileOrgService(StorageService):
+    """One configured TempFile.org service.
+
+    Args:
+        name: stable name from `network.json` (used as the cache key in
+            the per-message `uploaded` sidecar).
+        url: the service base URL — e.g. `https://tempfile.org`.
+        **opts: per-service options forwarded from `network.json`. Recognized:
+            expiry_hours (1, 6, 24, or 48; default 24), timeout_s (default 30).
+            Unknown keys raise ValueError so a typo in the config doesn't
+            silently produce a broken service.
+    """
+
+    def __init__(self, name: str, *, url: str, **opts: Any) -> None:
+        unknown = set(opts) - _KNOWN_OPTS
+        if unknown:
+            raise ValueError(
+                f"storage {name!r}: unknown option(s) {sorted(unknown)} "
+                f"(known: {sorted(_KNOWN_OPTS)})"
+            )
+        expiry_hours = int(opts.get("expiry_hours", 24))
+        if expiry_hours not in _VALID_EXPIRY_HOURS:
+            raise ValueError(
+                f"storage {name!r}: expiry_hours must be one of {sorted(_VALID_EXPIRY_HOURS)}, "
+                f"got {expiry_hours}"
+            )
+        timeout_s = float(opts.get("timeout_s", 30))
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme not in ("http", "https"):
+            raise ValueError(
+                f"storage {name!r}: unsupported scheme {parsed.scheme!r} (expected http or https)"
+            )
+        if not parsed.hostname:
+            raise ValueError(f"storage {name!r}: URL missing host: {url!r}")
+        self._name = name
+        self._base = url.rstrip("/")
+        self._host = parsed.hostname
+        self._expiry_hours = expiry_hours
+        self._timeout_s = timeout_s
+
+    @property
+    def id(self) -> str:
+        return self._name
+
+    @classmethod
+    def supports_config_url(cls, url: str) -> bool:
+        try:
+            parsed = urllib.parse.urlparse(url)
+        except ValueError:
+            return False
+        if parsed.scheme not in ("http", "https"):
+            return False
+        host = (parsed.hostname or "").lower()
+        return host in _DEFAULT_HOSTS
+
+    def store(self, src: Path) -> str:
+        try:
+            size = src.stat().st_size
+            with src.open("rb") as f:
+                body = f.read()
+        except OSError as e:
+            raise StorageError(f"{self._name}: cannot read {src}: {e}") from e
+        content_type = mimetypes.guess_type(src.name)[0] or "application/octet-stream"
+        encoded, ct_header = _build_multipart(src.name, content_type, body, self._expiry_hours)
+        req = urllib.request.Request(
+            f"{self._base}/api/upload/local",
+            data=encoded,
+            method="POST",
+            headers={
+                "Content-Type": ct_header,
+                "Content-Length": str(len(encoded)),
+                "User-Agent": "a8s/1",
+                "Accept": "application/json",
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=self._timeout_s) as resp:
+                payload = resp.read()
+        except urllib.error.HTTPError as e:
+            raise StorageError(
+                f"{self._name}: upload HTTP {e.code} ({size} bytes): {e.reason}"
+            ) from e
+        except urllib.error.URLError as e:
+            raise StorageError(f"{self._name}: upload network error: {e.reason}") from e
+        try:
+            data = json.loads(payload)
+            files = data.get("files") or []
+            if not files or "url" not in files[0]:
+                raise ValueError(f"unexpected response shape: {data!r}")
+            return str(files[0]["url"])
+        except (ValueError, json.JSONDecodeError) as e:
+            raise StorageError(f"{self._name}: malformed upload response: {e}") from e
+
+    def retrieve(self, url: str, dest: Path) -> bool:
+        try:
+            parsed = urllib.parse.urlparse(url)
+        except ValueError:
+            return False
+        host = (parsed.hostname or "").lower()
+        if host != self._host.lower():
+            return False
+        # The upload response's `url` ends with a trailing slash; the GET
+        # endpoint is `<url>download`. Tolerate either form gracefully.
+        download_url = url if url.endswith("/download") else url.rstrip("/") + "/download"
+        req = urllib.request.Request(
+            download_url,
+            method="GET",
+            headers={"User-Agent": "a8s/1"},
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=self._timeout_s) as resp:
+                tmp = dest.with_name(dest.name + ".part")
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                with tmp.open("wb") as out:
+                    shutil.copyfileobj(resp, out)
+                os.replace(str(tmp), str(dest))
+        except urllib.error.HTTPError as e:
+            raise StorageError(
+                f"{self._name}: download HTTP {e.code} for {url}: {e.reason}"
+            ) from e
+        except urllib.error.URLError as e:
+            raise StorageError(
+                f"{self._name}: download network error for {url}: {e.reason}"
+            ) from e
+        except OSError as e:
+            raise StorageError(f"{self._name}: write failed for {dest}: {e}") from e
+        return True

--- a/apps/a8s/skills/tell/SKILL.md
+++ b/apps/a8s/skills/tell/SKILL.md
@@ -12,7 +12,18 @@ tell <name> <message>
 ```
 
 - `<name>` is the recipient's name. Treat it as opaque — do not assume whether the recipient is a person or another assistant, and do not change your tone based on a guess.
-- `<message>` is the body. To attach files, append one or more `FILE: <absolute-path>` lines at the end. Lines starting with `FILE: ` are stripped from the body and added as attachments.
+- `<message>` is the body. To attach files, append one or more `FILE: <path>` lines at the end. Lines starting with `FILE: ` are stripped from the body and added as attachments. Paths can be absolute or relative to your current directory.
+
+**Quoting**: the body may be one quoted argument (with embedded newlines for FILE: lines) OR multiple shell arguments — `tell` joins them. A `FILE:`-prefixed argument is automatically lifted onto its own line, so both shapes work:
+
+```
+tell alice "Here's the doc.
+FILE: ./report.pdf"
+```
+
+```
+tell alice "Here's the doc." "FILE: ./report.pdf"
+```
 
 The command returns immediately. Delivery and processing are asynchronous: the recipient may receive the message seconds, minutes, hours, or longer after you send it, and may take additional time to read and act on it. Don't make assumptions about what causes the delay — it isn't necessarily mechanical. Do not block waiting for a reply; if you need a response, send the message and continue with other work. If a reply is essential, ask the user how to proceed rather than polling.
 

--- a/apps/a8s/tests/_fake_storage.py
+++ b/apps/a8s/tests/_fake_storage.py
@@ -1,0 +1,95 @@
+"""Shared in-process fake of TempFile.org's HTTP API for tests.
+
+`POST /api/upload/local` accepts a multipart `files` field and returns
+`{"files": [{"id", "name", "size", "url", "expiryTime"}]}` where `url`
+points back at this same server. `GET /<id>/download` streams the
+stashed bytes. Used by:
+  - test_service_tempfile_org.py — round-trip + error-path coverage.
+  - test_remote_e2e.py            — cross-cluster FILE: delivery via the
+                                    full sender-side route_outboxes →
+                                    MQTT → receive_envelope path.
+"""
+from __future__ import annotations
+
+import json
+import re
+import socket
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def log_message(self, format, *args):
+        return
+
+    def do_POST(self):
+        if self.path != "/api/upload/local":
+            self.send_error(404)
+            return
+        ctype = self.headers.get("Content-Type", "")
+        m = re.search(r"boundary=(.+)$", ctype)
+        if not m:
+            self.send_error(400, "missing boundary")
+            return
+        boundary = m.group(1).encode()
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length)
+        parts = body.split(b"--" + boundary)
+        file_bytes: bytes | None = None
+        for part in parts:
+            if b'name="files"' in part:
+                _, _, rest = part.partition(b"\r\n\r\n")
+                file_bytes = rest.rsplit(b"\r\n", 1)[0]
+                break
+        if file_bytes is None:
+            self.send_error(400, "missing files field")
+            return
+        file_id = f"f{len(self.server.files):04d}"
+        self.server.files[file_id] = file_bytes
+        port = self.server.server_address[1]
+        url = f"http://127.0.0.1:{port}/{file_id}/"
+        body_out = json.dumps({
+            "files": [{
+                "id": file_id, "name": "x", "size": len(file_bytes),
+                "url": url, "expiryTime": 0,
+            }]
+        }).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body_out)))
+        self.end_headers()
+        self.wfile.write(body_out)
+
+    def do_GET(self):
+        m = re.match(r"^/(?P<id>[^/]+)/download$", self.path)
+        if not m:
+            self.send_error(404)
+            return
+        file_id = m.group("id")
+        if file_id not in self.server.files:
+            self.send_error(404, "unknown id")
+            return
+        data = self.server.files[file_id]
+        self.send_response(200)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+
+def free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def start_fake_tempfile_server() -> tuple[ThreadingHTTPServer, str]:
+    """Spin up the fake server on a random port. Returns
+    (server_handle, base_url). Caller stops via:
+        server.shutdown(); server.server_close()."""
+    port = free_port()
+    server = ThreadingHTTPServer(("127.0.0.1", port), _Handler)
+    server.files = {}  # type: ignore[attr-defined]
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    return server, f"http://127.0.0.1:{port}"

--- a/apps/a8s/tests/agents/codex-agent/CODEX.md
+++ b/apps/a8s/tests/agents/codex-agent/CODEX.md
@@ -14,3 +14,14 @@ When you wake to a message:
 - **Group** (`<from> tells you (CODEX) and N others on the <alias> alias: ...`): default response is **none**. Reply only if the message explicitly asks a question or requests action *and* you have a meaningful contribution. Greetings, announcements, and state-change notes do **not** need acknowledgment.
 
 **Avoid loops.** Don't reply just to acknowledge. Don't echo greetings ("Hi" → "Hi back") or send empty "noted" / "received" / "thanks" messages. Use your conversation history: if you already responded to a similar message from this sender, stay silent. For narrow replies, prefer `tell <from>` over telling the alias.
+
+## Files
+
+Your current working directory IS your agent root. To attach a file to a `tell`, write or place the file under your root, then append a trailing `FILE: ./<relative-path>` line:
+
+```
+tell gerry Here is the script you asked for.
+FILE: ./build.sh
+```
+
+Multiple `FILE:` lines are allowed; only trailing ones are recognized. When *you* receive a message with files, they appear as `FILE: ./.files/<filename>` lines in the message body — read the file from that path under your CWD.

--- a/apps/a8s/tests/agents/gemini-agent/GEMINI.md
+++ b/apps/a8s/tests/agents/gemini-agent/GEMINI.md
@@ -14,3 +14,14 @@ When you wake to a message:
 - **Group** (`<from> tells you (GEMINI) and N others on the <alias> alias: ...`): default response is **none**. Reply only if the message explicitly asks a question or requests action *and* you have a meaningful contribution. Greetings, announcements, and state-change notes do **not** need acknowledgment.
 
 **Avoid loops.** Don't reply just to acknowledge. Don't echo greetings ("Hi" → "Hi back") or send empty "noted" / "received" / "thanks" messages. Use your conversation history: if you already responded to a similar message from this sender, stay silent. For narrow replies, prefer `tell <from>` over telling the alias.
+
+## Files
+
+Your current working directory IS your agent root. To attach a file to a `tell`, write or place the file under your root, then append a trailing `FILE: ./<relative-path>` line:
+
+```
+tell codex Here are the notes you asked for.
+FILE: ./notes.md
+```
+
+Multiple `FILE:` lines are allowed; only trailing ones are recognized. When *you* receive a message with files, they appear as `FILE: ./.files/<filename>` lines in the message body — read the file from that path under your CWD.

--- a/apps/a8s/tests/test_commands.py
+++ b/apps/a8s/tests/test_commands.py
@@ -16,9 +16,11 @@ from commands import (
     cmd_kill,
     cmd_remote,
     cmd_remove,
+    cmd_storage,
     cmd_tell,
     cmd_unalias,
     cmd_unremote,
+    cmd_unstorage,
 )
 from core import Participant, agent_dir, kill_request_path, outbox_dir, pid_path
 from mailbox import ensure_mailboxes
@@ -404,5 +406,110 @@ class TestCmdTellRemoteRecipient:
         msg = _json.loads(outbox_files[0].read_text())
         assert msg["to"] == "GHOST"
         assert msg["content"] == "hi from sender"
+
+
+# ---------- storage services (issue #90) ----------
+
+
+class TestCmdStorage:
+    """Mirrors `TestCmdRemote`. Same surface shape, configured under
+    `network.json`'s `services` map instead of `remotes`."""
+
+    def test_list_empty(self, fake_home, capsys):
+        rc = cmd_storage([])
+        assert rc == 0
+        assert "no storage services configured" in capsys.readouterr().out
+
+    def test_set_then_list(self, fake_home, capsys):
+        rc = cmd_storage(["tempfile", "https://tempfile.org"])
+        assert rc == 0
+        cfg = load_network_config()
+        assert cfg["services"]["tempfile"]["service"] == "tempfile_org"
+        assert cfg["services"]["tempfile"]["url"] == "https://tempfile.org"
+        capsys.readouterr()
+        cmd_storage([])
+        out = capsys.readouterr().out
+        assert "tempfile" in out
+        assert "tempfile_org" in out
+
+    def test_show_one(self, fake_home, capsys):
+        cmd_storage(["tempfile", "https://tempfile.org"])
+        capsys.readouterr()
+        rc = cmd_storage(["tempfile"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "tempfile: " in out
+        assert "https://tempfile.org" in out
+
+    def test_show_unknown(self, fake_home, capsys):
+        rc = cmd_storage(["nope"])
+        assert rc == 1
+        assert "no storage named" in capsys.readouterr().err
+
+    def test_set_overwrites_existing(self, fake_home, capsys):
+        cmd_storage(["tempfile", "https://tempfile.org", "--expiry_hours", "6"])
+        capsys.readouterr()
+        rc = cmd_storage(["tempfile", "https://tempfile.org", "--expiry_hours", "24"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "updated storage tempfile" in out
+        spec = load_network_config()["services"]["tempfile"]
+        assert spec["expiry_hours"] == "24"
+
+    def test_set_passes_arbitrary_options_to_spec(self, fake_home):
+        rc = cmd_storage([
+            "tempfile", "https://tempfile.org",
+            "--expiry_hours", "48", "--timeout_s", "60",
+        ])
+        assert rc == 0
+        spec = load_network_config()["services"]["tempfile"]
+        assert spec["expiry_hours"] == "48"
+        assert spec["timeout_s"] == "60"
+
+    def test_set_rejects_unknown_url(self, fake_home, capsys):
+        rc = cmd_storage(["weird", "https://example.com"])
+        assert rc == 2
+        assert "no storage service matches URL" in capsys.readouterr().err
+
+    def test_set_rejects_dangling_option(self, fake_home, capsys):
+        rc = cmd_storage(["tempfile", "https://tempfile.org", "--expiry_hours"])
+        assert rc == 2
+        assert "missing value" in capsys.readouterr().err
+
+    def test_set_rejects_bare_value(self, fake_home, capsys):
+        rc = cmd_storage(["tempfile", "https://tempfile.org", "12"])
+        assert rc == 2
+        assert "expected --<opt>" in capsys.readouterr().err
+
+    def test_set_rejects_duplicate_option(self, fake_home, capsys):
+        rc = cmd_storage([
+            "tempfile", "https://tempfile.org",
+            "--expiry_hours", "6", "--expiry_hours", "24",
+        ])
+        assert rc == 2
+        assert "duplicate option" in capsys.readouterr().err
+
+    def test_set_invalid_name(self, fake_home, capsys):
+        rc = cmd_storage(["with space", "https://tempfile.org"])
+        assert rc == 2
+        assert "must be alphanumeric" in capsys.readouterr().err
+
+
+class TestCmdUnstorage:
+    def test_remove(self, fake_home):
+        cmd_storage(["tempfile", "https://tempfile.org"])
+        rc = cmd_unstorage(["tempfile"])
+        assert rc == 0
+        assert "tempfile" not in load_network_config()["services"]
+
+    def test_unknown(self, fake_home, capsys):
+        rc = cmd_unstorage(["nope"])
+        assert rc == 1
+        assert "no storage named" in capsys.readouterr().err
+
+    def test_usage(self, fake_home, capsys):
+        rc = cmd_unstorage([])
+        assert rc == 2
+        assert "usage:" in capsys.readouterr().err
 
 

--- a/apps/a8s/tests/test_commands.py
+++ b/apps/a8s/tests/test_commands.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 
 from commands import (
+    _join_tell_args,
     cmd_add,
     cmd_alias,
     cmd_kill,
@@ -511,5 +512,65 @@ class TestCmdUnstorage:
         rc = cmd_unstorage([])
         assert rc == 2
         assert "usage:" in capsys.readouterr().err
+
+
+# ---------- _join_tell_args (FILE:-lifting argv joiner) ----------
+
+
+class TestJoinTellArgs:
+    """`tell` accepts the message body as one or more argv elements. An LLM
+    that splits the FILE: tag onto its own argument used to silently lose
+    the attachment because the joined string had no newline before FILE:.
+    `_join_tell_args` lifts FILE:-leading argv elements onto their own line
+    so trailing-FILE: detection in `_split_content_and_files` recognizes
+    them."""
+
+    def test_plain_join_unchanged(self):
+        assert _join_tell_args(["hello", "world"]) == "hello world"
+
+    def test_single_arg_unchanged(self):
+        assert _join_tell_args(["just a message"]) == "just a message"
+
+    def test_file_promoted_to_own_line(self):
+        # Gemini's actual misfire — message and FILE: as separate args.
+        assert _join_tell_args(["msg", "FILE: ./x"]) == "msg\nFILE: ./x"
+
+    def test_bare_file_only(self):
+        # Just a file, no body — still works.
+        assert _join_tell_args(["FILE: ./x"]) == "FILE: ./x"
+
+    def test_multiple_files(self):
+        assert _join_tell_args(["body", "FILE: ./a", "FILE: ./b"]) == "body\nFILE: ./a\nFILE: ./b"
+
+    def test_file_with_leading_whitespace_still_detected(self):
+        # If an LLM passes a leading-space-padded element, normalize it.
+        assert _join_tell_args(["msg", "  FILE: ./x"]) == "msg\nFILE: ./x"
+
+    def test_file_substring_in_body_unchanged(self):
+        # The word `FILE:` mid-string (not as the leading characters of an
+        # argv element) is left alone.
+        assert _join_tell_args(["see FILE: x in middle"]) == "see FILE: x in middle"
+
+
+class TestCmdTellWithSplitFileArg:
+    """End-to-end: `cmd_tell` with FILE: as a separate argv element should
+    produce an outbox message with the file extracted."""
+
+    def test_split_file_arg_extracts_attachment(self, fake_home, tmp_path, monkeypatch):
+        sender_root = tmp_path / "sender"
+        sender_root.mkdir()
+        save_registry({"sender": {"root": str(sender_root)}, "alice": {"root": str(tmp_path / "alice")}})
+        (tmp_path / "alice").mkdir()
+        ensure_mailboxes(Participant("sender", sender_root))
+        monkeypatch.chdir(sender_root)
+
+        rc = cmd_tell(["alice", "Here is the doc.", "FILE: ./report.pdf"])
+        assert rc == 0
+        outbox_files = list(outbox_dir(sender_root).iterdir())
+        assert len(outbox_files) == 1
+        import json as _json
+        msg = _json.loads(outbox_files[0].read_text())
+        assert msg["content"] == "Here is the doc."
+        assert msg["files"] == [{"filename": "report.pdf", "path": "./report.pdf"}]
 
 

--- a/apps/a8s/tests/test_mailbox.py
+++ b/apps/a8s/tests/test_mailbox.py
@@ -366,7 +366,10 @@ class TestFileTransfer:
         # Routed message's path points at B's local copy.
         delivered = json.loads(next(inbox_dir("B").iterdir()).read_text())
         assert len(delivered["files"]) == 1
-        assert delivered["files"][0]["path"] == str(b_files[0])
+        # Path is CWD-relative-to-recipient-root, not an absolute host path —
+        # so an agent running in a container with its dir mapped under a
+        # different prefix still finds the file via $MESSAGE's `FILE:` line.
+        assert delivered["files"][0]["path"] == "./.files/report.txt"
         assert delivered["files"][0]["filename"] == "report.txt"
 
     def test_alias_fanout_copies_to_each_recipient(self, fake_home, tmp_path):
@@ -887,7 +890,9 @@ class TestStorageDownload:
         assert files[0].read_bytes() == b"the-payload"
         # The inbox-written envelope has the local-path shape.
         inbox_msg = json.loads(next(inbox_dir("B").iterdir()).read_text())
-        assert inbox_msg["files"] == [{"filename": "doc.txt", "path": str(files[0])}]
+        # Same CWD-relative shape as the local-routing case — the receiver's
+        # agent doesn't see an absolute host path either.
+        assert inbox_msg["files"] == [{"filename": "doc.txt", "path": "./.files/doc.txt"}]
 
     def test_all_urls_unsupported_drops_file_keeps_message(self, fake_home, tmp_path):
         from network import receive_envelope

--- a/apps/a8s/tests/test_mailbox.py
+++ b/apps/a8s/tests/test_mailbox.py
@@ -672,3 +672,261 @@ class TestRemotePublishHook:
         assert called == []  # publish hook not invoked
         assert list(pending_dir("A").iterdir()) == []  # finalized
         assert len(list(inbox_dir("B").iterdir())) == 1  # local delivery happened
+
+
+# ---------- storage services (#90) ----------
+
+
+class _StubStorage:
+    """Test double for `StorageService`. Records uploads, returns deterministic
+    URLs; can be configured to fail a fixed number of times before succeeding,
+    or to refuse downloads of foreign URLs to mirror the real dispatch logic."""
+
+    def __init__(self, name: str, *, fail_n: int = 0):
+        self._id = name
+        self._counter = 0
+        self._fail_n = fail_n
+        self.uploads: list[Path] = []
+        self.downloads: list[str] = []
+        self.bytes_for: dict[str, bytes] = {}
+
+    @property
+    def id(self) -> str:
+        return self._id
+
+    @classmethod
+    def supports_config_url(cls, url: str) -> bool:
+        return True
+
+    def store(self, src: Path) -> str:
+        if self._fail_n > 0:
+            self._fail_n -= 1
+            from services import StorageError
+
+            raise StorageError(f"{self._id}: simulated failure")
+        self._counter += 1
+        url = f"stub://{self._id}/{self._counter}"
+        self.uploads.append(src)
+        self.bytes_for[url] = src.read_bytes()
+        return url
+
+    def retrieve(self, url: str, dest: Path) -> bool:
+        if not url.startswith(f"stub://{self._id}/"):
+            return False
+        self.downloads.append(url)
+        if url not in self.bytes_for:
+            from services import StorageError
+
+            raise StorageError(f"{self._id}: missing {url}")
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(self.bytes_for[url])
+        return True
+
+
+class TestStorageUpload:
+    """`_upload_files_for_remote` and the rerouted `_process_pending` branch."""
+
+    def test_upload_to_single_service_publishes_with_storage_urls(self, two_agents):
+        a, b = two_agents
+        payload = a.root / "doc.txt"
+        payload.write_text("payload bytes")
+        published: list[dict] = []
+
+        def stub_publish(msg, sender_name, succeeded_so_far, attempt_count):
+            published.append(msg)
+            return list(succeeded_so_far) + ["hub"]
+
+        s = _StubStorage("svc")
+        _write_outbox("A", a.root, "GHOST", "see attached", [
+            {"filename": "doc.txt", "path": str(payload)},
+        ])
+        route_outboxes(
+            [a, b],
+            all_agents=[a, b],
+            publish_remotes=stub_publish,
+            configured_remote_ids=["hub"],
+            services=[s],
+        )
+        # Upload happened exactly once.
+        assert len(s.uploads) == 1
+        # Publish hook saw the rewritten wire shape.
+        assert len(published) == 1
+        files = published[0]["files"]
+        assert len(files) == 1
+        assert files[0]["filename"] == "doc.txt"
+        assert files[0]["storage"] == [f"stub://svc/1"]
+        # `path` is dropped on the wire.
+        assert "path" not in files[0]
+        # Message finalized — no pending leftovers.
+        assert list(pending_dir("A").iterdir()) == []
+
+    def test_upload_cached_in_sidecar_on_failure(self, two_agents):
+        # When ONE of two services fails on the first pass, the success on
+        # the other is cached in the sidecar so the retry doesn't re-upload
+        # to it. The publish hook is NOT called this pass (uploads
+        # incomplete).
+        a, b = two_agents
+        payload = a.root / "doc.txt"
+        payload.write_text("payload bytes")
+        published: list[dict] = []
+
+        def stub_publish(msg, sender_name, succeeded_so_far, attempt_count):
+            published.append(msg)
+            return list(succeeded_so_far) + ["hub"]
+
+        good = _StubStorage("good")
+        flaky = _StubStorage("flaky", fail_n=1)
+        _write_outbox("A", a.root, "GHOST", "see attached", [
+            {"filename": "doc.txt", "path": str(payload)},
+        ])
+        route_outboxes(
+            [a, b],
+            all_agents=[a, b],
+            publish_remotes=stub_publish,
+            configured_remote_ids=["hub"],
+            services=[good, flaky],
+        )
+        # First pass: good succeeded, flaky failed → no publish, sidecar
+        # written.
+        assert len(good.uploads) == 1
+        assert len(flaky.uploads) == 0
+        assert published == []
+        # Sidecar has the good service cached.
+        pending_files = [f for f in pending_dir("A").iterdir()
+                         if f.name.endswith(".json") and not f.name.endswith(".retry")]
+        sidecar = json.loads(retry_sidecar_path(pending_files[0]).read_text())
+        assert sidecar["uploaded"]["doc.txt"]["good"].startswith("stub://good/")
+        assert "flaky" not in sidecar["uploaded"]["doc.txt"]
+        # Force the next-attempt clock open and route again.
+        sidecar["next_attempt"] = ""
+        retry_sidecar_path(pending_files[0]).write_text(json.dumps(sidecar))
+        route_outboxes(
+            [a, b],
+            all_agents=[a, b],
+            publish_remotes=stub_publish,
+            configured_remote_ids=["hub"],
+            services=[good, flaky],
+        )
+        # Second pass: good was NOT re-uploaded; flaky succeeded; publish
+        # was called.
+        assert len(good.uploads) == 1  # unchanged
+        assert len(flaky.uploads) == 1
+        assert len(published) == 1
+        # Wire entry has both URLs.
+        urls = published[0]["files"][0]["storage"]
+        assert any(u.startswith("stub://good/") for u in urls)
+        assert any(u.startswith("stub://flaky/") for u in urls)
+
+    def test_no_services_keeps_v1_skip(self, two_agents):
+        # Already covered by `test_file_payloads_skip_remote_publish`, but
+        # this version asserts the v1 fallback log explicitly hits when
+        # services list is empty (vs unset).
+        a, b = two_agents
+        payload = a.root / "doc.txt"
+        payload.write_text("x")
+        published = []
+
+        def stub_publish(msg, sender_name, succeeded_so_far, attempt_count):
+            published.append(msg)
+            return list(succeeded_so_far) + ["hub"]
+
+        _write_outbox("A", a.root, "B", "see attached", [
+            {"filename": "doc.txt", "path": str(payload)},
+        ])
+        route_outboxes(
+            [a, b],
+            all_agents=[a, b],
+            publish_remotes=stub_publish,
+            configured_remote_ids=["hub"],
+            services=[],
+        )
+        assert published == []  # remote skipped — no storage configured
+        # Local delivery still works.
+        assert len(list(inbox_dir("B").iterdir())) == 1
+
+
+class TestStorageDownload:
+    """`_download_files_to_recipient` — exercised via `network.receive_envelope`
+    so the test covers the whole receive-side path that an MQTT subscriber
+    would drive."""
+
+    def test_falls_through_to_second_url(self, fake_home, tmp_path):
+        from network import receive_envelope
+        from registry import save_registry
+        from ulid import new as new_ulid
+
+        b_root = tmp_path / "B"; b_root.mkdir()
+        save_registry({"B": {"root": str(b_root)}})
+        b = Participant("B", b_root)
+
+        # Two services: one only handles its own URLs, one handles the second.
+        s_first = _StubStorage("first")
+        s_second = _StubStorage("second")
+        # Pre-populate `second`'s store with a synthetic URL+bytes (as if
+        # the sender had uploaded there).
+        s_second.bytes_for["stub://second/42"] = b"the-payload"
+
+        msg_id = new_ulid()
+        envelope = json.dumps({
+            "id": msg_id,
+            "from": "REMOTE_X",
+            "to": "B",
+            "content": "see attached",
+            "files": [{
+                "filename": "doc.txt",
+                # First URL belongs to NO configured service (foreign host).
+                # Second URL belongs to `s_second`.
+                "storage": ["stub://other/99", "stub://second/42"],
+            }],
+        }).encode()
+        receive_envelope(envelope, [b], services=[s_first, s_second])
+        # File materialized into B's .files/.
+        files = list(files_dir(b_root).iterdir())
+        assert len(files) == 1
+        assert files[0].name == "doc.txt"
+        assert files[0].read_bytes() == b"the-payload"
+        # The inbox-written envelope has the local-path shape.
+        inbox_msg = json.loads(next(inbox_dir("B").iterdir()).read_text())
+        assert inbox_msg["files"] == [{"filename": "doc.txt", "path": str(files[0])}]
+
+    def test_all_urls_unsupported_drops_file_keeps_message(self, fake_home, tmp_path):
+        from network import receive_envelope
+        from registry import save_registry
+        from ulid import new as new_ulid
+
+        b_root = tmp_path / "B"; b_root.mkdir()
+        save_registry({"B": {"root": str(b_root)}})
+        b = Participant("B", b_root)
+
+        s = _StubStorage("only-one")  # doesn't recognize stub://other/ URLs
+        msg_id = new_ulid()
+        envelope = json.dumps({
+            "id": msg_id, "from": "X", "to": "B",
+            "content": "see attached",
+            "files": [{"filename": "doc.txt", "storage": ["stub://other/99"]}],
+        }).encode()
+        receive_envelope(envelope, [b], services=[s])
+        # Message delivered, files dropped.
+        body = json.loads(next(inbox_dir("B").iterdir()).read_text())
+        assert body["files"] == []
+        assert body["content"] == "see attached"
+
+    def test_no_services_strips_files(self, fake_home, tmp_path):
+        from network import receive_envelope
+        from registry import save_registry
+        from ulid import new as new_ulid
+
+        b_root = tmp_path / "B"; b_root.mkdir()
+        save_registry({"B": {"root": str(b_root)}})
+        b = Participant("B", b_root)
+
+        msg_id = new_ulid()
+        envelope = json.dumps({
+            "id": msg_id, "from": "X", "to": "B",
+            "content": "see attached",
+            "files": [{"filename": "doc.txt", "storage": ["stub://x/1"]}],
+        }).encode()
+        # No `services` argument → falls back to v1 behavior.
+        receive_envelope(envelope, [b])
+        body = json.loads(next(inbox_dir("B").iterdir()).read_text())
+        assert body["files"] == []

--- a/apps/a8s/tests/test_network.py
+++ b/apps/a8s/tests/test_network.py
@@ -76,7 +76,7 @@ class StubTransport(Transport):
 class TestNetworkConfig:
     def test_absent_file_returns_empty(self, fake_home):
         cfg = load_network_config()
-        assert cfg == {"remotes": {}}
+        assert cfg == {"remotes": {}, "services": {}}
 
     def test_round_trip(self, fake_home):
         save_network_config({"remotes": {"hub": {"transport": "mqtt", "broker": "mqtt://x", "topic": "t"}}})
@@ -88,7 +88,7 @@ class TestNetworkConfig:
         p.parent.mkdir(parents=True, exist_ok=True)
         p.write_text("not json {")
         cfg = load_network_config()
-        assert cfg == {"remotes": {}}
+        assert cfg == {"remotes": {}, "services": {}}
 
     def test_configured_remote_ids_order_preserved(self, fake_home):
         save_network_config({"remotes": {"a": {}, "z": {}, "m": {}}})

--- a/apps/a8s/tests/test_remote_e2e.py
+++ b/apps/a8s/tests/test_remote_e2e.py
@@ -62,10 +62,16 @@ def mqtt_broker(tmp_path):
         proc.kill()
 
 
-def _write_network_json(home: Path, port: int, topic: str, client_id: str) -> None:
+def _write_network_json(
+    home: Path,
+    port: int,
+    topic: str,
+    client_id: str,
+    storage_url: str | None = None,
+) -> None:
     a8s_dir = home / ".a8s"
     a8s_dir.mkdir(parents=True, exist_ok=True)
-    (a8s_dir / "network.json").write_text(json.dumps({
+    cfg: dict = {
         "remotes": {
             "hub": {
                 "transport": "mqtt",
@@ -74,7 +80,12 @@ def _write_network_json(home: Path, port: int, topic: str, client_id: str) -> No
                 "client_id": client_id,
             }
         }
-    }))
+    }
+    if storage_url is not None:
+        cfg["services"] = {
+            "fake": {"service": "tempfile_org", "url": storage_url},
+        }
+    (a8s_dir / "network.json").write_text(json.dumps(cfg))
 
 
 def test_remote_round_trip(tmp_path, mqtt_broker, monkeypatch):
@@ -149,3 +160,102 @@ def test_remote_round_trip(tmp_path, mqtt_broker, monkeypatch):
         assert body["to"] == "TARGET"
     finally:
         stop_remotes(rx_remotes)
+
+
+def test_remote_round_trip_with_file_via_storage(tmp_path, mqtt_broker, monkeypatch):
+    """Two-cluster end-to-end for issue #90: cluster A writes a `FILE:`
+    outbox, attached_loop uploads to the configured storage service,
+    publishes the envelope (with `files[i].storage` URLs in place of
+    sender-local paths), broker holds for B's persistent session, B's
+    subscriber receives, downloads via the same storage service into
+    TARGET's `.files/`, and the inbox JSON has the local-path shape.
+
+    Both clusters point at the SAME fake tempfile.org-shaped HTTP server
+    (a stand-in for a real shared backend). The MQTT round-trip uses the
+    persistent-session warmup pattern from the no-files test above so we
+    don't need two HOMEs running subscribers concurrently."""
+    from _fake_storage import start_fake_tempfile_server
+
+    storage_server, storage_url = start_fake_tempfile_server()
+    try:
+        topic = f"a8s/test-storage-{os.getpid()}-{int(time.time() * 1000)}"
+        cluster_a_home = tmp_path / "clusterA"; cluster_a_home.mkdir()
+        cluster_b_home = tmp_path / "clusterB"; cluster_b_home.mkdir()
+        _write_network_json(cluster_a_home, mqtt_broker, topic, "a8s-test-storage-A", storage_url)
+        _write_network_json(cluster_b_home, mqtt_broker, topic, "a8s-test-storage-B", storage_url)
+
+        import core
+        core.PRINT_LOCK = None
+
+        # Pre-register cluster B's persistent session (matches the no-files
+        # test's pattern) and create TARGET's mailbox.
+        monkeypatch.setenv("HOME", str(cluster_b_home))
+        monkeypatch.delenv("USERPROFILE", raising=False)
+        target_root = cluster_b_home / "target"
+        target_root.mkdir()
+        from core import Participant, files_dir, inbox_dir
+        from mailbox import ensure_mailboxes
+        from registry import save_registry
+        save_registry({"TARGET": {"root": str(target_root)}})
+        target_p = Participant("TARGET", target_root)
+        ensure_mailboxes(target_p)
+
+        from network import (
+            load_remotes, load_services, start_remotes, stop_remotes,
+        )
+        b_services = load_services()
+        warmup = start_remotes(load_remotes(), lambda: [target_p], services=b_services)
+        stop_remotes(warmup)
+
+        # Cluster A: write a FILE: outbox, run attached_loop to publish.
+        monkeypatch.setenv("HOME", str(cluster_a_home))
+        core.PRINT_LOCK = None
+        sender_root = cluster_a_home / "sender"
+        sender_root.mkdir()
+        save_registry({"SENDER": {"root": str(sender_root)}})
+        sender_p = Participant("SENDER", sender_root)
+        ensure_mailboxes(sender_p)
+        # The payload lives inside the sender's root (sandbox check enforces this).
+        payload = sender_root / "report.txt"
+        payload.write_text("hello from cluster A\n")
+        from mailbox import _write_outbox
+        _write_outbox("SENDER", sender_root, "TARGET", "see attached", [
+            {"filename": "report.txt", "path": str(payload)},
+        ])
+        from daemon import attached_loop
+        rc = attached_loop(["SENDER"], 0.2, single_pass=True)
+        assert rc == 0
+        # Sender uploaded to the fake server.
+        assert len(storage_server.files) == 1, "sender did not upload to storage"
+
+        # Cluster B reconnects with the same client_id; broker replays.
+        monkeypatch.setenv("HOME", str(cluster_b_home))
+        core.PRINT_LOCK = None
+        b_services = load_services()
+        rx_remotes = start_remotes(load_remotes(), lambda: [target_p], services=b_services)
+        try:
+            deadline = time.time() + 5.0
+            files: list[Path] = []
+            while time.time() < deadline:
+                files = list(inbox_dir("TARGET").iterdir())
+                if files:
+                    break
+                time.sleep(0.1)
+            assert files, "envelope did not arrive at TARGET via the remote"
+            body = json.loads(files[0].read_text())
+            assert body["from"] == "SENDER"
+            assert body["content"] == "see attached"
+            assert body["to"] == "TARGET"
+            # File materialized into TARGET's .files/, path rewritten to local.
+            assert len(body["files"]) == 1
+            assert body["files"][0]["filename"] == "report.txt"
+            local_files = list(files_dir(target_root).iterdir())
+            assert len(local_files) == 1
+            assert local_files[0].name == "report.txt"
+            assert local_files[0].read_text() == "hello from cluster A\n"
+            assert body["files"][0]["path"] == str(local_files[0])
+        finally:
+            stop_remotes(rx_remotes)
+    finally:
+        storage_server.shutdown()
+        storage_server.server_close()

--- a/apps/a8s/tests/test_remote_e2e.py
+++ b/apps/a8s/tests/test_remote_e2e.py
@@ -253,7 +253,11 @@ def test_remote_round_trip_with_file_via_storage(tmp_path, mqtt_broker, monkeypa
             assert len(local_files) == 1
             assert local_files[0].name == "report.txt"
             assert local_files[0].read_text() == "hello from cluster A\n"
-            assert body["files"][0]["path"] == str(local_files[0])
+            # Path is CWD-relative — the agent's wake subprocess runs with
+            # cwd=target_root, so `./.files/report.txt` resolves whether
+            # target_root is /tmp/clusterB/target on the host or remapped
+            # to /workspace inside a container.
+            assert body["files"][0]["path"] == "./.files/report.txt"
         finally:
             stop_remotes(rx_remotes)
     finally:

--- a/apps/a8s/tests/test_service_dispatch.py
+++ b/apps/a8s/tests/test_service_dispatch.py
@@ -1,0 +1,111 @@
+"""Tests for the storage-service dispatcher (#90) — `_build_service`,
+`load_services`, `configured_service_ids`, `detect_service_kind`. The
+TempFile.org-specific HTTP behavior lives in test_service_tempfile_org.py."""
+from __future__ import annotations
+
+from network import (
+    configured_service_ids,
+    detect_service_kind,
+    load_network_config,
+    load_services,
+    save_network_config,
+)
+
+
+class TestNetworkConfigServices:
+    def test_absent_file_includes_services(self, fake_home):
+        cfg = load_network_config()
+        assert cfg == {"remotes": {}, "services": {}}
+
+    def test_round_trip(self, fake_home):
+        save_network_config({
+            "remotes": {},
+            "services": {
+                "tempfile": {"service": "tempfile_org", "url": "https://tempfile.org"},
+            },
+        })
+        cfg = load_network_config()
+        assert cfg["services"]["tempfile"]["service"] == "tempfile_org"
+
+    def test_configured_service_ids_order_preserved(self, fake_home):
+        save_network_config({"remotes": {}, "services": {"a": {}, "z": {}, "m": {}}})
+        assert configured_service_ids() == ["a", "z", "m"]
+
+    def test_non_dict_services_value_resets(self, fake_home):
+        # A bad services value (string, list, etc.) gets treated as empty
+        # rather than crashing the config loader.
+        from core import network_config_path
+
+        p = network_config_path()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text('{"remotes": {}, "services": "not-a-dict"}')
+        cfg = load_network_config()
+        assert cfg["services"] == {}
+
+
+class TestLoadServices:
+    def test_unknown_kind_skipped(self, fake_home):
+        save_network_config({
+            "remotes": {},
+            "services": {"weird": {"service": "telepathy", "url": "https://x"}},
+        })
+        # Should not raise; just skip the bad entry.
+        assert load_services() == []
+
+    def test_missing_url_skipped(self, fake_home):
+        save_network_config({
+            "remotes": {},
+            "services": {"tempfile": {"service": "tempfile_org"}},
+        })
+        assert load_services() == []
+
+    def test_unknown_option_skips_service(self, fake_home):
+        # `_build_service` forwards unknown opts to the service constructor,
+        # which raises ValueError — load_services catches and skips. Same
+        # backstop pattern the remote dispatcher uses.
+        save_network_config({
+            "remotes": {},
+            "services": {
+                "tempfile": {
+                    "service": "tempfile_org",
+                    "url": "https://tempfile.org",
+                    "boguskey": "x",
+                }
+            },
+        })
+        assert load_services() == []
+
+    def test_valid_entry_loads(self, fake_home):
+        save_network_config({
+            "remotes": {},
+            "services": {
+                "tempfile": {"service": "tempfile_org", "url": "https://tempfile.org"},
+            },
+        })
+        services = load_services()
+        assert len(services) == 1
+        assert services[0].id == "tempfile"
+
+    def test_non_dict_entry_skipped(self, fake_home):
+        save_network_config({
+            "remotes": {},
+            "services": {"bad": "not-a-dict"},
+        })
+        assert load_services() == []
+
+
+class TestDetectServiceKind:
+    def test_tempfile_org_url_matches(self):
+        assert detect_service_kind("https://tempfile.org") == "tempfile_org"
+
+    def test_tempfile_org_with_path_matches(self):
+        assert detect_service_kind("https://tempfile.org/api") == "tempfile_org"
+
+    def test_www_subdomain_matches(self):
+        assert detect_service_kind("https://www.tempfile.org") == "tempfile_org"
+
+    def test_unrelated_host_returns_none(self):
+        assert detect_service_kind("https://example.com") is None
+
+    def test_bad_scheme_returns_none(self):
+        assert detect_service_kind("ftp://tempfile.org") is None

--- a/apps/a8s/tests/test_service_tempfile_org.py
+++ b/apps/a8s/tests/test_service_tempfile_org.py
@@ -1,17 +1,12 @@
 """Tests for the TempFile.org storage service.
 
-The fake HTTP server below mimics tempfile.org's two endpoints
-(`POST /api/upload/local` and `GET /<id>/download`) so the round-trip
-behavior is exercised without real network calls. A separate marker test
-verifies that an upload to a deliberately-bogus URL surfaces
+The fake HTTP server (`_fake_storage`) mimics tempfile.org's two
+endpoints (`POST /api/upload/local` and `GET /<id>/download`) so the
+round-trip behavior is exercised without real network calls. A separate
+marker test verifies that an upload to a deliberately-bogus URL surfaces
 `StorageError`."""
 from __future__ import annotations
 
-import json
-import re
-import socket
-import threading
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 import pytest
@@ -19,96 +14,16 @@ import pytest
 from services import StorageError
 from services.tempfile_org import TempFileOrgService
 
-
-# ---------- fake server fixture ----------
-
-
-class _Handler(BaseHTTPRequestHandler):
-    """Minimal in-process tempfile.org clone. Stores uploads in
-    `self.server.files: dict[str, bytes]` keyed by hex id."""
-
-    # Silence the default stdout logging.
-    def log_message(self, format, *args):
-        return
-
-    def do_POST(self):
-        if self.path != "/api/upload/local":
-            self.send_error(404)
-            return
-        ctype = self.headers.get("Content-Type", "")
-        m = re.search(r"boundary=(.+)$", ctype)
-        if not m:
-            self.send_error(400, "missing boundary")
-            return
-        boundary = m.group(1).encode()
-        length = int(self.headers.get("Content-Length", "0"))
-        body = self.rfile.read(length)
-        # Crude multipart parse — just enough for the test fixture. Pull out
-        # the `files` field's binary payload.
-        parts = body.split(b"--" + boundary)
-        file_bytes: bytes | None = None
-        for part in parts:
-            if b'name="files"' in part:
-                # Skip headers (terminated by \r\n\r\n) and trailing CRLF.
-                _, _, rest = part.partition(b"\r\n\r\n")
-                file_bytes = rest.rsplit(b"\r\n", 1)[0]
-                break
-        if file_bytes is None:
-            self.send_error(400, "missing files field")
-            return
-        file_id = f"f{len(self.server.files):04d}"  # deterministic id
-        self.server.files[file_id] = file_bytes
-        port = self.server.server_address[1]
-        url = f"http://127.0.0.1:{port}/{file_id}/"
-        body_out = json.dumps({
-            "files": [{
-                "id": file_id,
-                "name": "x",
-                "size": len(file_bytes),
-                "url": url,
-                "expiryTime": 0,
-            }]
-        }).encode()
-        self.send_response(200)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(body_out)))
-        self.end_headers()
-        self.wfile.write(body_out)
-
-    def do_GET(self):
-        m = re.match(r"^/(?P<id>[^/]+)/download$", self.path)
-        if not m:
-            self.send_error(404)
-            return
-        file_id = m.group("id")
-        if file_id not in self.server.files:
-            self.send_error(404, "unknown id")
-            return
-        data = self.server.files[file_id]
-        self.send_response(200)
-        self.send_header("Content-Type", "application/octet-stream")
-        self.send_header("Content-Length", str(len(data)))
-        self.end_headers()
-        self.wfile.write(data)
-
-
-def _free_port() -> int:
-    with socket.socket() as s:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
+from _fake_storage import free_port, start_fake_tempfile_server
 
 
 @pytest.fixture
 def fake_tempfile():
     """Spin up an in-process tempfile.org clone on a random port. Yields
     its base URL (e.g. `http://127.0.0.1:<port>`)."""
-    port = _free_port()
-    server = ThreadingHTTPServer(("127.0.0.1", port), _Handler)
-    server.files = {}  # type: ignore[attr-defined]
-    t = threading.Thread(target=server.serve_forever, daemon=True)
-    t.start()
+    server, base_url = start_fake_tempfile_server()
     try:
-        yield f"http://127.0.0.1:{port}"
+        yield base_url
     finally:
         server.shutdown()
         server.server_close()
@@ -210,7 +125,7 @@ class TestErrorPaths:
     def test_unreachable_upload_raises(self, tmp_path):
         # No server on this port — `urlopen` raises URLError quickly.
         s = TempFileOrgService(
-            "t", url=f"http://127.0.0.1:{_free_port()}", timeout_s=0.5,
+            "t", url=f"http://127.0.0.1:{free_port()}", timeout_s=0.5,
         )
         src = tmp_path / "payload.bin"
         src.write_bytes(b"x")

--- a/apps/a8s/tests/test_service_tempfile_org.py
+++ b/apps/a8s/tests/test_service_tempfile_org.py
@@ -1,0 +1,230 @@
+"""Tests for the TempFile.org storage service.
+
+The fake HTTP server below mimics tempfile.org's two endpoints
+(`POST /api/upload/local` and `GET /<id>/download`) so the round-trip
+behavior is exercised without real network calls. A separate marker test
+verifies that an upload to a deliberately-bogus URL surfaces
+`StorageError`."""
+from __future__ import annotations
+
+import json
+import re
+import socket
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+from services import StorageError
+from services.tempfile_org import TempFileOrgService
+
+
+# ---------- fake server fixture ----------
+
+
+class _Handler(BaseHTTPRequestHandler):
+    """Minimal in-process tempfile.org clone. Stores uploads in
+    `self.server.files: dict[str, bytes]` keyed by hex id."""
+
+    # Silence the default stdout logging.
+    def log_message(self, format, *args):
+        return
+
+    def do_POST(self):
+        if self.path != "/api/upload/local":
+            self.send_error(404)
+            return
+        ctype = self.headers.get("Content-Type", "")
+        m = re.search(r"boundary=(.+)$", ctype)
+        if not m:
+            self.send_error(400, "missing boundary")
+            return
+        boundary = m.group(1).encode()
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length)
+        # Crude multipart parse — just enough for the test fixture. Pull out
+        # the `files` field's binary payload.
+        parts = body.split(b"--" + boundary)
+        file_bytes: bytes | None = None
+        for part in parts:
+            if b'name="files"' in part:
+                # Skip headers (terminated by \r\n\r\n) and trailing CRLF.
+                _, _, rest = part.partition(b"\r\n\r\n")
+                file_bytes = rest.rsplit(b"\r\n", 1)[0]
+                break
+        if file_bytes is None:
+            self.send_error(400, "missing files field")
+            return
+        file_id = f"f{len(self.server.files):04d}"  # deterministic id
+        self.server.files[file_id] = file_bytes
+        port = self.server.server_address[1]
+        url = f"http://127.0.0.1:{port}/{file_id}/"
+        body_out = json.dumps({
+            "files": [{
+                "id": file_id,
+                "name": "x",
+                "size": len(file_bytes),
+                "url": url,
+                "expiryTime": 0,
+            }]
+        }).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body_out)))
+        self.end_headers()
+        self.wfile.write(body_out)
+
+    def do_GET(self):
+        m = re.match(r"^/(?P<id>[^/]+)/download$", self.path)
+        if not m:
+            self.send_error(404)
+            return
+        file_id = m.group("id")
+        if file_id not in self.server.files:
+            self.send_error(404, "unknown id")
+            return
+        data = self.server.files[file_id]
+        self.send_response(200)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture
+def fake_tempfile():
+    """Spin up an in-process tempfile.org clone on a random port. Yields
+    its base URL (e.g. `http://127.0.0.1:<port>`)."""
+    port = _free_port()
+    server = ThreadingHTTPServer(("127.0.0.1", port), _Handler)
+    server.files = {}  # type: ignore[attr-defined]
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    try:
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+# ---------- option-bag handling ----------
+
+
+class TestTempFileOrgServiceOptions:
+    def test_defaults(self):
+        s = TempFileOrgService("t", url="https://tempfile.org")
+        assert s.id == "t"
+        assert s._expiry_hours == 24
+        assert s._timeout_s == 30.0
+
+    def test_custom_expiry(self):
+        s = TempFileOrgService("t", url="https://tempfile.org", expiry_hours=6)
+        assert s._expiry_hours == 6
+
+    def test_string_expiry_coerced(self):
+        # `network.json` values come through as strings (CLI parsing).
+        s = TempFileOrgService("t", url="https://tempfile.org", expiry_hours="48")
+        assert s._expiry_hours == 48
+
+    def test_bad_expiry_raises(self):
+        with pytest.raises(ValueError, match="expiry_hours must be one of"):
+            TempFileOrgService("t", url="https://tempfile.org", expiry_hours=12)
+
+    def test_unknown_option_raises(self):
+        with pytest.raises(ValueError, match="unknown option"):
+            TempFileOrgService("t", url="https://tempfile.org", boguskey="x")
+
+    def test_unsupported_scheme_raises(self):
+        with pytest.raises(ValueError, match="unsupported scheme"):
+            TempFileOrgService("t", url="ftp://tempfile.org")
+
+    def test_missing_host_raises(self):
+        with pytest.raises(ValueError, match="missing host"):
+            TempFileOrgService("t", url="https://")
+
+
+# ---------- supports_config_url dispatch ----------
+
+
+class TestSupportsConfigUrl:
+    def test_canonical_host(self):
+        assert TempFileOrgService.supports_config_url("https://tempfile.org") is True
+
+    def test_path_tolerated(self):
+        assert TempFileOrgService.supports_config_url("https://tempfile.org/api") is True
+
+    def test_www_subdomain(self):
+        assert TempFileOrgService.supports_config_url("https://www.tempfile.org") is True
+
+    def test_other_host(self):
+        assert TempFileOrgService.supports_config_url("https://example.com") is False
+
+    def test_non_http_scheme(self):
+        assert TempFileOrgService.supports_config_url("ftp://tempfile.org") is False
+
+
+# ---------- store / retrieve round-trip ----------
+
+
+class TestRoundTrip:
+    def test_upload_then_download_match(self, fake_tempfile, tmp_path):
+        s = TempFileOrgService("t", url=fake_tempfile)
+        src = tmp_path / "payload.bin"
+        src.write_bytes(b"hello payload \x00\x01\x02")
+        url = s.store(src)
+        assert url.startswith(fake_tempfile)
+        dest = tmp_path / "downloaded.bin"
+        assert s.retrieve(url, dest) is True
+        assert dest.read_bytes() == src.read_bytes()
+
+
+class TestRetrieveDispatch:
+    def test_foreign_host_returns_false(self, fake_tempfile, tmp_path):
+        s = TempFileOrgService("t", url=fake_tempfile)
+        # URL belongs to a host this service isn't configured for.
+        dest = tmp_path / "downloaded.bin"
+        assert s.retrieve("https://other.example/abc/", dest) is False
+        assert not dest.exists()
+
+    def test_already_has_download_suffix(self, fake_tempfile, tmp_path):
+        # Tolerate either the trailing-slash form (what tempfile.org returns)
+        # or an explicit `/download` suffix (operator-typed for testing).
+        s = TempFileOrgService("t", url=fake_tempfile)
+        src = tmp_path / "payload.bin"
+        src.write_bytes(b"x")
+        landing_url = s.store(src)
+        explicit = landing_url.rstrip("/") + "/download"
+        dest = tmp_path / "downloaded.bin"
+        assert s.retrieve(explicit, dest) is True
+        assert dest.read_bytes() == b"x"
+
+
+class TestErrorPaths:
+    def test_unreachable_upload_raises(self, tmp_path):
+        # No server on this port — `urlopen` raises URLError quickly.
+        s = TempFileOrgService(
+            "t", url=f"http://127.0.0.1:{_free_port()}", timeout_s=0.5,
+        )
+        src = tmp_path / "payload.bin"
+        src.write_bytes(b"x")
+        with pytest.raises(StorageError):
+            s.store(src)
+
+    def test_404_download_raises(self, fake_tempfile, tmp_path):
+        # URL host matches the service but the file doesn't exist server-side.
+        s = TempFileOrgService("t", url=fake_tempfile)
+        dest = tmp_path / "downloaded.bin"
+        with pytest.raises(StorageError, match="download HTTP 404"):
+            s.retrieve(f"{fake_tempfile}/no-such-id/", dest)
+
+    def test_missing_source_raises(self, fake_tempfile, tmp_path):
+        s = TempFileOrgService("t", url=fake_tempfile)
+        with pytest.raises(StorageError, match="cannot read"):
+            s.store(tmp_path / "no-such-file.bin")


### PR DESCRIPTION
Closes #90.

## Summary

- New `StorageService` abstraction parallel to `Transport`, with `a8s storage` / `a8s unstorage` CLI mirroring `remote`/`unremote`.
- First impl: `TempFileOrgService` (pure-stdlib `urllib`, multipart upload, no auth).
- Sender uploads each file to every configured service; receiver downloads from the first accepting service into the recipient's `<root>/.files/`.
- Per-file × per-service success cached in the retry sidecar so backoff retries don't re-upload to services that already accepted.
- No-services fallback preserves pre-#90 behavior: files stay local-only, remotes marked succeeded so the message finalizes.

## Wire format

Outgoing envelope after upload (per file):

```json
{
  "files": [{
    "filename": "build.log",
    "storage": [
      "https://tempfile.org/abc123/",
      "https://other-storage.example/xyz789"
    ]
  }]
}
```

Note `path` is omitted on the wire (sender-local; meaningless to a remote). Multiple services produce multiple equivalent URLs — the receiver picks the first one its configured services accept, which means a recipient with a different storage provider can still pull the file as long as one URL on the list matches. Local-only routing keeps the existing `{filename, path}` shape; the storage detour activates only in `_process_pending`'s remote-publish branch.

## Sidecar bookkeeping

`<f>.json.retry` gains an `uploaded: {filename: {service_id: url}}` field. Backoff retries only re-upload to services still missing.

## Test plan

- [x] Full pytest suite: 347 passing (294 → 347, 53 new tests).
- [x] Service dispatch tests (URL-based class lookup, unknown kind/option rejection).
- [x] In-process fake-server tests for TempFile.org round-trip + error paths.
- [x] Mailbox upload caching (single service success → publish; partial failure → cache + retry; second pass uses cache).
- [x] Receive-side URL fallthrough (first URL belongs to no configured service → second URL downloaded).
- [x] Storage CLI surface (list/show/set/duplicate-key/auto-dispatch from URL/unstorage).
- [x] Live smoke test against `https://tempfile.org` — upload + download round-trip works against the real API.
- [x] **Two-cluster end-to-end** via real mosquitto broker + fake-tempfile-shaped HTTP server on localhost. Both clusters share both backends; sender uploads, broker delivers envelope to receiver, receiver downloads via storage service into TARGET's `.files/`. Production topology, faux-clustered locally.

## Out of scope

- App-level envelope encryption / per-message symmetric keys (originally scoped under #62; left for a follow-up once cross-cluster signed-URL flows shake out in practice).
- Multiple services per scheme (operators wanting two TempFile-shaped endpoints configure both with distinct names).
- A storage-service registry CLI for receivers to enumerate remote URLs (the receiver's configured services are authoritative; mismatches just mean a file isn't downloadable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)