### PR TITLE
Add FILE: delivery logging + a8s health command

### DIFF
--- a/apps/a8s/cli.py
+++ b/apps/a8s/cli.py
@@ -12,6 +12,7 @@ from commands import (
     cmd_define,
     cmd_discover,
     cmd_exit,
+    cmd_health,
     cmd_install,
     cmd_kill,
     cmd_logs,
@@ -53,6 +54,7 @@ COMMANDS: list[tuple[str, str, str]] = [
     ("storage",  "[<name> [<url> [--<k> <v> ...]]]",            "List, show, or set a cross-cluster file storage service."),
     ("unstorage","<name>",                    "Remove a configured storage service."),
     ("install",  "",                          "Install the `tell` skill into supported tools."),
+    ("health",   "",                          "Test connectivity of remotes and storage services."),
 ]
 
 KNOWN_COMMANDS = {name for name, _, _ in COMMANDS}
@@ -115,6 +117,8 @@ def dispatch(cmd: str, args: list[str], interval: float) -> int:
         return cmd_storage(args)
     if cmd == "unstorage":
         return cmd_unstorage(args)
+    if cmd == "health":
+        return cmd_health()
     raise ValueError(f"unknown command: {cmd!r}")
 
 

--- a/apps/a8s/commands.py
+++ b/apps/a8s/commands.py
@@ -1228,3 +1228,71 @@ def cmd_unstorage(args: list[str]) -> int:
     save_network_config(cfg)
     print(f"removed storage {name}")
     return 0
+
+
+def cmd_health() -> int:
+    """`a8s health` — test connectivity of all configured remotes and storage services."""
+    import tempfile
+    from network import load_remotes, load_services
+
+    errors = 0
+
+    remotes = load_remotes()
+    if not remotes:
+        print("remotes: (none configured)")
+    for t in remotes:
+        name = getattr(t, "name", t.__class__.__name__)
+        try:
+            t.start(lambda *_: None)
+            connected = t.is_connected() if hasattr(t, "is_connected") else True
+            t.stop()
+            if connected:
+                print(f"remote {name}: OK")
+            else:
+                print(f"remote {name}: FAIL (connected but is_connected=False)")
+                errors += 1
+        except Exception as e:
+            print(f"remote {name}: FAIL ({e})")
+            errors += 1
+
+    services = load_services()
+    if not services:
+        print("storage: (none configured)")
+    for svc in services:
+        name = getattr(svc, "name", svc.__class__.__name__)
+        tmp = tempfile.NamedTemporaryFile(suffix=".txt", delete=False, mode="w")
+        tmp.write("a8s health check")
+        tmp.close()
+        tmp_path = Path(tmp.name)
+        try:
+            url = svc.store(tmp_path)
+            dl_dir = Path(tempfile.mkdtemp())
+            dl_dest = dl_dir / "health-check.txt"
+            ok = svc.retrieve(url, dl_dest)
+            if ok and dl_dest.is_file() and dl_dest.read_text().strip() == "a8s health check":
+                print(f"storage {name}: OK (upload + download verified)")
+            elif ok:
+                print(f"storage {name}: WARN (download succeeded but content mismatch)")
+                errors += 1
+            else:
+                print(f"storage {name}: FAIL (retrieve returned False)")
+                errors += 1
+            dl_dest.unlink(missing_ok=True)
+            dl_dir.rmdir()
+        except Exception as e:
+            print(f"storage {name}: FAIL ({e})")
+            errors += 1
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+    agents = load_registry()
+    print(f"agents: {len(agents)} registered")
+    for name, info in agents.items():
+        root = Path(info.get("root", ""))
+        if not root.is_dir():
+            print(f"  {name}: WARN (root missing: {root})")
+            errors += 1
+        else:
+            print(f"  {name}: OK ({root})")
+
+    return 1 if errors else 0

--- a/apps/a8s/mailbox.py
+++ b/apps/a8s/mailbox.py
@@ -168,10 +168,7 @@ def _transfer_file_to_recipient(
     except OSError as e:
         out_agent(sender_name, f"FILE: copy failed {src_resolved} -> {dest}: {e}")
         return None
-    # Recipient-CWD-relative path (e.g. "./.files/report.txt"). The agent's
-    # wake subprocess runs with cwd=recipient.root; an absolute host path
-    # wouldn't resolve inside a container that has the agent's directory
-    # mapped to a different prefix.
+    out_agent(sender_name, f"FILE: delivered {src_resolved.name} -> {dest_dir}")
     return {"filename": dest.name, "path": _recipient_relative_path(dest_dir, dest)}
 
 


### PR DESCRIPTION
## Summary

- `mailbox.py`: Log successful file transfers (`FILE: delivered <name> -> <dest>`)
- `a8s health`: New command that tests all configured infrastructure:
  - Remotes: MQTT connect/disconnect test
  - Storage: full upload + download round-trip with content verification  
  - Agents: checks root directories exist

```
$ a8s health
remote MqttTransport: OK
storage TempFileOrgService: OK (upload + download verified)
agents: 8 registered
  my-agent: OK (/path/to/root)
```

## Test plan

- [x] 393 tests pass
- [x] `a8s health` verified locally (MQTT + tempfile.org + agent roots)

🤖 Generated with [Claude Code](https://claude.com/claude-code)