### PR TITLE
feat(a8s): echo-agent persists each wake to .files/<ulid>.txt

### DIFF
--- a/apps/a8s/definitions/echo.json
+++ b/apps/a8s/definitions/echo.json
@@ -1,0 +1,10 @@
+{
+  "description": "Echo agent.",
+  "invoke": [
+    "./echo-agent-cli",
+    "$AGE",
+    "$SENDER",
+    "$RECIPIENT",
+    "$MESSAGE"
+  ]
+}

--- a/apps/a8s/tests/agents/echo-agent/echo-agent-cli
+++ b/apps/a8s/tests/agents/echo-agent/echo-agent-cli
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+echo `# <#` >/dev/null
+
+# Polyglot bash + PowerShell wrapper. Defers to a sibling echo_agent.py so
+# the Python can grow without touching the shell scaffolding. Bash side
+# execs python3; PowerShell side resolves python3/python/py via Get-Command.
+
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$HERE/echo_agent.py" "$@"
+
+#> > $null
+
+$ScriptPath = $PSCommandPath
+if (-not $ScriptPath) { $ScriptPath = $MyInvocation.MyCommand.Path }
+if (-not $ScriptPath) { $ScriptPath = Join-Path (Get-Location) "echo-agent-cli" }
+
+$Here = Split-Path -Parent $ScriptPath
+$PyFile = Join-Path $Here "echo_agent.py"
+
+$Python = $null
+foreach ($cmd in @('python3', 'python', 'py')) {
+    $found = Get-Command $cmd -ErrorAction SilentlyContinue
+    if ($found) { $Python = $found.Source; break }
+}
+if (-not $Python) {
+    Write-Error "echo-agent-cli: python3 not found on PATH"
+    exit 127
+}
+
+& $Python $PyFile @args
+exit $LASTEXITCODE
+#>

--- a/apps/a8s/tests/agents/echo-agent/echo_agent.py
+++ b/apps/a8s/tests/agents/echo-agent/echo_agent.py
@@ -1,0 +1,99 @@
+"""Echo agent wake handler.
+
+Receives `<age> <sender> <recipient> <message>` from the a8s wake
+expansion, prints the canonical `Date:` / `From:` / `To:` / blank /
+body lines to stdout (so `a8s logs echoman` keeps working), and
+persists each tell to `.files/<ulid>.txt` for easy monitoring.
+
+Trailing `FILE: <path>` lines in the message body are stripped from
+the persisted body and the referenced files are copied to
+`.files/<ulid>-<basename>` via shutil.copy2. Missing referenced files
+are logged to stderr and skipped (the wake still succeeds).
+"""
+from __future__ import annotations
+
+import os
+import secrets
+import shutil
+import sys
+import time
+from pathlib import Path
+
+ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+ULID_LENGTH = 26
+_TS_BITS = 48
+_RND_BITS = 80
+_RND_BYTES = _RND_BITS // 8
+_TS_MASK = (1 << _TS_BITS) - 1
+
+
+def new_ulid() -> str:
+    ts_ms = int(time.time() * 1000) & _TS_MASK
+    rnd = int.from_bytes(secrets.token_bytes(_RND_BYTES), "big")
+    n = (ts_ms << _RND_BITS) | rnd
+    chars = []
+    for _ in range(ULID_LENGTH):
+        chars.append(ALPHABET[n & 0x1f])
+        n >>= 5
+    return "".join(reversed(chars))
+
+
+def split_body_and_files(text: str) -> tuple[str, list[str]]:
+    lines = text.splitlines()
+    files: list[str] = []
+    while lines and lines[-1].startswith("FILE: "):
+        files.insert(0, lines.pop()[len("FILE: "):].strip())
+    return "\n".join(lines), files
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 4:
+        print(
+            "usage: echo-agent-cli <age> <sender> <recipient> <message>",
+            file=sys.stderr,
+        )
+        return 2
+    age, sender, recipient, raw_message = argv
+    body, files = split_body_and_files(raw_message)
+
+    print(f"Date: {age}")
+    print(f"From: {sender}")
+    print(f"To: {recipient}")
+    print("")
+    print(raw_message)
+
+    ulid = new_ulid()
+    files_dir = Path.cwd() / ".files"
+    files_dir.mkdir(exist_ok=True)
+
+    out_path = files_dir / f"{ulid}.txt"
+    header = (
+        f"Date: {age}\n"
+        f"From: {sender}\n"
+        f"To: {recipient}\n"
+        f"ULID: {ulid}\n"
+        f"\n"
+    )
+    tmp = files_dir / f".{ulid}.txt.tmp"
+    tmp.write_text(header + body, encoding="utf-8")
+    os.replace(tmp, out_path)
+
+    for ref in files:
+        src = Path(ref)
+        if not src.is_file():
+            print(f"echo-agent: skipping missing file {ref!r}", file=sys.stderr)
+            continue
+        dest = files_dir / f"{ulid}-{src.name}"
+        try:
+            shutil.copy2(src, dest)
+        except OSError as e:
+            print(
+                f"echo-agent: failed to copy {ref!r}: {e}",
+                file=sys.stderr,
+            )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Why
The fixture echo agent under `apps/a8s/tests/agents/echo-agent/` is the canonical "did the round-trip work" test rig. Previously its wake handler was a one-line `echo-cli.sh` that printed to stdout — readable via `a8s logs echoman` but transient. With the a8s-android `/screenshot`, `/logs`, `/info` commands now active, I want to `tail .files/` for new round-trip artifacts instead of grepping the agent log.

## What
- **`echo-agent-cli`** — polyglot bash + PowerShell wrapper (same scaffold as `~/bin/tell` and `~/bin/a8s`), defers to a sibling `echo_agent.py` so the Python can grow without touching shell scaffolding.
- **`echo_agent.py`** — pure stdlib. Preserves the existing stdout shape (`Date:`/`From:`/`To:`/blank/body) so `a8s logs echoman` keeps working, and additionally persists each wake to `.files/<ulid>.txt` with a `Date/From/To/ULID/blank/body` header. Trailing `FILE: <path>` lines are stripped from the persisted body and the referenced files copied to `.files/<ulid>-<basename>`. Missing files log to stderr and skip without failing the wake. ULID matches `apps/a8s/ulid.py`'s Crockford-base32 shape.
- **`apps/a8s/definitions/echo.json`** — invokes the new wrapper. Argv shape unchanged (`$AGE $SENDER $RECIPIENT $MESSAGE`).
- **`echo-cli.sh`** removed.

## Tests
Existing pytest suite (373 cases) green — the fixture wasn't referenced from any test code path.

## Test plan
- [x] `python3 -m pytest apps/a8s/tests/` — 373 passing.
- [ ] Live: \`tell echoman 'hi'\` — see `.files/<ulid>.txt` containing the `Date:`/`From:`/`To:`/`ULID:`/`hi` lines.
- [ ] Live with attachment: \`tell echoman 'see attached\nFILE: /tmp/foo.txt'\` — `.files/<ulid>.txt` contains the body without the FILE line, and `.files/<ulid>-foo.txt` contains the file payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)