### PR TITLE
feat(a8s): OpenCode as 5th tool kind + AGENTS.md fallback marker (#94)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -433,6 +433,21 @@ and echoes the prompt). Wakes never crash on missing config.
   consumers. (We deliberately did NOT invent a `COPILOT.md` marker:
   using Copilot's native location avoids the symlink-or-duplicate dance
   the other markers would otherwise require.)
+- **OpenCode** — BYO-model coding CLI (https://opencode.ai/). Non-interactive
+  is the `opencode run "<message>"` *subcommand*, not a `-p` flag.
+  `--continue` resumes the most recent session;
+  `--dangerously-skip-permissions` is required for headless tool use. The
+  model is **not** baked into the a8s definition — operators pick the
+  provider/model in each agent's own `opencode.json`
+  (`{"model": "ollama/gpt-oss:20b"}`, `{"model": "anthropic/claude-sonnet-4-6"}`,
+  etc.). OpenCode's CLI priority is `-m` flag > `opencode.json` > last-used
+  > default, so adding `-m` to the shared definition would clobber per-agent
+  config — we deliberately don't. `AGENTS.md` is OpenCode's native
+  instruction file and is also the a8s **fallback marker**: a directory
+  with only `AGENTS.md` resolves to `opencode`; a kind-specific marker
+  (CLAUDE/GEMINI/CODEX/`.github/copilot-instructions.md`) wins when both
+  are present. No user-scope skill mechanism, so `tell` instructions live
+  inline in each agent's `AGENTS.md`.
 
 ### SKILL.md YAML — quoted scalars only
 
@@ -477,6 +492,8 @@ The locked-design refactor (#52) is closed. The following are open:
 | #63 | partially landed | Transparent multi-cluster routing. MQTT transport (paho-mqtt impl) + layered remotes + per-message backoff + ULID dedup are in. Still open: mini-MQTT pure-stdlib fallback (auto-activates when paho isn't importable), HTTPS long-poll transport, peer-to-peer TCP transport, app-level envelope encryption (per-network PSK). |
 | #90 | landed | Cross-cluster `FILE:` payloads via pluggable storage services (`a8s storage`/`unstorage`). TempFile.org first impl (pure-stdlib HTTP). Per-file × per-service success cached in the retry sidecar; receive side downloads into recipient's `.files/`. App-level encryption / per-message symmetric keys (originally scoped under #62) deferred. |
 | #72 | open question | Design discussion surfaced by the review panel: mailbox file format. (#67's atomic fan-out and #63's ULID + ingest-to-pending split partially address this; revisit before mini-MQTT lands.) |
+| #93 | open | Grok via `superagent-ai/grok-cli` as a 5th tool kind. Open question: marker file (grok-cli reads `AGENTS.md` like OpenCode, so a8s needs a different discovery hint — recommendation in the issue is `GROK.md`). |
+| #94 | landed | OpenCode as BYO-model tool kind + `AGENTS.md` as fallback marker resolving to `opencode`. Specific markers (CLAUDE/GEMINI/CODEX/`.github/copilot-instructions.md`) still win when both are present. Model lives in each agent's own `opencode.json` (not in the shared a8s definition). |
 
 ### What I tried that didn't work (concrete)
 

--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -306,6 +306,52 @@ python3 -m pytest apps/a8s/tests/
 
 Tests are isolated via a `fake_home` fixture that monkey-patches `HOME` to a tmp dir, so they never touch the real `~/.a8s/`. The daemon tests run real subprocesses against `tests/fixtures/mock-cli` (a deterministic bash script that echoes its argv) so wake_once's argv expansion and routing fan-out can be asserted on the per-agent log.
 
+## Troubleshooting
+
+### My agent created files locally but nothing arrived at the recipient
+
+**Symptom:** The agent's own root has the files it produced (e.g. `fib.py`, `fib.txt`), but the recipient's `.files/` is empty and the recipient's inbox has no new message. The agent's log shows the model **emitted the `tell` command as plain text** in its final output instead of invoking it via its bash/shell tool — typical line: `opencode> tell <name> "..." FILE: ./...` with no `$` shell-tool prefix.
+
+**Why it happens:** A tool-selection failure in the underlying model. The model conflates *"responding to the user"* (final assistant text) with *"running the tell shell command"*. Smaller and weaker local models hit this often; instruction-tuned frontier models almost never do.
+
+**Fixes, in order of preference:**
+
+1. **Strengthen the persona file.** Add a line to the agent's marker file (`AGENTS.md` / `CLAUDE.md` / etc.): *"`tell` is a shell command — invoke it via your bash/shell tool. Never print the command as text; that is not a reply, it is just narration."*
+2. **Be explicit in the message.** When you suspect a model will fall back to text, append: *"Use your bash tool to actually execute the command — do not just print it as text."*
+3. **Use a stronger model.** For OpenCode + Ollama, models with explicit tool-use training (e.g. Qwen3-Coder, GPT-OSS 20B+) compose tool calls more reliably than general-purpose chat models at the same parameter count.
+
+### Ollama silently truncates context to 2k tokens
+
+Ollama's default `num_ctx` is **2048**. Anything past that is dropped without warning, which means a long persona file plus message history can quietly lose your instructions. For agentic workflows, set `OLLAMA_CONTEXT_LENGTH=16384` (or more) in the environment Ollama runs under, or pull a model with a `Modelfile` that bumps `PARAMETER num_ctx`.
+
+### `opencode models <provider>` says "Provider not found: ollama"
+
+OpenCode's built-in providers don't include Ollama. Register it once in `~/.config/opencode/opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "ollama": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Ollama (local)",
+      "options": { "baseURL": "http://localhost:11434/v1" },
+      "models": { "gpt-oss:20b": { "name": "gpt-oss 20B" } }
+    }
+  }
+}
+```
+
+Per-agent `opencode.json` then just picks the model: `{"model": "ollama/gpt-oss:20b"}`. The provider registration is shared infrastructure; the model selection is per-agent.
+
+### A wake hangs forever with no output
+
+The most common causes:
+
+- **Codex without `stdin=DEVNULL`.** Codex CLI hangs reading stdin in headless mode. a8s already passes `stdin=subprocess.DEVNULL` for every wake (`daemon.run_with_prefix`), so this only bites if you're running the underlying CLI manually.
+- **Headless permission denial.** Gemini without `--yolo`, Claude without `--permission-mode dontAsk`, Copilot without `--allow-all-tools`, OpenCode without `--dangerously-skip-permissions` — all silently deny tool calls in non-interactive mode and the wake stalls. The bundled `definitions/<kind>.json` files include the required flag for each kind; only worry if you write a custom definition.
+- **Ollama model still loading.** A cold-start of a 20B model can take 10–30s before any output. `ps aux | grep ollama` should show a `runner` process consuming RAM proportional to the model size.
+
 ## Roadmap
 
 Pre-v1 — the surface still moves. Tracked threads:

--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -168,11 +168,12 @@ Each agent has a definition file: a JSON document describing how to invoke its C
 | `gemini.json` | Gemini CLI with `--yolo` (Policy Engine doesn't apply in headless mode; tracked upstream) + `--resume latest` |
 | `codex.json` | Codex CLI with `--full-auto` workspace-write sandbox + `resume --last` |
 | `copilot.json` | GitHub Copilot CLI with `--allow-all-tools` (required for non-interactive `-p` mode) + `--continue`. Marker is `.github/copilot-instructions.md` (Copilot's native repo-instructions location). |
+| `opencode.json` | [OpenCode](https://opencode.ai/) — BYO model. `opencode run --continue --dangerously-skip-permissions`. Operator picks the provider/model in each agent's own `opencode.json` (e.g. `{"model": "ollama/gpt-oss:20b"}`), not in the a8s definition. |
 | `default.json` | Fallback — runs `dummy-cli` and prints "no real CLI configured" |
 
 ### Marker files & auto-discovery
 
-`a8s discover <path>` and `a8s add <name> <dir>` (without an explicit definition) figure out which CLI an agent uses by scanning for one of these **kind-specific** marker files at the agent's root:
+`a8s discover <path>` and `a8s add <name> <dir>` (without an explicit definition) figure out which CLI an agent uses by scanning for one of these marker files at the agent's root, in order:
 
 | Marker | Kind | Where the CLI itself looks |
 |---|---|---|
@@ -180,10 +181,11 @@ Each agent has a definition file: a JSON document describing how to invoke its C
 | `GEMINI.md` | gemini | [Gemini CLI context files](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/configuration.md) |
 | `CODEX.md` | codex | [Codex CLI configuration](https://github.com/openai/codex) |
 | `.github/copilot-instructions.md` | copilot | [Copilot CLI repository custom instructions](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions/add-repository-instructions) — the same file Copilot itself auto-loads |
+| `AGENTS.md` (fallback) | opencode | [The agents.md standard](https://agents.md/) — tool-agnostic instructions stewarded by the [Agentic AI Foundation](https://agentic.foundation/) under the Linux Foundation |
 
-a8s deliberately keys on **kind-specific** locations so a single scan can answer "which CLI is this agent?". For Copilot we use its native repo-instructions location (`.github/copilot-instructions.md`) rather than inventing a `COPILOT.md` — that way one file serves both a8s discovery and Copilot's own persona loading.
+The first four are **kind-specific** locations — for the tools that have a distinct native instruction file, a8s uses that location directly. For Copilot we use its repo-instructions location (`.github/copilot-instructions.md`) rather than inventing a `COPILOT.md` — same file serves both a8s discovery and Copilot's own persona loading.
 
-Don't confuse these with [AGENTS.md](https://agents.md/) — that's a separate, **tool-agnostic** convention now adopted by 20+ tools (OpenAI Codex, Google Gemini CLI, GitHub Copilot, Cursor, Aider, Zed, Warp, JetBrains Junie, …) and stewarded by the [Agentic AI Foundation](https://agentic.foundation/) under the Linux Foundation. Because AGENTS.md is intentionally tool-agnostic ("one AGENTS.md works across many agents"), it cannot disambiguate which CLI to invoke, so a8s does not treat it as a marker. Operators are welcome to keep an `AGENTS.md` alongside the kind-specific marker — the kind-specific file tells a8s which CLI to invoke; AGENTS.md is whatever shared content you want every agent in the dir to see.
+[AGENTS.md](https://agents.md/) is **tool-agnostic** and shared by 20+ tools (OpenAI Codex, Google Gemini CLI, GitHub Copilot, Cursor, Aider, Zed, Warp, JetBrains Junie, OpenCode, …). Because it can't disambiguate which CLI to invoke, a8s only resolves it as a marker when **no kind-specific marker is present** — and it falls through to **OpenCode**, which is BYO-model (the operator picks the provider in each agent's own `opencode.json`). A directory with `CLAUDE.md` + `AGENTS.md` resolves to `claude`; a directory with only `AGENTS.md` resolves to `opencode`.
 
 ### The single verb
 

--- a/apps/a8s/commands.py
+++ b/apps/a8s/commands.py
@@ -139,6 +139,16 @@ def _install_skill_copilot(skill_dir: Path) -> str:
     return "  copilot: skill install delegated to per-agent .github/copilot-instructions.md (no user-scope skill mechanism)"
 
 
+def _install_skill_opencode(skill_dir: Path) -> str:
+    """OpenCode auto-loads `AGENTS.md` plus `.claude/CLAUDE.md` and
+    `.claude/skills/` per project, but lacks a user-scope skill registry.
+    Per-agent `tell` instructions live directly in each agent's
+    `AGENTS.md` (the a8s marker — see `tests/agents/opencode-agent/`)."""
+    if shutil.which("opencode") is None:
+        return "  opencode: not on PATH; skipping"
+    return "  opencode: skill install delegated to per-agent AGENTS.md (no user-scope skill mechanism)"
+
+
 # ---------- registry management commands ----------
 
 def cmd_add(args: list[str]) -> int:
@@ -376,6 +386,7 @@ def cmd_install() -> int:
         print(_install_skill_gemini(skill_dir))
         print(_install_skill_codex(skill_dir))
         print(_install_skill_copilot(skill_dir))
+        print(_install_skill_opencode(skill_dir))
     return 0
 
 

--- a/apps/a8s/core.py
+++ b/apps/a8s/core.py
@@ -30,6 +30,12 @@ MARKER_FILES = {
     # an a8s agent should expect `a8s discover` to surface it as a
     # candidate — `discover` is read-only and only suggests, never adds.
     ".github/copilot-instructions.md": "copilot",
+    # Tool-agnostic standard (https://agents.md/) adopted by 20+ tools.
+    # Listed LAST so kind-specific markers above always win when both are
+    # present; AGENTS.md alone falls through to OpenCode (the BYO-model
+    # default — operator picks the actual provider via per-agent
+    # opencode.json).
+    "AGENTS.md": "opencode",
 }
 
 NAME_RE = re.compile(r"[A-Za-z0-9]+")

--- a/apps/a8s/definitions/opencode.json
+++ b/apps/a8s/definitions/opencode.json
@@ -1,0 +1,10 @@
+{
+  "description": "OpenCode default — BYO model via per-agent opencode.json. Resumes most recent session; --dangerously-skip-permissions for headless tool use.",
+  "invoke": [
+    "opencode",
+    "run",
+    "--continue",
+    "--dangerously-skip-permissions",
+    "$SENDER tells $RECIPIENT ($AGE): $MESSAGE"
+  ]
+}

--- a/apps/a8s/skills/tell/SKILL.md
+++ b/apps/a8s/skills/tell/SKILL.md
@@ -11,6 +11,8 @@ Use the `tell` shell command (available on PATH) to send a message to a recipien
 tell <name> <message>
 ```
 
+**`tell` is a shell command — invoke it via your bash/shell tool.** Printing `tell <name> "..."` as your final assistant text is *not* a reply; it is just narration and the message will not be sent. The recipient hears you only when you actually execute `tell` through the shell tool.
+
 - `<name>` is the recipient's name. Treat it as opaque — do not assume whether the recipient is a person or another assistant, and do not change your tone based on a guess.
 - `<message>` is the body. To attach files, append one or more `FILE: <path>` lines at the end. Lines starting with `FILE: ` are stripped from the body and added as attachments. Paths can be absolute or relative to your current directory.
 

--- a/apps/a8s/tests/agents/claude-agent/CLAUDE.md
+++ b/apps/a8s/tests/agents/claude-agent/CLAUDE.md
@@ -8,6 +8,8 @@ Reach others via the `tell` shell command:
 
 - `tell <NAME> "<MESSAGE>"` — `<NAME>` may be a single recipient or an alias (a named group). The system fans out aliases automatically.
 
+**`tell` is a shell command — invoke it via your bash/shell tool.** Printing `tell <name> "..."` as your final assistant text is *not* a reply; it is just narration and the message will not be sent. The recipient hears you only when you actually execute `tell` through the shell tool.
+
 When you wake to a message:
 
 - **Direct** (`<from> tells you (CLAUDE): ...`): reply with `tell <from> "<reply>"` only if you have new information or a meaningful action to take.

--- a/apps/a8s/tests/agents/codex-agent/CODEX.md
+++ b/apps/a8s/tests/agents/codex-agent/CODEX.md
@@ -8,6 +8,8 @@ Reach others via the `tell` shell command. **Always use this — do not look for
 
 - `tell <NAME> "<MESSAGE>"` — `<NAME>` may be a single recipient or an alias (a named group). The system fans out aliases automatically.
 
+**`tell` is a shell command — invoke it via your bash/shell tool.** Printing `tell <name> "..."` as your final assistant text is *not* a reply; it is just narration and the message will not be sent. The recipient hears you only when you actually execute `tell` through the shell tool.
+
 When you wake to a message:
 
 - **Direct** (`<from> tells you (CODEX): ...`): reply with `tell <from> "<reply>"` only if you have new information or a meaningful action to take.

--- a/apps/a8s/tests/agents/copilot-agent/.github/copilot-instructions.md
+++ b/apps/a8s/tests/agents/copilot-agent/.github/copilot-instructions.md
@@ -8,6 +8,8 @@ Reach others via the `tell` shell command. **Always use this — do not look for
 
 - `tell <NAME> "<MESSAGE>"` — `<NAME>` may be a single recipient or an alias (a named group). The system fans out aliases automatically.
 
+**`tell` is a shell command — invoke it via your bash/shell tool.** Printing `tell <name> "..."` as your final assistant text is *not* a reply; it is just narration and the message will not be sent. The recipient hears you only when you actually execute `tell` through the shell tool.
+
 When you wake to a message:
 
 - **Direct** (`<from> tells you (COPILOT): ...`): reply with `tell <from> "<reply>"` only if you have new information or a meaningful action to take.

--- a/apps/a8s/tests/agents/gemini-agent/GEMINI.md
+++ b/apps/a8s/tests/agents/gemini-agent/GEMINI.md
@@ -8,6 +8,8 @@ Reach others via the `tell` shell command:
 
 - `tell <NAME> "<MESSAGE>"` — `<NAME>` may be a single recipient or an alias (a named group). The system fans out aliases automatically.
 
+**`tell` is a shell command — invoke it via your bash/shell tool.** Printing `tell <name> "..."` as your final assistant text is *not* a reply; it is just narration and the message will not be sent. The recipient hears you only when you actually execute `tell` through the shell tool.
+
 When you wake to a message:
 
 - **Direct** (`<from> tells you (GEMINI): ...`): reply with `tell <from> "<reply>"` only if you have new information or a meaningful action to take.

--- a/apps/a8s/tests/agents/opencode-agent/AGENTS.md
+++ b/apps/a8s/tests/agents/opencode-agent/AGENTS.md
@@ -1,0 +1,27 @@
+# OPENCODE: local-first coding helper
+
+You are OPENCODE, a coding helper running on a BYO-model OpenCode installation. Your model and provider are configured in this directory's `opencode.json` — operators can swap to Anthropic, OpenAI, or a local Ollama model without changing this persona file. Keep answers tight; if you produce code, ship the smallest working version and one line of explanation.
+
+## Communication
+
+Reach others via the `tell` shell command. **Always use this — do not look for built-in messaging tools or subagent calls.**
+
+- `tell <NAME> "<MESSAGE>"` — `<NAME>` may be a single recipient or an alias (a named group). The system fans out aliases automatically.
+
+When you wake to a message:
+
+- **Direct** (`<from> tells you (OPENCODE): ...`): reply with `tell <from> "<reply>"` only if you have new information or a meaningful action to take.
+- **Group** (`<from> tells you (OPENCODE) and N others on the <alias> alias: ...`): default response is **none**. Reply only if the message explicitly asks a question or requests action *and* you have a meaningful contribution. Greetings, announcements, and state-change notes do **not** need acknowledgment.
+
+**Avoid loops.** Don't reply just to acknowledge. Don't echo greetings ("Hi" → "Hi back") or send empty "noted" / "received" / "thanks" messages. Use your conversation history: if you already responded to a similar message from this sender, stay silent. For narrow replies, prefer `tell <from>` over telling the alias.
+
+## Files
+
+Your current working directory IS your agent root. To attach a file to a `tell`, write or place the file under your root, then append a trailing `FILE: ./<relative-path>` line:
+
+```
+tell gerry Here is the snippet you asked for.
+FILE: ./snippet.py
+```
+
+Multiple `FILE:` lines are allowed; only trailing ones are recognized. When *you* receive a message with files, they appear as `FILE: ./.files/<filename>` lines in the message body — read the file from that path under your CWD.

--- a/apps/a8s/tests/agents/opencode-agent/AGENTS.md
+++ b/apps/a8s/tests/agents/opencode-agent/AGENTS.md
@@ -8,6 +8,8 @@ Reach others via the `tell` shell command. **Always use this — do not look for
 
 - `tell <NAME> "<MESSAGE>"` — `<NAME>` may be a single recipient or an alias (a named group). The system fans out aliases automatically.
 
+**`tell` is a shell command — invoke it via your bash/shell tool.** Printing `tell <name> "..."` as your final assistant text is *not* a reply; it is just narration and the message will not be sent. The recipient hears you only when you actually execute `tell` through the shell tool.
+
 When you wake to a message:
 
 - **Direct** (`<from> tells you (OPENCODE): ...`): reply with `tell <from> "<reply>"` only if you have new information or a meaningful action to take.

--- a/apps/a8s/tests/agents/opencode-agent/opencode.json
+++ b/apps/a8s/tests/agents/opencode-agent/opencode.json
@@ -1,3 +1,4 @@
 {
+  "$schema": "https://opencode.ai/config.json",
   "model": "ollama/gpt-oss:20b"
 }

--- a/apps/a8s/tests/agents/opencode-agent/opencode.json
+++ b/apps/a8s/tests/agents/opencode-agent/opencode.json
@@ -1,0 +1,3 @@
+{
+  "model": "ollama/gpt-oss:20b"
+}

--- a/apps/a8s/tests/test_registry.py
+++ b/apps/a8s/tests/test_registry.py
@@ -284,3 +284,21 @@ class TestScanForMarkers:
         found = _scan_for_markers(tmp_path)
         # Only one entry per directory (the break in _scan_for_markers).
         assert len(found) == 1
+
+    def test_finds_agents_md_as_opencode_fallback(self, tmp_path):
+        d = tmp_path / "agent1"; d.mkdir()
+        (d / "AGENTS.md").write_text("# O: opencode helper\n")
+        found = _scan_for_markers(tmp_path)
+        assert len(found) == 1
+        name, kind, dirpath = found[0]
+        assert name == "O"
+        assert kind == "opencode"
+        assert dirpath == d.resolve()
+
+    def test_specific_marker_wins_over_agents_md(self, tmp_path):
+        d = tmp_path / "agent1"; d.mkdir()
+        (d / "CLAUDE.md").write_text("# A: x\n")
+        (d / "AGENTS.md").write_text("# B: y\n")
+        found = _scan_for_markers(tmp_path)
+        assert len(found) == 1
+        assert found[0][1] == "claude"


### PR DESCRIPTION
Closes #94.

## Summary

- Adds **OpenCode** (https://opencode.ai/) as a 5th supported a8s tool kind. Provider-agnostic; operators pick the model in each agent's own `opencode.json` (e.g. `{"model": "ollama/gpt-oss:20b"}`) — not in the shared a8s definition.
- Adds `AGENTS.md` as a **fallback marker** resolving to `opencode`. `MARKER_FILES` is already an insertion-ordered Python dict and `_scan_for_markers` breaks on first match per dir, so listing AGENTS.md last gives us fallback semantics with **zero logic changes**.
- Specific markers (`CLAUDE.md` / `GEMINI.md` / `CODEX.md` / `.github/copilot-instructions.md`) still win when both are present. A dir with only `AGENTS.md` resolves to `opencode`.

## Why OpenCode is the right AGENTS.md fallback

Same lesson as PR #92 (`.github/copilot-instructions.md` over inventing `COPILOT.md`): use the tool's native location. OpenCode reads `AGENTS.md` natively, is BYO-model (maximum flexibility — Anthropic, OpenAI, local Ollama, etc.), and is terminal-native. Per-agent `tell` instructions live inline in `AGENTS.md` mirroring the `.github/copilot-instructions.md` pattern.

## Files

- `apps/a8s/core.py` — append `"AGENTS.md": "opencode"` to `MARKER_FILES` (one-line behavior change).
- `apps/a8s/definitions/opencode.json` — new. `opencode run --continue --dangerously-skip-permissions "$SENDER tells $RECIPIENT (\$AGE): \$MESSAGE"`. Deliberately no `-m` flag so per-agent `opencode.json` wins.
- `apps/a8s/commands.py` — `_install_skill_opencode` returns the "delegated to per-agent AGENTS.md" notice; wired into `cmd_install`.
- `apps/a8s/tests/agents/opencode-agent/AGENTS.md` — new fixture (persona + tell + files sections, mirrors codex/gemini/copilot fixtures).
- `apps/a8s/tests/agents/opencode-agent/opencode.json` — `{"model": "ollama/gpt-oss:20b"}` — demonstrates the native config pattern for live local-model testing.
- `apps/a8s/tests/test_registry.py` — two new `TestScanForMarkers` cases: AGENTS.md-only resolves to opencode; specific marker wins when both present.
- `apps/a8s/README.md`, `CLAUDE.md` — docs updated (new definitions row, fallback rule, per-tool quirks bullet, design-threads entry).

## Follow-up commit (docs from live smoke)

While smoke-testing this PR, gpt-oss:20b on the first wake printed `tell <name> "..." FILE: ...` as plain assistant text instead of running it via the bash tool — the files were created locally but never routed. A more directive prompt fixed it on retry. The durable fix landed in this PR's docs:

- `README.md` — new `## Troubleshooting` section: tell-as-text failure (cause + 3 fixes), Ollama 2k-context truncation, OpenCode + non-built-in providers (Ollama registration example), headless permissions hang.
- `skills/tell/SKILL.md` — one-paragraph clarification under the command shape.
- All 5 fixture personas (claude/gemini/codex/copilot/opencode) — same paragraph after the bullet.

## Test plan

- [x] `python3 -m pytest apps/a8s/tests/` — **358 passed** (was 356; +2 new TestScanForMarkers cases).
- [x] **Live smoke against Ollama `gpt-oss:20b`** — registered the fixture, sent `tell opencode "Please write a small Python program (fib.py) that prints the first 10 Fibonacci numbers, run it with python3 and capture the output to fib.txt, then send both fib.py and fib.txt back to me as FILE attachments..."`, opencode wake fired, gpt-oss:20b loaded via Ollama (visible as `> build · gpt-oss:20b`), wrote `fib.py`, ran `python3 fib.py > fib.txt` via shell tool, executed `tell gerry "..." $'\nFILE: ./fib.py\nFILE: ./fib.txt'` via bash tool. Both files routed into `gerry/.files/` with correct content (recursive generator + first 10 Fibonacci numbers).
- [x] **`a8s install` reports the new line** — verified via worktree of this branch:
  ```
  [tell]
    claude: docs/tell.md already linked
    gemini: 'tell' already linked
    codex: linked 'tell' at /Users/neilo/.codex/skills/tell
    copilot: skill install delegated to per-agent .github/copilot-instructions.md (no user-scope skill mechanism)
    opencode: skill install delegated to per-agent AGENTS.md (no user-scope skill mechanism)
  ```
- [x] **`a8s discover apps/a8s/tests/agents/opencode-agent` surfaces kind `opencode`** — registration output confirmed `definition: /Users/neilo/bin/apps/a8s/definitions/opencode.json  (auto-detected via AGENTS.md)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)