### PR TITLE
fix(a8s): allow dashes and underscores in agent/alias names

### DIFF
--- a/apps/a8s/core.py
+++ b/apps/a8s/core.py
@@ -38,7 +38,7 @@ MARKER_FILES = {
     "AGENTS.md": "opencode",
 }
 
-NAME_RE = re.compile(r"[A-Za-z0-9]+")
+NAME_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_-]*")
 
 # File-transfer cap for FILE: payloads. Larger sources are dropped at routing
 # time with a log line; agents needing larger payloads should use a side-
@@ -89,7 +89,9 @@ def canonical_name(name: str) -> str:
     where `claude` and `Claude` produced two separate agent dirs."""
     s = (name or "").strip().lower()
     if not s or not NAME_RE.fullmatch(s):
-        raise ValueError(f"name must be alphanumeric: {name!r}")
+        raise ValueError(
+            f"name must be alphanumeric (with -, _) and start with a letter or digit: {name!r}"
+        )
     return s
 
 

--- a/apps/a8s/tests/test_commands.py
+++ b/apps/a8s/tests/test_commands.py
@@ -66,7 +66,7 @@ class TestCmdAddCanonicalization:
         assert agent_dir("claude") == agent_dir("CLAUDE".lower())
 
     def test_invalid_name_rejected(self, agent_root, capsys):
-        rc = cmd_add(["foo-bar", str(agent_root)])
+        rc = cmd_add(["foo bar", str(agent_root)])
         assert rc == 2
         err = capsys.readouterr().err
         assert "alphanumeric" in err
@@ -122,7 +122,7 @@ class TestCmdRemove:
         assert "no agent" in capsys.readouterr().err
 
     def test_invalid_name_rejected(self, fake_home, capsys):
-        rc = cmd_remove(["foo-bar"])
+        rc = cmd_remove(["foo bar"])
         assert rc == 2
         assert "alphanumeric" in capsys.readouterr().err
 

--- a/apps/a8s/tests/test_registry.py
+++ b/apps/a8s/tests/test_registry.py
@@ -52,14 +52,21 @@ class TestCanonicalName:
         with pytest.raises(ValueError):
             canonical_name("   ")
 
-    def test_hyphen_rejected(self):
-        # NAME_RE is [A-Za-z0-9]+ — no separators allowed.
-        with pytest.raises(ValueError):
-            canonical_name("foo-bar")
+    def test_hyphen_accepted(self):
+        assert canonical_name("knobert-android") == "knobert-android"
+
+    def test_underscore_accepted(self):
+        assert canonical_name("foo_bar") == "foo_bar"
 
     def test_space_rejected(self):
         with pytest.raises(ValueError):
             canonical_name("foo bar")
+
+    def test_leading_separator_rejected(self):
+        with pytest.raises(ValueError):
+            canonical_name("-foo")
+        with pytest.raises(ValueError):
+            canonical_name("_foo")
 
 
 # ---------- low-level I/O ----------


### PR DESCRIPTION
## Summary
- `NAME_RE` was `[A-Za-z0-9]+`, so `a8s add knobert-android` errored at `canonical_name()` and `parse_name` silently truncated marker comments containing separators (e.g. `# knobert-android` → `knobert`).
- Widen to `[A-Za-z0-9][A-Za-z0-9_-]*` — first char alphanumeric, then alphanumerics + `-`/`_`. Mirrors the existing `_REMOTE_NAME_RE` shape (no `.` here — dots in agent dir keys would be confusing).
- `_safe_name` already escapes `[^A-Za-z0-9_-]`, so disk-path code is unchanged.

## Repro
On an Android device registered as `knobert-android`, messages from the host weren't received. Likely the receiver's registry key was `knobert` (truncated by `parse_name` at marker-discovery time) while senders emitted envelopes with `to: knobert-android`, so resolution / cross-cluster filtering dropped them.

## Test plan
- [x] `python3 -m pytest apps/a8s/tests/` — 373 passing locally.
- [x] New `test_hyphen_accepted` (`knobert-android`) and `test_underscore_accepted` (`foo_bar`).
- [x] `test_leading_separator_rejected` (`-foo`, `_foo`).
- [x] `test_space_rejected` still passes.
- [x] Updated the two `test_invalid_name_rejected` cases (cmd_add, cmd_remove) to use `foo bar` since `foo-bar` is now valid.
- [ ] Live-smoke: re-register `knobert-android` on the phone and confirm messages route end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)