### PR TITLE
fix(a8s): gmail connector attachment shape matches GAS bridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ __pycache__/
 .claude/scheduled_tasks.lock
 
 # A8S
+**/.files/
 **/.inbox/
 **/.outbox/
 **/.trash/

--- a/apps/a8s/connectors/gmail/gmail_connector.py
+++ b/apps/a8s/connectors/gmail/gmail_connector.py
@@ -11,11 +11,14 @@ POSTs `gmail.send` to the GAS Bridge configured via `GAS_BRIDGE_URL` /
 from __future__ import annotations
 
 import argparse
+import base64
 import json
+import mimetypes
 import os
 import sys
 import urllib.error
 import urllib.request
+from pathlib import Path
 
 
 TIMEOUT_S = 30
@@ -47,13 +50,37 @@ def send(to: str, subject: str, body: str) -> int:
         )
         return 2
 
+    attachments = []
+    body_lines = []
+    for line in body.splitlines():
+        if line.startswith("FILE: "):
+            path = line[len("FILE: "):].strip()
+            try:
+                p = Path(path)
+                data = p.read_bytes()
+                mime, _ = mimetypes.guess_type(p.name)
+                attachments.append({
+                    "name": p.name,
+                    "data": base64.b64encode(data).decode("ascii"),
+                    "mimeType": mime or "application/octet-stream",
+                })
+            except OSError as e:
+                print(f"gmail-connector: failed to read attachment {path}: {e}", file=sys.stderr)
+        else:
+            body_lines.append(line)
+
+    clean_body = "\n".join(body_lines)
+
     payload = {
         "action": "gmail.send",
         "key": key,
         "to": to,
         "subject": subject,
-        "body": body,
+        "body": clean_body,
     }
+
+    if attachments:
+        payload["attachments"] = attachments
     try:
         result = _bridge_post(url, payload)
     except urllib.error.HTTPError as e:

--- a/apps/a8s/tests/connectors/gmail/test_outbound.py
+++ b/apps/a8s/tests/connectors/gmail/test_outbound.py
@@ -1,6 +1,7 @@
 """Outbound-side tests for gmail_connector — mock urlopen, assert POST shape."""
 from __future__ import annotations
 
+import base64
 import io
 import json
 import sys
@@ -95,6 +96,45 @@ def test_send_bridge_error_response(monkeypatch, capsys):
     assert rc == 1
     err = capsys.readouterr().err
     assert "missing 'to'" in err
+
+
+def test_send_extracts_file_lines_as_bridge_attachments(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("GAS_BRIDGE_URL", "https://example/exec")
+    monkeypatch.setenv("GAS_BRIDGE_KEY", "TESTKEY")
+    monkeypatch.chdir(tmp_path)
+    src = tmp_path / "primes.py"
+    src.write_bytes(b"print(2)\n")
+    captured: list = []
+    fake = _fake_urlopen(captured, {"status": "sent"})
+    body = "Here you go.\nFILE: ./primes.py"
+    with patch.object(gmail_connector.urllib.request, "urlopen", fake):
+        rc = gmail_connector.send("rcpt@example.com", "GERRY", body)
+    assert rc == 0
+    payload = captured[0]["body"]
+    assert payload["body"] == "Here you go."  # FILE: line stripped from body
+    # Bridge schema: a.name, a.data, a.mimeType — NOT filename/content_base64.
+    # Mismatch produces a "newBlob on object Utilities" error in GAS.
+    assert payload["attachments"] == [{
+        "name": "primes.py",
+        "data": base64.b64encode(b"print(2)\n").decode("ascii"),
+        "mimeType": "text/x-python",
+    }]
+
+
+def test_send_unreadable_file_logs_and_continues(monkeypatch, capsys):
+    monkeypatch.setenv("GAS_BRIDGE_URL", "https://example/exec")
+    monkeypatch.setenv("GAS_BRIDGE_KEY", "TESTKEY")
+    captured: list = []
+    fake = _fake_urlopen(captured, {"status": "sent"})
+    body = "Cover note.\nFILE: ./does-not-exist.bin"
+    with patch.object(gmail_connector.urllib.request, "urlopen", fake):
+        rc = gmail_connector.send("rcpt@example.com", "S", body)
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "failed to read attachment" in err
+    payload = captured[0]["body"]
+    assert "attachments" not in payload  # nothing successfully read
+    assert payload["body"] == "Cover note."
 
 
 def test_main_argparse(monkeypatch):


### PR DESCRIPTION
## Summary

Fixes the live failure observed when neil-via-gmail received a tell with a FILE: attachment from gerry:

```
neil> gmail-connector: bridge error: Unexpected error while getting the method or property newBlob on object Utilities.
neil> (exit 1)
```

## Root cause

`gmail_connector.py` POSTs attachments to the GAS Bridge as `{filename, content_base64}`, but `gas/bridge/Code.js` line 646-647's `gmail.send` handler reads `{name, data, mimeType}`:

```javascript
opts.attachments = req.attachments.map(function(a) {
  return Utilities.newBlob(Utilities.base64Decode(a.data), a.mimeType || 'application/octet-stream', a.name);
});
```

Three field-name mismatches → `base64Decode(undefined)` throws inside the `map` → GAS surfaces it as the unhelpful "newBlob on object Utilities" error.

## Fix

- `gmail_connector.py`: emit `{name, data, mimeType}` matching the bridge schema. Add `mimeType` via stdlib `mimetypes.guess_type` so Gmail displays `.py` / `.txt` / `.pdf` correctly (bridge has a fallback, but the explicit type is nicer).
- Narrow the read-bytes try/except from bare `Exception` to `OSError` — base64 encoding can't fail on bytes input.
- New tests assert the exact shape so this can't regress, and that an unreadable FILE path logs + skips without aborting the send.
- `.gitignore`: add `**/.files/` alongside `**/.outbox/` etc. Recipient `.files/` dirs are routing artifacts, not source.

## Test plan

- [x] `python3 -m pytest apps/a8s/tests/` — **358 passed**.
- [x] New `test_send_extracts_file_lines_as_bridge_attachments` pins the bridge schema.
- [x] **Live re-run verified.** Sent `tell gerry "Write times7.py..."` from neil's CWD; gerry wrote the multiplication-by-7 program, ran it, and shelled `tell neil "Here is the multiplication-by-7 table" FILE: ./times7.py FILE: ./times7.txt`. neil's wake fired, gmail_connector.py POSTed to the GAS Bridge with the new `{name, data, mimeType}` shape, and the bridge succeeded:

  ```
  2026-04-30T20:58:59.885740Z [neil] exec: python3 .../gmail_connector.py --to ... --subject gerry --body 'Here is the multiplication-by-7 table ... FILE: ./.files/times7.py FILE: ./.files/times7.txt'
  2026-04-30T20:59:03.352837Z neil> sent to masta@gibdon.com: gerry
  ```

  No `bridge error` after the fix took over. Email arrived in inbox with both attachments.

## Reference

Bridge code at https://github.com/neilobremski/gas/blob/main/bridge/Code.js (line ~646).

🤖 Generated with [Claude Code](https://claude.com/claude-code)