### PR TITLE
feat(a8s): file-proxy agent type

### DIFF
--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -272,6 +272,44 @@ A connector is just an a8s agent whose `definition.invoke` runs a script instead
 
 Strict recipient opacity holds: other participants `tell <name> ...` with no awareness that the recipient is Gmail-backed, a script, a human, or another LLM agent. The connector is the only thing that knows about its bridge format. See `apps/a8s/connectors/gmail/README.md` for setup.
 
+## File proxy
+
+A file-proxy agent communicates through filesystem sync instead of a CLI invocation. Designed for agents whose root is on a remote mount (rclone, NFS, Google Drive FUSE, etc.) where the "other side" polls for files independently.
+
+### Setup
+
+```bash
+# Create the definition
+cat > file-proxy.json << 'EOF'
+{"proxy": "file", "idle": {"timeout": 30}, "files_ttl_hours": 48}
+EOF
+
+# Register with a mounted root directory
+a8s add my-email /mnt/gdrive/my-email/ file-proxy.json
+```
+
+### How it works
+
+- **On message:** A8S moves inbox JSON files into `<root>/.inbox/` instead of invoking a subprocess. The remote side polls `.inbox/`, processes, deletes.
+- **Outbox:** The remote side writes response envelopes to `<root>/.outbox/`. A8S ingests these on its normal routing pass (no change from regular agents).
+- **Files:** Attachments flow through `<root>/.files/` bidirectionally. A8S cleans up files older than `files_ttl_hours` (default 48) on each idle cycle.
+- **Idle:** The `idle.timeout` controls how often A8S syncs (moves inbox files + runs TTL cleanup). No CLI is invoked.
+
+### Filesystem layout (agent root)
+
+```
+/mnt/gdrive/my-email/
+├── .inbox/     ← a8s writes here; remote side reads + deletes
+├── .outbox/    ← remote side writes here; a8s ingests as normal
+└── .files/     ← bidirectional attachments; TTL cleanup by a8s
+```
+
+### Use cases
+
+- Google Apps Script participants (GAS polls Drive natively)
+- Cross-machine agents without exposed ports
+- Any system that can read/write files but can't run MQTT or hold sockets
+
 ## Source layout
 
 ```

--- a/apps/a8s/daemon.py
+++ b/apps/a8s/daemon.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import json
 import os
 import shlex
+import shutil
 import signal
 import subprocess
 import sys
@@ -47,7 +48,9 @@ from core import (
 from definitions import (
     build_command,
     build_idle_command,
+    files_ttl_seconds,
     idle_timeout_seconds,
+    is_file_proxy,
     load_definition,
 )
 from mailbox import ensure_mailboxes, next_inbox_message, route_outboxes
@@ -109,6 +112,21 @@ def run_with_prefix(name: str, cmd: list[str], cwd: Path) -> int:
         _CURRENT_WAKE_NAME = None
 
 
+def _deliver_file_proxy(p: Participant) -> None:
+    """Move ALL inbox files to <root>/.inbox/ for file-proxy agents."""
+    dest = p.root / ".inbox"
+    dest.mkdir(parents=True, exist_ok=True)
+    src = inbox_dir(p.name)
+    if not src.is_dir():
+        return
+    for f in sorted(src.iterdir()):
+        if not (f.is_file() and f.name.endswith(".json")):
+            continue
+        target = dest / f.name
+        shutil.move(str(f), str(target))
+        out_agent(p.name, f"[{p.name}] proxy: delivered {f.name}")
+
+
 def wake_once(p: Participant, msg_path: Path) -> None:
     # Mark activity before any work — covers the parse-error / load-error
     # exits below too. Without this, a bad inbox file in the only handled
@@ -131,6 +149,11 @@ def wake_once(p: Participant, msg_path: Path) -> None:
         msg_path.rename(bad)
         return
 
+    if is_file_proxy(definition):
+        _deliver_file_proxy(p)
+        touch_last_active(p.name)
+        return
+
     trashed = unique_path(trash_dir(p.name) / msg_path.name)
     msg_path.rename(trashed)
     out_agent(p.name, f"[{p.name}] waking from {trashed.name}: {_preview(msg.get('content', ''))}")
@@ -140,6 +163,27 @@ def wake_once(p: Participant, msg_path: Path) -> None:
     # And again after the wake returns — a long-running LLM call shouldn't
     # leave last-active stuck at the pre-wake timestamp.
     touch_last_active(p.name)
+
+
+def _file_proxy_ttl_cleanup(p: Participant, definition: dict) -> None:
+    """Delete files in <root>/.files/ older than files_ttl_hours."""
+    ttl = files_ttl_seconds(definition)
+    files_path = p.root / ".files"
+    if not files_path.is_dir():
+        return
+    cutoff = _time.time() - ttl
+    removed = 0
+    for f in files_path.iterdir():
+        if not f.is_file():
+            continue
+        try:
+            if os.path.getmtime(f) < cutoff:
+                f.unlink()
+                removed += 1
+        except OSError:
+            pass
+    if removed:
+        out_agent(p.name, f"[{p.name}] proxy: TTL cleanup removed {removed} file(s)")
 
 
 def maybe_run_idle(p: Participant) -> bool:
@@ -155,6 +199,20 @@ def maybe_run_idle(p: Participant) -> bool:
     timeout = idle_timeout_seconds(definition)
     if timeout is None:
         return False
+
+    if is_file_proxy(definition):
+        last = read_last_active(p.name)
+        if last is None:
+            touch_last_active(p.name)
+            return False
+        elapsed = (datetime.now(timezone.utc) - last).total_seconds()
+        if elapsed < timeout:
+            return False
+        _deliver_file_proxy(p)
+        _file_proxy_ttl_cleanup(p, definition)
+        touch_last_active(p.name)
+        return True
+
     cmd = build_idle_command(definition, p.name)
     if cmd is None:
         return False

--- a/apps/a8s/definitions.py
+++ b/apps/a8s/definitions.py
@@ -29,6 +29,19 @@ def default_definition_path(kind: str) -> Path:
     return DEFINITIONS_DIR / f"{kind}.json"
 
 
+def is_file_proxy(definition: dict) -> bool:
+    return definition.get("proxy") == "file"
+
+
+def files_ttl_seconds(definition: dict) -> float:
+    hours = definition.get("files_ttl_hours", 48)
+    try:
+        h = float(hours)
+    except (TypeError, ValueError):
+        h = 48.0
+    return max(0.0, h * 3600)
+
+
 def load_definition(name: str) -> dict:
     """Load the JSON definition for `name`. Every agent always has one — if
     the registry lacks an explicit `definition` field, falls back to the

--- a/apps/a8s/tests/test_file_proxy.py
+++ b/apps/a8s/tests/test_file_proxy.py
@@ -1,0 +1,235 @@
+"""Tests for file-proxy agent type — filesystem delivery instead of CLI invocation."""
+from __future__ import annotations
+
+import json
+import os
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from core import (
+    Participant,
+    agent_log_path,
+    inbox_dir,
+    touch_last_active,
+)
+from daemon import attached_loop, maybe_run_idle, wake_once
+from definitions import files_ttl_seconds, is_file_proxy
+from mailbox import _write_outbox, ensure_mailboxes
+from registry import save_registry
+
+
+def _read_log(name: str) -> str:
+    return agent_log_path(name).read_text() if agent_log_path(name).is_file() else ""
+
+
+def _write_file_proxy_def(path: Path, *, timeout: int = 30, ttl_hours: int | None = None) -> None:
+    defn: dict = {"proxy": "file", "idle": {"timeout": timeout}}
+    if ttl_hours is not None:
+        defn["files_ttl_hours"] = ttl_hours
+    path.write_text(json.dumps(defn))
+
+
+class TestIsFileProxy:
+    def test_recognizes_file_proxy(self):
+        assert is_file_proxy({"proxy": "file"}) is True
+
+    def test_rejects_normal_definition(self):
+        assert is_file_proxy({"invoke": ["echo", "hello"]}) is False
+
+    def test_rejects_other_proxy_value(self):
+        assert is_file_proxy({"proxy": "mqtt"}) is False
+
+    def test_rejects_empty_definition(self):
+        assert is_file_proxy({}) is False
+
+
+class TestFilesTtlSeconds:
+    def test_default_48_hours(self):
+        assert files_ttl_seconds({}) == 48 * 3600
+
+    def test_custom_value(self):
+        assert files_ttl_seconds({"files_ttl_hours": 24}) == 24 * 3600
+
+    def test_string_value_parses(self):
+        assert files_ttl_seconds({"files_ttl_hours": "12"}) == 12 * 3600
+
+    def test_invalid_falls_back_to_48(self):
+        assert files_ttl_seconds({"files_ttl_hours": "bogus"}) == 48 * 3600
+
+
+class TestWakeOnceFileProxy:
+    """wake_once should move inbox files to <root>/.inbox/ instead of invoking CLI."""
+
+    def test_delivers_to_root_inbox(self, fake_home, tmp_path):
+        d = tmp_path / "agent"
+        d.mkdir()
+        defp = tmp_path / "proxy.json"
+        _write_file_proxy_def(defp)
+        save_registry({"PROXY": {"root": str(d), "definition": str(defp)}})
+        p = Participant("PROXY", d)
+        ensure_mailboxes(p)
+
+        msg = {"id": "test1", "from": "ALICE", "to": "PROXY", "content": "hello", "files": []}
+        msg_file = inbox_dir("PROXY") / "test1.json"
+        msg_file.write_text(json.dumps(msg))
+
+        wake_once(p, msg_file)
+
+        delivered = d / ".inbox" / "test1.json"
+        assert delivered.is_file()
+        assert json.loads(delivered.read_text())["content"] == "hello"
+        assert "proxy: delivered test1.json" in _read_log("PROXY")
+
+    def test_batch_delivers_all_inbox_files(self, fake_home, tmp_path):
+        d = tmp_path / "agent"
+        d.mkdir()
+        defp = tmp_path / "proxy.json"
+        _write_file_proxy_def(defp)
+        save_registry({"PROXY": {"root": str(d), "definition": str(defp)}})
+        p = Participant("PROXY", d)
+        ensure_mailboxes(p)
+
+        for i in range(3):
+            msg = {"id": f"msg{i}", "from": "ALICE", "to": "PROXY", "content": f"msg-{i}", "files": []}
+            (inbox_dir("PROXY") / f"msg{i}.json").write_text(json.dumps(msg))
+
+        # Trigger with the first file — all three should be delivered
+        wake_once(p, inbox_dir("PROXY") / "msg0.json")
+
+        inbox_dest = d / ".inbox"
+        delivered = sorted(f.name for f in inbox_dest.iterdir())
+        assert delivered == ["msg0.json", "msg1.json", "msg2.json"]
+
+    def test_does_not_invoke_subprocess(self, fake_home, tmp_path, monkeypatch):
+        d = tmp_path / "agent"
+        d.mkdir()
+        defp = tmp_path / "proxy.json"
+        _write_file_proxy_def(defp)
+        save_registry({"PROXY": {"root": str(d), "definition": str(defp)}})
+        p = Participant("PROXY", d)
+        ensure_mailboxes(p)
+
+        msg = {"id": "test1", "from": "ALICE", "to": "PROXY", "content": "hi", "files": []}
+        msg_file = inbox_dir("PROXY") / "test1.json"
+        msg_file.write_text(json.dumps(msg))
+
+        called = []
+        monkeypatch.setattr("daemon.run_with_prefix", lambda *a, **kw: called.append(1) or 0)
+        wake_once(p, msg_file)
+        assert called == []
+
+
+class TestNormalAgentUnaffected:
+    """Normal (non-proxy) agents still invoke CLI as before."""
+
+    def test_normal_agent_invokes_cli(self, fake_home, tmp_path, fixtures_dir):
+        d = tmp_path / "normal"
+        d.mkdir()
+        save_registry({"NORM": {"root": str(d), "definition": str(fixtures_dir / "mock.json")}})
+        p = Participant("NORM", d)
+        ensure_mailboxes(p)
+
+        msg = {"id": "n1", "from": "BOB", "to": "NORM", "content": "check", "date": "2026-05-01T00:00:00Z", "files": []}
+        msg_file = inbox_dir("NORM") / "n1.json"
+        msg_file.write_text(json.dumps(msg))
+
+        wake_once(p, msg_file)
+
+        log = _read_log("NORM")
+        assert "exec:" in log
+        assert "FROM:BOB" in log
+        assert not (d / ".inbox").exists()
+
+
+class TestIdleFileProxy:
+    """Idle for file-proxy agents: move remaining inbox, TTL cleanup on .files/."""
+
+    def test_idle_moves_inbox_and_cleans_ttl(self, fake_home, tmp_path):
+        d = tmp_path / "agent"
+        d.mkdir()
+        defp = tmp_path / "proxy.json"
+        _write_file_proxy_def(defp, timeout=1, ttl_hours=1)
+        save_registry({"PROXY": {"root": str(d), "definition": str(defp)}})
+        p = Participant("PROXY", d)
+        ensure_mailboxes(p)
+
+        # Seed an inbox message
+        msg = {"id": "idle1", "from": "X", "to": "PROXY", "content": "stale", "files": []}
+        (inbox_dir("PROXY") / "idle1.json").write_text(json.dumps(msg))
+
+        # Create an old file in .files/
+        files_path = d / ".files"
+        files_path.mkdir(parents=True, exist_ok=True)
+        old_file = files_path / "old.txt"
+        old_file.write_text("expired")
+        old_mtime = time.time() - 7200  # 2 hours ago
+        os.utime(old_file, (old_mtime, old_mtime))
+
+        # Create a fresh file that should survive
+        fresh_file = files_path / "fresh.txt"
+        fresh_file.write_text("keep")
+
+        # Mark last-active as stale
+        touch_last_active("PROXY", datetime.now(timezone.utc) - timedelta(seconds=60))
+
+        fired = maybe_run_idle(p)
+        assert fired is True
+
+        # Inbox message moved to .inbox/
+        assert (d / ".inbox" / "idle1.json").is_file()
+        assert not (inbox_dir("PROXY") / "idle1.json").is_file()
+
+        # Old file removed, fresh file kept
+        assert not old_file.is_file()
+        assert fresh_file.is_file()
+
+        log = _read_log("PROXY")
+        assert "TTL cleanup removed 1 file(s)" in log
+
+    def test_idle_skips_when_not_yet_expired(self, fake_home, tmp_path):
+        d = tmp_path / "agent"
+        d.mkdir()
+        defp = tmp_path / "proxy.json"
+        _write_file_proxy_def(defp, timeout=300)
+        save_registry({"PROXY": {"root": str(d), "definition": str(defp)}})
+        p = Participant("PROXY", d)
+        ensure_mailboxes(p)
+
+        touch_last_active("PROXY", datetime.now(timezone.utc) - timedelta(seconds=10))
+        assert maybe_run_idle(p) is False
+
+
+class TestAttachedLoopFileProxy:
+    """Integration: attached_loop handles file-proxy agents end-to-end."""
+
+    def test_routed_message_delivered_via_proxy(self, fake_home, tmp_path, fixtures_dir):
+        sender_root = tmp_path / "sender"
+        proxy_root = tmp_path / "proxy"
+        sender_root.mkdir()
+        proxy_root.mkdir()
+
+        defp = tmp_path / "proxy.json"
+        _write_file_proxy_def(defp)
+
+        save_registry({
+            "SENDER": {"root": str(sender_root), "definition": str(fixtures_dir / "mock.json")},
+            "PROXY": {"root": str(proxy_root), "definition": str(defp)},
+        })
+        ensure_mailboxes(Participant("SENDER", sender_root))
+        ensure_mailboxes(Participant("PROXY", proxy_root))
+
+        _write_outbox("SENDER", sender_root, "PROXY", "file-proxy test", [])
+
+        rc = attached_loop(["SENDER", "PROXY"], 0.1, single_pass=True)
+        assert rc == 0
+
+        inbox_dest = proxy_root / ".inbox"
+        assert inbox_dest.is_dir()
+        delivered = list(inbox_dest.iterdir())
+        assert len(delivered) == 1
+        content = json.loads(delivered[0].read_text())
+        assert content["content"] == "file-proxy test"
+        assert "proxy: delivered" in _read_log("PROXY")


### PR DESCRIPTION
## Summary
- Adds `"proxy": "file"` definition type for agents that receive messages via filesystem sync (rclone, Google Drive, etc.) instead of CLI invocation
- On wake: batch-moves all `~/.a8s/agents/<name>/inbox/` files to `<root>/.inbox/` where a remote poller picks them up
- On idle: same delivery + TTL cleanup of `<root>/.files/` (default 48h, configurable via `files_ttl_hours`)
- Normal agents unaffected — `route_outboxes` already handles outbox collection for all agent types

## Test plan
- [x] `is_file_proxy` recognizes file-proxy definitions and rejects others
- [x] `wake_once` moves inbox files to `<root>/.inbox/` without invoking subprocess
- [x] Batch delivery: all inbox files move on a single wake trigger
- [x] Normal agents still invoke CLI as before
- [x] Idle fires delivery + TTL cleanup of expired `.files/`
- [x] Full integration via `attached_loop` single-pass with routed message
- [x] All 393 existing tests still pass

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)