### PR TITLE
fix(a8s): alias <name> shows one alias's members (#101)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,7 +289,9 @@ remove <name>                unregister an agent; wipes its mailbox dir and prun
 agents                       list all registered
 discover <path>              read-only scan; suggests add+define commands
 define <name> [<path>]       show or set definition
-alias <alias> <member>       add to alias (creates if new); cycles rejected
+alias                                   list all aliases
+alias <name>                            show one alias's members
+alias <alias> <member>                  add to alias (creates if new); cycles rejected
 unalias <alias> [<member>]   remove member or whole alias
 aliases                      list aliases + resolved members
 start <name>                 detached background handler (alias = ONE process for N agents)

--- a/apps/a8s/cli.py
+++ b/apps/a8s/cli.py
@@ -36,7 +36,7 @@ COMMANDS: list[tuple[str, str, str]] = [
     ("agents",   "",                          "List registered agents."),
     ("discover", "<path>",                    "Scan a path for agents and suggest `add` commands."),
     ("define",   "<name> [<path>]",           "Show or set an agent's command definition."),
-    ("alias",    "[<alias> <member>]",        "Group agents under an alias name."),
+    ("alias",    "[<name> [<member>]]",       "Group agents under an alias name; show one with `<name>`."),
     ("unalias",  "<alias> [<member>]",        "Remove a member from an alias, or the whole alias."),
     ("aliases",  "",                          "List aliases and their members."),
     ("start",    "<name>",                    "Run an agent in the background."),

--- a/apps/a8s/commands.py
+++ b/apps/a8s/commands.py
@@ -393,16 +393,25 @@ def cmd_install() -> int:
 # ---------- alias commands ----------
 
 def cmd_alias(args: list[str]) -> int:
-    """`a8s alias <alias> <member>` — add member to alias, creating the alias
-    if new. Members may be agent names OR existing alias names (nesting OK,
-    cycles rejected at resolve time). The alias name must not collide with
-    an existing agent name. Both alias name and member are canonicalized
-    (lowercase) so `a8s alias Devs CLAUDE` and `a8s alias devs claude` are
-    the same operation (issue #65)."""
+    """`a8s alias` — manage aliases.
+
+    Forms (mirror `a8s remote` / `a8s storage`):
+      a8s alias                      list all
+      a8s alias <name>               show one alias's members
+      a8s alias <alias> <member>     add or create
+
+    Names are canonicalized (lowercase) so `a8s alias Devs CLAUDE` and
+    `a8s alias devs claude` are the same operation (issue #65). Members
+    may be agent names OR existing alias names (nesting OK, cycles
+    rejected at resolve time). The alias name must not collide with an
+    existing agent name."""
     if len(args) == 0:
         return cmd_aliases()
+    if len(args) == 1:
+        return _cmd_alias_show(args[0])
     if len(args) != 2:
         print("usage: a8s alias <alias> <member>     # add or create", file=sys.stderr)
+        print("       a8s alias <name>               # show one", file=sys.stderr)
         print("       a8s alias                      # list", file=sys.stderr)
         return 2
     raw_alias, raw_member = args
@@ -500,6 +509,33 @@ def cmd_unalias(args: list[str]) -> int:
         aliases[canonical] = new_members
     save_aliases(aliases)
     print(f"{canonical} -= {member}")
+    return 0
+
+
+def _cmd_alias_show(name: str) -> int:
+    """`a8s alias <name>` — show one alias's members. Mirrors `remote <name>`
+    and `storage <name>`."""
+    try:
+        target = canonical_name(name)
+    except ValueError as e:
+        print(str(e), file=sys.stderr)
+        return 2
+    aliases = load_aliases()
+    canonical: str | None = None
+    for k in aliases:
+        if k.lower() == target:
+            canonical = k
+            break
+    if canonical is None:
+        print(f"no alias named {name!r}", file=sys.stderr)
+        return 1
+    members = aliases[canonical]
+    try:
+        _, resolved = resolve_name(canonical)
+        tail = "" if len(members) == len(resolved) else f"  → {len(resolved)} agents"
+    except (KeyError, ValueError) as e:
+        tail = f"  [{e}]"
+    print(f"{canonical}: [{', '.join(members)}]{tail}")
     return 0
 
 

--- a/apps/a8s/tests/test_commands.py
+++ b/apps/a8s/tests/test_commands.py
@@ -115,6 +115,53 @@ class TestCmdAliasCanonicalization:
         assert "unknown member" in err
 
 
+class TestCmdAliasShowOne:
+    def test_show_one_alias_lists_members(self, fake_home, tmp_path, agent_root, capsys):
+        cmd_add(["claude", str(agent_root)])
+        other = tmp_path / "g"; other.mkdir()
+        cmd_add(["gemini", str(other)])
+        cmd_alias(["devs", "claude"])
+        cmd_alias(["devs", "gemini"])
+        capsys.readouterr()
+        rc = cmd_alias(["devs"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "devs:" in out
+        assert "claude" in out
+        assert "gemini" in out
+
+    def test_show_one_alias_with_dashed_name(self, fake_home, agent_root, capsys):
+        cmd_add(["claude", str(agent_root)])
+        cmd_alias(["bin-test", "claude"])
+        capsys.readouterr()
+        rc = cmd_alias(["bin-test"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "bin-test:" in out
+        assert "claude" in out
+
+    def test_show_one_alias_case_insensitive(self, fake_home, agent_root, capsys):
+        cmd_add(["claude", str(agent_root)])
+        cmd_alias(["devs", "claude"])
+        capsys.readouterr()
+        rc = cmd_alias(["DEVS"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "devs:" in out
+
+    def test_show_unknown_alias_errors(self, fake_home, capsys):
+        rc = cmd_alias(["nobody"])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "no alias" in err
+
+    def test_show_invalid_name_errors(self, fake_home, capsys):
+        rc = cmd_alias(["bad name with spaces"])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "alphanumeric" in err
+
+
 class TestCmdRemove:
     def test_unknown_agent_rejected(self, fake_home, capsys):
         rc = cmd_remove(["nobody"])


### PR DESCRIPTION
## Summary
- `a8s alias <name>` (single arg) used to fall through to the usage error; now it prints that one alias's members, matching the show-one form already supported by `remote <name>` and `storage <name>`.
- Names canonicalize the same way as the two-arg form, so dashed names (`bin-test`) and mixed case work.

Closes #101.

## Test plan
- [x] `python3 -m pytest apps/a8s/tests/` — 378 passed (5 new tests under `TestCmdAliasShowOne`).
- [x] Manual smoke: create dashed alias `bin-test` with two members, then `a8s alias bin-test` prints `bin-test: [claude, bin-claude]`. Unknown alias errors with rc=1; invalid name errors with rc=2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)