### PR TITLE
fix(tell): self-contained polyglot, decoupled from a8s package (#97)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -543,11 +543,30 @@ The locked-design refactor (#52) is closed. The following are open:
 
 ### Top-level scripts: `tell`
 
-`~/bin/tell` is the polyglot shim that agents use to send messages. It
-execs into `apps/a8s/a8s.py tell ...`. There used to be a `says` polyglot
-too; it's gone. If you're considering re-adding any "broadcast" command,
-read phase-4's PR description (#58) first — the consensus was that aliases
-subsume it and the dual-verb API confuses LLMs.
+`~/bin/tell` is a **self-contained polyglot** — bash + PowerShell wrapper
+around an inline Python script (stdlib only, no a8s imports). It walks up
+from CWD to find the first `.outbox/` directory, builds a JSON envelope
+({`id`, `date`, `to`, `content`, `files`}), and atomic-writes it. The
+router (`mailbox.py:_process_pending`) force-overwrites `from` based on
+which agent owns the enclosing root, so the simpler client doesn't
+compromise identity — the filesystem is the unforgeable identity, the
+sender field is advisory.
+
+The container scenario this enables: mount only `~/bin/tell` (one file)
+plus a `.outbox/` dir into a slim Python container; the agent inside can
+emit a8s messages without the `apps/a8s/` package being present. Earlier
+versions execed into the full a8s python package, requiring the whole
+~2200-LOC tree to ride along.
+
+Don't reintroduce a8s-package imports in the polyglot. The single Python
+script lives between `# >>>PY` and `# <<<PY` markers; both bash and
+PowerShell halves extract that block (awk in bash, regex in PS) and pipe
+it to `python3 -`. One source of truth.
+
+There used to be a `says` polyglot too; it's gone. If you're considering
+re-adding any "broadcast" command, read phase-4's PR description (#58)
+first — the consensus was that aliases subsume it and the dual-verb API
+confuses LLMs.
 
 ### When using subagents (Agent tool) for review
 

--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -77,8 +77,9 @@ a8s ls
 #   CLAUDE  PID 12345  /Users/me/projects/code-review
 #   GEMINI  PID 12345  /Users/me/projects/research
 
-# Send messages. From anywhere, you can `a8s tell` directly.
-# From inside an agent's own root, the agent can use the `tell` skill.
+# Send messages. `tell` writes a JSON file to the nearest enclosing
+# `.outbox/` directory (the agent root, walking up from CWD), so you
+# must `cd` into one of your agents first.
 cd ~/projects/code-review
 tell GEMINI "look at lines 40-80 of foo.py"
 tell devs   "stand-up at 3pm"
@@ -124,7 +125,8 @@ That's the full loop. Members don't know they're "in a8s" — they just see a `t
 ### Messaging
 | | |
 |---|---|
-| `a8s tell <name> <msg>` | Routed message. `<name>` may be an agent or alias (fans out at routing time). Sender = agent enclosing CWD; `tell` from outside any agent root errors. There is no senderless channel — every message has a force-stamped agent `from`. |
+| `a8s tell <name> <msg>` | Routed message. `<name>` may be an agent or alias (fans out at routing time). Sender = agent whose `.outbox/` encloses CWD (walks up); errors if no `.outbox/` is found. There is no senderless channel — every message has a force-stamped agent `from` (the router stamps it from the outbox's owning agent, regardless of what the client wrote). |
+| `tell <name> <msg>` (top-level shim, [`~/bin/tell`](/Users/neilo/bin/tell)) | Same end result, but **self-contained** — pure-stdlib Python with zero a8s imports. Walks up CWD to find any `.outbox/`, drops a JSON envelope. Mount this single file into a container alongside any dir containing `.outbox/` and it just works. The router still force-stamps `from`, so identity isn't compromised by the simpler client. |
 | `a8s logs <name>... [--tail N] [-f]` | Read per-agent log files; merge-sort by ISO timestamp across multiple agents. `-f` follows. |
 
 ### Skills

--- a/apps/a8s/skills/tell/SKILL.md
+++ b/apps/a8s/skills/tell/SKILL.md
@@ -13,6 +13,8 @@ tell <name> <message>
 
 **`tell` is a shell command — invoke it via your bash/shell tool.** Printing `tell <name> "..."` as your final assistant text is *not* a reply; it is just narration and the message will not be sent. The recipient hears you only when you actually execute `tell` through the shell tool.
 
+**Run from inside an agent's directory tree.** `tell` walks up from CWD to find the first `.outbox/` directory and drops the message JSON there. If no `.outbox/` exists in CWD or any parent, the command errors with `tell: no .outbox/ found in CWD or any parent`.
+
 - `<name>` is the recipient's name. Treat it as opaque — do not assume whether the recipient is a person or another assistant, and do not change your tone based on a guess.
 - `<message>` is the body. To attach files, append one or more `FILE: <path>` lines at the end. Lines starting with `FILE: ` are stripped from the body and added as attachments. Paths can be absolute or relative to your current directory.
 
@@ -42,5 +44,5 @@ tell w heads up — running the migration tonight
 
 ## Failures
 
-- **"current directory is not inside any registered participant"** — `tell` could not determine who the message is from. Report this to the user and stop; do not try to work around it.
-- **"no participant named or aliased X"** — recipient is unknown. Report it; do not invent or guess names.
+- **"tell: no .outbox/ found in CWD or any parent"** — you ran `tell` outside any agent's directory tree. Report this to the user and stop; do not try to work around it (e.g. don't `cd` somewhere unusual to make the error go away).
+- **The recipient name is not validated.** `tell` accepts any `<name>` and the routing layer decides what to do with it. If the name is unknown to the router and no remote clusters are configured, the message is logged + trashed silently. Use names you actually know.

--- a/apps/a8s/tests/test_tell_polyglot.py
+++ b/apps/a8s/tests/test_tell_polyglot.py
@@ -1,0 +1,145 @@
+"""Tests for the self-contained ~/bin/tell polyglot — invoked as a subprocess.
+
+Verifies that the polyglot works without importing anything from apps/a8s/.
+The script walks up CWD to find .outbox/, generates a Crockford ULID, parses
+argv (with FILE: lifting), and atomic-writes a JSON envelope.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+TELL = Path(__file__).resolve().parent.parent.parent.parent / "tell"
+
+
+def _run(cwd: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [str(TELL), *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+    )
+
+
+def _read_outbox(outbox: Path) -> tuple[str, dict]:
+    files = list(outbox.glob("*.json"))
+    assert len(files) == 1, f"expected exactly one outbox file, found {files}"
+    return files[0].name, json.loads(files[0].read_text())
+
+
+def test_tell_writes_outbox_from_root(tmp_path):
+    (tmp_path / ".outbox").mkdir()
+    res = _run(tmp_path, "gerry", "hello there")
+    assert res.returncode == 0, res.stderr
+    name, msg = _read_outbox(tmp_path / ".outbox")
+    assert name.endswith(".json")
+    assert msg["to"] == "gerry"
+    assert msg["content"] == "hello there"
+    assert msg["files"] == []
+    assert "id" in msg and len(msg["id"]) == 26
+    assert "date" in msg and msg["date"].endswith("Z")
+
+
+def test_tell_walks_up_from_subdir(tmp_path):
+    (tmp_path / ".outbox").mkdir()
+    sub = tmp_path / "deep" / "nested"
+    sub.mkdir(parents=True)
+    res = _run(sub, "codex", "from below")
+    assert res.returncode == 0, res.stderr
+    _name, msg = _read_outbox(tmp_path / ".outbox")
+    assert msg["to"] == "codex"
+    assert msg["content"] == "from below"
+
+
+def test_tell_errors_when_no_outbox(tmp_path):
+    res = _run(tmp_path, "anyone", "should fail")
+    assert res.returncode != 0
+    assert "no .outbox/" in res.stderr
+
+
+def test_tell_lifts_file_lines_into_files_array(tmp_path):
+    (tmp_path / ".outbox").mkdir()
+    res = _run(tmp_path, "gerry", "Here you go.", "FILE: ./report.pdf", "FILE: /tmp/data.csv")
+    assert res.returncode == 0, res.stderr
+    _name, msg = _read_outbox(tmp_path / ".outbox")
+    assert msg["content"] == "Here you go."
+    assert msg["files"] == [
+        {"filename": "report.pdf", "path": "./report.pdf"},
+        {"filename": "data.csv", "path": "/tmp/data.csv"},
+    ]
+
+
+def test_tell_handles_inline_newline_file_lines(tmp_path):
+    (tmp_path / ".outbox").mkdir()
+    body = "Here you go.\nFILE: ./report.pdf"
+    res = _run(tmp_path, "gerry", body)
+    assert res.returncode == 0, res.stderr
+    _name, msg = _read_outbox(tmp_path / ".outbox")
+    assert msg["content"] == "Here you go."
+    assert msg["files"] == [{"filename": "report.pdf", "path": "./report.pdf"}]
+
+
+def test_tell_omits_from_field(tmp_path):
+    """The polyglot doesn't know who's sending — the router force-stamps it.
+    Producing a `from`-less envelope is correct: the parser tolerates missing
+    `from` and overwrites it from the enclosing agent's registry entry."""
+    (tmp_path / ".outbox").mkdir()
+    res = _run(tmp_path, "x", "y")
+    assert res.returncode == 0, res.stderr
+    _name, msg = _read_outbox(tmp_path / ".outbox")
+    assert "from" not in msg
+
+
+def test_tell_ids_are_unique_across_rapid_invocations(tmp_path):
+    (tmp_path / ".outbox").mkdir()
+    ids = set()
+    for i in range(10):
+        res = _run(tmp_path, "x", f"msg-{i}")
+        assert res.returncode == 0, res.stderr
+        ids.update(p.stem for p in (tmp_path / ".outbox").glob("*.json"))
+    assert len(ids) == 10
+
+
+def test_tell_id_is_crockford_base32_ulid(tmp_path):
+    (tmp_path / ".outbox").mkdir()
+    res = _run(tmp_path, "x", "y")
+    assert res.returncode == 0, res.stderr
+    _name, msg = _read_outbox(tmp_path / ".outbox")
+    assert re.fullmatch(r"[0-9A-HJKMNP-TV-Z]{26}", msg["id"]), msg["id"]
+
+
+def test_tell_no_args_prints_usage(tmp_path):
+    res = _run(tmp_path)
+    assert res.returncode == 2
+    assert "usage: tell" in res.stderr
+
+
+def test_tell_only_recipient_prints_usage(tmp_path):
+    (tmp_path / ".outbox").mkdir()
+    res = _run(tmp_path, "gerry")
+    assert res.returncode == 2
+    assert "usage: tell" in res.stderr
+
+
+def test_tell_envelope_shape_is_router_compatible(tmp_path):
+    """End-to-end: write via the polyglot, then parse via the same logic
+    the router uses (split content + files), and assert nothing breaks."""
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    try:
+        from mailbox import _split_content_and_files
+    finally:
+        sys.path.pop(0)
+    (tmp_path / ".outbox").mkdir()
+    res = _run(tmp_path, "gerry", "header line\nbody line", "FILE: ./x.txt")
+    assert res.returncode == 0, res.stderr
+    _name, msg = _read_outbox(tmp_path / ".outbox")
+    assert msg["to"] == "gerry"
+    assert msg["files"] == [{"filename": "x.txt", "path": "./x.txt"}]
+    assert "header line" in msg["content"]
+    assert "body line" in msg["content"]

--- a/tell
+++ b/tell
@@ -1,40 +1,132 @@
 #!/usr/bin/env bash
 echo `# <#` >/dev/null
 
-set -euo pipefail
+# Self-contained polyglot. Walks up CWD to find the first .outbox/ and drops
+# a JSON envelope there. NO dependency on the a8s package — this file plus
+# python3 plus a .outbox/ dir is enough. Mount it into a container and it
+# just works.
+#
+# The actual logic lives in the inline Python script between the
+# `# >>>PY` / `# <<<PY` markers below. Bash extracts and pipes it to
+# `python3 -`; PowerShell does the same via a regex match on
+# $PSCommandPath. One source of truth for the Python; both shells just
+# wrap.
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec python3 "$SCRIPT_DIR/apps/a8s/a8s.py" tell "$@"
+set -euo pipefail
+awk '/^# >>>PY$/{flag=1;next} /^# <<<PY$/{flag=0} flag' "${BASH_SOURCE[0]}" | python3 - "$@"
+exit $?
+
 #> > $null
 
 $ScriptPath = $PSCommandPath
-if (-not $ScriptPath) {
-    $ScriptPath = $MyInvocation.MyCommand.Path
-}
-if (-not $ScriptPath) {
-    $ScriptPath = Join-Path (Get-Location) "tell"
-}
+if (-not $ScriptPath) { $ScriptPath = $MyInvocation.MyCommand.Path }
+if (-not $ScriptPath) { $ScriptPath = Join-Path (Get-Location) "tell" }
 
-$ScriptDir = Split-Path -Parent $ScriptPath
-$A8sPath = Join-Path $ScriptDir "apps/a8s/a8s.py"
-
-$Python = Get-Command python3 -ErrorAction SilentlyContinue
-if ($Python) {
-    & $Python.Source $A8sPath tell @args
-    exit $LASTEXITCODE
+$Content = Get-Content $ScriptPath -Raw
+$Match = [regex]::Match($Content, '(?ms)^# >>>PY$\r?\n(.+?)\r?\n^# <<<PY$')
+if (-not $Match.Success) {
+    Write-Error "tell: could not locate inline Python block"
+    exit 2
 }
+$PyScript = $Match.Groups[1].Value
 
-$Python = Get-Command python -ErrorAction SilentlyContinue
-if ($Python) {
-    & $Python.Source $A8sPath tell @args
-    exit $LASTEXITCODE
+$Python = $null
+foreach ($cmd in @('python3', 'python', 'py')) {
+    $found = Get-Command $cmd -ErrorAction SilentlyContinue
+    if ($found) { $Python = $found.Source; break }
 }
-
-$Python = Get-Command py -ErrorAction SilentlyContinue
-if ($Python) {
-    & $Python.Source -3 $A8sPath tell @args
-    exit $LASTEXITCODE
+if (-not $Python) {
+    Write-Error "tell: python3 not found on PATH"
+    exit 127
 }
 
-Write-Error "Could not find python3, python, or py on PATH."
-exit 127
+$PyScript | & $Python - @args
+exit $LASTEXITCODE
+#>
+
+# >>>PY
+import json
+import os
+import secrets
+import sys
+import time
+from pathlib import Path
+
+
+def find_outbox():
+    cur = Path.cwd().resolve()
+    for d in (cur, *cur.parents):
+        candidate = d / ".outbox"
+        if candidate.is_dir():
+            return candidate
+    return None
+
+
+def make_ulid():
+    alphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+    ts_ms = int(time.time() * 1000)
+    out = []
+    for i in range(9, -1, -1):
+        out.append(alphabet[(ts_ms >> (i * 5)) & 0x1F])
+    rand = int.from_bytes(secrets.token_bytes(10), "big")
+    for i in range(15, -1, -1):
+        out.append(alphabet[(rand >> (i * 5)) & 0x1F])
+    return "".join(out)
+
+
+def join_args(args):
+    parts = []
+    for a in args:
+        if a.lstrip().startswith("FILE:"):
+            parts.append("\n" + a.lstrip())
+        else:
+            if parts:
+                parts.append(" ")
+            parts.append(a)
+    return "".join(parts).strip()
+
+
+def split_content_and_files(text):
+    lines = text.splitlines()
+    files = []
+    while lines and lines[-1].startswith("FILE: "):
+        files.insert(0, lines.pop()[len("FILE: "):].strip())
+    return "\n".join(lines), files
+
+
+def main(argv):
+    if len(argv) < 2:
+        print("usage: tell <name> <message...>", file=sys.stderr)
+        return 2
+    outbox = find_outbox()
+    if outbox is None:
+        print(
+            "tell: no .outbox/ found in CWD or any parent "
+            "(run from inside an agent root)",
+            file=sys.stderr,
+        )
+        return 1
+    to = argv[0]
+    body = join_args(argv[1:])
+    content, files = split_content_and_files(body)
+    msg = {
+        "id": make_ulid(),
+        "date": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "to": to,
+        "content": content,
+        "files": [{"filename": Path(p).name, "path": p} for p in files],
+    }
+    dest = outbox / f"{msg['id']}.json"
+    tmp = outbox / f".{msg['id']}.tmp"
+    tmp.write_text(json.dumps(msg, indent=2), encoding="utf-8")
+    os.replace(tmp, dest)
+    preview = content.replace("\n", " ")[:80]
+    if len(content) > 80:
+        preview += "..."
+    print(f"tell -> {to}: {preview}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))
+# <<<PY


### PR DESCRIPTION
Closes #97.

## Summary

- Rewrites `~/bin/tell` as a self-contained polyglot. Bash and PowerShell halves both extract an inline Python script (between `# >>>PY` / `# <<<PY` markers) and pipe it to `python3 -`. **The Python uses stdlib only — no a8s imports.** Walks up CWD to find the first `.outbox/`, generates a Crockford-base32 ULID, atomic-writes the envelope.
- Fixes the stale README/SKILL claim that `tell` works "from anywhere" — it doesn't, and never did.
- `cmd_tell` (the `a8s tell` subcommand) stays as-is. Power users get registry validation; container users get the no-deps path.

## Why this is safe

`mailbox._process_pending` force-overwrites `from` based on which agent owns the enclosing root. The filesystem is the unforgeable identity authority; the sender field on the wire is advisory. So the polyglot can omit `from` entirely (the parser tolerates missing) without compromising the security model.

## Container scenario this enables

```bash
docker run --rm -it \
  -v ~/bin/tell:/usr/local/bin/tell \
  -v /host/agent:/work \
  python:3.12-slim bash

# inside the container:
cd /work && tell gerry "hello from inside"
# /work/.outbox/<ulid>.json appears with {id, date, to, content, files}
```

Container needs only `python3` + a `.outbox/` dir. No `apps/a8s/` tree mounted.

## Files

- `~/bin/tell` — full rewrite. Polyglot wrapper (~30 lines bash + pwsh) + inline Python (~75 lines).
- `apps/a8s/README.md` — fix Quickstart's "From anywhere" claim; refresh Commands→Messaging row to describe both `tell` and `a8s tell`.
- `CLAUDE.md` — rewrite "Top-level scripts: `tell`" section to document the container-portability invariant and the marker-block convention.
- `apps/a8s/skills/tell/SKILL.md` — add a line about WHERE the command can run; refresh the Failures section to match the new error string and note that recipient names aren't client-validated anymore.
- `apps/a8s/tests/test_tell_polyglot.py` — **new**, 11 tests invoking the polyglot via subprocess.

## Test plan

- [x] `python3 -m pytest apps/a8s/tests/` — **371 passed** (was 360 post-merge of #95/#96; +11 new).
- [x] **Live host smoke** — from `apps/a8s/tests/agents/gemini-agent`, `tell codex "live smoke from new polyglot — landing in .outbox"` produced a clean envelope:
  ```json
  {
    "id": "01KQG3XQBVRWRS3E4803PY1DBW",
    "date": "2026-04-30T21:15:09Z",
    "to": "codex",
    "content": "live smoke from new polyglot — landing in .outbox",
    "files": []
  }
  ```
- [x] **Negative test** — from `/tmp` (no `.outbox/` in tree): `tell anyone "should fail"` exits 1 with `tell: no .outbox/ found in CWD or any parent (run from inside an agent root)`.
- [x] **No a8s import** — `grep apps/a8s ~/bin/tell` returns nothing.
- [ ] **Container smoke** (manual, post-merge if interested) — `docker run --rm -v ~/bin/tell:/usr/local/bin/tell ...` to confirm zero-package portability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)