### PR TITLE
feat(l9m): rolling conversation context window

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,19 @@ jobs:
       - run: pip install pytest
       - run: python -m pytest apps/k7e/tests/ -x -q -m "not llm"
 
+  l9m-unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install pytest
+      - run: python -m pytest apps/l9m/tests/ apps/q3w/tests/ -x -q
+
   l9m:
     runs-on: ubuntu-latest
+    needs: [l9m-unit]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/apps/l9m/l9m.py
+++ b/apps/l9m/l9m.py
@@ -25,10 +25,9 @@ DEFAULT_MODEL = "qwen3:0.6b"
 
 CONTEXT_DIR = Path(os.environ.get("L9M_CONTEXT_DIR") or str(Path.home() / ".cache" / "l9m"))
 CONTEXT_FILE = CONTEXT_DIR / "context.txt"
-try:
-    CONTEXT_LIMIT = int(os.environ.get("L9M_CONTEXT_LIMIT", "10000"))
-except ValueError:
-    CONTEXT_LIMIT = 10000
+CONTEXT_LIMIT_OVERRIDE = os.environ.get("L9M_CONTEXT_LIMIT", "").strip()
+CHARS_PER_TOKEN = 3
+CONTEXT_FRACTION = 0.25
 
 
 # ---------- model resolution ----------
@@ -81,21 +80,65 @@ def _version_key(name: str) -> tuple:
     return tuple(parts)
 
 
-def _read_cache() -> str | None:
+def _read_cache() -> dict[str, str]:
+    result = {}
     if not CACHE_FILE.exists():
-        return None
+        return result
     try:
         for line in CACHE_FILE.read_text().splitlines():
-            if line.startswith("MODEL="):
-                return line[6:].strip()
+            if "=" in line:
+                key, _, val = line.partition("=")
+                result[key.strip()] = val.strip()
     except OSError:
+        pass
+    return result
+
+
+def _write_cache(model: str, num_ctx: int | None = None) -> None:
+    CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    lines = [f"MODEL={model}"]
+    if num_ctx:
+        lines.append(f"NUM_CTX={num_ctx}")
+    CACHE_FILE.write_text("\n".join(lines) + "\n")
+
+
+def _model_num_ctx(model: str) -> int | None:
+    """Query ollama for the model's context window size (in tokens)."""
+    body = json.dumps({"name": model}).encode()
+    req = urllib.request.Request(
+        f"{OLLAMA_URL}/api/show",
+        data=body,
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            data = json.loads(resp.read())
+        params = data.get("model_info", {})
+        for key, val in params.items():
+            if "context_length" in key:
+                return int(val)
+    except Exception:
         pass
     return None
 
 
-def _write_cache(model: str) -> None:
-    CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
-    CACHE_FILE.write_text(f"MODEL={model}\n")
+def resolve_context_limit(model: str) -> int:
+    """Derive rolling context char limit from model's context window."""
+    if CONTEXT_LIMIT_OVERRIDE:
+        try:
+            return int(CONTEXT_LIMIT_OVERRIDE)
+        except ValueError:
+            pass
+
+    cache = _read_cache()
+    if cache.get("MODEL") == model and "NUM_CTX" in cache:
+        num_ctx = int(cache["NUM_CTX"])
+    else:
+        num_ctx = _model_num_ctx(model) or 0
+
+    if num_ctx:
+        return int(num_ctx * CONTEXT_FRACTION * CHARS_PER_TOKEN)
+    return 10000
 
 
 def resolve_model() -> str:
@@ -103,9 +146,9 @@ def resolve_model() -> str:
     if env:
         return env
 
-    cached = _read_cache()
-    if cached:
-        return cached
+    cache = _read_cache()
+    if cache.get("MODEL"):
+        return cache["MODEL"]
 
     if not _ollama_running():
         if not _start_ollama():
@@ -114,7 +157,8 @@ def resolve_model() -> str:
     qwen_models = _installed_qwen_models()
     if qwen_models:
         best = sorted(qwen_models, key=_version_key)[-1]
-        _write_cache(best)
+        num_ctx = _model_num_ctx(best)
+        _write_cache(best, num_ctx)
         return best
 
     print(f"pulling {DEFAULT_MODEL}...", file=sys.stderr)
@@ -122,7 +166,8 @@ def resolve_model() -> str:
         [shutil.which("ollama") or "ollama", "pull", DEFAULT_MODEL],
         stdout=sys.stderr, stderr=sys.stderr,
     )
-    _write_cache(DEFAULT_MODEL)
+    num_ctx = _model_num_ctx(DEFAULT_MODEL)
+    _write_cache(DEFAULT_MODEL, num_ctx)
     return DEFAULT_MODEL
 
 
@@ -237,24 +282,25 @@ def _read_context() -> str:
         return ""
 
 
-def _append_context(prompt: str, response: str) -> None:
+def _append_context(prompt: str, response: str, limit: int = 0) -> None:
+    ctx_limit = limit or 10000
     entry = f">>> {prompt}\n{response}\n"
     existing = _read_context()
     combined = existing + entry
-    if len(combined) > CONTEXT_LIMIT:
-        combined = combined[-CONTEXT_LIMIT:]
+    if len(combined) > ctx_limit:
+        combined = combined[-ctx_limit:]
         nl = combined.find("\n")
         if nl != -1 and nl < len(combined) - 1:
             combined = combined[nl + 1:]
         else:
-            combined = entry[-CONTEXT_LIMIT:]
+            combined = entry[-ctx_limit:]
     CONTEXT_DIR.mkdir(parents=True, exist_ok=True)
     CONTEXT_FILE.write_text(combined, encoding="utf-8")
 
 
 # ---------- chat REPL ----------
 
-def _chat_loop(model: str, response_type: str, instruction: str) -> int:
+def _chat_loop(model: str, response_type: str, instruction: str, context_limit: int = 0) -> int:
     """Interactive REPL. Rolling context accumulates across turns."""
     try:
         import readline  # noqa: F401 — enables line editing in input()
@@ -287,7 +333,7 @@ def _chat_loop(model: str, response_type: str, instruction: str) -> int:
             print(f"error: {e}", file=sys.stderr)
             continue
 
-        _append_context(prompt, output.strip())
+        _append_context(prompt, output.strip(), context_limit)
 
 
 # ---------- main ----------
@@ -312,13 +358,15 @@ options:
   -s, --silent            Suppress stderr
   --chat                  Interactive REPL (CTRL+D or "quit" to exit)
   --model                 Print resolved model and exit
+  --context-size          Print rolling context limit (chars) and exit
 
 rolling context: prompt+response pairs are kept in ~/.cache/l9m/context.txt
-  as a sliding window (default 10k chars). Overridden by -c/--context.
+  as a sliding window. Size is auto-derived from the model's context window
+  (25% * ~3 chars/token). Override with L9M_CONTEXT_LIMIT env var.
 
 env vars:
   L9M_CONTEXT_DIR     Directory for context storage (default: ~/.cache/l9m)
-  L9M_CONTEXT_LIMIT   Max context size in chars (default: 10000)
+  L9M_CONTEXT_LIMIT   Override auto-derived context size (chars)
 
 model resolution: MODEL env > ~/.cache/l9m.env > best installed qwen > pull qwen3:0.6b""")
         return 0
@@ -331,6 +379,7 @@ model resolution: MODEL env > ~/.cache/l9m.env > best installed qwen > pull qwen
     echo_prompt = False
     silent = False
     show_model = False
+    show_context_size = False
     chat_mode = False
 
     i = 0
@@ -355,6 +404,8 @@ model resolution: MODEL env > ~/.cache/l9m.env > best installed qwen > pull qwen
             silent = True
         elif arg == "--model":
             show_model = True
+        elif arg == "--context-size":
+            show_context_size = True
         elif arg == "--chat":
             chat_mode = True
         elif not arg.startswith("-") and not arg.startswith(".") and not arg.startswith("/"):
@@ -371,8 +422,14 @@ model resolution: MODEL env > ~/.cache/l9m.env > best installed qwen > pull qwen
         print(f"error: {e}", file=sys.stderr)
         return 1
 
+    context_limit = resolve_context_limit(model)
+
+    if show_context_size:
+        print(context_limit)
+        return 0
+
     if chat_mode:
-        return _chat_loop(model, response_type, instruction)
+        return _chat_loop(model, response_type, instruction, context_limit)
 
     # stdin handling
     stdin_content = ""
@@ -424,7 +481,7 @@ model resolution: MODEL env > ~/.cache/l9m.env > best installed qwen > pull qwen
         return 1
 
     if use_rolling_context and prompt and (prompt_flag or not stdin_content):
-        _append_context(prompt, output.strip())
+        _append_context(prompt, output.strip(), context_limit)
 
     return 0
 

--- a/apps/l9m/l9m.py
+++ b/apps/l9m/l9m.py
@@ -252,6 +252,44 @@ def _append_context(prompt: str, response: str) -> None:
     CONTEXT_FILE.write_text(combined, encoding="utf-8")
 
 
+# ---------- chat REPL ----------
+
+def _chat_loop(model: str, response_type: str, instruction: str) -> int:
+    """Interactive REPL. Rolling context accumulates across turns."""
+    try:
+        import readline  # noqa: F401 — enables line editing in input()
+    except ImportError:
+        pass
+
+    while True:
+        try:
+            line = input("> ")
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return 0
+
+        prompt = line.strip()
+        if not prompt:
+            continue
+        if prompt in ("quit", "exit"):
+            return 0
+
+        context = _read_context()
+        context_wrapped = f"<Memories>\n{context}\n</Memories>" if context else ""
+        full_prompt = assemble_prompt(prompt, response_type, instruction, context_wrapped)
+
+        try:
+            output = generate(model, full_prompt)
+        except KeyboardInterrupt:
+            print()
+            continue
+        except L9mError as e:
+            print(f"error: {e}", file=sys.stderr)
+            continue
+
+        _append_context(prompt, output.strip())
+
+
 # ---------- main ----------
 
 def main(argv: list[str] | None = None) -> int:
@@ -263,6 +301,7 @@ def main(argv: list[str] | None = None) -> int:
 
 usage: l9m [options] [prompt]
        echo "text" | l9m [-p "question"]
+       l9m --chat [-t bash] [-i "instruction"]
 
 options:
   -p, --prompt <text>     Prompt text
@@ -271,6 +310,7 @@ options:
   -c, --context <file>    Context from file (overrides rolling context)
   -e, --echo              Echo assembled prompt before generation
   -s, --silent            Suppress stderr
+  --chat                  Interactive REPL (CTRL+D or "quit" to exit)
   --model                 Print resolved model and exit
 
 rolling context: prompt+response pairs are kept in ~/.cache/l9m/context.txt
@@ -291,6 +331,7 @@ model resolution: MODEL env > ~/.cache/l9m.env > best installed qwen > pull qwen
     echo_prompt = False
     silent = False
     show_model = False
+    chat_mode = False
 
     i = 0
     while i < len(argv):
@@ -314,6 +355,8 @@ model resolution: MODEL env > ~/.cache/l9m.env > best installed qwen > pull qwen
             silent = True
         elif arg == "--model":
             show_model = True
+        elif arg == "--chat":
+            chat_mode = True
         elif not arg.startswith("-") and not arg.startswith(".") and not arg.startswith("/"):
             if not prompt:
                 prompt = arg
@@ -327,6 +370,9 @@ model resolution: MODEL env > ~/.cache/l9m.env > best installed qwen > pull qwen
     except L9mError as e:
         print(f"error: {e}", file=sys.stderr)
         return 1
+
+    if chat_mode:
+        return _chat_loop(model, response_type, instruction)
 
     # stdin handling
     stdin_content = ""

--- a/apps/l9m/l9m.py
+++ b/apps/l9m/l9m.py
@@ -357,6 +357,7 @@ options:
   -e, --echo              Echo assembled prompt before generation
   -s, --silent            Suppress stderr
   --chat                  Interactive REPL (CTRL+D or "quit" to exit)
+  --clear                 Clear rolling context and exit
   --model                 Print resolved model and exit
   --context-size          Print rolling context limit (chars) and exit
 
@@ -380,6 +381,7 @@ model resolution: MODEL env > ~/.cache/l9m.env > best installed qwen > pull qwen
     silent = False
     show_model = False
     show_context_size = False
+    clear_context = False
     chat_mode = False
 
     i = 0
@@ -406,12 +408,21 @@ model resolution: MODEL env > ~/.cache/l9m.env > best installed qwen > pull qwen
             show_model = True
         elif arg == "--context-size":
             show_context_size = True
+        elif arg == "--clear":
+            clear_context = True
         elif arg == "--chat":
             chat_mode = True
         elif not arg.startswith("-") and not arg.startswith(".") and not arg.startswith("/"):
             if not prompt:
                 prompt = arg
         i += 1
+
+    if clear_context:
+        try:
+            CONTEXT_FILE.unlink()
+        except OSError:
+            pass
+        return 0
 
     try:
         if show_model:

--- a/apps/l9m/l9m.py
+++ b/apps/l9m/l9m.py
@@ -132,7 +132,10 @@ def resolve_context_limit(model: str) -> int:
 
     cache = _read_cache()
     if cache.get("MODEL") == model and "NUM_CTX" in cache:
-        num_ctx = int(cache["NUM_CTX"])
+        try:
+            num_ctx = int(cache["NUM_CTX"])
+        except ValueError:
+            num_ctx = _model_num_ctx(model) or 0
     else:
         num_ctx = _model_num_ctx(model) or 0
 
@@ -220,9 +223,14 @@ class L9mError(RuntimeError):
     pass
 
 
-def generate(model: str, prompt: str, stream: object | None = sys.stdout) -> str:
+_STREAM_DEFAULT = object()
+
+
+def generate(model: str, prompt: str, stream: object | None = _STREAM_DEFAULT) -> str:
     """Generate text from ollama. Streams to `stream` if provided, returns full text.
     Raises L9mError on failure (never calls sys.exit)."""
+    if stream is _STREAM_DEFAULT:
+        stream = sys.stdout
     if not _ollama_running():
         if not _start_ollama():
             raise L9mError("ollama not installed or won't start")
@@ -275,17 +283,17 @@ def generate(model: str, prompt: str, stream: object | None = sys.stdout) -> str
 
 # ---------- rolling context ----------
 
-def _read_context() -> str:
+def read_context() -> str:
     try:
         return CONTEXT_FILE.read_text(encoding="utf-8")
     except OSError:
         return ""
 
 
-def _append_context(prompt: str, response: str, limit: int = 0) -> None:
+def append_context(prompt: str, response: str, limit: int = 0) -> None:
     ctx_limit = limit or 10000
     entry = f">>> {prompt}\n{response}\n"
-    existing = _read_context()
+    existing = read_context()
     combined = existing + entry
     if len(combined) > ctx_limit:
         combined = combined[-ctx_limit:]
@@ -320,7 +328,7 @@ def _chat_loop(model: str, response_type: str, instruction: str, context_limit: 
         if prompt in ("quit", "exit"):
             return 0
 
-        context = _read_context()
+        context = read_context()
         context_wrapped = f"<Memories>\n{context}\n</Memories>" if context else ""
         full_prompt = assemble_prompt(prompt, response_type, instruction, context_wrapped)
 
@@ -333,7 +341,7 @@ def _chat_loop(model: str, response_type: str, instruction: str, context_limit: 
             print(f"error: {e}", file=sys.stderr)
             continue
 
-        _append_context(prompt, output.strip(), context_limit)
+        append_context(prompt, output.strip(), context_limit)
 
 
 # ---------- main ----------
@@ -468,7 +476,7 @@ model resolution: MODEL env > ~/.cache/l9m.env > best installed qwen > pull qwen
         else:
             context_payload = file_content
     elif use_rolling_context:
-        rolling = _read_context()
+        rolling = read_context()
         if rolling:
             if context_payload:
                 context_payload = f"{rolling}\n{context_payload}"
@@ -492,7 +500,7 @@ model resolution: MODEL env > ~/.cache/l9m.env > best installed qwen > pull qwen
         return 1
 
     if use_rolling_context and prompt and (prompt_flag or not stdin_content):
-        _append_context(prompt, output.strip(), context_limit)
+        append_context(prompt, output.strip(), context_limit)
 
     return 0
 

--- a/apps/l9m/l9m.py
+++ b/apps/l9m/l9m.py
@@ -23,6 +23,13 @@ OLLAMA_URL = os.environ.get("OLLAMA_URL", "http://localhost:11434")
 CACHE_FILE = Path.home() / ".cache" / "l9m.env"
 DEFAULT_MODEL = "qwen3:0.6b"
 
+CONTEXT_DIR = Path(os.environ.get("L9M_CONTEXT_DIR") or str(Path.home() / ".cache" / "l9m"))
+CONTEXT_FILE = CONTEXT_DIR / "context.txt"
+try:
+    CONTEXT_LIMIT = int(os.environ.get("L9M_CONTEXT_LIMIT", "10000"))
+except ValueError:
+    CONTEXT_LIMIT = 10000
+
 
 # ---------- model resolution ----------
 
@@ -127,7 +134,7 @@ def assemble_prompt(
     instruction: str,
     context: str,
 ) -> str:
-    if response_type and instruction:
+    if response_type:
         prefix, suffix = "", ""
         if response_type == "bash":
             prefix = "Answer ONLY with the bash command, no explanation. "
@@ -142,10 +149,18 @@ def assemble_prompt(
             print(f"invalid type: {response_type}", file=sys.stderr)
             sys.exit(2)
 
+        framing = instruction if instruction else "Answer"
         return (
-            f"INSTRUCTION: {prefix}{instruction}:\n\n"
+            f"INSTRUCTION: {prefix}{framing}:\n\n"
             f"{prompt}\n{context}\n"
-            f"{instruction}: <Prompt>{prompt}</Prompt>{suffix}"
+            f"{framing}: <Prompt>{prompt}</Prompt>{suffix}"
+        )
+
+    if instruction:
+        return (
+            f"INSTRUCTION: {instruction}:\n\n"
+            f"{prompt}\n{context}\n"
+            f"{instruction}: <Prompt>{prompt}</Prompt>"
         )
 
     if context:
@@ -213,6 +228,30 @@ def generate(model: str, prompt: str, stream: object | None = sys.stdout) -> str
     return output
 
 
+# ---------- rolling context ----------
+
+def _read_context() -> str:
+    try:
+        return CONTEXT_FILE.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def _append_context(prompt: str, response: str) -> None:
+    entry = f">>> {prompt}\n{response}\n"
+    existing = _read_context()
+    combined = existing + entry
+    if len(combined) > CONTEXT_LIMIT:
+        combined = combined[-CONTEXT_LIMIT:]
+        nl = combined.find("\n")
+        if nl != -1 and nl < len(combined) - 1:
+            combined = combined[nl + 1:]
+        else:
+            combined = entry[-CONTEXT_LIMIT:]
+    CONTEXT_DIR.mkdir(parents=True, exist_ok=True)
+    CONTEXT_FILE.write_text(combined, encoding="utf-8")
+
+
 # ---------- main ----------
 
 def main(argv: list[str] | None = None) -> int:
@@ -229,10 +268,17 @@ options:
   -p, --prompt <text>     Prompt text
   -t, --type <type>       Response type: bash, bool, list
   -i, --instruction <text> Instruction framing
-  -c, --context <file>    Context from file
+  -c, --context <file>    Context from file (overrides rolling context)
   -e, --echo              Echo assembled prompt before generation
   -s, --silent            Suppress stderr
   --model                 Print resolved model and exit
+
+rolling context: prompt+response pairs are kept in ~/.cache/l9m/context.txt
+  as a sliding window (default 10k chars). Overridden by -c/--context.
+
+env vars:
+  L9M_CONTEXT_DIR     Directory for context storage (default: ~/.cache/l9m)
+  L9M_CONTEXT_LIMIT   Max context size in chars (default: 10000)
 
 model resolution: MODEL env > ~/.cache/l9m.env > best installed qwen > pull qwen3:0.6b""")
         return 0
@@ -295,6 +341,8 @@ model resolution: MODEL env > ~/.cache/l9m.env > best installed qwen > pull qwen
     else:
         context_payload = ""
 
+    use_rolling_context = not context_file
+
     if context_file:
         path = Path(context_file)
         if not path.is_file():
@@ -305,6 +353,13 @@ model resolution: MODEL env > ~/.cache/l9m.env > best installed qwen > pull qwen
             context_payload = f"{context_payload}\n{file_content}"
         else:
             context_payload = file_content
+    elif use_rolling_context:
+        rolling = _read_context()
+        if rolling:
+            if context_payload:
+                context_payload = f"{rolling}\n{context_payload}"
+            else:
+                context_payload = rolling
 
     context = f"<Memories>\n{context_payload}\n</Memories>" if context_payload else ""
 
@@ -317,10 +372,14 @@ model resolution: MODEL env > ~/.cache/l9m.env > best installed qwen > pull qwen
         return 0
 
     try:
-        generate(model, full_prompt)
+        output = generate(model, full_prompt)
     except L9mError as e:
         print(f"error: {e}", file=sys.stderr)
         return 1
+
+    if use_rolling_context and prompt and (prompt_flag or not stdin_content):
+        _append_context(prompt, output.strip())
+
     return 0
 
 

--- a/apps/l9m/tests/test_l9m.py
+++ b/apps/l9m/tests/test_l9m.py
@@ -49,19 +49,23 @@ class TestCache:
         cache_file = tmp_path / ".cache" / "l9m.env"
         monkeypatch.setattr(l9m, "CACHE_FILE", cache_file)
 
-        l9m._write_cache("qwen3:7b")
-        assert l9m._read_cache() == "qwen3:7b"
+        l9m._write_cache("qwen3:7b", 32768)
+        cache = l9m._read_cache()
+        assert cache["MODEL"] == "qwen3:7b"
+        assert cache["NUM_CTX"] == "32768"
 
     def test_read_missing_file(self, tmp_path, monkeypatch):
         cache_file = tmp_path / "nonexistent" / "l9m.env"
         monkeypatch.setattr(l9m, "CACHE_FILE", cache_file)
-        assert l9m._read_cache() is None
+        assert l9m._read_cache() == {}
 
-    def test_read_ignores_other_lines(self, tmp_path, monkeypatch):
+    def test_read_parses_all_keys(self, tmp_path, monkeypatch):
         cache_file = tmp_path / "l9m.env"
-        cache_file.write_text("# comment\nFOO=bar\nMODEL=mymodel\nEXTRA=stuff\n")
+        cache_file.write_text("MODEL=mymodel\nNUM_CTX=4096\nEXTRA=stuff\n")
         monkeypatch.setattr(l9m, "CACHE_FILE", cache_file)
-        assert l9m._read_cache() == "mymodel"
+        cache = l9m._read_cache()
+        assert cache["MODEL"] == "mymodel"
+        assert cache["NUM_CTX"] == "4096"
 
     def test_write_creates_parent_dirs(self, tmp_path, monkeypatch):
         cache_file = tmp_path / "deep" / "nested" / "l9m.env"
@@ -95,6 +99,53 @@ class TestResolveModel:
         cache_file.write_text("MODEL=cached-model\n")
         monkeypatch.setattr(l9m, "CACHE_FILE", cache_file)
         assert l9m.resolve_model() == "cached-model"
+
+
+# ---------- resolve_context_limit ----------
+
+class TestResolveContextLimit:
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setattr(l9m, "CONTEXT_LIMIT_OVERRIDE", "5000")
+        assert l9m.resolve_context_limit("any-model") == 5000
+
+    def test_invalid_env_falls_through(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(l9m, "CONTEXT_LIMIT_OVERRIDE", "bad")
+        cache_file = tmp_path / "l9m.env"
+        cache_file.write_text("MODEL=test\nNUM_CTX=8192\n")
+        monkeypatch.setattr(l9m, "CACHE_FILE", cache_file)
+        assert l9m.resolve_context_limit("test") == int(8192 * 0.25 * 3)
+
+    def test_cached_num_ctx(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(l9m, "CONTEXT_LIMIT_OVERRIDE", "")
+        cache_file = tmp_path / "l9m.env"
+        cache_file.write_text("MODEL=qwen3:7b\nNUM_CTX=32768\n")
+        monkeypatch.setattr(l9m, "CACHE_FILE", cache_file)
+        expected = int(32768 * 0.25 * 3)
+        assert l9m.resolve_context_limit("qwen3:7b") == expected
+
+    def test_model_mismatch_queries_ollama(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(l9m, "CONTEXT_LIMIT_OVERRIDE", "")
+        cache_file = tmp_path / "l9m.env"
+        cache_file.write_text("MODEL=old-model\nNUM_CTX=4096\n")
+        monkeypatch.setattr(l9m, "CACHE_FILE", cache_file)
+        monkeypatch.setattr(l9m, "_model_num_ctx", lambda m: 16384)
+        expected = int(16384 * 0.25 * 3)
+        assert l9m.resolve_context_limit("new-model") == expected
+
+    def test_fallback_when_no_num_ctx(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(l9m, "CONTEXT_LIMIT_OVERRIDE", "")
+        cache_file = tmp_path / "l9m.env"
+        cache_file.write_text("MODEL=test\n")
+        monkeypatch.setattr(l9m, "CACHE_FILE", cache_file)
+        monkeypatch.setattr(l9m, "_model_num_ctx", lambda m: None)
+        assert l9m.resolve_context_limit("test") == 10000
+
+    def test_context_size_flag(self, monkeypatch, capsys):
+        monkeypatch.setenv("MODEL", "fake")
+        monkeypatch.setattr(l9m, "resolve_context_limit", lambda m: 24576)
+        assert l9m.main(["--context-size"]) == 0
+        out = capsys.readouterr().out.strip()
+        assert out == "24576"
 
 
 # ---------- assemble_prompt ----------
@@ -157,6 +208,7 @@ class TestMain:
         ctx_dir = tmp_path / "l9m"
         monkeypatch.setattr(l9m, "CONTEXT_DIR", ctx_dir)
         monkeypatch.setattr(l9m, "CONTEXT_FILE", ctx_dir / "context.txt")
+        monkeypatch.setattr(l9m, "resolve_context_limit", lambda m: 10000)
 
     def test_help_returns_zero(self, capsys):
         assert l9m.main(["--help"]) == 0
@@ -279,7 +331,7 @@ class TestRollingContext:
         ctx_dir.mkdir()
         monkeypatch.setattr(l9m, "CONTEXT_DIR", ctx_dir)
         monkeypatch.setattr(l9m, "CONTEXT_FILE", ctx_dir / "context.txt")
-        monkeypatch.setattr(l9m, "CONTEXT_LIMIT", 10000)
+        monkeypatch.setattr(l9m, "resolve_context_limit", lambda m: 10000)
         self.ctx_dir = ctx_dir
         self.ctx_file = ctx_dir / "context.txt"
 
@@ -300,32 +352,28 @@ class TestRollingContext:
         assert ">>> q1" in content
         assert ">>> q2" in content
 
-    def test_rolling_window_trims(self, monkeypatch):
-        monkeypatch.setattr(l9m, "CONTEXT_LIMIT", 50)
-        l9m._append_context("first question", "first answer")
-        l9m._append_context("second question", "second answer")
+    def test_rolling_window_trims(self):
+        l9m._append_context("first question", "first answer", limit=50)
+        l9m._append_context("second question", "second answer", limit=50)
         content = self.ctx_file.read_text()
         assert len(content) <= 50
         assert ">>> second question" in content
         assert ">>> first question" not in content
 
-    def test_trim_at_line_boundary(self, monkeypatch):
-        monkeypatch.setattr(l9m, "CONTEXT_LIMIT", 30)
-        l9m._append_context("aaa", "bbb")
-        l9m._append_context("ccc", "ddd")
+    def test_trim_at_line_boundary(self):
+        l9m._append_context("aaa", "bbb", limit=30)
+        l9m._append_context("ccc", "ddd", limit=30)
         content = self.ctx_file.read_text()
         assert content.startswith(">>>") or content == ""
 
-    def test_no_trim_at_exact_limit(self, monkeypatch):
+    def test_no_trim_at_exact_limit(self):
         entry = ">>> X\nY\n"
-        monkeypatch.setattr(l9m, "CONTEXT_LIMIT", len(entry))
-        l9m._append_context("X", "Y")
+        l9m._append_context("X", "Y", limit=len(entry))
         content = self.ctx_file.read_text()
         assert content == entry
 
-    def test_extremely_small_limit(self, monkeypatch):
-        monkeypatch.setattr(l9m, "CONTEXT_LIMIT", 1)
-        l9m._append_context("hello", "world")
+    def test_extremely_small_limit(self):
+        l9m._append_context("hello", "world", limit=1)
         content = self.ctx_file.read_text()
         assert isinstance(content, str)
 
@@ -442,7 +490,7 @@ class TestChat:
         ctx_dir.mkdir()
         monkeypatch.setattr(l9m, "CONTEXT_DIR", ctx_dir)
         monkeypatch.setattr(l9m, "CONTEXT_FILE", ctx_dir / "context.txt")
-        monkeypatch.setattr(l9m, "CONTEXT_LIMIT", 10000)
+        monkeypatch.setattr(l9m, "resolve_context_limit", lambda m: 10000)
         self.ctx_dir = ctx_dir
         self.ctx_file = ctx_dir / "context.txt"
 

--- a/apps/l9m/tests/test_l9m.py
+++ b/apps/l9m/tests/test_l9m.py
@@ -431,3 +431,158 @@ class TestRollingContext:
         monkeypatch.setattr("sys.stdin", type("FakeStdin", (), {"isatty": lambda self: True, "read": lambda self: ""})())
         l9m.main(["-c", str(ctx), "-p", "q"])
         assert not self.ctx_file.exists()
+
+
+# ---------- chat mode ----------
+
+class TestChat:
+    @pytest.fixture(autouse=True)
+    def _isolate_context(self, tmp_path, monkeypatch):
+        ctx_dir = tmp_path / "l9m"
+        ctx_dir.mkdir()
+        monkeypatch.setattr(l9m, "CONTEXT_DIR", ctx_dir)
+        monkeypatch.setattr(l9m, "CONTEXT_FILE", ctx_dir / "context.txt")
+        monkeypatch.setattr(l9m, "CONTEXT_LIMIT", 10000)
+        self.ctx_dir = ctx_dir
+        self.ctx_file = ctx_dir / "context.txt"
+
+    @pytest.fixture(autouse=True)
+    def _isolate_model(self, monkeypatch):
+        monkeypatch.setenv("MODEL", "fake")
+        monkeypatch.setattr(l9m, "_ollama_running", lambda: True)
+        monkeypatch.setattr("sys.stdin", type("FakeStdin", (), {"isatty": lambda self: True, "read": lambda self: ""})())
+
+    def test_one_prompt_then_exit(self, monkeypatch):
+        inputs = iter(["hello", "exit"])
+        monkeypatch.setattr("builtins.input", lambda prompt="": next(inputs))
+        captured = []
+
+        def mock_generate(model, prompt, stream=None):
+            captured.append(prompt)
+            return "hi there"
+
+        monkeypatch.setattr(l9m, "generate", mock_generate)
+        result = l9m.main(["--chat"])
+        assert result == 0
+        assert len(captured) == 1
+        assert "hello" in captured[0]
+
+    def test_multiple_turns_accumulate_context(self, monkeypatch):
+        inputs = iter(["first question", "second question", "quit"])
+        monkeypatch.setattr("builtins.input", lambda prompt="": next(inputs))
+        captured = []
+
+        def mock_generate(model, prompt, stream=None):
+            captured.append(prompt)
+            if len(captured) == 1:
+                return "first answer"
+            return "second answer"
+
+        monkeypatch.setattr(l9m, "generate", mock_generate)
+        l9m.main(["--chat"])
+        assert len(captured) == 2
+        assert "first question" in captured[1]
+        assert "first answer" in captured[1]
+
+    def test_quit_terminates(self, monkeypatch):
+        inputs = iter(["quit"])
+        monkeypatch.setattr("builtins.input", lambda prompt="": next(inputs))
+        monkeypatch.setattr(l9m, "generate", lambda m, p, stream=None: "x")
+        result = l9m.main(["--chat"])
+        assert result == 0
+
+    def test_exit_terminates(self, monkeypatch):
+        inputs = iter(["exit"])
+        monkeypatch.setattr("builtins.input", lambda prompt="": next(inputs))
+        monkeypatch.setattr(l9m, "generate", lambda m, p, stream=None: "x")
+        result = l9m.main(["--chat"])
+        assert result == 0
+
+    def test_eof_terminates_cleanly(self, monkeypatch):
+        def raise_eof(prompt=""):
+            raise EOFError
+
+        monkeypatch.setattr("builtins.input", raise_eof)
+        monkeypatch.setattr(l9m, "generate", lambda m, p, stream=None: "x")
+        result = l9m.main(["--chat"])
+        assert result == 0
+
+    def test_empty_lines_skipped(self, monkeypatch):
+        inputs = iter(["", "  ", "actual prompt", "quit"])
+        monkeypatch.setattr("builtins.input", lambda prompt="": next(inputs))
+        captured = []
+
+        def mock_generate(model, prompt, stream=None):
+            captured.append(prompt)
+            return "response"
+
+        monkeypatch.setattr(l9m, "generate", mock_generate)
+        l9m.main(["--chat"])
+        assert len(captured) == 1
+        assert "actual prompt" in captured[0]
+
+    def test_type_flag_respected(self, monkeypatch):
+        inputs = iter(["list files", "exit"])
+        monkeypatch.setattr("builtins.input", lambda prompt="": next(inputs))
+        captured = []
+
+        def mock_generate(model, prompt, stream=None):
+            captured.append(prompt)
+            return "ls -la"
+
+        monkeypatch.setattr(l9m, "generate", mock_generate)
+        l9m.main(["--chat", "-t", "bash"])
+        assert len(captured) == 1
+        assert "ONLY with the bash command" in captured[0]
+
+    def test_instruction_flag_respected(self, monkeypatch):
+        inputs = iter(["do something", "exit"])
+        monkeypatch.setattr("builtins.input", lambda prompt="": next(inputs))
+        captured = []
+
+        def mock_generate(model, prompt, stream=None):
+            captured.append(prompt)
+            return "done"
+
+        monkeypatch.setattr(l9m, "generate", mock_generate)
+        l9m.main(["--chat", "-i", "be concise"])
+        assert len(captured) == 1
+        assert "be concise" in captured[0]
+
+    def test_keyboard_interrupt_on_input_exits(self, monkeypatch):
+        call_count = [0]
+
+        def interrupt_input(prompt=""):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise KeyboardInterrupt
+
+        monkeypatch.setattr("builtins.input", interrupt_input)
+        monkeypatch.setattr(l9m, "generate", lambda m, p, stream=None: "resp")
+        result = l9m.main(["--chat"])
+        assert result == 0
+
+    def test_keyboard_interrupt_during_generate_continues(self, monkeypatch):
+        inputs = iter(["hello", "world", "quit"])
+        monkeypatch.setattr("builtins.input", lambda prompt="": next(inputs))
+        call_count = [0]
+
+        def mock_generate(model, prompt, stream=None):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise KeyboardInterrupt
+            return "response"
+
+        monkeypatch.setattr(l9m, "generate", mock_generate)
+        result = l9m.main(["--chat"])
+        assert result == 0
+        assert call_count[0] == 2
+
+    def test_context_persists_to_file(self, monkeypatch):
+        inputs = iter(["remember this", "quit"])
+        monkeypatch.setattr("builtins.input", lambda prompt="": next(inputs))
+        monkeypatch.setattr(l9m, "generate", lambda m, p, stream=None: "noted")
+        l9m.main(["--chat"])
+        content = self.ctx_file.read_text()
+        assert ">>> remember this" in content
+        assert "noted" in content

--- a/apps/l9m/tests/test_l9m.py
+++ b/apps/l9m/tests/test_l9m.py
@@ -101,6 +101,54 @@ class TestResolveModel:
         assert l9m.resolve_model() == "cached-model"
 
 
+# ---------- _model_num_ctx ----------
+
+class TestModelNumCtx:
+    def test_extracts_context_length(self, monkeypatch):
+        import json
+        fake_resp = json.dumps({
+            "model_info": {"qwen2.context_length": 32768}
+        }).encode()
+
+        class FakeResp:
+            def read(self): return fake_resp
+            def __enter__(self): return self
+            def __exit__(self, *a): pass
+
+        monkeypatch.setattr(l9m.urllib.request, "urlopen", lambda *a, **kw: FakeResp())
+        assert l9m._model_num_ctx("qwen3:7b") == 32768
+
+    def test_returns_none_on_missing_key(self, monkeypatch):
+        import json
+        fake_resp = json.dumps({"model_info": {"other_key": 999}}).encode()
+
+        class FakeResp:
+            def read(self): return fake_resp
+            def __enter__(self): return self
+            def __exit__(self, *a): pass
+
+        monkeypatch.setattr(l9m.urllib.request, "urlopen", lambda *a, **kw: FakeResp())
+        assert l9m._model_num_ctx("qwen3:7b") is None
+
+    def test_returns_none_on_network_error(self, monkeypatch):
+        def boom(*a, **kw):
+            raise OSError("timeout")
+        monkeypatch.setattr(l9m.urllib.request, "urlopen", boom)
+        assert l9m._model_num_ctx("qwen3:7b") is None
+
+    def test_returns_none_on_empty_response(self, monkeypatch):
+        import json
+        fake_resp = json.dumps({}).encode()
+
+        class FakeResp:
+            def read(self): return fake_resp
+            def __enter__(self): return self
+            def __exit__(self, *a): pass
+
+        monkeypatch.setattr(l9m.urllib.request, "urlopen", lambda *a, **kw: FakeResp())
+        assert l9m._model_num_ctx("qwen3:7b") is None
+
+
 # ---------- resolve_context_limit ----------
 
 class TestResolveContextLimit:
@@ -349,60 +397,60 @@ class TestRollingContext:
         self.ctx_file = ctx_dir / "context.txt"
 
     def test_read_empty_when_no_file(self):
-        assert l9m._read_context() == ""
+        assert l9m.read_context() == ""
 
     def test_append_creates_file(self):
-        l9m._append_context("hello", "world")
+        l9m.append_context("hello", "world")
         assert self.ctx_file.exists()
         content = self.ctx_file.read_text()
         assert ">>> hello" in content
         assert "world" in content
 
     def test_append_accumulates(self):
-        l9m._append_context("q1", "a1")
-        l9m._append_context("q2", "a2")
+        l9m.append_context("q1", "a1")
+        l9m.append_context("q2", "a2")
         content = self.ctx_file.read_text()
         assert ">>> q1" in content
         assert ">>> q2" in content
 
     def test_rolling_window_trims(self):
-        l9m._append_context("first question", "first answer", limit=50)
-        l9m._append_context("second question", "second answer", limit=50)
+        l9m.append_context("first question", "first answer", limit=50)
+        l9m.append_context("second question", "second answer", limit=50)
         content = self.ctx_file.read_text()
         assert len(content) <= 50
         assert ">>> second question" in content
         assert ">>> first question" not in content
 
     def test_trim_at_line_boundary(self):
-        l9m._append_context("aaa", "bbb", limit=30)
-        l9m._append_context("ccc", "ddd", limit=30)
+        l9m.append_context("aaa", "bbb", limit=30)
+        l9m.append_context("ccc", "ddd", limit=30)
         content = self.ctx_file.read_text()
         assert content.startswith(">>>") or content == ""
 
     def test_no_trim_at_exact_limit(self):
         entry = ">>> X\nY\n"
-        l9m._append_context("X", "Y", limit=len(entry))
+        l9m.append_context("X", "Y", limit=len(entry))
         content = self.ctx_file.read_text()
         assert content == entry
 
     def test_extremely_small_limit(self):
-        l9m._append_context("hello", "world", limit=1)
+        l9m.append_context("hello", "world", limit=1)
         content = self.ctx_file.read_text()
         assert isinstance(content, str)
 
     def test_empty_prompt_and_response(self):
-        l9m._append_context("", "")
+        l9m.append_context("", "")
         content = self.ctx_file.read_text()
         assert ">>> \n\n" in content
 
     def test_multiline_content(self):
-        l9m._append_context("line1\nline2", "resp\nwith\nnewlines")
+        l9m.append_context("line1\nline2", "resp\nwith\nnewlines")
         content = self.ctx_file.read_text()
         assert ">>> line1\nline2" in content
         assert "resp\nwith\nnewlines" in content
 
     def test_unicode_roundtrip(self):
-        l9m._append_context("café \U0001f680", "你好世界")
+        l9m.append_context("café \U0001f680", "你好世界")
         content = self.ctx_file.read_text()
         assert "\U0001f680" in content
         assert "你好" in content
@@ -412,7 +460,7 @@ class TestRollingContext:
             raise PermissionError("denied")
         self.ctx_file.write_text("data")
         monkeypatch.setattr(l9m.CONTEXT_FILE.__class__, "read_text", raise_perm)
-        assert l9m._read_context() == ""
+        assert l9m.read_context() == ""
 
     def test_stdin_not_stored_in_context(self, monkeypatch):
         monkeypatch.setenv("MODEL", "fake")
@@ -429,7 +477,7 @@ class TestRollingContext:
         monkeypatch.setenv("MODEL", "fake")
         monkeypatch.setattr(l9m, "_ollama_running", lambda: True)
         # Pre-populate context
-        l9m._append_context("earlier question", "earlier answer")
+        l9m.append_context("earlier question", "earlier answer")
 
         captured = {}
 
@@ -447,7 +495,7 @@ class TestRollingContext:
         monkeypatch.setenv("MODEL", "fake")
         monkeypatch.setattr(l9m, "_ollama_running", lambda: True)
         # Pre-populate rolling context
-        l9m._append_context("rolling stuff", "rolling response")
+        l9m.append_context("rolling stuff", "rolling response")
 
         ctx = tmp_path / "explicit.txt"
         ctx.write_text("explicit context here")

--- a/apps/l9m/tests/test_l9m.py
+++ b/apps/l9m/tests/test_l9m.py
@@ -138,19 +138,26 @@ class TestAssemblePrompt:
         assert result.endswith("question")
         assert "<Memories>" in result
 
-    def test_type_without_instruction_still_plain(self):
-        # If instruction is empty, type alone doesn't trigger framing
+    def test_type_without_instruction_uses_default_framing(self):
         result = l9m.assemble_prompt("hello", "bash", "", "")
-        assert result == "hello"
+        assert "Answer ONLY with the bash command" in result
+        assert "Answer:" in result
 
-    def test_instruction_without_type_still_plain(self):
+    def test_instruction_without_type_uses_instruction(self):
         result = l9m.assemble_prompt("hello", "", "do stuff", "")
-        assert result == "hello"
+        assert "INSTRUCTION: do stuff:" in result
+        assert "<Prompt>hello</Prompt>" in result
 
 
 # ---------- main (argument parsing) ----------
 
 class TestMain:
+    @pytest.fixture(autouse=True)
+    def _isolate_context(self, tmp_path, monkeypatch):
+        ctx_dir = tmp_path / "l9m"
+        monkeypatch.setattr(l9m, "CONTEXT_DIR", ctx_dir)
+        monkeypatch.setattr(l9m, "CONTEXT_FILE", ctx_dir / "context.txt")
+
     def test_help_returns_zero(self, capsys):
         assert l9m.main(["--help"]) == 0
         out = capsys.readouterr().out
@@ -170,7 +177,7 @@ class TestMain:
     def test_context_file_not_found(self, tmp_path, monkeypatch, capsys):
         monkeypatch.setenv("MODEL", "fake")
         monkeypatch.setattr(l9m, "_ollama_running", lambda: True)
-        monkeypatch.setattr(l9m, "generate", lambda m, p, silent=False: "")
+        monkeypatch.setattr(l9m, "generate", lambda m, p, stream=None: "")
         monkeypatch.setattr("sys.stdin", type("FakeStdin", (), {"isatty": lambda self: True, "read": lambda self: ""})())
         result = l9m.main(["-c", str(tmp_path / "nope.txt"), "-p", "hi"])
         assert result == 2
@@ -180,7 +187,7 @@ class TestMain:
         monkeypatch.setattr(l9m, "_ollama_running", lambda: True)
         captured = {}
 
-        def mock_generate(model, prompt, silent=False):
+        def mock_generate(model, prompt, stream=None):
             captured["prompt"] = prompt
             return ""
 
@@ -195,7 +202,7 @@ class TestMain:
         monkeypatch.setattr(l9m, "_ollama_running", lambda: True)
         captured = {}
 
-        def mock_generate(model, prompt, silent=False):
+        def mock_generate(model, prompt, stream=None):
             captured["prompt"] = prompt
             return ""
 
@@ -209,7 +216,7 @@ class TestMain:
     def test_echo_flag_prints_prompt(self, monkeypatch, capsys):
         monkeypatch.setenv("MODEL", "fake")
         monkeypatch.setattr(l9m, "_ollama_running", lambda: True)
-        monkeypatch.setattr(l9m, "generate", lambda m, p, silent=False: "")
+        monkeypatch.setattr(l9m, "generate", lambda m, p, stream=None: "")
         monkeypatch.setattr("sys.stdin", type("FakeStdin", (), {"isatty": lambda self: True, "read": lambda self: ""})())
         l9m.main(["-e", "-p", "test prompt"])
         out = capsys.readouterr().out
@@ -220,7 +227,7 @@ class TestMain:
         monkeypatch.setattr(l9m, "_ollama_running", lambda: True)
         captured = {}
 
-        def mock_generate(model, prompt, silent=False):
+        def mock_generate(model, prompt, stream=None):
             captured["prompt"] = prompt
             return ""
 
@@ -261,3 +268,166 @@ class TestInstalledQwenModels:
             raise ConnectionError("no ollama")
         monkeypatch.setattr(l9m.urllib.request, "urlopen", boom)
         assert l9m._installed_qwen_models() == []
+
+
+# ---------- rolling context ----------
+
+class TestRollingContext:
+    @pytest.fixture(autouse=True)
+    def _isolate_context(self, tmp_path, monkeypatch):
+        ctx_dir = tmp_path / "l9m"
+        ctx_dir.mkdir()
+        monkeypatch.setattr(l9m, "CONTEXT_DIR", ctx_dir)
+        monkeypatch.setattr(l9m, "CONTEXT_FILE", ctx_dir / "context.txt")
+        monkeypatch.setattr(l9m, "CONTEXT_LIMIT", 10000)
+        self.ctx_dir = ctx_dir
+        self.ctx_file = ctx_dir / "context.txt"
+
+    def test_read_empty_when_no_file(self):
+        assert l9m._read_context() == ""
+
+    def test_append_creates_file(self):
+        l9m._append_context("hello", "world")
+        assert self.ctx_file.exists()
+        content = self.ctx_file.read_text()
+        assert ">>> hello" in content
+        assert "world" in content
+
+    def test_append_accumulates(self):
+        l9m._append_context("q1", "a1")
+        l9m._append_context("q2", "a2")
+        content = self.ctx_file.read_text()
+        assert ">>> q1" in content
+        assert ">>> q2" in content
+
+    def test_rolling_window_trims(self, monkeypatch):
+        monkeypatch.setattr(l9m, "CONTEXT_LIMIT", 50)
+        l9m._append_context("first question", "first answer")
+        l9m._append_context("second question", "second answer")
+        content = self.ctx_file.read_text()
+        assert len(content) <= 50
+        assert ">>> second question" in content
+        assert ">>> first question" not in content
+
+    def test_trim_at_line_boundary(self, monkeypatch):
+        monkeypatch.setattr(l9m, "CONTEXT_LIMIT", 30)
+        l9m._append_context("aaa", "bbb")
+        l9m._append_context("ccc", "ddd")
+        content = self.ctx_file.read_text()
+        assert content.startswith(">>>") or content == ""
+
+    def test_no_trim_at_exact_limit(self, monkeypatch):
+        entry = ">>> X\nY\n"
+        monkeypatch.setattr(l9m, "CONTEXT_LIMIT", len(entry))
+        l9m._append_context("X", "Y")
+        content = self.ctx_file.read_text()
+        assert content == entry
+
+    def test_extremely_small_limit(self, monkeypatch):
+        monkeypatch.setattr(l9m, "CONTEXT_LIMIT", 1)
+        l9m._append_context("hello", "world")
+        content = self.ctx_file.read_text()
+        assert isinstance(content, str)
+
+    def test_empty_prompt_and_response(self):
+        l9m._append_context("", "")
+        content = self.ctx_file.read_text()
+        assert ">>> \n\n" in content
+
+    def test_multiline_content(self):
+        l9m._append_context("line1\nline2", "resp\nwith\nnewlines")
+        content = self.ctx_file.read_text()
+        assert ">>> line1\nline2" in content
+        assert "resp\nwith\nnewlines" in content
+
+    def test_unicode_roundtrip(self):
+        l9m._append_context("café \U0001f680", "你好世界")
+        content = self.ctx_file.read_text()
+        assert "\U0001f680" in content
+        assert "你好" in content
+
+    def test_read_context_unreadable_file(self, monkeypatch):
+        def raise_perm(*a, **kw):
+            raise PermissionError("denied")
+        self.ctx_file.write_text("data")
+        monkeypatch.setattr(l9m.CONTEXT_FILE.__class__, "read_text", raise_perm)
+        assert l9m._read_context() == ""
+
+    def test_stdin_not_stored_in_context(self, monkeypatch):
+        monkeypatch.setenv("MODEL", "fake")
+        monkeypatch.setattr(l9m, "_ollama_running", lambda: True)
+        monkeypatch.setattr(l9m, "generate", lambda m, p, stream=None: "resp")
+        monkeypatch.setattr("sys.stdin", type("FakeStdin", (), {
+            "isatty": lambda self: False,
+            "read": lambda self: "big piped document content",
+        })())
+        l9m.main([])
+        assert not self.ctx_file.exists()
+
+    def test_context_injected_into_prompt(self, monkeypatch):
+        monkeypatch.setenv("MODEL", "fake")
+        monkeypatch.setattr(l9m, "_ollama_running", lambda: True)
+        # Pre-populate context
+        l9m._append_context("earlier question", "earlier answer")
+
+        captured = {}
+
+        def mock_generate(model, prompt, stream=None):
+            captured["prompt"] = prompt
+            return "response"
+
+        monkeypatch.setattr(l9m, "generate", mock_generate)
+        monkeypatch.setattr("sys.stdin", type("FakeStdin", (), {"isatty": lambda self: True, "read": lambda self: ""})())
+        l9m.main(["-p", "new question"])
+        assert "earlier question" in captured["prompt"]
+        assert "earlier answer" in captured["prompt"]
+
+    def test_context_file_overrides_rolling(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("MODEL", "fake")
+        monkeypatch.setattr(l9m, "_ollama_running", lambda: True)
+        # Pre-populate rolling context
+        l9m._append_context("rolling stuff", "rolling response")
+
+        ctx = tmp_path / "explicit.txt"
+        ctx.write_text("explicit context here")
+
+        captured = {}
+
+        def mock_generate(model, prompt, stream=None):
+            captured["prompt"] = prompt
+            return "response"
+
+        monkeypatch.setattr(l9m, "generate", mock_generate)
+        monkeypatch.setattr("sys.stdin", type("FakeStdin", (), {"isatty": lambda self: True, "read": lambda self: ""})())
+        l9m.main(["-c", str(ctx), "-p", "new question"])
+        assert "explicit context here" in captured["prompt"]
+        assert "rolling stuff" not in captured["prompt"]
+
+    def test_response_appended_after_generation(self, monkeypatch):
+        monkeypatch.setenv("MODEL", "fake")
+        monkeypatch.setattr(l9m, "_ollama_running", lambda: True)
+
+        def mock_generate(model, prompt, stream=None):
+            return "generated response"
+
+        monkeypatch.setattr(l9m, "generate", mock_generate)
+        monkeypatch.setattr("sys.stdin", type("FakeStdin", (), {"isatty": lambda self: True, "read": lambda self: ""})())
+        l9m.main(["-p", "my question"])
+        content = self.ctx_file.read_text()
+        assert ">>> my question" in content
+        assert "generated response" in content
+
+    def test_no_append_when_context_file_used(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("MODEL", "fake")
+        monkeypatch.setattr(l9m, "_ollama_running", lambda: True)
+
+        ctx = tmp_path / "explicit.txt"
+        ctx.write_text("stuff")
+
+        def mock_generate(model, prompt, stream=None):
+            return "response"
+
+        monkeypatch.setattr(l9m, "generate", mock_generate)
+        monkeypatch.setattr("sys.stdin", type("FakeStdin", (), {"isatty": lambda self: True, "read": lambda self: ""})())
+        l9m.main(["-c", str(ctx), "-p", "q"])
+        assert not self.ctx_file.exists()

--- a/apps/l9m/tests/test_l9m.py
+++ b/apps/l9m/tests/test_l9m.py
@@ -147,6 +147,19 @@ class TestResolveContextLimit:
         out = capsys.readouterr().out.strip()
         assert out == "24576"
 
+    def test_clear_flag_removes_context(self, tmp_path, monkeypatch):
+        ctx_dir = tmp_path / "l9m"
+        ctx_dir.mkdir()
+        ctx_file = ctx_dir / "context.txt"
+        ctx_file.write_text(">>> old\nstuff\n")
+        monkeypatch.setattr(l9m, "CONTEXT_FILE", ctx_file)
+        assert l9m.main(["--clear"]) == 0
+        assert not ctx_file.exists()
+
+    def test_clear_flag_no_error_when_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(l9m, "CONTEXT_FILE", tmp_path / "nope.txt")
+        assert l9m.main(["--clear"]) == 0
+
 
 # ---------- assemble_prompt ----------
 

--- a/apps/q3w/q3w.py
+++ b/apps/q3w/q3w.py
@@ -82,7 +82,10 @@ the LLM must produce a program — it doesn't get to speak directly""")
         print(f"error: {e}", file=sys.stderr)
         return 1
 
-    full_prompt = l9m.assemble_prompt(prompt, "bash", instruction, "")
+    context_limit = l9m.resolve_context_limit(model)
+    rolling = l9m._read_context()
+    context = f"<Memories>\n{rolling}\n</Memories>" if rolling else ""
+    full_prompt = l9m.assemble_prompt(prompt, "bash", instruction, context)
 
     try:
         output = l9m.generate(model, full_prompt, stream=None)
@@ -94,6 +97,8 @@ the LLM must produce a program — it doesn't get to speak directly""")
     if not cmd:
         print("error: LLM produced empty output", file=sys.stderr)
         return 1
+
+    l9m._append_context(prompt, cmd, context_limit)
 
     # Always show what's about to run
     is_tty = sys.stderr.isatty()

--- a/apps/q3w/q3w.py
+++ b/apps/q3w/q3w.py
@@ -36,7 +36,7 @@ def _looks_dangerous(cmd: str, model: str) -> bool:
     try:
         answer = l9m.generate(model, check_prompt, stream=None)
     except l9m.L9mError:
-        return False
+        return True
     return answer.strip().upper().startswith("YES")
 
 
@@ -83,7 +83,7 @@ the LLM must produce a program — it doesn't get to speak directly""")
         return 1
 
     context_limit = l9m.resolve_context_limit(model)
-    rolling = l9m._read_context()
+    rolling = l9m.read_context()
     context = f"<Memories>\n{rolling}\n</Memories>" if rolling else ""
     full_prompt = l9m.assemble_prompt(prompt, "bash", instruction, context)
 
@@ -106,7 +106,7 @@ the LLM must produce a program — it doesn't get to speak directly""")
         print(f"$ {cmd}", file=sys.stderr)
 
     if dry_run:
-        l9m._append_context(prompt, cmd, context_limit)
+        l9m.append_context(prompt, cmd, context_limit)
         print(cmd)
         return 0
 
@@ -135,26 +135,40 @@ the LLM must produce a program — it doesn't get to speak directly""")
                 print("aborted", file=sys.stderr)
                 return 130
 
-    proc = subprocess.run(
+    MAX_CONTEXT_LINES = 20
+
+    proc = subprocess.Popen(
         [shell, "-c", cmd],
-        capture_output=True, text=True,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        text=True, errors="replace",
     )
 
-    if proc.stdout:
-        sys.stdout.write(proc.stdout)
-    if proc.stderr:
-        sys.stderr.write(proc.stderr)
+    stdout_lines: list[str] = []
+    stderr_lines: list[str] = []
 
-    output_lines = []
-    for line in (proc.stdout or "").splitlines():
-        output_lines.append(f"STDOUT: {line}")
-    for line in (proc.stderr or "").splitlines():
-        output_lines.append(f"STDERR: {line}")
-    if output_lines:
-        result_text = cmd + "\n" + "\n".join(output_lines)
-    else:
-        result_text = cmd
-    l9m._append_context(prompt, result_text, context_limit)
+    # Stream stdout in real-time
+    for line in (proc.stdout or []):
+        sys.stdout.write(line)
+        sys.stdout.flush()
+        stdout_lines.append(line.rstrip("\n"))
+
+    # Collect stderr after stdout closes
+    for line in (proc.stderr or []):
+        sys.stderr.write(line)
+        stderr_lines.append(line.rstrip("\n"))
+
+    proc.wait()
+
+    context_lines = []
+    for line in stdout_lines[:MAX_CONTEXT_LINES]:
+        context_lines.append(f"STDOUT: {line}")
+    if len(stdout_lines) > MAX_CONTEXT_LINES:
+        context_lines.append(f"[...{len(stdout_lines) - MAX_CONTEXT_LINES} lines truncated]")
+    for line in stderr_lines[:MAX_CONTEXT_LINES]:
+        context_lines.append(f"STDERR: {line}")
+
+    result_text = cmd if not context_lines else cmd + "\n" + "\n".join(context_lines)
+    l9m.append_context(prompt, result_text, context_limit)
 
     return proc.returncode
 

--- a/apps/q3w/q3w.py
+++ b/apps/q3w/q3w.py
@@ -98,8 +98,6 @@ the LLM must produce a program — it doesn't get to speak directly""")
         print("error: LLM produced empty output", file=sys.stderr)
         return 1
 
-    l9m._append_context(prompt, cmd, context_limit)
-
     # Always show what's about to run
     is_tty = sys.stderr.isatty()
     if is_tty:
@@ -108,6 +106,7 @@ the LLM must produce a program — it doesn't get to speak directly""")
         print(f"$ {cmd}", file=sys.stderr)
 
     if dry_run:
+        l9m._append_context(prompt, cmd, context_limit)
         print(cmd)
         return 0
 
@@ -136,7 +135,28 @@ the LLM must produce a program — it doesn't get to speak directly""")
                 print("aborted", file=sys.stderr)
                 return 130
 
-    return subprocess.call([shell, "-c", cmd])
+    proc = subprocess.run(
+        [shell, "-c", cmd],
+        capture_output=True, text=True,
+    )
+
+    if proc.stdout:
+        sys.stdout.write(proc.stdout)
+    if proc.stderr:
+        sys.stderr.write(proc.stderr)
+
+    output_lines = []
+    for line in (proc.stdout or "").splitlines():
+        output_lines.append(f"STDOUT: {line}")
+    for line in (proc.stderr or "").splitlines():
+        output_lines.append(f"STDERR: {line}")
+    if output_lines:
+        result_text = cmd + "\n" + "\n".join(output_lines)
+    else:
+        result_text = cmd
+    l9m._append_context(prompt, result_text, context_limit)
+
+    return proc.returncode
 
 
 if __name__ == "__main__":

--- a/apps/q3w/tests/test_q3w.py
+++ b/apps/q3w/tests/test_q3w.py
@@ -1,0 +1,133 @@
+"""Tests for q3w — NLP to bash command generation and execution."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_PKG_DIR = Path(__file__).resolve().parent.parent
+_L9M_DIR = _PKG_DIR.parent / "l9m"
+sys.path.insert(0, str(_PKG_DIR))
+sys.path.insert(0, str(_L9M_DIR))
+
+import l9m
+import q3w
+
+
+class TestQ3w:
+    @pytest.fixture(autouse=True)
+    def _isolate(self, tmp_path, monkeypatch):
+        ctx_dir = tmp_path / "l9m"
+        ctx_dir.mkdir()
+        monkeypatch.setattr(l9m, "CONTEXT_DIR", ctx_dir)
+        monkeypatch.setattr(l9m, "CONTEXT_FILE", ctx_dir / "context.txt")
+        monkeypatch.setattr(l9m, "resolve_context_limit", lambda m: 10000)
+        monkeypatch.setenv("MODEL", "fake")
+        monkeypatch.setattr(l9m, "_ollama_running", lambda: True)
+        self.ctx_file = ctx_dir / "context.txt"
+
+    def test_help_returns_zero(self, monkeypatch, capsys):
+        monkeypatch.setattr("sys.argv", ["q3w", "--help"])
+        assert q3w.main() == 0
+        assert "NLP to bash" in capsys.readouterr().out
+
+    def test_no_words_returns_one(self, monkeypatch, capsys):
+        monkeypatch.setattr("sys.argv", ["q3w", "-n"])
+        assert q3w.main() == 1
+
+    def test_dry_run_prints_command(self, monkeypatch, capsys):
+        monkeypatch.setattr("sys.argv", ["q3w", "-n", "list", "files"])
+        monkeypatch.setattr(l9m, "generate", lambda m, p, stream=None: "ls -la")
+        assert q3w.main() == 0
+        assert "ls -la" in capsys.readouterr().out
+
+    def test_dry_run_stores_context(self, monkeypatch, capsys):
+        monkeypatch.setattr("sys.argv", ["q3w", "-n", "list", "files"])
+        monkeypatch.setattr(l9m, "generate", lambda m, p, stream=None: "ls -la")
+        q3w.main()
+        content = self.ctx_file.read_text()
+        assert ">>> list files" in content
+        assert "ls -la" in content
+
+    def test_execution_stores_stdout_in_context(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["q3w", "say", "hello"])
+        monkeypatch.setattr(l9m, "generate", lambda m, p, stream=None: "echo hello")
+        monkeypatch.setattr(q3w, "_looks_dangerous", lambda cmd, model: False)
+        q3w.main()
+        content = self.ctx_file.read_text()
+        assert "STDOUT: hello" in content
+
+    def test_execution_stores_stderr_in_context(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["q3w", "warn"])
+        monkeypatch.setattr(l9m, "generate", lambda m, p, stream=None: "echo oops >&2")
+        monkeypatch.setattr(q3w, "_looks_dangerous", lambda cmd, model: False)
+        q3w.main()
+        content = self.ctx_file.read_text()
+        assert "STDERR: oops" in content
+
+    def test_reads_rolling_context(self, monkeypatch):
+        l9m.append_context("previous", "prev_cmd")
+        captured = {}
+
+        def mock_generate(model, prompt, stream=None):
+            captured["prompt"] = prompt
+            return "echo hi"
+
+        monkeypatch.setattr(l9m, "generate", mock_generate)
+        monkeypatch.setattr("sys.argv", ["q3w", "-n", "next"])
+        q3w.main()
+        assert "previous" in captured["prompt"]
+
+    def test_empty_output_returns_one(self, monkeypatch, capsys):
+        monkeypatch.setattr("sys.argv", ["q3w", "do", "stuff"])
+        monkeypatch.setattr(l9m, "generate", lambda m, p, stream=None: "   ")
+        assert q3w.main() == 1
+        assert "empty output" in capsys.readouterr().err
+
+    def test_invalid_syntax_returns_two(self, monkeypatch, capsys):
+        monkeypatch.setattr("sys.argv", ["q3w", "bad"])
+        monkeypatch.setattr(l9m, "generate", lambda m, p, stream=None: "if then fi done")
+        monkeypatch.setattr(q3w, "_looks_dangerous", lambda cmd, model: False)
+        assert q3w.main() == 2
+
+    def test_invalid_syntax_no_context_stored(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["q3w", "bad"])
+        monkeypatch.setattr(l9m, "generate", lambda m, p, stream=None: "if then fi done")
+        monkeypatch.setattr(q3w, "_looks_dangerous", lambda cmd, model: False)
+        q3w.main()
+        assert not self.ctx_file.exists()
+
+    def test_force_skips_danger_prompt(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["q3w", "-f", "delete"])
+        monkeypatch.setattr(l9m, "generate", lambda m, p, stream=None: "echo safe")
+        monkeypatch.setattr(q3w, "_looks_dangerous", lambda cmd, model: True)
+        assert q3w.main() == 0
+
+    def test_safety_check_fails_closed(self, monkeypatch):
+        """If LLM is unreachable during safety check, treat as dangerous."""
+        monkeypatch.setattr("sys.argv", ["q3w", "delete"])
+        monkeypatch.setattr(l9m, "generate", lambda m, p, stream=None: "rm -rf /")
+
+        call_count = [0]
+        def generate_that_fails_on_safety(model, prompt, stream=None):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return "rm -rf /"
+            raise l9m.L9mError("unreachable")
+
+        monkeypatch.setattr(l9m, "generate", generate_that_fails_on_safety)
+        monkeypatch.setattr("builtins.input", lambda p: "n")
+        assert q3w.main() == 130
+
+    def test_output_capped_at_20_lines(self, monkeypatch):
+        long_output = "\n".join(f"line{i}" for i in range(50))
+        monkeypatch.setattr("sys.argv", ["q3w", "many", "lines"])
+        monkeypatch.setattr(l9m, "generate",
+                            lambda m, p, stream=None: f"printf '{long_output}'")
+        monkeypatch.setattr(q3w, "_looks_dangerous", lambda cmd, model: False)
+        q3w.main()
+        content = self.ctx_file.read_text()
+        stdout_lines = [l for l in content.splitlines() if l.startswith("STDOUT:")]
+        assert len(stdout_lines) <= 20
+        assert "truncated" in content


### PR DESCRIPTION
## Summary
- l9m now maintains a sliding window of prompt+response pairs in `~/.cache/l9m/context.txt`
- Gives the LLM conversational memory across invocations with no explicit flag
- Default 10k char limit, configurable via `L9M_CONTEXT_DIR` and `L9M_CONTEXT_LIMIT` env vars
- `-c/--context` overrides rolling context (explicit wins)
- Piped stdin is not stored in context (avoids flooding with large docs)
- Also fixes `-t/--type` working without `-i/--instruction`

## Test plan
- [x] 49 unit tests pass (16 new tests for rolling context)
- [ ] Manual: `l9m -p "my name is Alice"` then `l9m -p "what is my name?"` confirms memory
- [ ] Manual: `l9m -c somefile.txt -p "question"` does NOT append to rolling context
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)