### PR TITLE
feat(a8s): batch message invoke

### DIFF
--- a/apps/a8s/DEVELOPMENT.md
+++ b/apps/a8s/DEVELOPMENT.md
@@ -7,8 +7,9 @@ Read `README.md` first for concept and usage.
 
 - **`cmd_start` re-execs via `core.ENTRYPOINT`**, not `__file__`.
 - **Argv interpolation** (`$SENDER`, `$RECIPIENT`, `$MESSAGE`, `$TIMESTAMP`,
-  `$AGE`, `$A8S_DIR`) expands via `definitions._expand_argv`. One wake verb
-  — `invoke` — and `build_command(definition, msg)` always reads it.
+  `$AGE`, `$A8S_DIR`) expands via `definitions._expand_argv`. Per-message
+  wakes use `invoke` via `build_command`; batch wakes use `batch.invoke` via
+  `build_batch_command` with message file paths appended as trailing argv.
 - **`core.PRINT_LOCK` is the cross-module log lock.** Only set when
   `daemon.attached_loop` starts.
 - **`run_with_prefix` uses `start_new_session=True`** — don't drop this.

--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -229,6 +229,26 @@ A definition's `idle` block fires `idle.invoke` when the agent has gone `idle.ti
 
 This subsumes the retired `clear` use-case: define an idle invoke that runs whatever your CLI needs to reset session state (e.g. `claude -p "/clear"`).
 
+### Batch invoke (optional)
+
+Agents that can process multiple tells in one subprocess can declare a `batch` block. When **two or more** inbox messages are waiting, a8s wakes once with `batch.invoke` plus the message JSON file paths as trailing argv elements (shell-style — no extra placeholder).
+
+```json
+{
+  "invoke": ["my-agent", "--single", "$SENDER", "$MESSAGE"],
+  "batch": {
+    "invoke": ["my-agent", "--batch"],
+    "limit": 5
+  }
+}
+```
+
+- `batch.invoke` — argv template with the same substitutions as `invoke` / `idle.invoke`.
+- `batch.limit` — max messages per batch wake; defaults to **5**.
+- One waiting message still uses normal `invoke` (unchanged).
+- Paths point at the trashed inbox JSON files (under `~/.a8s/agents/<NAME>/trash/`), appended after the expanded `batch.invoke` argv.
+- Batch argv expansion matches idle: `$RECIPIENT` is the agent's own name; `$SENDER` / `$MESSAGE` / `$TIMESTAMP` / `$AGE` are empty.
+
 ### Recipient transparency
 
 The default definitions follow the opacity rule — `$SENDER tells $RECIPIENT: $MESSAGE` works equally well whether `$RECIPIENT` is an LLM session, a Python script, or (someday) an SMS gateway. Customize at your own risk.

--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -235,6 +235,7 @@ Agents that can process multiple tells in one subprocess can declare a `batch` b
 
 ```json
 {
+  "pause": 3,
   "invoke": ["my-agent", "--single", "$SENDER", "$MESSAGE"],
   "batch": {
     "invoke": ["my-agent", "--batch"],
@@ -243,11 +244,14 @@ Agents that can process multiple tells in one subprocess can declare a `batch` b
 }
 ```
 
+- `pause` — seconds to wait after the first inbox message of a burst before waking. Closely-spaced tells accumulate across handler iterations so `batch` is more likely to fire. `0` or omitted = wake as soon as the loop drains (previous behavior).
 - `batch.invoke` — argv template with the same substitutions as `invoke` / `idle.invoke`.
 - `batch.limit` — max messages per batch wake; defaults to **5**.
 - One waiting message still uses normal `invoke` (unchanged).
 - Paths point at the trashed inbox JSON files (under `~/.a8s/agents/<NAME>/trash/`), appended after the expanded `batch.invoke` argv.
 - Batch argv expansion matches idle: `$RECIPIENT` is the agent's own name; `$SENDER` / `$MESSAGE` / `$TIMESTAMP` / `$AGE` are empty.
+
+Debounce mechanics: on the first inbox message, a8s stamps `~/.a8s/agents/<NAME>/inbox-waiting-since` and skips waking until `pause` seconds elapse. Each loop iteration re-routes outboxes, so messages that arrive during the wait window join the inbox before the wake decision. The stamp clears when the inbox drains or a wake fires.
 
 ### Recipient transparency
 

--- a/apps/a8s/core.py
+++ b/apps/a8s/core.py
@@ -185,6 +185,46 @@ def touch_last_active(name: str, when: datetime | None = None) -> None:
         pass
 
 
+def inbox_waiting_since_path(name: str) -> Path:
+    """When the first inbox message of a burst arrived. `attached_loop` reads
+    this to debounce wakes per `definition.pause` so closely-spaced tells can
+    accumulate before invoke/batch runs."""
+    return agent_dir(name) / "inbox-waiting-since"
+
+
+def read_inbox_waiting_since(name: str) -> datetime | None:
+    p = inbox_waiting_since_path(name)
+    if not p.is_file():
+        return None
+    try:
+        s = p.read_text().strip()
+    except OSError:
+        return None
+    if not s:
+        return None
+    try:
+        return datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def touch_inbox_waiting_since(name: str, when: datetime | None = None) -> None:
+    ts = (when or datetime.now(timezone.utc)).isoformat().replace("+00:00", "Z")
+    p = inbox_waiting_since_path(name)
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(ts)
+    except OSError:
+        pass
+
+
+def clear_inbox_waiting_since(name: str) -> None:
+    try:
+        inbox_waiting_since_path(name).unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
 def pending_dir(name: str) -> Path:
     """Ingested-but-not-yet-fully-routed messages. `route_outboxes` atomically
     moves each new file from `<root>/.outbox/` into here on every pass before

--- a/apps/a8s/daemon.py
+++ b/apps/a8s/daemon.py
@@ -40,7 +40,10 @@ from core import (
     kill_request_path,
     out_agent,
     pid_path,
+    clear_inbox_waiting_since,
+    read_inbox_waiting_since,
     read_last_active,
+    touch_inbox_waiting_since,
     touch_last_active,
     trash_dir,
     unique_path,
@@ -55,6 +58,7 @@ from definitions import (
     idle_timeout_seconds,
     is_file_proxy,
     load_definition,
+    pause_seconds,
 )
 from mailbox import ensure_mailboxes, next_inbox_message, peek_inbox_messages, route_outboxes
 from network import (
@@ -135,6 +139,26 @@ def _deliver_file_proxy(p: Participant) -> None:
             txlog.log("PROXY_DELIVERED", msg_id=envelope.get("id", f.stem), sender=envelope.get("from", ""), recipient=p.name, files=file_names or None, detail=_preview(envelope.get("content", "")))
         except (json.JSONDecodeError, OSError):
             txlog.log("PROXY_DELIVERED", msg_id=f.stem, recipient=p.name)
+
+
+def _pause_ready_for_wake(
+    name: str, pause: float, *, now: datetime | None = None
+) -> bool:
+    """Return True when `pause` has elapsed since the first inbox message of
+    the current burst. Zero/negative pause means immediate readiness."""
+    if pause <= 0:
+        return True
+    if now is None:
+        now = datetime.now(timezone.utc)
+    since = read_inbox_waiting_since(name)
+    if since is None:
+        touch_inbox_waiting_since(name, now)
+        out_agent(name, f"[{name}] pause {pause:g}s before wake")
+        return False
+    if (now - since).total_seconds() < pause:
+        return False
+    clear_inbox_waiting_since(name)
+    return True
 
 
 def wake_once(p: Participant, msg_path: Path) -> None:
@@ -689,9 +713,21 @@ def attached_loop(names: list[str], interval: float, *, single_pass: bool = Fals
                         if drain_seconds > 0:
                             msg = next_inbox_message(p)
                             if msg is None:
+                                clear_inbox_waiting_since(p.name)
                                 break
                             _drain_one(p, msg)
                             continue
+                        if not peek_inbox_messages(p, 1):
+                            clear_inbox_waiting_since(p.name)
+                            break
+                        if (
+                            definition is not None
+                            and not is_file_proxy(definition)
+                            and not _pause_ready_for_wake(
+                                p.name, pause_seconds(definition)
+                            )
+                        ):
+                            break
                         if (
                             definition is not None
                             and has_batch_invoke(definition)
@@ -704,6 +740,7 @@ def attached_loop(names: list[str], interval: float, *, single_pass: bool = Fals
                                 continue
                         msg = next_inbox_message(p)
                         if msg is None:
+                            clear_inbox_waiting_since(p.name)
                             break
                         wake_once(p, msg)
                 # Idle invoke: per-agent, only after the inbox has drained.

--- a/apps/a8s/daemon.py
+++ b/apps/a8s/daemon.py
@@ -46,14 +46,17 @@ from core import (
     unique_path,
 )
 from definitions import (
+    batch_limit,
+    build_batch_command,
     build_command,
     build_idle_command,
     files_ttl_seconds,
+    has_batch_invoke,
     idle_timeout_seconds,
     is_file_proxy,
     load_definition,
 )
-from mailbox import ensure_mailboxes, next_inbox_message, route_outboxes
+from mailbox import ensure_mailboxes, next_inbox_message, peek_inbox_messages, route_outboxes
 from network import (
     load_remotes,
     load_services,
@@ -169,6 +172,39 @@ def wake_once(p: Participant, msg_path: Path) -> None:
     run_with_prefix(p.name, cmd, p.root)
     # And again after the wake returns — a long-running LLM call shouldn't
     # leave last-active stuck at the pre-wake timestamp.
+    touch_last_active(p.name)
+
+
+def wake_batch(p: Participant, msg_paths: list[Path], definition: dict) -> None:
+    touch_last_active(p.name)
+    if is_file_proxy(definition):
+        _deliver_file_proxy(p)
+        touch_last_active(p.name)
+        return
+
+    trashed: list[Path] = []
+    previews: list[str] = []
+    for msg_path in msg_paths:
+        try:
+            with msg_path.open("r", encoding="utf-8") as f:
+                msg = json.load(f)
+            previews.append(_preview(msg.get("content", "")))
+        except (OSError, json.JSONDecodeError):
+            previews.append(msg_path.name)
+        dest = unique_path(trash_dir(p.name) / msg_path.name)
+        msg_path.rename(dest)
+        trashed.append(dest)
+
+    summary = "; ".join(previews[:3])
+    if len(previews) > 3:
+        summary += f"; +{len(previews) - 3} more"
+    out_agent(
+        p.name,
+        f"[{p.name}] batch waking ({len(trashed)}): {summary}",
+    )
+    cmd = build_batch_command(definition, p.name, trashed)
+    out_agent(p.name, f"[{p.name}] batch exec: {shlex.join(cmd)}")
+    run_with_prefix(p.name, cmd, p.root)
     touch_last_active(p.name)
 
 
@@ -643,14 +679,33 @@ def attached_loop(names: list[str], interval: float, *, single_pass: bool = Fals
                         services=services,
                     )
                 for p in handled:
+                    definition = None
+                    if drain_seconds == 0:
+                        try:
+                            definition = load_definition(p.name)
+                        except (FileNotFoundError, RuntimeError) as e:
+                            out_agent(p.name, f"[{p.name}] {e}")
                     while not _STOP_EVENT.is_set():
+                        if drain_seconds > 0:
+                            msg = next_inbox_message(p)
+                            if msg is None:
+                                break
+                            _drain_one(p, msg)
+                            continue
+                        if (
+                            definition is not None
+                            and has_batch_invoke(definition)
+                            and not is_file_proxy(definition)
+                        ):
+                            limit = batch_limit(definition)
+                            batch_paths = peek_inbox_messages(p, limit)
+                            if len(batch_paths) >= 2:
+                                wake_batch(p, batch_paths, definition)
+                                continue
                         msg = next_inbox_message(p)
                         if msg is None:
                             break
-                        if drain_seconds > 0:
-                            _drain_one(p, msg)
-                        else:
-                            wake_once(p, msg)
+                        wake_once(p, msg)
                 # Idle invoke: per-agent, only after the inbox has drained.
                 # Skipped while a wake is in flight automatically — the
                 # drain loop above is the only thing that calls

--- a/apps/a8s/definitions.py
+++ b/apps/a8s/definitions.py
@@ -191,6 +191,41 @@ def build_idle_command(definition: dict, agent_name: str) -> list[str] | None:
     return _expand_argv(list(argv), "", agent_name, "", "", "")
 
 
+def has_batch_invoke(definition: dict) -> bool:
+    batch = definition.get("batch")
+    if not isinstance(batch, dict):
+        return False
+    return bool(batch.get("invoke"))
+
+
+def batch_limit(definition: dict) -> int:
+    batch = definition.get("batch")
+    if not isinstance(batch, dict):
+        return 5
+    raw = batch.get("limit", 5)
+    try:
+        v = int(raw)
+    except (TypeError, ValueError):
+        return 5
+    return max(1, v)
+
+
+def build_batch_command(
+    definition: dict, agent_name: str, msg_paths: list[Path]
+) -> list[str]:
+    """Expand `batch.invoke` like idle (no incoming message) and append each
+    message file path as a trailing argv element."""
+    batch = definition.get("batch")
+    if not isinstance(batch, dict):
+        raise ValueError("definition missing 'batch'")
+    argv = batch.get("invoke")
+    if not argv:
+        raise ValueError("definition missing 'batch.invoke'")
+    cmd = _expand_argv(list(argv), "", agent_name, "", "", "")
+    cmd.extend(str(p.resolve()) for p in msg_paths)
+    return cmd
+
+
 def idle_timeout_seconds(definition: dict) -> float | None:
     """Returns `definition.idle.timeout` as a positive float, or None if
     not configured / not a positive number. Loose typing tolerated:

--- a/apps/a8s/definitions.py
+++ b/apps/a8s/definitions.py
@@ -191,6 +191,17 @@ def build_idle_command(definition: dict, agent_name: str) -> list[str] | None:
     return _expand_argv(list(argv), "", agent_name, "", "", "")
 
 
+def pause_seconds(definition: dict) -> float:
+    raw = definition.get("pause")
+    if raw is None:
+        return 0.0
+    try:
+        v = float(raw)
+    except (TypeError, ValueError):
+        return 0.0
+    return v if v > 0 else 0.0
+
+
 def has_batch_invoke(definition: dict) -> bool:
     batch = definition.get("batch")
     if not isinstance(batch, dict):

--- a/apps/a8s/mailbox.py
+++ b/apps/a8s/mailbox.py
@@ -717,12 +717,20 @@ def route_outboxes(
     return routed
 
 
-def next_inbox_message(p: Participant) -> Path | None:
+def _inbox_json_files(p: Participant) -> list[Path]:
     inbox = inbox_dir(p.name)
     if not inbox.is_dir():
-        return None
-    files = sorted(f for f in inbox.iterdir() if f.is_file() and f.name.endswith(".json"))
+        return []
+    return sorted(f for f in inbox.iterdir() if f.is_file() and f.name.endswith(".json"))
+
+
+def next_inbox_message(p: Participant) -> Path | None:
+    files = _inbox_json_files(p)
     return files[0] if files else None
+
+
+def peek_inbox_messages(p: Participant, limit: int) -> list[Path]:
+    return _inbox_json_files(p)[:limit]
 
 
 # ---------- queue helpers (used by cmd_tell, cmd_prompt, cmd_clear) ----------

--- a/apps/a8s/tests/fixtures/mock-batch.json
+++ b/apps/a8s/tests/fixtures/mock-batch.json
@@ -1,0 +1,8 @@
+{
+  "description": "Test batch invoke — message file paths trail the expanded batch.invoke argv.",
+  "invoke": ["$A8S_DIR/tests/fixtures/mock-cli", "SINGLE|FROM:$SENDER|TO:$RECIPIENT|MSG:$MESSAGE"],
+  "batch": {
+    "invoke": ["$A8S_DIR/tests/fixtures/mock-cli", "BATCH|TO:$RECIPIENT"],
+    "limit": 5
+  }
+}

--- a/apps/a8s/tests/test_daemon.py
+++ b/apps/a8s/tests/test_daemon.py
@@ -640,3 +640,92 @@ class TestAttachedLoopIdleIntegration:
         # Idle did NOT fire — wake_once just touched last-active.
         assert "idle exec:" not in log
         assert "IDLE-FIRED-FOR" not in log
+
+
+class TestBatchWake:
+    def _queue_inbox(self, recipient: str, n: int, *, prefix: str = "msg") -> list[Path]:
+        paths: list[Path] = []
+        for i in range(n):
+            msg = {
+                "id": f"{prefix}{i}",
+                "date": "2026-04-28T14:30:00.000000Z",
+                "from": "A",
+                "to": recipient,
+                "content": f"{prefix}-{i}",
+                "files": [],
+            }
+            p = inbox_dir(recipient) / f"{prefix}{i}.json"
+            p.write_text(json.dumps(msg))
+            paths.append(p)
+        return paths
+
+    def test_three_messages_batch_wake(self, fake_home, tmp_path, fixtures_dir):
+        d = tmp_path / "b"
+        d.mkdir()
+        save_registry({
+            "B": {"root": str(d), "definition": str(fixtures_dir / "mock-batch.json")},
+        })
+        ensure_mailboxes(Participant("B", d))
+        self._queue_inbox("B", 3)
+
+        rc = attached_loop(["B"], 0.1, single_pass=True)
+        assert rc == 0
+        log = _read_log("B")
+        assert log.count("batch exec:") == 1
+        assert "BATCH|TO:B" in log
+        assert log.count("MOCK-CLI: BATCH|TO:B") == 1
+        assert log.count("SINGLE|") == 0
+        for i in range(3):
+            assert str(trash_dir("B") / f"msg{i}.json") in log or f"msg{i}.json" in log
+
+    def test_single_message_uses_normal_invoke(self, fake_home, tmp_path, fixtures_dir):
+        d = tmp_path / "b"
+        d.mkdir()
+        save_registry({
+            "B": {"root": str(d), "definition": str(fixtures_dir / "mock-batch.json")},
+        })
+        ensure_mailboxes(Participant("B", d))
+        self._queue_inbox("B", 1)
+
+        attached_loop(["B"], 0.1, single_pass=True)
+        log = _read_log("B")
+        assert "batch exec:" not in log
+        assert "SINGLE|FROM:A|TO:B|MSG:msg-0" in log
+
+    def test_without_batch_block_one_wake_per_message(self, fake_home, tmp_path, fixtures_dir):
+        d = tmp_path / "b"
+        d.mkdir()
+        save_registry({
+            "B": {"root": str(d), "definition": str(fixtures_dir / "mock.json")},
+        })
+        ensure_mailboxes(Participant("B", d))
+        self._queue_inbox("B", 3, prefix="solo")
+
+        attached_loop(["B"], 0.1, single_pass=True)
+        log = _read_log("B")
+        assert "batch exec:" not in log
+        assert log.count("[B] exec: ") == 3
+
+    def test_limit_caps_batch_then_drains_remainder(self, fake_home, tmp_path, fixtures_dir):
+        d = tmp_path / "b"
+        d.mkdir()
+        defn = {
+            "invoke": ["$A8S_DIR/tests/fixtures/mock-cli", "SINGLE"],
+            "batch": {
+                "invoke": ["$A8S_DIR/tests/fixtures/mock-cli", "BATCH"],
+                "limit": 5,
+            },
+        }
+        defp = tmp_path / "batch5.json"
+        defp.write_text(json.dumps(defn))
+        save_registry({"B": {"root": str(d), "definition": str(defp)}})
+        ensure_mailboxes(Participant("B", d))
+        self._queue_inbox("B", 7, prefix="q")
+
+        attached_loop(["B"], 0.1, single_pass=True)
+        log = _read_log("B")
+        assert log.count("batch exec:") == 2
+        first_batch = log.split("batch exec:")[1].split("\n")[0]
+        assert first_batch.count(".json") == 5
+        second_batch = log.split("batch exec:")[2].split("\n")[0]
+        assert second_batch.count(".json") == 2

--- a/apps/a8s/tests/test_daemon.py
+++ b/apps/a8s/tests/test_daemon.py
@@ -12,6 +12,7 @@ import json
 import os
 import shutil
 import time
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -19,13 +20,16 @@ import pytest
 from core import (
     Participant,
     agent_log_path,
+    clear_inbox_waiting_since,
     detach_request_path,
     inbox_dir,
     kill_request_path,
     pid_path,
+    touch_inbox_waiting_since,
     trash_dir,
 )
 from daemon import (
+    _pause_ready_for_wake,
     _clear_detach_request,
     _clear_kill_request,
     _read_detach_request,
@@ -729,3 +733,63 @@ class TestBatchWake:
         assert first_batch.count(".json") == 5
         second_batch = log.split("batch exec:")[2].split("\n")[0]
         assert second_batch.count(".json") == 2
+
+
+class TestPauseBeforeWake:
+    T0 = datetime(2026, 4, 28, 14, 30, 0, tzinfo=timezone.utc)
+
+    def test_pause_ready_immediate_when_zero(self, fake_home):
+        assert _pause_ready_for_wake("X", 0, now=self.T0) is True
+
+    def test_pause_ready_starts_timer_then_waits(self, fake_home):
+        clear_inbox_waiting_since("X")
+        assert _pause_ready_for_wake("X", 5, now=self.T0) is False
+        assert _pause_ready_for_wake("X", 5, now=self.T0 + timedelta(seconds=3)) is False
+        assert _pause_ready_for_wake("X", 5, now=self.T0 + timedelta(seconds=5)) is True
+
+    def _batch_pause_def(self, tmp_path, fixtures_dir, pause: float) -> Path:
+        defn = {
+            "pause": pause,
+            "invoke": ["$A8S_DIR/tests/fixtures/mock-cli", "SINGLE"],
+            "batch": {
+                "invoke": ["$A8S_DIR/tests/fixtures/mock-cli", "BATCH|TO:$RECIPIENT"],
+                "limit": 5,
+            },
+        }
+        defp = tmp_path / "pause-batch.json"
+        defp.write_text(json.dumps(defn))
+        return defp
+
+    def test_pause_defers_wake_until_elapsed(self, fake_home, tmp_path, fixtures_dir):
+        d = tmp_path / "b"
+        d.mkdir()
+        defp = self._batch_pause_def(tmp_path, fixtures_dir, pause=60)
+        save_registry({"B": {"root": str(d), "definition": str(defp)}})
+        ensure_mailboxes(Participant("B", d))
+        clear_inbox_waiting_since("B")
+        (inbox_dir("B") / "m0.json").write_text(json.dumps({
+            "id": "m0", "date": "2026-04-28T14:30:00Z",
+            "from": "A", "to": "B", "content": "one", "files": [],
+        }))
+
+        attached_loop(["B"], 0.1, single_pass=True)
+        log = _read_log("B")
+        assert "exec:" not in log
+        assert "batch exec:" not in log
+        assert "pause 60s before wake" in log
+
+    def test_pause_after_elapsed_batches_all(self, fake_home, tmp_path, fixtures_dir):
+        d = tmp_path / "b"
+        d.mkdir()
+        defp = self._batch_pause_def(tmp_path, fixtures_dir, pause=2)
+        save_registry({"B": {"root": str(d), "definition": str(defp)}})
+        ensure_mailboxes(Participant("B", d))
+        touch_inbox_waiting_since(
+            "B", datetime.now(timezone.utc) - timedelta(seconds=10)
+        )
+        TestBatchWake()._queue_inbox("B", 3, prefix="late")
+
+        attached_loop(["B"], 0.1, single_pass=True)
+        log = _read_log("B")
+        assert log.count("batch exec:") == 1
+        assert "SINGLE" not in log

--- a/apps/a8s/tests/test_definitions.py
+++ b/apps/a8s/tests/test_definitions.py
@@ -262,6 +262,23 @@ class TestLoadDefinition:
 
 # ---------- batch invoke ----------
 
+class TestPauseSeconds:
+    def test_zero_when_missing(self):
+        from definitions import pause_seconds
+        assert pause_seconds({"invoke": ["x"]}) == 0.0
+
+    def test_returns_positive_float(self):
+        from definitions import pause_seconds
+        assert pause_seconds({"invoke": ["x"], "pause": 3}) == 3.0
+        assert pause_seconds({"invoke": ["x"], "pause": "2.5"}) == 2.5
+
+    def test_zero_or_negative_or_garbage_disables(self):
+        from definitions import pause_seconds
+        assert pause_seconds({"invoke": ["x"], "pause": 0}) == 0.0
+        assert pause_seconds({"invoke": ["x"], "pause": -1}) == 0.0
+        assert pause_seconds({"invoke": ["x"], "pause": "soon"}) == 0.0
+
+
 class TestBatchInvoke:
     def test_has_batch_invoke_false_when_missing(self):
         from definitions import has_batch_invoke

--- a/apps/a8s/tests/test_definitions.py
+++ b/apps/a8s/tests/test_definitions.py
@@ -260,6 +260,52 @@ class TestLoadDefinition:
             load_definition("X")
 
 
+# ---------- batch invoke ----------
+
+class TestBatchInvoke:
+    def test_has_batch_invoke_false_when_missing(self):
+        from definitions import has_batch_invoke
+        assert has_batch_invoke({"invoke": ["x"]}) is False
+
+    def test_has_batch_invoke_true_when_set(self):
+        from definitions import has_batch_invoke
+        defn = {"invoke": ["x"], "batch": {"invoke": ["y"]}}
+        assert has_batch_invoke(defn) is True
+
+    def test_batch_limit_defaults_to_five(self):
+        from definitions import batch_limit
+        assert batch_limit({"invoke": ["x"]}) == 5
+        assert batch_limit({"invoke": ["x"], "batch": {"invoke": ["y"]}}) == 5
+
+    def test_batch_limit_respects_custom_value(self):
+        from definitions import batch_limit
+        defn = {"invoke": ["x"], "batch": {"invoke": ["y"], "limit": 3}}
+        assert batch_limit(defn) == 3
+
+    def test_batch_limit_tolerates_bad_input(self):
+        from definitions import batch_limit
+        defn = {"invoke": ["x"], "batch": {"invoke": ["y"], "limit": "nope"}}
+        assert batch_limit(defn) == 5
+
+    def test_build_batch_command_appends_paths(self, tmp_path):
+        from definitions import build_batch_command
+        p1 = tmp_path / "a.json"
+        p2 = tmp_path / "b.json"
+        p1.write_text("{}")
+        p2.write_text("{}")
+        defn = {"invoke": ["x"], "batch": {"invoke": ["agent", "--batch", "$RECIPIENT"]}}
+        argv = build_batch_command(defn, "neil", [p1, p2])
+        assert argv == ["agent", "--batch", "neil", str(p1.resolve()), str(p2.resolve())]
+
+    def test_build_batch_command_empty_message_fields(self):
+        from definitions import build_batch_command
+        defn = {"invoke": ["x"], "batch": {"invoke": [
+            "echo", "S=$SENDER", "M=$MESSAGE", "T=$TIMESTAMP", "A=$AGE",
+        ]}}
+        argv = build_batch_command(defn, "neil", [])
+        assert argv == ["echo", "S=", "M=", "T=", "A="]
+
+
 # ---------- build_idle_command + idle_timeout_seconds ----------
 
 class TestBuildIdleCommand:


### PR DESCRIPTION
## Summary
- Add optional `batch: {invoke, limit}` to agent definitions — when 2+ inbox messages are waiting, wake once with `batch.invoke` plus trashed message JSON paths as trailing argv (shell-style, no placeholder)
- Add top-level `pause` — debounce wakes so closely-spaced tells accumulate across handler iterations before invoke/batch runs (stamps `inbox-waiting-since`, re-routes each loop pass)
- `batch.limit` defaults to 5; single-message delivery unchanged via normal `invoke`; `pause: 0` or omitted = immediate wake
- Closes #123

Example definition:

```json
{
  "pause": 3,
  "invoke": ["my-agent", "--single", "$SENDER", "$MESSAGE"],
  "batch": {
    "invoke": ["my-agent", "--batch"],
    "limit": 5
  }
}
```

## Test plan
- [x] `python3 -m pytest apps/a8s/tests/` — 444 passed
- [x] Unit tests for `batch_limit`, `build_batch_command`, `has_batch_invoke`, `pause_seconds`, `_pause_ready_for_wake`
- [x] End-to-end: 3 messages → one batch wake; 1 message → normal invoke; 7 messages with limit 5 → batch of 5 then batch of 2
- [x] Pause defers wake until elapsed; after elapsed, staggered messages batch together