### PR TITLE
feat(b3t): Bear Tracks newsletter automation CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ node_modules/
 
 # Python
 __pycache__/
+.venv/
+venv/
 
 # Claude
 .claude/scheduled_tasks.lock

--- a/apps/b3t/.env.example
+++ b/apps/b3t/.env.example
@@ -1,0 +1,41 @@
+# b3t configuration — copy to your project root as .env
+# All values below are examples; replace with your org's settings.
+
+# --- Browser (optional) ---
+# B3T_SESSION=b3t
+# B3T_CHROME_PROFILE=~/.b3t-chrome-profile
+
+# --- GiveBacks ---
+GIVEBACKS_BASE=https://your-org.givebacks.com
+GIVEBACKS_CAUSE_ID=your-cause-uuid
+GIVEBACKS_USER=your-email@example.com
+GIVEBACKS_PASS=your-password
+
+# --- Microsoft 365 (Outlook + Forms) ---
+OUTLOOK_USER=your-email@example.com
+OUTLOOK_PASS=your-password
+FORMS_URL=https://forms.office.com/Pages/DesignPageV2.aspx?id=YOUR-FORM-ID
+# FORMS_DOWNLOAD_PREFIX=My-Form-Name   # optional filter for downloaded .xlsx filename
+
+# --- PeachJar ---
+PEACHJAR_API_KEY=your-api-key
+PEACHJAR_AUDIENCE_ID=12345
+PEACHJAR_DISTRICT_ID=1234
+
+# --- ParentSquare ---
+PARENTSQUARE_USER=your-email@example.com
+PARENTSQUARE_PASS=your-password
+PARENTSQUARE_SCHOOL_ID=12345
+
+# --- OurSchoolPages ---
+OSP_BASE=https://yoursite.example.org
+OSP_FOLDER_ID=1234
+# OSP_SCAN_PAGES=Home|/,Calendar|/Event/MonthCalendar,Volunteer|/Page/Volunteer
+
+# --- School / district websites (optional) ---
+LWSD_SCHOOL_URL=https://school.example.org
+# LWSD_DISTRICT_URL=https://www.district.example.org
+
+# --- OurSchoolPages admin (optional) ---
+OURSCHOOLPAGES_USER=your-email@example.com
+OURSCHOOLPAGES_PASS=your-password

--- a/apps/b3t/__main__.py
+++ b/apps/b3t/__main__.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+"""b3t - Bear Tracks newsletter automation CLI."""
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/b3t/cli.py
+++ b/apps/b3t/cli.py
@@ -1,0 +1,246 @@
+"""CLI argument parsing and dispatch for b3t."""
+import argparse
+import sys
+
+import env
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="b3t",
+        description="Bear Tracks newsletter automation",
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    # -- Browser management --
+    sub.add_parser("open", help="Launch browser with persistent profile")
+    sub.add_parser("close", help="Save state and close browser")
+    sub.add_parser("status", help="Check browser status")
+    sub.add_parser("snap", help="Print page accessibility snapshot")
+
+    p = sub.add_parser("go", help="Navigate to URL")
+    p.add_argument("url")
+
+    p = sub.add_parser("click", help="Click element by ref")
+    p.add_argument("ref")
+
+    p = sub.add_parser("fill", help="Fill field by ref")
+    p.add_argument("ref")
+    p.add_argument("text")
+
+    # -- GiveBacks --
+    gb = sub.add_parser("givebacks", aliases=["gb"], help="GiveBacks newsletter CMS")
+    gb_sub = gb.add_subparsers(dest="action")
+
+    gb_sub.add_parser("login", help="Auto-login using env credentials")
+
+    p = gb_sub.add_parser("pull", help="Pull design JSON from API")
+    p.add_argument("--id", required=True, help="Message/draft UUID")
+    p.add_argument("-o", "--output", help="Output file (default: stdout)")
+
+    p = gb_sub.add_parser("push", help="Push design JSON to API")
+    p.add_argument("--id", required=True, help="Message/draft UUID")
+    p.add_argument("--design", required=True, help="Design JSON file path")
+    p.add_argument("--verify", action="store_true", help="Verify row count after push")
+
+    p = gb_sub.add_parser("open", help="Open editor in browser")
+    p.add_argument("--id", required=True, help="Message/draft UUID")
+
+    gb_sub.add_parser("list", help="List recent drafts")
+
+    p = gb_sub.add_parser("duplicate", help="Duplicate a newsletter (returns new draft UUID)")
+    p.add_argument("--id", required=True, help="Source message UUID to duplicate")
+
+    p = gb_sub.add_parser("upload", help="Upload image to editor placeholder")
+    p.add_argument("--id", required=True, help="Message/draft UUID")
+    p.add_argument("--image", required=True, help="Image file path to upload")
+    p.add_argument("--index", type=int, default=0, help="Image placeholder index (0-based, top to bottom)")
+
+    p = gb_sub.add_parser("screenshot", help="Take visual screenshot of newsletter")
+    p.add_argument("--id", required=True, help="Message/draft UUID")
+    p.add_argument("--dir", default=".", help="Output directory for screenshot")
+
+    p = gb_sub.add_parser("rename", help="Rename draft subject")
+    p.add_argument("--id", required=True, help="Message/draft UUID")
+    p.add_argument("--subject", required=True, help="New subject line")
+
+    # -- Forms --
+    fm = sub.add_parser("forms", help="Microsoft Forms submissions")
+    fm_sub = fm.add_subparsers(dest="action")
+
+    fm_sub.add_parser("login", help="Auto-login to M365")
+
+    p = fm_sub.add_parser("download", help="Download submissions.xlsx")
+    p.add_argument("--edition", required=True, help="Edition date YYYY-MM-DD")
+
+    p = fm_sub.add_parser("list", help="Parse and filter submissions")
+    p.add_argument("--edition", required=True, help="Edition date YYYY-MM-DD")
+    p.add_argument("--since", help="Filter submissions since date YYYY-MM-DD")
+    p.add_argument("--json", action="store_true", help="Output as JSON")
+
+    # -- PeachJar --
+    pj = sub.add_parser("peachjar", aliases=["pj"], help="PeachJar school flyers")
+    pj_sub = pj.add_subparsers(dest="action")
+
+    p = pj_sub.add_parser("list", help="List recent flyers")
+    p.add_argument("--since", help="Filter flyers since date YYYY-MM-DD")
+    p.add_argument("--json", action="store_true", help="Output as JSON")
+
+    p = pj_sub.add_parser("get", help="Get flyer details")
+    p.add_argument("flyer_id", help="Flyer ID")
+    p.add_argument("--json", action="store_true", help="Output as JSON")
+
+    # -- ParentSquare --
+    ps = sub.add_parser("parentsquare", aliases=["ps"], help="ParentSquare school comms")
+    ps_sub = ps.add_subparsers(dest="action")
+
+    ps_sub.add_parser("login", help="Auto-login")
+    ps_sub.add_parser("scan", help="Scan recent feed posts")
+
+    # -- LWSD --
+    lw = sub.add_parser("lwsd", help="School and district website scanning")
+    lw_sub = lw.add_subparsers(dest="action")
+
+    lw_sub.add_parser("scan", help="Scan for events and news")
+
+    # -- OurSchoolPages --
+    osp = sub.add_parser("osp", help="OurSchoolPages CMS")
+    osp_sub = osp.add_subparsers(dest="action")
+
+    osp_sub.add_parser("login", help="Auto-login")
+    osp_sub.add_parser("scan", help="Scan site pages for content updates")
+
+    p = osp_sub.add_parser("archive", help="Create archive page")
+    p.add_argument("--edition", required=True, help="Edition date YYYY-MM-DD")
+    p.add_argument("--html", required=True, help="HTML file to publish")
+
+    # -- Gemini --
+    gm = sub.add_parser("gemini", aliases=["gm"], help="Gemini header image generation")
+    gm_sub = gm.add_subparsers(dest="action")
+
+    gm_sub.add_parser("login", help="Navigate and verify Google auth")
+
+    p = gm_sub.add_parser("generate", help="Generate header images")
+    p.add_argument("--prompt", required=True, help="Generation prompt text")
+    p.add_argument("--template", help="Template image to upload")
+    p.add_argument("--dir", "-o", default=".", help="Output directory for downloaded image")
+
+    p = gm_sub.add_parser("download", help="Download generated images")
+    p.add_argument("--dir", default=".", help="Output directory")
+
+    # -- Outlook --
+    ol = sub.add_parser("outlook", aliases=["ol"], help="Outlook email")
+    ol_sub = ol.add_subparsers(dest="action")
+
+    ol_sub.add_parser("login", help="Auto-login")
+
+    p = ol_sub.add_parser("check", help="Check for new messages")
+    p.add_argument("--folder", default="Submissions", help="Folder to check")
+
+    p = ol_sub.add_parser("read", help="Read a message (expands full thread)")
+    p.add_argument("number", help="Message number from check output")
+    p.add_argument("--folder", default="Submissions", help="Folder containing the message")
+    p.add_argument("--dir", help="Download attachments to this directory")
+
+    # -- Edition --
+    ed = sub.add_parser("edition", aliases=["ed"], help="Edition management")
+    ed_sub = ed.add_subparsers(dest="action")
+
+    p = ed_sub.add_parser("create", help="Create new edition directory")
+    p.add_argument("date", help="Edition date YYYY-MM-DD")
+    p.add_argument("--title", required=True, help="Edition title")
+
+    p = ed_sub.add_parser("status", help="Show edition status")
+    p.add_argument("date", nargs="?", help="Edition date (default: latest)")
+
+    ed_sub.add_parser("manifest", help="Show manifest")
+
+    # -- Parse and dispatch --
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.print_help()
+        return 0
+
+    env.load_env()
+
+    return _dispatch(args)
+
+
+def _dispatch(args):
+    """Route to the correct handler."""
+    import session
+
+    cmd = args.command
+
+    # Top-level browser commands
+    if cmd == "open":
+        return session.open_browser()
+    elif cmd == "close":
+        return session.close_browser()
+    elif cmd == "status":
+        return _cmd_status()
+    elif cmd == "snap":
+        return _cmd_snap()
+    elif cmd == "go":
+        return session.navigate(args.url)
+    elif cmd == "click":
+        result = session.run("click", args.ref)
+        if result.returncode != 0:
+            print(f"ERROR: {result.stderr}", file=sys.stderr)
+        return result.returncode
+    elif cmd == "fill":
+        result = session.run("fill", args.ref, args.text)
+        if result.returncode != 0:
+            print(f"ERROR: {result.stderr}", file=sys.stderr)
+        return result.returncode
+
+    # Group commands
+    elif cmd in ("givebacks", "gb"):
+        import givebacks
+        return givebacks.dispatch(args)
+    elif cmd == "forms":
+        import forms
+        return forms.dispatch(args)
+    elif cmd in ("peachjar", "pj"):
+        import peachjar
+        return peachjar.dispatch(args)
+    elif cmd in ("parentsquare", "ps"):
+        import parentsquare
+        return parentsquare.dispatch(args)
+    elif cmd == "lwsd":
+        import lwsd
+        return lwsd.dispatch(args)
+    elif cmd == "osp":
+        import osp
+        return osp.dispatch(args)
+    elif cmd in ("gemini", "gm"):
+        import gemini
+        return gemini.dispatch(args)
+    elif cmd in ("outlook", "ol"):
+        import outlook
+        return outlook.dispatch(args)
+    elif cmd in ("edition", "ed"):
+        import edition
+        return edition.dispatch(args)
+
+    return 0
+
+
+def _cmd_status():
+    import session
+    if session.is_running():
+        url = session.current_url()
+        print(f"Running: {url}")
+    else:
+        print("Not running.")
+    return 0
+
+
+def _cmd_snap():
+    import session
+    text = session.snapshot()
+    if text:
+        print(text)
+        return 0
+    return 1

--- a/apps/b3t/cli.py
+++ b/apps/b3t/cli.py
@@ -95,7 +95,12 @@ def main():
     ps_sub = ps.add_subparsers(dest="action")
 
     ps_sub.add_parser("login", help="Auto-login")
-    ps_sub.add_parser("scan", help="Scan recent feed posts")
+    p = ps_sub.add_parser("scan", help="Scan feed posts with full bodies")
+    p.add_argument("--json", action="store_true", help="JSON output")
+    p.add_argument("--since", type=int, help="Only posts from last N days")
+    p = ps_sub.add_parser("save", help="Save posts as submission markdown files")
+    p.add_argument("--dir", required=True, help="Output directory (e.g. editions/YYYY-MM-DD/submissions)")
+    p.add_argument("--since", type=int, help="Only posts from last N days")
 
     # -- LWSD --
     lw = sub.add_parser("lwsd", help="School and district website scanning")

--- a/apps/b3t/constants.py
+++ b/apps/b3t/constants.py
@@ -1,0 +1,86 @@
+"""Centralized configuration for b3t.
+
+All org-specific values come from environment variables (loaded from .env).
+Platform-level URLs that are the same for any user stay as defaults.
+"""
+import os
+import sys
+
+
+def _require(key):
+    """Get required env var or exit with clear error."""
+    val = os.environ.get(key)
+    if not val:
+        print(f"ERROR: {key} not set. Add it to .env or export it.", file=sys.stderr)
+        sys.exit(1)
+    return val
+
+
+def _optional(key, default=""):
+    """Get optional env var with default."""
+    return os.environ.get(key, default)
+
+
+# --- Session / Browser ---
+SESSION_NAME = _optional("B3T_SESSION", "b3t")
+CHROME_PROFILE_DIR = os.path.expanduser(
+    _optional("B3T_CHROME_PROFILE", "~/.b3t-chrome-profile")
+)
+STATE_FILE = ".playwright-cli/b3t-state.json"
+
+
+# --- GiveBacks ---
+# Platform (same for everyone)
+GIVEBACKS_API = "https://api.givebacks.com/services/communication/messages"
+# Org-specific (from .env)
+GIVEBACKS_BASE = _optional("GIVEBACKS_BASE")  # e.g. https://redmondmsptsa.givebacks.com
+GIVEBACKS_LOGIN = f"{GIVEBACKS_BASE}/users/sign_in" if GIVEBACKS_BASE else ""
+GIVEBACKS_CAUSE_ID = _optional("GIVEBACKS_CAUSE_ID")  # org UUID on GiveBacks
+
+
+# --- Microsoft 365 ---
+# Platform (same for everyone)
+OUTLOOK_URL = "https://outlook.office.com/mail/"
+# Org-specific (from .env)
+FORMS_URL = _optional("FORMS_URL")  # full URL to the Forms responses page
+FORMS_DOWNLOAD_PREFIX = _optional("FORMS_DOWNLOAD_PREFIX")  # optional xlsx filename filter
+
+
+# --- PeachJar ---
+# Platform
+PEACHJAR_GRAPHQL = "https://parent-app-bff.peachjar.com/graphql"
+# Org-specific
+PEACHJAR_API_KEY = _optional("PEACHJAR_API_KEY")
+_pj_id = _optional("PEACHJAR_AUDIENCE_ID")
+PEACHJAR_AUDIENCE_ID = int(_pj_id) if _pj_id else 0
+_pj_dist = _optional("PEACHJAR_DISTRICT_ID")
+PEACHJAR_DISTRICT_ID = int(_pj_dist) if _pj_dist else 0
+
+
+# --- ParentSquare ---
+# Platform
+PARENTSQUARE_BASE = "https://www.parentsquare.com"
+PARENTSQUARE_LOGIN = f"{PARENTSQUARE_BASE}/signin"
+# Org-specific
+_PS_SCHOOL_ID = _optional("PARENTSQUARE_SCHOOL_ID")
+PARENTSQUARE_FEED = f"{PARENTSQUARE_BASE}/schools/{_PS_SCHOOL_ID}/feeds" if _PS_SCHOOL_ID else ""
+
+
+# --- OurSchoolPages ---
+# Org-specific
+OSP_BASE = _optional("OSP_BASE")  # e.g. https://rmsptsa.org
+OSP_LOGIN = f"{OSP_BASE}/Account/LogOn" if OSP_BASE else ""
+_osp_folder = _optional("OSP_FOLDER_ID")
+OSP_FOLDER_ID = int(_osp_folder) if _osp_folder else 0
+OSP_CREATE_PAGE = f"{OSP_BASE}/PageManager/AdminCreate/{OSP_FOLDER_ID}" if OSP_BASE and OSP_FOLDER_ID else ""
+# Comma-separated name|path pairs, e.g. "Home|/,Calendar|/Event/MonthCalendar"
+OSP_SCAN_PAGES = _optional("OSP_SCAN_PAGES")
+
+
+# --- LWSD / school website ---
+LWSD_SCHOOL_URL = _optional("LWSD_SCHOOL_URL")  # e.g. https://rms.lwsd.org
+LWSD_DISTRICT_URL = _optional("LWSD_DISTRICT_URL", "https://www.lwsd.org")
+
+
+# --- Gemini ---
+GEMINI_URL = "https://gemini.google.com/app"

--- a/apps/b3t/docs/TODO.md
+++ b/apps/b3t/docs/TODO.md
@@ -1,0 +1,42 @@
+# b3t TODO
+
+## High Priority
+
+- [ ] **`givebacks regen --id UUID`** — After API push, `raw_html` is stale. Must open editor, make trivial edit (click text block, type char, delete), wait for auto-save. Without this, sent email won't match template.
+- [ ] **`givebacks images --id UUID`** — List all images in the editor with index + alt text + current URL. Agent needs this to know which `--index` to pass to `upload`.
+- [ ] **`givebacks delete --id UUID`** — Delete a draft via three-dot menu or API. Needed to clean up test duplicates.
+- [ ] **`edition update DATE --field value`** — Update manifest fields (status, draft_id, archive_url) as edition progresses through phases.
+- [ ] **SQLite content index** — `~/.b3t-content.db` indexing all gathered content across editions/sources. Tables: `content_items`, `editions`, `sources`. Commands: `b3t index rebuild`, `b3t index query --since DATE`, `b3t index duplicates`. Eliminates rediscovery cost for cheaper agents.
+
+## Medium Priority
+
+- [ ] **`osp archive --edition DATE --html FILE`** — Has code, never tested end-to-end. Needs verification.
+- [ ] **`givebacks preview --id UUID --email ADDRESS`** — Send a test email preview via API or UI.
+- [ ] **`outlook send --draft FILE`** — Send a board review draft from a prepared markdown/HTML file.
+- [ ] **Automated link validation** — Curl all URLs in design JSON before send. Catch 404s.
+- [ ] **Automated sync check** — Extract headings from draft.md and design JSON, diff for mismatches.
+
+## Low Priority / Future
+
+- [ ] **Convert article bodies to `paragraph` content type** — Unlayer's Lexical JSON (`textJson`) gives better UI editing. Needs HTML→Lexical converter.
+- [ ] **Fix legacy boilerplate grammar** — Evergreen sections had grammar issues; verify in current template.
+- [ ] **Standardize all links to `https://`** — Some legacy links use `http://`.
+- [ ] **Clean up stale `textJson` placeholders** — Heading blocks have `"text":"Heading"` in Lexical JSON. Harmless, cosmetic.
+
+## Done
+
+- [x] `givebacks login` — Auto-login with OTP handling
+- [x] `givebacks list` — List recent drafts/sent via API
+- [x] `givebacks pull/push` — Design JSON via API with localStorage buffer
+- [x] `givebacks duplicate --id UUID` — Three-dot menu → Duplicate → return new UUID
+- [x] `givebacks rename --id UUID --subject "..."` — Update subject via API PUT
+- [x] `givebacks upload --id UUID --image FILE --index N` — Coordinate-based click + chained upload
+- [x] `givebacks screenshot --id UUID` — Full-page PNG of newsletter page
+- [x] `parentsquare scan` — Deterministic feed scan with auto-login
+- [x] `lwsd scan` — RMS + district events/news (no auth)
+- [x] `osp scan` — Site pages + calendar parsing
+- [x] `peachjar list/get` — GraphQL queries (no browser)
+- [x] `forms download/list` — Excel download + openpyxl parse
+- [x] `outlook check/read` — Folder scan + thread expansion + attachments
+- [x] `gemini generate` — Template upload + prompt + download
+- [x] Constants moved to `.env` — Source code is org-agnostic

--- a/apps/b3t/docs/TODO.md
+++ b/apps/b3t/docs/TODO.md
@@ -30,9 +30,10 @@
 - [x] `givebacks pull/push` — Design JSON via API with localStorage buffer
 - [x] `givebacks duplicate --id UUID` — Three-dot menu → Duplicate → return new UUID
 - [x] `givebacks rename --id UUID --subject "..."` — Update subject via API PUT
-- [x] `givebacks upload --id UUID --image FILE --index N` — Coordinate-based click + chained upload
+- [x] `givebacks upload --id UUID --image FILE --index N` — Coordinate-based click + chained upload; waits for S3 save (size-scaled timeout)
 - [x] `givebacks screenshot --id UUID` — Full-page PNG of newsletter page
-- [x] `parentsquare scan` — Deterministic feed scan with auto-login
+- [x] `parentsquare scan` — Feed scan with full bodies (`--json`, `--since`)
+- [x] `parentsquare save --dir PATH` — Write `parentsquare-*.md` submission files
 - [x] `lwsd scan` — RMS + district events/news (no auth)
 - [x] `osp scan` — Site pages + calendar parsing
 - [x] `peachjar list/get` — GraphQL queries (no browser)

--- a/apps/b3t/docs/forms.md
+++ b/apps/b3t/docs/forms.md
@@ -1,0 +1,44 @@
+# Microsoft Forms
+
+## Overview
+
+Newsletter submission form hosted on Microsoft Forms. Responses are downloaded as Excel (`.xlsx`) and parsed for new submissions since the last edition.
+
+## Authentication
+
+Uses Microsoft 365 session (same as Outlook). Env vars: `OUTLOOK_USER`, `OUTLOOK_PASS`
+
+Env var: `FORMS_URL` — full URL to the form's design page (contains the form ID).
+
+## Commands
+
+### `forms download --edition YYYY-MM-DD`
+
+Downloads the submissions Excel file to `editions/{date}/wip/submissions.xlsx`.
+
+Flow:
+1. Navigate to `{FORMS_URL}&analysis=true` (responses view)
+2. Dismiss "Got it" popup if present (find ref via snapshot, not text-based click)
+3. Click "More options" button (the one for Responses, not individual questions)
+4. Click "Download a copy" menuitem
+5. Wait for the downloaded `.xlsx` in `.playwright-cli/` (optionally filter with `FORMS_DOWNLOAD_PREFIX` in `.env`)
+6. Move to edition wip directory
+
+### `forms list --edition YYYY-MM-DD [--since DATE] [--json]`
+
+Parse the downloaded Excel and filter/display submissions.
+
+Uses `openpyxl` to read the xlsx. Columns include: Start time, Name, Email, Article title, Article body, Image attachment.
+
+`--since` filters by submission date (Start time column).
+
+## Auth Check
+
+Navigate to `forms.office.com` → check if URL stays on forms.office.com (authenticated) or redirects to login (not authenticated).
+
+## Gotchas
+
+- The "Got it" popup on first visit can't be dismissed by text-based click — must use ref from snapshot
+- "More options" button exists in multiple places — need the one for the whole Responses section, not per-question
+- Downloaded files go to `.playwright-cli/`, not `~/Downloads`
+- Forms reply-to is broken: replies to the confirmation email do NOT reach the newsletter editor. Contact submitters directly for attachments.

--- a/apps/b3t/docs/gemini.md
+++ b/apps/b3t/docs/gemini.md
@@ -1,0 +1,69 @@
+# Gemini (Header Image Generation)
+
+## Overview
+
+Uses Google Gemini (gemini.google.com) to generate newsletter header images. Requires a Google account with Gemini access (AI Pro for image generation).
+
+## Authentication
+
+Manual login required (Google auth is not automatable). Browser state can be saved but is unreliable — plan for re-login each session.
+
+Session: persistent Chrome profile handles this naturally.
+
+## Commands
+
+### `gemini generate --prompt TEXT [--template FILE] --dir DIR`
+
+Full deterministic flow:
+1. Navigate to gemini.google.com/app
+2. Upload template image (style reference)
+3. Send generation prompt
+4. Wait for image generation (polls for "Download" button, 45s timeout)
+5. Download generated image
+6. Save to `--dir` with sequential naming (`header-option-1.png`, etc.)
+
+### `gemini login`
+
+Navigate to Gemini and verify Google auth is active.
+
+## Template Upload
+
+The template image establishes the visual style (colors, bear mascot, layout). Upload flow:
+1. Click attachment/upload button in chat input area
+2. Click "Upload files" menu item (triggers OS file chooser)
+3. Chain: `click {menu_ref} && upload "/path/to/template.png"`
+
+## Image Generation
+
+After uploading template and sending prompt:
+- Gemini takes 10-30s to generate
+- Poll every 3s for "Download full size image" button appearance
+- Timeout after 45s
+
+## Download
+
+The download button is below the fold — must scroll down first.
+1. `mousewheel 3000 0` to scroll down
+2. Wait 2s for layout to settle
+3. Re-snapshot to get fresh ref for download button
+4. Click download button (may need double-click with delay)
+
+Downloaded files go to `.playwright-cli/`.
+
+## Quality Check
+
+Before accepting a generated image:
+- Visual-check for duplicated/garbled text (common failure mode)
+- Verify the title text matches what was requested
+- If wrong, follow up in same chat (retry 2x max, then start new chat)
+
+## Sequential Naming
+
+Output files are named `header-option-{N}.png` where N increments from existing files in the output directory.
+
+## Gotchas
+
+- Google saved browser state is unreliable — expect manual re-login
+- Download button is below viewport fold — scroll first
+- Generated text in images may be garbled — always verify visually
+- First click on download may register as hover — click twice with 1s delay

--- a/apps/b3t/docs/givebacks.md
+++ b/apps/b3t/docs/givebacks.md
@@ -1,0 +1,135 @@
+# GiveBacks / Unlayer
+
+## Architecture
+
+- **Frontend:** JS SPA at `{GIVEBACKS_BASE}` (env var)
+- **API:** `https://api.givebacks.com` (platform-level, same for all orgs)
+- **Editor engine:** Unlayer, loaded in a cross-origin iframe
+- **Image hosting:** `https://s3.us-east-1.amazonaws.com/unlayer.memberhub/{timestamp}-{filename}`
+- **Org identifier:** `GIVEBACKS_CAUSE_ID` env var (UUID)
+
+## Authentication
+
+Env vars: `GIVEBACKS_USER`, `GIVEBACKS_PASS`
+
+Login flow:
+1. Navigate to `/messages` — if page loads, already authenticated
+2. If redirected to `/users/sign_in` — fill email/password, submit
+3. If redirected to `/one-time-passcode` — OTP sent to email
+4. OTP handling: open Outlook in new tab, find code, close tab, enter 6 digits, check "Trust this browser", submit
+
+Session persists via Chrome profile. Trust cookie avoids OTP on subsequent logins.
+
+## Messages API
+
+```
+GET/PUT https://api.givebacks.com/services/communication/messages/{uuid}?cause_id={CAUSE_ID}
+```
+
+Auth: cookies from browser session. Fetch with `credentials: "include"` from a GiveBacks-origin page.
+
+**Response fields:** `message.template` (Unlayer JSON as string), `subject`, `uuid`, `status`, `raw_html`, `raw_text`, `recipients`, `sent_at`
+
+**Update:** `PUT {message: {template: jsonString}}` or `{message: {subject: "new title"}}`
+
+**Large payloads:** Use `localStorage` as transfer buffer — `localstorage-set` then fetch from localStorage in eval.
+
+## Newsletter Lifecycle
+
+1. **Duplicate** previous edition (three-dot menu → "Duplicate")
+2. **Rename** subject via API PUT
+3. **Pull** design JSON → modify programmatically → **Push** back
+4. **Open editor** after push (loads fresh from server)
+5. **Upload images** via UI (see below)
+6. **Regen raw_html** — trivial edit in editor triggers auto-save
+7. **Send Preview** → editor reviews → **Send Now**
+
+## Image Upload (UI Automation)
+
+Direct click on `<img>` elements fails because Unlayer's `.blockbuilder-layer-selector` overlay divs intercept pointer events. Solution: coordinate-based clicking.
+
+**Deterministic flow:**
+1. Navigate to editor (`/messages/{uuid}/design`)
+2. Resize viewport: `resize 1600 1000`
+3. Get image bounding box via `run-code` (locator in Unlayer iframe):
+   ```js
+   async function main() {
+     const frames = page.frames();
+     for (const f of frames) {
+       if (f.url().includes("unlayer")) {
+         const imgs = await f.locator("img[alt]").all();
+         await imgs[N].scrollIntoViewIfNeeded();
+         const box = await imgs[N].boundingBox();
+         return JSON.stringify(box);
+       }
+     }
+   }
+   ```
+4. Click center coordinates: `page.mouse.click(cx, cy)` — hits overlay, selects block
+5. Snapshot → find `button "Upload Image"` ref in right panel
+6. Chain: `click {upload_ref} && upload "/absolute/path/to/file"`
+
+**Key constraints:**
+- `scrollIntoViewIfNeeded()` required for images below the fold
+- Click and upload MUST be chained (`&&`) — file chooser is only pending briefly
+- Refs change after every action — always re-snapshot
+- Use absolute file paths
+
+## raw_html Regeneration
+
+API push updates `template` but NOT `raw_html` (what gets emailed). To regen:
+1. Open editor at `/messages/{uuid}/design`
+2. Click any text block to enter edit mode
+3. Type a character then delete it (net-zero edit that sets dirty flag)
+4. Wait for auto-save ("Save Changes" button becomes disabled = saved)
+5. Verify via API: `raw_html` contains expected content
+
+**Important:** `space + backspace` does NOT trigger dirty flag. Must be a visible character.
+
+## Design JSON Structure
+
+Schema version 12:
+```
+design.counters         — content type counters
+design.body.id          — body ID
+design.body.rows[]      — array of row objects
+design.body.values      — body styles (fontFamily, textColor, backgroundColor, contentWidth: 600)
+```
+
+**Row:**
+```json
+{"id": "...", "cells": [1], "columns": [{
+  "id": "...",
+  "contents": [{"id": "...", "type": "image", "values": {...}}],
+  "values": {"padding": "0px", "backgroundColor": ""}
+}], "values": {"backgroundColor": "", "padding": "0px"}}
+```
+
+**Content types:** `text`, `heading`, `image`, `button`, `divider`, `html`
+
+**Image src structure:**
+```json
+{"url": "https://s3....", "width": 2752, "height": 1536, "id": 40206112,
+ "filename": "header.jpg", "contentType": "image/jpeg", "size": 5764950,
+ "dynamic": false, "autoWidth": true}
+```
+
+## Push-then-Save Race Condition
+
+Unlayer editor keeps an in-memory copy of the design. If editor is open during API push, saving overwrites the push.
+
+**Correct sequence:** Close editor → Push via API → Open editor fresh → Trivial edit → Auto-save.
+
+## Known Issues
+
+| Issue | Solution |
+|-------|----------|
+| Overlay blocks `click` on images | Use coordinate-based `page.mouse.click(x, y)` |
+| `type` command escapes `!` as `\!` | Use `eval 'el => el.textContent = "..."'` |
+| `Meta+a` selects entire block | Use eval on specific element ref |
+| Refs change after every action | Fresh snapshot before every interaction |
+| `run-code` can crash session | Prefer built-in commands + `&&` chaining |
+| `mousewheel` args reversed | First arg = vertical despite `dx` label |
+| Large payloads exceed inline eval | Use `localstorage-set` as transfer buffer |
+| API push doesn't update `raw_html` | Open editor → trivial edit → auto-save |
+| push_design verify has parsing bug | Use `push` only, skip verify |

--- a/apps/b3t/docs/lwsd.md
+++ b/apps/b3t/docs/lwsd.md
@@ -1,0 +1,45 @@
+# LWSD (School District Websites)
+
+## Overview
+
+Scans both the school website and the district website for events and news. No authentication required.
+
+## URLs
+
+- School site: `https://rms.lwsd.org` (configurable per school)
+- District site: `https://www.lwsd.org`
+
+## Commands
+
+### `lwsd scan`
+
+Navigates to both sites, parses events and news sections from each.
+
+Output sections:
+- RMS School Events
+- RMS School News
+- LWSD District Events
+- LWSD District News
+
+## Parsing: Events
+
+Events section contains elements with:
+- Month abbreviation in `generic` elements (Jan, Feb, Mar...)
+- Day number in `generic` elements
+- Event title in `button` or `group` elements
+- Time ranges in `time` elements
+- Location in `generic` elements (matched by keywords: GYM, Center, Library, etc.)
+
+Output format: `Mon DD: Event Title (time) @ Location`
+
+## Parsing: School News
+
+News items appear as `link` or `heading` elements in the news section. Filtered by length (>15 chars) and deduplicated. Skip the "News" section when looking for newsletter content — that's Bear Tracks itself.
+
+## Parsing: District News
+
+Links on the lwsd.org homepage filtered to actual news articles (>20 chars, excludes nav/social/generic links).
+
+## Calendar
+
+The school site has a calendar page with events laid out in a grid. Date rows contain 7 cells (one per day of week). Event rows contain events positioned by column index matching the corresponding day.

--- a/apps/b3t/docs/osp.md
+++ b/apps/b3t/docs/osp.md
@@ -1,0 +1,54 @@
+# OurSchoolPages (PTSA Website CMS)
+
+## Overview
+
+CMS for the PTSA website. Used for two purposes:
+1. **Scanning** for content updates (programs, calendar, club pages)
+2. **Archiving** newsletter editions as pages on the site
+
+## Authentication
+
+Env vars: `OURSCHOOLPAGES_USER`, `OURSCHOOLPAGES_PASS`, `OSP_BASE`, `OSP_FOLDER_ID`
+
+Login URL: `{OSP_BASE}/Account/LogOn`
+
+## Commands
+
+### `osp scan`
+
+Scans multiple site pages for content that could be newsletter-worthy:
+- Home, Programs, Volunteer, Calendar
+- Club pages (Drama, Science, Math, Quiz Bowl, Spelling Bee)
+- About, Spirit Gear, Reflections
+
+**Calendar parsing:** Grid layout with alternating date rows (7 cells = days of week) and event rows (events positioned by column index).
+
+### `osp archive --edition DATE --html FILE`
+
+Creates an archive page for a sent newsletter edition.
+
+Flow:
+1. Login if needed
+2. Navigate to `{OSP_BASE}/PageManager/AdminCreate/{OSP_FOLDER_ID}`
+3. Set page title and URL slug
+4. Paste HTML content via TinyMCE source code editor
+5. Save/publish
+
+Archive URL pattern: `{OSP_BASE}/Page/BearTracks/YYYY-MM-DD-english`
+
+## Site Structure
+
+Pages scanned (typical PTSA site):
+- `/` — Home (announcements, featured content)
+- `/Page/Programs` — After-school programs
+- `/Packet/Volunteer` — Volunteer opportunities
+- `/Page/Calendar` — Event calendar grid
+- `/Page/Clubs/{name}` — Individual club pages
+- `/Page/BearTracks/Archive` — Newsletter archive listing
+
+## Calendar Grid
+
+The calendar uses an HTML table where:
+- Date rows have 7 cells containing day numbers
+- Event rows have event text positioned in the column corresponding to the day of week
+- Parser tracks current row's days and maps events by column position

--- a/apps/b3t/docs/outlook.md
+++ b/apps/b3t/docs/outlook.md
@@ -1,0 +1,60 @@
+# Outlook (Microsoft 365)
+
+## Overview
+
+Email client for newsletter submissions. Content arrives in a dedicated "Submissions" folder. Also used for OTP retrieval during GiveBacks login.
+
+## Authentication
+
+Env vars: `OUTLOOK_USER`, `OUTLOOK_PASS`
+
+URL: `https://outlook.office.com/mail/`
+
+Auth check: navigate to Outlook URL → if redirected to `login.microsoftonline.com`, not authenticated.
+
+## Commands
+
+### `outlook check --folder NAME`
+
+Lists messages in a folder. Default folder: "Submissions".
+
+Flow:
+1. Navigate to Outlook
+2. Click folder treeitem in sidebar
+3. Parse `option` elements from `listbox "Message list"`
+4. Output: message number, subject, sender preview
+
+### `outlook read N --dir PATH`
+
+Read a specific message by number, expanding the full thread.
+
+Flow:
+1. Click message in list
+2. Expand conversation (click "See more messages" if present)
+3. Parse thread: `listitem` elements within conversation view
+4. Parse reading pane: content inside `document "Message body"`
+5. Find attachments: `option` elements with file extensions + size (e.g., "flyer.pdf 11 MB")
+6. Download: click attachment → click "Download" menuitem in preview → move from `.playwright-cli/` to `--dir`
+
+## Message Structure (Accessibility Tree)
+
+```
+listbox "Message list"
+  option "Subject preview..."    ← one per message
+  option "Subject preview..."
+
+document "Message body"
+  generic [ref=eNNN]: body text lines
+```
+
+## Attachments
+
+Downloaded files land in `.playwright-cli/` (not `~/Downloads`). The `--dir` flag moves them to the specified path after download.
+
+## Tab Management (OTP Flow)
+
+For GiveBacks OTP retrieval:
+1. `tab-new "https://outlook.office.com/mail/"` — open Outlook in new tab
+2. Scan message list for "passcode" or "givebacks" keywords
+3. Click message → extract 6-digit code from body
+4. `tab-close` → `tab-select 0` — return to GiveBacks tab

--- a/apps/b3t/docs/parentsquare.md
+++ b/apps/b3t/docs/parentsquare.md
@@ -1,0 +1,45 @@
+# ParentSquare
+
+## Overview
+
+School communication platform. Posts from teachers, staff, and district. Feed is a lazy-loaded list of announcements.
+
+## Authentication
+
+Env vars: `PARENTSQUARE_USER`, `PARENTSQUARE_PASS`, `PARENTSQUARE_SCHOOL_ID`
+
+Login page: `https://www.parentsquare.com/signin`
+Feed URL: `https://www.parentsquare.com/schools/{SCHOOL_ID}/feeds`
+
+Login flow: navigate to feed → if redirected to `/signin` → fill email + password textboxes → submit. No CAPTCHA or MFA.
+
+## Feed Structure (Accessibility Tree)
+
+```
+region "Posts"
+  heading "Post Title" [level=2]
+  list
+    listitem: link "Posted by Author Name"
+    listitem: text: • N days ago • DayOfWeek, Mon DD at HH:MM PM •
+```
+
+**Key insight:** Only top-level posts have `"Posted by"` metadata within ~12 lines of their heading. Nested sub-headings (e.g., inside district newsletters like "Connections") do NOT have "Posted by" nearby — this differentiates real posts from newsletter content.
+
+## Scan Flow
+
+1. Auto-login if needed
+2. Navigate to feed URL
+3. Scroll down twice (`mousewheel 3000 0`) to trigger lazy-load
+4. Snapshot → parse headings that have "Posted by" nearby
+5. Extract: title, author, relative date
+
+## Scrolling
+
+Feed is lazy-loaded. Two scrolls loads ~2 weeks of posts. The `mousewheel` command's first argument is vertical (despite being labeled `dx`).
+
+## Limitations
+
+- No public API
+- Feed is the only content endpoint
+- District-level posts (Connections newsletter) appear in feed but are better captured via `lwsd scan`
+- Individual post content requires clicking into it (not implemented — editor reviews manually if needed)

--- a/apps/b3t/docs/parentsquare.md
+++ b/apps/b3t/docs/parentsquare.md
@@ -13,25 +13,36 @@ Feed URL: `https://www.parentsquare.com/schools/{SCHOOL_ID}/feeds`
 
 Login flow: navigate to feed → if redirected to `/signin` → fill email + password textboxes → submit. No CAPTCHA or MFA.
 
-## Feed Structure (Accessibility Tree)
+## Commands
 
-```
-region "Posts"
-  heading "Post Title" [level=2]
-  list
-    listitem: link "Posted by Author Name"
-    listitem: text: • N days ago • DayOfWeek, Mon DD at HH:MM PM •
+```bash
+b3t ps login
+b3t ps scan                    # print posts with full bodies
+b3t ps scan --json             # JSON for scripts
+b3t ps scan --since 14         # filter by "N days ago"
+b3t ps save --dir editions/YYYY-MM-DD/submissions --since 14
 ```
 
-**Key insight:** Only top-level posts have `"Posted by"` metadata within ~12 lines of their heading. Nested sub-headings (e.g., inside district newsletters like "Connections") do NOT have "Posted by" nearby — this differentiates real posts from newsletter content.
+`ps save` writes `parentsquare-{slug}.md` with title, author, date, URL, body, and extracted links.
 
 ## Scan Flow
 
 1. Auto-login if needed
 2. Navigate to feed URL
-3. Scroll down twice (`mousewheel 3000 0`) to trigger lazy-load
-4. Snapshot → parse headings that have "Posted by" nearby
-5. Extract: title, author, relative date
+3. Scroll twice (`mousewheel 3000 0`) to lazy-load recent posts
+4. Click every **Read More** button to expand truncated bodies
+5. Run in-page extraction via `run-code`: each `[role="region"]` with `Posted by` → title, author, date, body text, links
+
+## Feed Structure
+
+Top-level posts have `h2` title + `Posted by Author` link. Nested headings inside district newsletters (e.g. Connections) lack `Posted by` and are skipped.
+
+## Editorial Notes
+
+- **Classroom posts** (single teacher, class roster in metadata) — usually skip for Bear Tracks unless editor wants them
+- **Expired posts** — skip even if still on feed
+- **Band / department posts** — optional one-liner if broadly relevant
+- Prefer folding PS body text into draft articles; do not write "see ParentSquare" when body was captured
 
 ## Scrolling
 
@@ -39,7 +50,6 @@ Feed is lazy-loaded. Two scrolls loads ~2 weeks of posts. The `mousewheel` comma
 
 ## Limitations
 
-- No public API
-- Feed is the only content endpoint
-- District-level posts (Connections newsletter) appear in feed but are better captured via `lwsd scan`
-- Individual post content requires clicking into it (not implemented — editor reviews manually if needed)
+- No public API — browser automation only
+- Very old posts require additional scrolling
+- District Connections newsletter appears as one feed item; sub-articles are not split out (use `lwsd scan` for district content)

--- a/apps/b3t/docs/peachjar.md
+++ b/apps/b3t/docs/peachjar.md
@@ -1,0 +1,62 @@
+# PeachJar
+
+## Overview
+
+School flyer distribution platform. Flyers are digital documents (PDF-like) posted by organizations (camps, health providers, nonprofits, the school itself).
+
+## Authentication
+
+**None required.** PeachJar has a public GraphQL API.
+
+Env vars: `PEACHJAR_API_KEY`, `PEACHJAR_AUDIENCE_ID`
+
+## API
+
+Endpoint: `https://parent-app-bff.peachjar.com/graphql`
+
+Auth header: `X-Api-Key: {PEACHJAR_API_KEY}`
+
+### List Flyers
+
+```graphql
+query($input: GetAllFlyersInput) {
+  getAllFlyers(input: $input) {
+    items { id title startDate endDate categories
+            distributionDetails { organization { name } } }
+    totalCount
+  }
+}
+```
+
+Variables:
+```json
+{"input": {"schoolIds": [AUDIENCE_ID], "statuses": ["APPROVED"], "limit": 50, "offset": 0}}
+```
+
+### Get Flyer Detail
+
+```graphql
+query($input: GetOneFlyerInput) {
+  getOneFlyer(input: $input) {
+    id title startDate endDate description
+    categories flyerPages { pageImage }
+    distributionDetails { organization { name } }
+  }
+}
+```
+
+Variables: `{"input": {"flyerId": ID, "schoolId": AUDIENCE_ID}}`
+
+## Filtering
+
+- `--since DATE` filters by `endDate >= DATE` (active flyers)
+- Categories: `health_and_safety`, `volunteer_and_fundraising`, `enrichment_and_camps`, `community`, `school_info`
+- Skip paid programs/camps unless board-approved
+
+## Output
+
+Human-readable (default) or `--json` for structured output. Each flyer shows: ID, title, org, end date, categories.
+
+## Flyer Images
+
+`flyerPages[].pageImage` contains CDN URLs to rendered flyer page images. These can be downloaded and included in the newsletter.

--- a/apps/b3t/docs/session.md
+++ b/apps/b3t/docs/session.md
@@ -1,0 +1,61 @@
+# Browser Session Management
+
+## Architecture
+
+b3t launches Chrome directly (no automation flags) and attaches `playwright-cli` via Chrome DevTools Protocol (CDP). This avoids all automation detection banners and fingerprinting.
+
+```
+Chrome (user-data-dir profile) ← CDP port 9222 → playwright-cli -s=b3t
+```
+
+## Chrome Launch
+
+```python
+cmd = [CHROME_PATH, f"--user-data-dir={CHROME_PROFILE_DIR}",
+       f"--remote-debugging-port={CDP_PORT}",
+       "--no-first-run", "--no-default-browser-check", "about:blank"]
+```
+
+- No `--disable-blink-features=AutomationControlled` (playwright-cli injects this; we bypass by launching Chrome ourselves)
+- Persistent profile at `~/.b3t-chrome-profile/` — cookies survive naturally
+- CDP port 9222 (checked via HTTP GET to `/json/version`)
+
+## Attach
+
+```bash
+playwright-cli -s=b3t attach --cdp=http://127.0.0.1:9222
+```
+
+## Graceful Close
+
+Must quit Chrome cleanly to avoid "not shut down properly" restore banner:
+- macOS: `osascript -e 'tell application "Google Chrome" to quit'`
+- Linux: `pgrep -f {profile_dir}` → `SIGTERM`
+
+Wait for Chrome to finish writing profile before returning.
+
+## Configuration
+
+| Env var | Default | Purpose |
+|---------|---------|---------|
+| `B3T_SESSION` | `b3t` | playwright-cli session name |
+| `B3T_CHROME_PROFILE` | `~/.b3t-chrome-profile` | Chrome user data dir |
+
+## Tab Management
+
+Commands: `tab-new URL`, `tab-close`, `tab-select N`
+
+Used for multi-service flows (e.g., opening Outlook to get OTP during GiveBacks login without leaving the GiveBacks page).
+
+## State Persistence
+
+Primary: Chrome profile directory (cookies persist naturally across restarts).
+Backup: `state-save`/`state-load` to `.playwright-cli/b3t-state.json`.
+
+## Testing with Fresh Profile
+
+```bash
+B3T_SESSION=b3t-test B3T_CHROME_PROFILE=~/.b3t-chrome-profile-test b3t open
+```
+
+Useful for testing OTP flows or verifying first-time-user experience.

--- a/apps/b3t/edition.py
+++ b/apps/b3t/edition.py
@@ -106,7 +106,7 @@ def cmd_status(args):
         print(json.dumps(entry, indent=2))
     else:
         # Show latest / all in-progress
-        in_progress = [e for e in editions if e.get("status") not in ("published",)]
+        in_progress = [e for e in editions if e.get("status") not in ("published", "unused")]
         if in_progress:
             print("In progress:")
             for e in in_progress[-5:]:

--- a/apps/b3t/edition.py
+++ b/apps/b3t/edition.py
@@ -1,0 +1,135 @@
+"""Edition directory and manifest management."""
+import json
+import os
+import sys
+from datetime import date
+
+
+def dispatch(args):
+    action = args.action
+    if not action:
+        print("Usage: b3t edition <create|status|manifest>", file=sys.stderr)
+        return 2
+    if action == "create":
+        return cmd_create(args)
+    elif action == "status":
+        return cmd_status(args)
+    elif action == "manifest":
+        return cmd_manifest(args)
+    return 2
+
+
+def _editions_dir():
+    return os.path.join(os.getcwd(), "editions")
+
+
+def _manifest_path():
+    return os.path.join(_editions_dir(), "manifest.json")
+
+
+def _load_manifest():
+    path = _manifest_path()
+    if os.path.exists(path):
+        with open(path) as f:
+            return json.load(f)
+    return {"editions": []}
+
+
+def _save_manifest(manifest):
+    path = _manifest_path()
+    with open(path, "w") as f:
+        json.dump(manifest, f, indent=2)
+        f.write("\n")
+
+
+def cmd_create(args):
+    """Create new edition directory structure."""
+    edition_date = args.date
+    title = args.title
+
+    # Validate date format
+    try:
+        date.fromisoformat(edition_date)
+    except ValueError:
+        print(f"ERROR: Invalid date: {edition_date} (use YYYY-MM-DD)", file=sys.stderr)
+        return 1
+
+    edition_dir = os.path.join(_editions_dir(), edition_date)
+    if os.path.exists(edition_dir):
+        print(f"Edition directory already exists: {edition_dir}", file=sys.stderr)
+        return 1
+
+    # Create directory structure
+    os.makedirs(os.path.join(edition_dir, "submissions"), exist_ok=True)
+    os.makedirs(os.path.join(edition_dir, "wip"), exist_ok=True)
+
+    # Create draft.md
+    with open(os.path.join(edition_dir, "draft.md"), "w") as f:
+        f.write(f"# Bear Tracks - {title}\n\n")
+        f.write(f"Edition: {edition_date}\n\n")
+
+    # Update manifest
+    manifest = _load_manifest()
+    entry = {
+        "date": edition_date,
+        "title": title,
+        "status": "draft",
+        "school_year": _school_year(date.fromisoformat(edition_date)),
+    }
+
+    # Check if entry already exists
+    existing = [e for e in manifest["editions"] if e.get("date") == edition_date]
+    if existing:
+        print(f"WARNING: Manifest entry for {edition_date} already exists.", file=sys.stderr)
+    else:
+        manifest["editions"].append(entry)
+        manifest["editions"].sort(key=lambda e: e.get("date", ""))
+        _save_manifest(manifest)
+
+    print(f"Created: {edition_dir}", file=sys.stderr)
+    print(edition_dir)
+    return 0
+
+
+def cmd_status(args):
+    """Show edition status."""
+    manifest = _load_manifest()
+    editions = manifest.get("editions", [])
+
+    if hasattr(args, "date") and args.date:
+        # Show specific edition
+        matches = [e for e in editions if e.get("date") == args.date]
+        if not matches:
+            print(f"Edition {args.date} not found in manifest.", file=sys.stderr)
+            return 1
+        entry = matches[0]
+        print(json.dumps(entry, indent=2))
+    else:
+        # Show latest / all in-progress
+        in_progress = [e for e in editions if e.get("status") not in ("published",)]
+        if in_progress:
+            print("In progress:")
+            for e in in_progress[-5:]:
+                print(f"  {e.get('date')}  [{e.get('status')}]  {e.get('title', '')}")
+        else:
+            # Show last few published
+            print("Recent:")
+            for e in editions[-5:]:
+                print(f"  {e.get('date')}  [{e.get('status')}]  {e.get('title', '')}")
+    return 0
+
+
+def cmd_manifest(args):
+    """Show full manifest."""
+    manifest = _load_manifest()
+    print(json.dumps(manifest, indent=2))
+    return 0
+
+
+def _school_year(d):
+    """Determine school year string from a date."""
+    year = d.year
+    if d.month >= 8:
+        return f"{year}-{str(year+1)[-2:]}"
+    else:
+        return f"{year-1}-{str(year)[-2:]}"

--- a/apps/b3t/env.py
+++ b/apps/b3t/env.py
@@ -1,0 +1,32 @@
+"""Load .env file from CWD into os.environ."""
+import os
+
+
+def load_env(path=None):
+    """Parse .env from CWD into os.environ. Existing vars take precedence."""
+    env_path = path or os.path.join(os.getcwd(), ".env")
+    if not os.path.exists(env_path):
+        return
+    with open(env_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "=" not in line:
+                continue
+            key, val = line.split("=", 1)
+            key = key.strip()
+            val = val.strip()
+            if (val.startswith('"') and val.endswith('"')) or \
+               (val.startswith("'") and val.endswith("'")):
+                val = val[1:-1]
+            if key not in os.environ:
+                os.environ[key] = val
+
+
+def get(key):
+    """Get env var or raise with helpful message."""
+    val = os.environ.get(key)
+    if not val:
+        raise SystemExit(f"ERROR: {key} not set. Add it to .env or export it.")
+    return val

--- a/apps/b3t/forms.py
+++ b/apps/b3t/forms.py
@@ -1,0 +1,219 @@
+"""Microsoft Forms submission download and parsing.
+
+Deterministic flow:
+    1. Navigate to Forms responses page (&analysis=true)
+    2. Dismiss "Got it" popup if present
+    3. Click "More options" next to Excel
+    4. Click "Download a copy"
+    5. Move downloaded .xlsx to edition wip/
+"""
+import json
+import os
+import shutil
+import sys
+import time
+
+import session
+import env
+from constants import FORMS_URL, FORMS_DOWNLOAD_PREFIX
+
+# Forms responses page with analysis=true to land on the Excel view
+FORMS_RESPONSES_URL = FORMS_URL + "&analysis=true"
+
+
+def dispatch(args):
+    action = args.action
+    if not action:
+        print("Usage: b3t forms <login|download|list>", file=sys.stderr)
+        return 2
+    if action == "login":
+        return cmd_login(args)
+    elif action == "download":
+        return cmd_download(args)
+    elif action == "list":
+        return cmd_list(args)
+    return 2
+
+
+def ensure_authenticated():
+    """Check M365 auth by navigating to Forms. Returns True if authed."""
+    session.ensure_running()
+
+    session.navigate("https://forms.office.com")
+    time.sleep(3)
+    url = session.current_url()
+    if url and "forms.office.com" in url and "login.microsoftonline.com" not in url:
+        return True
+
+    print("ERROR: Not authenticated to M365.", file=sys.stderr)
+    print("Run: b3t open, log into outlook.office.com, b3t close", file=sys.stderr)
+    return False
+
+
+def cmd_login(args):
+    if ensure_authenticated():
+        print("M365 authenticated.", file=sys.stderr)
+        return 0
+    return 1
+
+
+def cmd_download(args):
+    """Download submissions Excel — deterministic click sequence."""
+    import re
+
+    if not ensure_authenticated():
+        return 1
+
+    edition_dir = os.path.join(os.getcwd(), "editions", args.edition, "wip")
+    os.makedirs(edition_dir, exist_ok=True)
+
+    # Step 1: Navigate to Forms responses/analysis page
+    print("Navigating to Forms responses...", file=sys.stderr)
+    session.navigate(FORMS_RESPONSES_URL)
+    time.sleep(4)
+
+    # Step 2: Dismiss "Got it" popup if present
+    snap = session.snapshot()
+    if snap:
+        ref = _find_ref(snap, lambda l: "Got it" in l and "button" in l.lower())
+        if ref:
+            session.run("click", ref)
+            time.sleep(1)
+
+    # Step 3: Click "More options" button (near the Excel section, not the Responses one)
+    snap = session.snapshot()
+    if not snap:
+        print("ERROR: Cannot get page snapshot.", file=sys.stderr)
+        return 1
+
+    # Find the "More options" button that's NOT "More options for Responses"
+    more_ref = None
+    for line in snap.split("\n"):
+        if 'button "More options"' in line and "Responses" not in line:
+            m = re.search(r'\[ref=(\w+)\]', line)
+            if m:
+                more_ref = m.group(1)
+                break
+    if not more_ref:
+        # Fallback: any "More options" button
+        more_ref = _find_ref(snap, lambda l: "More options" in l and "button" in l.lower() and "Responses" not in l)
+
+    if not more_ref:
+        print("ERROR: Cannot find 'More options' button.", file=sys.stderr)
+        return 1
+
+    session.run("click", more_ref)
+    time.sleep(1)
+
+    # Step 4: Click "Download a copy" menuitem
+    snap = session.snapshot()
+    dl_ref = _find_ref(snap, lambda l: "Download a copy" in l and "menuitem" in l.lower())
+    if not dl_ref:
+        print("ERROR: Cannot find 'Download a copy' menu item.", file=sys.stderr)
+        return 1
+
+    session.run("click", dl_ref)
+    print("Downloading...", file=sys.stderr)
+    time.sleep(6)
+
+    # Step 5: Find downloaded file
+    pw_dir = os.path.join(os.getcwd(), ".playwright-cli")
+    xlsx_files = []
+    if os.path.isdir(pw_dir):
+        candidates = [f for f in os.listdir(pw_dir) if f.endswith(".xlsx")]
+        if FORMS_DOWNLOAD_PREFIX:
+            candidates = [f for f in candidates if FORMS_DOWNLOAD_PREFIX in f]
+        xlsx_files = sorted(
+            candidates,
+            key=lambda f: os.path.getmtime(os.path.join(pw_dir, f)),
+            reverse=True,
+        )
+
+    if not xlsx_files:
+        print("ERROR: No .xlsx downloaded.", file=sys.stderr)
+        return 1
+
+    src = os.path.join(pw_dir, xlsx_files[0])
+    dst = os.path.join(edition_dir, "submissions.xlsx")
+    shutil.copy2(src, dst)
+    os.remove(src)
+    print(f"Saved: {dst}", file=sys.stderr)
+    print(dst)
+    return 0
+
+
+def _find_ref(snapshot_text, test_fn):
+    """Find first ref matching test_fn(line) -> bool."""
+    import re
+    for line in snapshot_text.split("\n"):
+        if test_fn(line):
+            m = re.search(r'\[ref=(\w+)\]', line)
+            if m:
+                return m.group(1)
+    return None
+
+
+def cmd_list(args):
+    """Parse submissions from downloaded Excel."""
+    from datetime import date, datetime
+
+    try:
+        from openpyxl import load_workbook
+    except ImportError:
+        print("ERROR: openpyxl not installed.", file=sys.stderr)
+        return 1
+
+    xlsx_path = os.path.join(os.getcwd(), "editions", args.edition, "wip", "submissions.xlsx")
+    if not os.path.exists(xlsx_path):
+        print(f"ERROR: {xlsx_path} not found. Run: b3t forms download --edition {args.edition}", file=sys.stderr)
+        return 1
+
+    since = None
+    if args.since:
+        since = datetime.fromisoformat(args.since)
+
+    wb = load_workbook(xlsx_path, data_only=True)
+    ws = wb.active
+
+    headers = [cell.value for cell in next(ws.iter_rows(max_row=1))]
+    time_col = "Completion time" if "Completion time" in headers else "Start time"
+    if time_col not in headers:
+        print(f"ERROR: Expected '{time_col}' column in {xlsx_path}. Found: {headers}", file=sys.stderr)
+        wb.close()
+        return 1
+
+    rows = []
+    for row in ws.iter_rows(min_row=2, values_only=True):
+        record = dict(zip(headers, row))
+        if not record.get("Title") and not record.get("Article Body"):
+            continue
+        submitted = record.get(time_col)
+        if submitted is None:
+            continue
+        if isinstance(submitted, str):
+            try:
+                submitted = datetime.fromisoformat(submitted)
+            except ValueError:
+                continue
+        if since and submitted < since:
+            continue
+        rows.append(record)
+
+    wb.close()
+
+    if hasattr(args, "json") and args.json:
+        def default(o):
+            if hasattr(o, "isoformat"):
+                return o.isoformat()
+            return str(o)
+        json.dump(rows, sys.stdout, indent=2, default=default)
+        print()
+    else:
+        print(f"{len(rows)} submissions", file=sys.stderr)
+        for r in rows:
+            title = r.get("Title") or "?"
+            name = r.get("Name2") or r.get("Name") or "?"
+            cat = r.get("Article Category") or ""
+            print(f"  {name}: {title} [{cat}]")
+
+    return 0

--- a/apps/b3t/gemini.py
+++ b/apps/b3t/gemini.py
@@ -1,0 +1,280 @@
+"""Gemini header image generation — deterministic single-command flow.
+
+Usage:
+    b3t gemini generate --prompt "BEAR TRACKS / SUMMER SEND-OFF" --template header-image-template.png -o wip/
+    b3t gemini login
+    b3t gemini download -o wip/
+
+The generate command does everything: opens Gemini, uploads template, sends prompt,
+waits for generation, downloads the result. One command, one image.
+"""
+import os
+import re
+import shutil
+import sys
+import time
+
+import session
+from constants import GEMINI_URL
+
+# Timeouts (seconds)
+GENERATION_TIMEOUT = 45
+GENERATION_POLL = 3
+PAGE_LOAD_WAIT = 3
+UPLOAD_WAIT = 3
+
+
+def dispatch(args):
+    action = args.action
+    if not action:
+        print("Usage: b3t gemini <login|generate|download>", file=sys.stderr)
+        return 2
+    if action == "login":
+        return cmd_login(args)
+    elif action == "generate":
+        return cmd_generate(args)
+    elif action == "download":
+        return cmd_download(args)
+    return 2
+
+
+def _find_ref(snapshot_text, test_fn):
+    """Find first ref matching test_fn(line) -> bool."""
+    for line in snapshot_text.split("\n"):
+        if test_fn(line):
+            m = re.search(r'\[ref=(\w+)\]', line)
+            if m:
+                return m.group(1)
+    return None
+
+
+def _wait_for_ref(test_fn, description, timeout=10, poll=1):
+    """Poll snapshots until a ref matching test_fn appears."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        snap = session.snapshot()
+        if snap:
+            ref = _find_ref(snap, test_fn)
+            if ref:
+                return ref
+        time.sleep(poll)
+    print(f"ERROR: Timed out waiting for: {description}", file=sys.stderr)
+    return None
+
+
+def _ensure_gemini():
+    """Navigate to Gemini new chat, verify auth. Returns 0 or error code."""
+    session.ensure_running()
+    session.navigate(GEMINI_URL)
+    time.sleep(PAGE_LOAD_WAIT)
+
+    url = session.current_url()
+    if url and "accounts.google.com" in url:
+        print("ERROR: Not authenticated. Run: b3t open, log into Google, b3t close", file=sys.stderr)
+        return 1
+    return 0
+
+
+def cmd_login(args):
+    """Navigate to Gemini and verify Google auth."""
+    rc = _ensure_gemini()
+    if rc == 0:
+        print("Gemini authenticated.", file=sys.stderr)
+    return rc
+
+
+def cmd_generate(args):
+    """Full flow: navigate to Gemini, upload template, send prompt, wait, download."""
+    output_dir = args.dir if hasattr(args, "dir") and args.dir else "."
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Step 1: Navigate to fresh Gemini chat
+    rc = _ensure_gemini()
+    if rc != 0:
+        return rc
+
+    # Step 2: Upload template (if provided)
+    if args.template:
+        template_path = os.path.abspath(args.template)
+        if not os.path.exists(template_path):
+            print(f"ERROR: Template not found: {template_path}", file=sys.stderr)
+            return 1
+
+        rc = _upload_file(template_path)
+        if rc != 0:
+            return rc
+
+    # Step 3: Send prompt
+    rc = _send_prompt(args.prompt)
+    if rc != 0:
+        return rc
+
+    # Step 4: Wait for generation to complete
+    print("Waiting for image generation...", file=sys.stderr)
+    download_ref = _wait_for_generation()
+    if not download_ref:
+        return 1
+
+    # Step 5: Download the result
+    return _download_image(download_ref, output_dir)
+
+
+def _upload_file(filepath):
+    """Click Upload & tools -> Upload files -> upload the file."""
+    snap = session.snapshot()
+    if not snap:
+        print("ERROR: Cannot get page snapshot.", file=sys.stderr)
+        return 1
+
+    # Find "Upload & tools" button
+    upload_btn = _find_ref(snap, lambda l: "Upload & tools" in l and "button" in l)
+    if not upload_btn:
+        # Fallback: look for any plus/attach button near the prompt
+        upload_btn = _find_ref(snap, lambda l: "plus" in l.lower() and "button" in l.lower())
+    if not upload_btn:
+        print("ERROR: Cannot find 'Upload & tools' button.", file=sys.stderr)
+        return 1
+
+    session.run("click", upload_btn)
+    time.sleep(1)
+
+    # Find "Upload files" menu item
+    upload_files_ref = _wait_for_ref(
+        lambda l: "Upload files" in l and "menuitem" in l.lower(),
+        "'Upload files' menu item",
+        timeout=5,
+    )
+    if not upload_files_ref:
+        # Fallback: look for file uploader button
+        snap = session.snapshot()
+        upload_files_ref = _find_ref(snap, lambda l: "upload" in l.lower() and ("file" in l.lower() or "document" in l.lower()) and "ref=" in l)
+        if not upload_files_ref:
+            print("ERROR: Cannot find 'Upload files' menu item.", file=sys.stderr)
+            return 1
+
+    # Click upload files and handle file chooser
+    result = session.run("click", upload_files_ref)
+    time.sleep(0.5)
+    session.run("upload", filepath)
+    time.sleep(UPLOAD_WAIT)
+
+    print(f"Uploaded: {os.path.basename(filepath)}", file=sys.stderr)
+    return 0
+
+
+def _send_prompt(prompt):
+    """Fill the prompt textbox and press Enter."""
+    snap = session.snapshot()
+    if not snap:
+        print("ERROR: Cannot get page snapshot.", file=sys.stderr)
+        return 1
+
+    # Find prompt textbox
+    input_ref = _find_ref(snap, lambda l: "textbox" in l.lower() and ("prompt" in l.lower() or "gemini" in l.lower() or "ask" in l.lower()))
+    if not input_ref:
+        input_ref = _find_ref(snap, lambda l: "textbox" in l.lower())
+    if not input_ref:
+        print("ERROR: Cannot find prompt input field.", file=sys.stderr)
+        return 1
+
+    session.run("fill", input_ref, prompt)
+    session.run("press", "Enter")
+    print("Prompt sent.", file=sys.stderr)
+    return 0
+
+
+def _wait_for_generation():
+    """Poll until 'Download full size image' button appears. Returns its ref."""
+    deadline = time.time() + GENERATION_TIMEOUT
+    while time.time() < deadline:
+        snap = session.snapshot()
+        if snap:
+            ref = _find_ref(snap, lambda l: "Download full size image" in l and "button" in l.lower())
+            if ref:
+                print("Generation complete.", file=sys.stderr)
+                return ref
+            # Also check for error states
+            if _find_ref(snap, lambda l: "couldn't generate" in l.lower() or "try again" in l.lower()):
+                print("ERROR: Gemini failed to generate image.", file=sys.stderr)
+                return None
+        time.sleep(GENERATION_POLL)
+
+    print("ERROR: Generation timed out.", file=sys.stderr)
+    return None
+
+
+def _download_image(download_ref, output_dir):
+    """Click download, wait for file, move to output_dir."""
+    # Scroll down to ensure download button is in view
+    session.run("mousewheel", "0", "2000")
+    time.sleep(2)
+
+    # Re-snapshot after scroll to get fresh ref (element may have shifted)
+    snap = session.snapshot()
+    fresh_ref = _find_ref(snap, lambda l: "Download full size image" in l and "button" in l.lower())
+    if fresh_ref:
+        download_ref = fresh_ref
+
+    session.run("click", download_ref)
+    time.sleep(1)
+    # Second click in case first registered as hover
+    session.run("click", download_ref)
+    print("Download initiated...", file=sys.stderr)
+
+    # Wait for file to appear in .playwright-cli/
+    pw_dir = os.path.join(os.getcwd(), ".playwright-cli")
+    deadline = time.time() + 15
+    new_file = None
+    existing = set(os.listdir(pw_dir)) if os.path.isdir(pw_dir) else set()
+
+    while time.time() < deadline:
+        time.sleep(1)
+        if os.path.isdir(pw_dir):
+            current = set(os.listdir(pw_dir))
+            new_files = [f for f in (current - existing)
+                         if f.lower().endswith((".png", ".jpg", ".jpeg", ".webp"))
+                         and not f.startswith("page-")]
+            if new_files:
+                new_file = new_files[0]
+                break
+
+    if not new_file:
+        print("ERROR: Download did not complete in time.", file=sys.stderr)
+        return 1
+
+    # Move to output dir
+    src = os.path.join(pw_dir, new_file)
+    # Name sequentially based on existing header-option-* files
+    existing_options = [f for f in os.listdir(output_dir) if f.startswith("header-option-")]
+    next_num = len(existing_options) + 1
+    ext = os.path.splitext(new_file)[1]
+    dst = os.path.join(output_dir, f"header-option-{next_num}{ext}")
+    shutil.move(src, dst)
+
+    print(dst)
+    print(f"Saved: {dst}", file=sys.stderr)
+    return 0
+
+
+def cmd_download(args):
+    """Download image from current Gemini chat (if generation already done)."""
+    output_dir = args.dir if hasattr(args, "dir") and args.dir else "."
+    os.makedirs(output_dir, exist_ok=True)
+
+    session.ensure_running()
+
+    # Scroll to find download button
+    session.run("mousewheel", "0", "3000")
+    time.sleep(1)
+
+    snap = session.snapshot()
+    if not snap:
+        print("ERROR: Cannot get page snapshot.", file=sys.stderr)
+        return 1
+
+    download_ref = _find_ref(snap, lambda l: "Download full size image" in l and "button" in l.lower())
+    if not download_ref:
+        print("ERROR: No 'Download full size image' button found.", file=sys.stderr)
+        return 1
+
+    return _download_image(download_ref, output_dir)

--- a/apps/b3t/givebacks.py
+++ b/apps/b3t/givebacks.py
@@ -302,11 +302,87 @@ def _parse_json_result(stdout):
         try:
             parsed = json.loads(line)
             if isinstance(parsed, str):
-                return json.loads(parsed)
+                try:
+                    return json.loads(parsed)
+                except json.JSONDecodeError:
+                    return parsed
             return parsed
         except (json.JSONDecodeError, ValueError, TypeError):
             continue
     return None
+
+
+def _run_code_json(js, timeout=15):
+    result = session.run("run-code", js, timeout=timeout)
+    return _parse_json_result(result.stdout)
+
+
+def _get_image_src(target_index):
+    """Return src URL for image slot in Unlayer iframe, or empty string."""
+    js = (
+        f'async function main() {{ for (const f of page.frames()) {{ '
+        f'if (f.url().includes("unlayer")) {{ '
+        f'const imgs = await f.locator("img[alt]").all(); '
+        f'if (imgs.length > {target_index}) {{ '
+        f'return await imgs[{target_index}].getAttribute("src") || ""; }} }} }} return ""; }}'
+    )
+    value = _run_code_json(js, timeout=10)
+    return value if isinstance(value, str) else ""
+
+
+def _wait_for_unlayer_images(min_count=1, timeout=40):
+    """Poll until Unlayer iframe has loaded image placeholders."""
+    js = (
+        f'async function main() {{ const deadline = Date.now() + {timeout * 1000}; '
+        f'while (Date.now() < deadline) {{ for (const f of page.frames()) {{ '
+        f'if (f.url().includes("unlayer")) {{ '
+        f'const n = await f.locator("img[alt]").count(); '
+        f'if (n >= {min_count}) return JSON.stringify({{count: n}}); }} }} '
+        f'await new Promise(r => setTimeout(r, 500)); }} '
+        f'return JSON.stringify({{count: 0}}); }}'
+    )
+    result = _run_code_json(js, timeout=timeout + 5)
+    return isinstance(result, dict) and result.get("count", 0) >= min_count
+
+
+def _image_loaded(target_index):
+    """Return True when image slot has finished loading (naturalWidth > 50)."""
+    js = (
+        f'async function main() {{ for (const f of page.frames()) {{ '
+        f'if (f.url().includes("unlayer")) {{ '
+        f'const imgs = await f.locator("img[alt]").all(); '
+        f'if (imgs.length > {target_index}) {{ '
+        f'const complete = await imgs[{target_index}].evaluate(el => el.complete); '
+        f'const w = await imgs[{target_index}].evaluate(el => el.naturalWidth); '
+        f'return JSON.stringify({{loaded: complete && w > 50, width: w}}); }} }} }} '
+        f'return JSON.stringify({{loaded: false}}); }}'
+    )
+    result = _run_code_json(js, timeout=10)
+    return isinstance(result, dict) and result.get("loaded")
+
+
+def _wait_for_image_saved(target_index, before_src="", timeout=90):
+    """Wait until image slot has a new persisted URL (Unlayer S3 upload complete)."""
+    deadline = time.time() + timeout
+    print(f"  Waiting for S3 save (up to {timeout}s)...", file=sys.stderr)
+    while time.time() < deadline:
+        src = _get_image_src(target_index)
+        if src.startswith("http") and src != before_src and _image_loaded(target_index):
+            print(f"  Saved: {src[:80]}...", file=sys.stderr)
+            return True
+        time.sleep(2)
+    return False
+
+
+def _click_save_changes_if_needed():
+    """Click Save Changes when Unlayer leaves the button enabled."""
+    snap = session.snapshot()
+    if not snap:
+        return
+    save_ref = _find_ref(snap, lambda l: "Save Changes" in l and "button" in l.lower() and "[disabled]" not in l.lower())
+    if save_ref:
+        session.run("click", save_ref, timeout=5)
+        time.sleep(3)
 
 
 def cmd_login(args):
@@ -627,9 +703,11 @@ def cmd_upload(args):
     # Open editor and resize viewport for full visibility
     url = _design_url(args.id)
     session.navigate(url)
-    time.sleep(5)
     session.run("resize", "1600", "1000")
-    time.sleep(1)
+    time.sleep(2)
+    if not _wait_for_unlayer_images(min_count=1, timeout=40):
+        print("ERROR: Unlayer editor did not load image placeholders.", file=sys.stderr)
+        return 1
 
     # Take snapshot of the editor iframe content
     snap = session.snapshot()
@@ -639,6 +717,7 @@ def cmd_upload(args):
 
     # Find image elements inside the Unlayer iframe (refs start with 'f')
     target_index = getattr(args, 'index', 0) or 0
+    before_src = _get_image_src(target_index)
     img_refs = []
     for line in snap.split("\n"):
         if "img" in line and "[ref=f" in line:
@@ -702,13 +781,23 @@ def cmd_upload(args):
         f'playwright-cli -s={SESSION_NAME} click {upload_ref} && '
         f'playwright-cli -s={SESSION_NAME} upload "{image_path}"'
     )
-    result = sp.run(shell_cmd, shell=True, capture_output=True, text=True, timeout=30)
+    file_mb = os.path.getsize(image_path) / (1024 * 1024)
+    upload_timeout = max(60, int(30 + file_mb * 10))
+    result = sp.run(shell_cmd, shell=True, capture_output=True, text=True, timeout=upload_timeout)
     if result.returncode != 0:
         print(f"ERROR: Upload failed: {result.stderr}", file=sys.stderr)
         return 1
 
-    time.sleep(3)
-    print(f"Uploaded: {os.path.basename(image_path)}", file=sys.stderr)
+    save_timeout = max(90, int(45 + file_mb * 15))
+    print(f"Waiting for upload to save ({file_mb:.1f} MB, up to {save_timeout}s)...", file=sys.stderr)
+    if not _wait_for_image_saved(target_index, before_src=before_src, timeout=save_timeout):
+        print("ERROR: Upload did not finish saving before timeout.", file=sys.stderr)
+        print("Stay on this page — do not navigate away — and re-run upload.", file=sys.stderr)
+        return 1
+
+    _click_save_changes_if_needed()
+    time.sleep(2)
+    print(f"Uploaded and saved: {os.path.basename(image_path)}", file=sys.stderr)
     return 0
 
 

--- a/apps/b3t/givebacks.py
+++ b/apps/b3t/givebacks.py
@@ -1,0 +1,781 @@
+"""GiveBacks newsletter CMS commands."""
+import json
+import os
+import re
+import sys
+import time
+
+import env
+import session
+from constants import (
+    GIVEBACKS_BASE, GIVEBACKS_API, GIVEBACKS_LOGIN, GIVEBACKS_CAUSE_ID, SESSION_NAME,
+)
+
+CAUSE_ID = GIVEBACKS_CAUSE_ID
+
+
+def dispatch(args):
+    if not GIVEBACKS_BASE or not CAUSE_ID:
+        print("ERROR: GIVEBACKS_BASE and GIVEBACKS_CAUSE_ID must be set in .env", file=sys.stderr)
+        return 1
+    action = args.action
+    if not action:
+        print("Usage: b3t givebacks <login|pull|push|open|list|duplicate|upload|screenshot>", file=sys.stderr)
+        return 2
+    if action == "login":
+        return cmd_login(args)
+    elif action == "pull":
+        return cmd_pull(args)
+    elif action == "push":
+        return cmd_push(args)
+    elif action == "open":
+        return cmd_open(args)
+    elif action == "list":
+        return cmd_list(args)
+    elif action == "duplicate":
+        return cmd_duplicate(args)
+    elif action == "upload":
+        return cmd_upload(args)
+    elif action == "screenshot":
+        return cmd_screenshot(args)
+    elif action == "rename":
+        return cmd_rename(args)
+    return 2
+
+
+def _api_url(message_id):
+    return f"{GIVEBACKS_API}/{message_id}?cause_id={CAUSE_ID}"
+
+
+def _design_url(message_id):
+    return f"{GIVEBACKS_BASE}/messages/{message_id}/design"
+
+
+def ensure_authenticated():
+    """Check auth, auto-login + OTP if needed. Returns True if authenticated.
+
+    Flow:
+    1. Navigate to /messages — if we land there, already logged in.
+    2. If on /sign-in — fill email/password from env, submit.
+    3. If on /one-time-passcode — fetch OTP from Outlook via new tab, enter it,
+       check "Trust this browser", submit. Close Outlook tab.
+    """
+    session.ensure_running()
+
+    # Step 1: Check if already authenticated
+    session.navigate(f"{GIVEBACKS_BASE}/messages")
+    time.sleep(3)
+    url = session.current_url() or ""
+
+    if "/sign-in" not in url and "/sign_in" not in url and "/one-time-passcode" not in url:
+        return True
+
+    # Step 2: If on a stale OTP page (browser reopened), sign out first
+    # because "Resend Code" doesn't work reliably with automation.
+    # A fresh _fill_login() always triggers a new code.
+    if "/one-time-passcode" in url:
+        print("Stale OTP page — signing out to trigger fresh code...", file=sys.stderr)
+        sign_out_ref = _find_ref(session.snapshot() or "", lambda l: "Sign Out" in l and "button" in l.lower())
+        if sign_out_ref:
+            session.run("click", sign_out_ref)
+            time.sleep(3)
+
+    # Step 3: Fill credentials (triggers a fresh OTP email)
+    url = session.current_url() or ""
+    if "/sign-in" in url or "/sign_in" in url:
+        if not _fill_login():
+            return False
+        time.sleep(4)
+        url = session.current_url() or ""
+
+    # Step 4: Handle OTP (code was just sent by _fill_login)
+    if "/one-time-passcode" in url:
+        if not _handle_otp():
+            return False
+        time.sleep(3)
+        url = session.current_url() or ""
+
+    # Final check
+    if "/sign-in" not in url and "/one-time-passcode" not in url:
+        session.save_state()
+        print("Login successful.", file=sys.stderr)
+        return True
+
+    print("ERROR: Login failed — still not on messages page.", file=sys.stderr)
+    return False
+
+
+def _fill_login():
+    """Fill email/password on the sign-in page and submit."""
+    user = os.environ.get("GIVEBACKS_USER")
+    passw = os.environ.get("GIVEBACKS_PASS")
+    if not user or not passw:
+        print("ERROR: Set GIVEBACKS_USER and GIVEBACKS_PASS in .env", file=sys.stderr)
+        return False
+
+    print("Logging in to GiveBacks...", file=sys.stderr)
+
+    snap = session.snapshot()
+    if not snap:
+        print("ERROR: Could not snapshot login page.", file=sys.stderr)
+        return False
+
+    email_ref = pass_ref = submit_ref = None
+    for line in snap.split("\n"):
+        ll = line.lower()
+        if "email" in ll and "textbox" in ll and not email_ref:
+            m = re.search(r'\[ref=(\w+)\]', line)
+            if m:
+                email_ref = m.group(1)
+        if "password" in ll and "textbox" in ll and not pass_ref:
+            m = re.search(r'\[ref=(\w+)\]', line)
+            if m:
+                pass_ref = m.group(1)
+        # "Sign In" button — NOT "Sign in with Apple/Google"
+        if "button" in ll and "sign in" in ll and "apple" not in ll and "google" not in ll and not submit_ref:
+            m = re.search(r'\[ref=(\w+)\]', line)
+            if m:
+                submit_ref = m.group(1)
+
+    if not email_ref or not pass_ref:
+        print("ERROR: Cannot find login form fields.", file=sys.stderr)
+        return False
+
+    session.run("fill", email_ref, user)
+    session.run("fill", pass_ref, passw)
+
+    if submit_ref:
+        session.run("click", submit_ref)
+    else:
+        session.run("press", pass_ref, "Enter")
+
+    return True
+
+
+def _handle_otp():
+    """Handle the one-time-passcode page.
+
+    1. Note where code was sent
+    2. Click "Resend Code" (prior code may be expired)
+    3. Open Outlook in new tab, find OTP email, extract 6-digit code
+    4. Close Outlook tab (switch back to GiveBacks tab)
+    5. Enter code into pin inputs
+    6. Check "Trust this browser"
+    7. Submit
+    """
+    snap = session.snapshot()
+    if not snap:
+        print("ERROR: Cannot snapshot OTP page.", file=sys.stderr)
+        return False
+
+    # Note where code was sent
+    sent_to = ""
+    for line in snap.split("\n"):
+        if "sent a 6-digit code to" in line:
+            m = re.search(r'code to ([^\s."]+)', line)
+            if m:
+                sent_to = m.group(1)
+                break
+    print(f"OTP required (sent to {sent_to}). Checking email...", file=sys.stderr)
+
+    # Wait a moment for the email to arrive
+    time.sleep(5)
+
+    # Open Outlook in a new tab to retrieve the code
+    session.run("tab-new", "https://outlook.office.com/mail/")
+    time.sleep(5)
+
+    # Get the OTP from the most recent GiveBacks email
+    otp_code = _extract_otp_from_outlook()
+
+    # Close Outlook tab and switch back to GiveBacks (tab 0)
+    session.run("tab-close")
+    time.sleep(1)
+    session.run("tab-select", "0")
+    time.sleep(1)
+
+    if not otp_code:
+        print("ERROR: Could not extract OTP code from email.", file=sys.stderr)
+        return False
+
+    print(f"Got OTP: {otp_code}", file=sys.stderr)
+
+    # Enter code into pin inputs (6 individual textboxes)
+    snap = session.snapshot()
+    pin_refs = []
+    for line in snap.split("\n"):
+        if "PinInput" in line and "textbox" in line:
+            m = re.search(r'\[ref=(\w+)\]', line)
+            if m:
+                pin_refs.append(m.group(1))
+
+    if len(pin_refs) < 6:
+        print(f"ERROR: Found {len(pin_refs)} pin inputs, need 6.", file=sys.stderr)
+        return False
+
+    # Fill each digit
+    for i, digit in enumerate(otp_code[:6]):
+        session.run("fill", pin_refs[i], digit)
+        time.sleep(0.2)
+
+    # Check "Trust this browser" if present
+    trust_ref = _find_ref(snap, lambda l: "trust" in l.lower() and ("checkbox" in l.lower() or "check" in l.lower()))
+    if trust_ref:
+        session.run("check", trust_ref)
+        time.sleep(0.5)
+
+    # Click Submit
+    submit_ref = _find_ref(snap, lambda l: "Submit" in l and "button" in l.lower() and "disabled" not in l.lower())
+    if submit_ref:
+        session.run("click", submit_ref)
+    else:
+        # Submit may auto-trigger after all digits entered
+        session.run("press", pin_refs[-1], "Enter")
+
+    time.sleep(3)
+    return True
+
+
+def _extract_otp_from_outlook():
+    """Find the most recent GiveBacks OTP email and extract the 6-digit code."""
+    # Wait for Outlook to load
+    snap = session.snapshot()
+    if not snap:
+        return None
+
+    # Check if we landed on Outlook (not login redirect)
+    url = session.current_url()
+    if url and "login.microsoftonline.com" in url:
+        print("ERROR: Outlook not authenticated.", file=sys.stderr)
+        return None
+
+    # Look for OTP email in the message list — click the first unread one from GiveBacks/noreply
+    # The email subject is typically "Your one-time passcode" or similar
+    # First, look at the message list for something with "passcode" or "code" or "GiveBacks"
+    snap = session.snapshot()
+    msg_ref = _find_ref(snap, lambda l: "option" in l.lower() and ("passcode" in l.lower() or "givebacks" in l.lower() or "verification" in l.lower() or "code" in l.lower()))
+
+    if msg_ref:
+        session.run("click", msg_ref)
+        time.sleep(2)
+        snap = session.snapshot()
+
+    # Look for the 6-digit code in the reading pane or message preview
+    # OTP codes are typically standalone 6-digit numbers
+    if snap:
+        for line in snap.split("\n"):
+            # Look for a standalone 6-digit number
+            m = re.search(r'\b(\d{6})\b', line)
+            if m:
+                code = m.group(1)
+                # Verify it's not a phone number or other noise
+                if "phone" not in line.lower() and "fax" not in line.lower():
+                    return code
+
+    # Fallback: look in generic elements for the code
+    if snap:
+        for line in snap.split("\n"):
+            if "generic" in line and "ref=" in line:
+                m = re.search(r'\b(\d{6})\b', line)
+                if m:
+                    return m.group(1)
+
+    return None
+
+
+def _find_ref(snapshot_text, test_fn):
+    """Find first ref matching test_fn(line) -> bool."""
+    for line in snapshot_text.split("\n"):
+        if test_fn(line):
+            m = re.search(r'\[ref=(\w+)\]', line)
+            if m:
+                return m.group(1)
+    return None
+
+
+def _parse_json_result(stdout):
+    """Parse JSON from run-code output. Result may be double-quoted."""
+    for line in stdout.split("\n"):
+        line = line.strip()
+        if not line or line.startswith("###") or line.startswith("```") or line.startswith("await"):
+            continue
+        try:
+            parsed = json.loads(line)
+            if isinstance(parsed, str):
+                return json.loads(parsed)
+            return parsed
+        except (json.JSONDecodeError, ValueError, TypeError):
+            continue
+    return None
+
+
+def cmd_login(args):
+    if ensure_authenticated():
+        return 0
+    return 1
+
+
+def cmd_pull(args):
+    """Pull design JSON from GiveBacks API."""
+    if not ensure_authenticated():
+        return 1
+
+    api_url = _api_url(args.id)
+    js = (
+        f'() => fetch("{api_url}", {{credentials: "include"}})'
+        f'.then(r => r.json()).then(d => d.message.template)'
+    )
+
+    print(f"Pulling design for {args.id}...", file=sys.stderr)
+    result = session.run("eval", js, timeout=15)
+
+    # Parse template string from eval output
+    template_str = None
+    for line in result.stdout.split("\n"):
+        line = line.strip()
+        if line.startswith('"') and "counters" in line:
+            template_str = json.loads(line)
+            break
+
+    if not template_str:
+        print("ERROR: Could not parse design from response.", file=sys.stderr)
+        print(result.stdout[:500], file=sys.stderr)
+        return 1
+
+    design = json.loads(template_str)
+    rows = len(design.get("body", {}).get("rows", []))
+    print(f"Got design: {rows} rows", file=sys.stderr)
+
+    output = json.dumps(design, indent=2)
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(output)
+        print(f"Written to {args.output}", file=sys.stderr)
+    else:
+        print(output)
+
+    return 0
+
+
+def cmd_push(args):
+    """Push design JSON to GiveBacks API."""
+    if not ensure_authenticated():
+        return 1
+
+    if not os.path.exists(args.design):
+        print(f"ERROR: File not found: {args.design}", file=sys.stderr)
+        return 1
+
+    with open(args.design) as f:
+        design = json.load(f)
+
+    template_str = json.dumps(design)
+    local_rows = len(design.get("body", {}).get("rows", []))
+    print(f"Pushing design: {local_rows} rows, {len(template_str)} bytes", file=sys.stderr)
+
+    # Store in localStorage (handles large payloads)
+    result = session.run("localstorage-set", "_b3t_template", template_str)
+    if result.returncode != 0:
+        print(f"ERROR: Could not store design: {result.stderr}", file=sys.stderr)
+        return 1
+
+    api_url = _api_url(args.id)
+    js = f'''() => {{
+  const template = localStorage.getItem("_b3t_template");
+  return fetch("{api_url}", {{
+    method: "PUT",
+    credentials: "include",
+    headers: {{"Content-Type": "application/json"}},
+    body: JSON.stringify({{message: {{template: template}}}})
+  }}).then(r => r.status + " " + r.statusText);
+}}'''
+
+    result = session.run("eval", js, timeout=30)
+
+    # Cleanup localStorage
+    session.run("localstorage-set", "_b3t_template", "")
+
+    if "200" not in result.stdout:
+        print(f"ERROR: Push failed: {result.stdout}", file=sys.stderr)
+        return 1
+
+    print("Push successful.", file=sys.stderr)
+
+    if args.verify:
+        js_verify = f'''() => fetch("{api_url}", {{credentials: "include"}}).then(r => r.json()).then(d => {{
+  const t = JSON.parse(d.message.template);
+  return JSON.stringify({{rows: t.body.rows.length}});
+}})'''
+        result = session.run("eval", js_verify)
+        for line in result.stdout.split("\n"):
+            line = line.strip().strip('"')
+            if "rows" in line:
+                try:
+                    data = json.loads(line)
+                    server_rows = data.get("rows", 0)
+                    if server_rows == local_rows:
+                        print(f"Verified: {server_rows} rows.", file=sys.stderr)
+                    else:
+                        print(f"MISMATCH: server={server_rows}, local={local_rows}", file=sys.stderr)
+                        return 1
+                except json.JSONDecodeError:
+                    pass
+
+    return 0
+
+
+def cmd_open(args):
+    """Open newsletter editor in browser."""
+    session.ensure_running()
+    url = _design_url(args.id)
+    print(f"Opening editor: {url}", file=sys.stderr)
+    return session.navigate(url)
+
+
+def cmd_list(args):
+    """List recent newsletter drafts."""
+    if not ensure_authenticated():
+        return 1
+
+    # Must be on a GiveBacks page for fetch to include auth cookies
+    js = f'''() => fetch("https://api.givebacks.com/services/communication/messages?cause_id={CAUSE_ID}&per_page=10", {{
+  credentials: "include"
+}}).then(r => r.json()).then(d => JSON.stringify(d.messages || d.data || d))'''
+
+    result = session.run("eval", js, timeout=15)
+
+    for line in result.stdout.split("\n"):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            # Output may be double-encoded (string within string)
+            parsed = line
+            if parsed.startswith('"'):
+                parsed = json.loads(parsed)
+            data = json.loads(parsed) if isinstance(parsed, str) else parsed
+            if isinstance(data, list):
+                for msg in data[:10]:
+                    mid = msg.get("id", msg.get("uuid", "?"))
+                    subj = msg.get("subject", msg.get("name", "?"))
+                    status = msg.get("status", "?")
+                    sent = msg.get("sent_at", "")[:10] if msg.get("sent_at") else ""
+                    print(f"  {mid}  [{status}]  {sent}  {subj}")
+                return 0
+        except (json.JSONDecodeError, TypeError, ValueError):
+            continue
+
+    print("Could not parse messages list.", file=sys.stderr)
+    print(result.stdout[:500], file=sys.stderr)
+    return 1
+
+
+def cmd_duplicate(args):
+    """Duplicate a newsletter. Returns new draft UUID on stdout.
+
+    Flow:
+    1. Navigate to /messages
+    2. Find the row matching --id
+    3. Click its three-dot menu button
+    4. Click "Duplicate" menuitem
+    5. Wait for page to reload with new draft
+    6. Find the "(Copy)" entry via API and return its UUID
+    """
+    if not ensure_authenticated():
+        return 1
+
+    source_id = args.id
+    print(f"Duplicating {source_id}...", file=sys.stderr)
+
+    # Navigate to messages list
+    session.navigate(f"{GIVEBACKS_BASE}/messages?search%5Bdeleted%5D%5Bvalue%5D=false")
+    time.sleep(3)
+
+    # Find the row containing this message and its kebab menu button
+    snap = session.snapshot()
+    if not snap:
+        print("ERROR: Cannot snapshot messages page.", file=sys.stderr)
+        return 1
+
+    # Rows have format: row "Subject ..." [ref=eNNN]
+    # Each row's last cell contains a button (the kebab menu)
+    # We need to find the row that matches our source subject, then click its button
+    kebab_ref = _find_kebab_for_message(snap, source_id)
+
+    if not kebab_ref:
+        print(f"ERROR: Cannot find message row for {source_id}.", file=sys.stderr)
+        return 1
+
+    # Click the three-dot menu
+    session.run("click", kebab_ref)
+    time.sleep(1)
+
+    # Snapshot to find "Duplicate" menuitem
+    snap = session.snapshot()
+    dup_ref = _find_ref(snap, lambda l: 'menuitem' in l.lower() and 'Duplicate' in l)
+    if not dup_ref:
+        print("ERROR: Cannot find Duplicate menuitem.", file=sys.stderr)
+        session.run("press", "Escape")
+        return 1
+
+    session.run("click", dup_ref)
+    time.sleep(4)
+
+    # The duplicate creates a new draft. Find it via API (it'll have "(Copy)" in subject)
+    js = f'''() => fetch("https://api.givebacks.com/services/communication/messages?cause_id={CAUSE_ID}&per_page=5&search%5Bstatus%5D%5Bvalue%5D=draft", {{
+  credentials: "include"
+}}).then(r => r.json()).then(d => JSON.stringify(d.messages || d.data || d))'''
+
+    result = session.run("eval", js, timeout=15)
+    new_id = _parse_newest_draft(result.stdout)
+
+    if not new_id:
+        print("ERROR: Could not find new draft after duplicate.", file=sys.stderr)
+        return 1
+
+    print(f"Created draft: {new_id}", file=sys.stderr)
+    print(new_id)
+    return 0
+
+
+def _find_kebab_for_message(snap, message_id):
+    """Find the kebab menu button ref for a message row.
+
+    Strategy: the message list is a table. Each row's last cell has a button.
+    We match by checking if the row text or the message subject corresponds to
+    our target. Since we know the UUID, we can also check by fetching the list
+    and matching subjects. But simpler: we rely on row order matching list order.
+    """
+    lines = snap.split("\n")
+    # Find the row that could contain our message by subject/ID
+    # We'll look for any row and its kebab button
+    # The API list gives us subjects — match by subject from the --id arg?
+    # Actually, let's just get the subject from the API first
+    js = f'''() => fetch("https://api.givebacks.com/services/communication/messages/{message_id}?cause_id={CAUSE_ID}", {{
+  credentials: "include"
+}}).then(r => r.json()).then(d => d.message ? d.message.subject : "NOT_FOUND")'''
+
+    result = session.run("eval", js, timeout=15)
+    subject = ""
+    for line in result.stdout.split("\n"):
+        line = line.strip().strip('"')
+        if line and line != "NOT_FOUND" and "Bear Tracks" in line:
+            subject = line
+            break
+
+    if not subject:
+        return None
+
+    # Now find the row with this subject in the snapshot
+    in_target_row = False
+    for line in lines:
+        if f'cell "{subject}"' in line:
+            in_target_row = True
+            continue
+        if in_target_row:
+            # Look for the button in subsequent cells of this row
+            if "button" in line and "ref=" in line and "cursor=pointer" in line:
+                m = re.search(r'\[ref=(\w+)\]', line)
+                if m:
+                    return m.group(1)
+            # If we hit the next row, stop
+            if 'row "' in line:
+                break
+
+    return None
+
+
+def _parse_newest_draft(stdout):
+    """Parse the newest draft UUID from messages API response."""
+    for line in stdout.split("\n"):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            parsed = line
+            if parsed.startswith('"'):
+                parsed = json.loads(parsed)
+            data = json.loads(parsed) if isinstance(parsed, str) else parsed
+            if isinstance(data, list) and data:
+                return data[0].get("id", data[0].get("uuid"))
+        except (json.JSONDecodeError, TypeError, ValueError):
+            continue
+    return None
+
+
+def cmd_upload(args):
+    """Upload an image to a placeholder in the newsletter editor.
+
+    Flow:
+    1. Open the editor at /messages/{id}/design
+    2. Wait for Unlayer iframe to load
+    3. Remove overlays (so clicks reach actual elements)
+    4. Click the target image placeholder (by index or alt text)
+    5. Click "Upload Image" in the right panel
+    6. Handle file chooser with the upload command
+    """
+    if not ensure_authenticated():
+        return 1
+
+    image_path = os.path.abspath(args.image)
+    if not os.path.exists(image_path):
+        print(f"ERROR: File not found: {image_path}", file=sys.stderr)
+        return 1
+
+    print(f"Uploading {os.path.basename(image_path)} to editor...", file=sys.stderr)
+
+    # Open editor and resize viewport for full visibility
+    url = _design_url(args.id)
+    session.navigate(url)
+    time.sleep(5)
+    session.run("resize", "1600", "1000")
+    time.sleep(1)
+
+    # Take snapshot of the editor iframe content
+    snap = session.snapshot()
+    if not snap:
+        print("ERROR: Cannot snapshot editor.", file=sys.stderr)
+        return 1
+
+    # Find image elements inside the Unlayer iframe (refs start with 'f')
+    target_index = getattr(args, 'index', 0) or 0
+    img_refs = []
+    for line in snap.split("\n"):
+        if "img" in line and "[ref=f" in line:
+            m = re.search(r'\[ref=(f\w+)\]', line)
+            if m:
+                img_refs.append(m.group(1))
+
+    if not img_refs:
+        print("ERROR: No images found in editor.", file=sys.stderr)
+        return 1
+
+    if target_index >= len(img_refs):
+        print(f"ERROR: Only {len(img_refs)} images found, index {target_index} out of range.", file=sys.stderr)
+        print("Available images:", file=sys.stderr)
+        for i, ref in enumerate(img_refs):
+            for line in snap.split("\n"):
+                if ref in line:
+                    print(f"  [{i}] {line.strip()}", file=sys.stderr)
+                    break
+        return 1
+
+    # Scroll image into view, get bounding box, click at center coordinates.
+    # Direct click on <img> ref fails because Unlayer's overlay div intercepts
+    # pointer events. Coordinate-based mouse.click hits the overlay, selecting the block.
+    scroll_and_bbox_js = (
+        'async function main() { const frames = page.frames(); '
+        'for (const f of frames) { if (f.url().includes("unlayer")) { '
+        'const imgs = await f.locator("img[alt]").all(); '
+        f'if (imgs.length > {target_index}) {{ '
+        f'await imgs[{target_index}].scrollIntoViewIfNeeded(); '
+        f'const box = await imgs[{target_index}].boundingBox(); '
+        'return JSON.stringify(box); } } } return "none"; }'
+    )
+    result = session.run("run-code", scroll_and_bbox_js, timeout=10)
+    bbox = _parse_json_result(result.stdout)
+
+    if not bbox or "x" not in bbox:
+        print("ERROR: Cannot get image bounding box.", file=sys.stderr)
+        print(f"  run-code output: {result.stdout[:200]}", file=sys.stderr)
+        return 1
+
+    cx = int(bbox["x"] + bbox["width"] / 2)
+    cy = int(bbox["y"] + bbox["height"] / 2)
+    click_js = f'async function main() {{ await page.mouse.click({cx}, {cy}); return "clicked"; }}'
+    session.run("run-code", click_js, timeout=5)
+    time.sleep(2)
+
+    # Re-snapshot: "Upload Image" button appears in right panel AFTER selection
+    snap = session.snapshot()
+    upload_ref = _find_ref(snap, lambda l: "Upload Image" in l and "button" in l.lower())
+
+    if not upload_ref:
+        print("ERROR: Cannot find 'Upload Image' button. Image block may not be selected.", file=sys.stderr)
+        print("Try: b3t givebacks open --id {id}, manually click the image, then re-run.", file=sys.stderr)
+        return 1
+
+    # CRITICAL: Click "Upload Image" AND handle file chooser in ONE chained call.
+    # The file chooser is only pending briefly after the button click.
+    import subprocess as sp
+    shell_cmd = (
+        f'playwright-cli -s={SESSION_NAME} click {upload_ref} && '
+        f'playwright-cli -s={SESSION_NAME} upload "{image_path}"'
+    )
+    result = sp.run(shell_cmd, shell=True, capture_output=True, text=True, timeout=30)
+    if result.returncode != 0:
+        print(f"ERROR: Upload failed: {result.stderr}", file=sys.stderr)
+        return 1
+
+    time.sleep(3)
+    print(f"Uploaded: {os.path.basename(image_path)}", file=sys.stderr)
+    return 0
+
+
+
+
+def cmd_screenshot(args):
+    """Take a screenshot of the newsletter for visual verification.
+
+    Opens the editor preview or the share link and captures a full-page screenshot.
+    Output: PNG file path on stdout.
+    """
+    if not ensure_authenticated():
+        return 1
+
+    output_dir = getattr(args, 'dir', '.') or '.'
+    os.makedirs(output_dir, exist_ok=True)
+    output_path = os.path.abspath(os.path.join(output_dir, f"newsletter-preview.png"))
+
+    # Use the "View Newsletter" share page (public once sent, or preview for drafts)
+    # For a cleaner view: use the messages/{id} page which shows a preview
+    url = f"{GIVEBACKS_BASE}/messages/{args.id}"
+    session.navigate(url)
+    time.sleep(4)
+
+    # Take a full-page screenshot
+    result = session.run("screenshot", "--full-page", f"--filename={output_path}", timeout=15)
+    if result.returncode != 0:
+        # Fallback: try using the design editor preview
+        url = _design_url(args.id)
+        session.navigate(url)
+        time.sleep(5)
+        result = session.run("screenshot", "--full-page", f"--filename={output_path}", timeout=15)
+        if result.returncode != 0:
+            print(f"ERROR: Screenshot failed: {result.stderr}", file=sys.stderr)
+            return 1
+
+    print(f"Screenshot saved.", file=sys.stderr)
+    print(output_path)
+    return 0
+
+
+def cmd_rename(args):
+    """Rename a newsletter draft (update subject via API).
+
+    Usage: b3t givebacks rename --id UUID --subject "Bear Tracks - Summer Send-Off"
+    """
+    if not ensure_authenticated():
+        return 1
+
+    subject = args.subject
+    print(f"Renaming to: {subject}", file=sys.stderr)
+
+    api_url = _api_url(args.id)
+    # Escape quotes in subject for JS
+    safe_subject = subject.replace('\\', '\\\\').replace('"', '\\"')
+    js = f'''() => fetch("{api_url}", {{
+  method: "PUT",
+  credentials: "include",
+  headers: {{"Content-Type": "application/json"}},
+  body: JSON.stringify({{message: {{subject: "{safe_subject}"}}}})
+}}).then(r => r.status + " " + r.statusText)'''
+
+    result = session.run("eval", js, timeout=15)
+
+    if "200" not in result.stdout:
+        print(f"ERROR: Rename failed: {result.stdout}", file=sys.stderr)
+        return 1
+
+    print("Done.", file=sys.stderr)
+    return 0

--- a/apps/b3t/lwsd.py
+++ b/apps/b3t/lwsd.py
@@ -1,0 +1,212 @@
+"""LWSD school website scanning. No auth needed.
+
+Usage:
+    b3t lwsd scan    # Scan both rms.lwsd.org and lwsd.org for events and news
+"""
+import re
+import sys
+import time
+
+import session
+from constants import LWSD_SCHOOL_URL, LWSD_DISTRICT_URL
+
+DISTRICT_URL = LWSD_DISTRICT_URL
+
+
+def dispatch(args):
+    action = args.action
+    if not action:
+        print("Usage: b3t lwsd <scan>", file=sys.stderr)
+        return 2
+    if action == "scan":
+        return cmd_scan(args)
+    return 2
+
+
+def cmd_scan(args):
+    """Scan school and district sites for events and news. No auth needed."""
+    session.ensure_running()
+
+    rms_events = []
+    rms_news = []
+
+    if LWSD_SCHOOL_URL:
+        session.navigate(LWSD_SCHOOL_URL)
+        time.sleep(3)
+        snap = session.snapshot()
+        rms_events = _parse_events(snap, "School events") if snap else []
+        rms_news = _parse_news(snap) if snap else []
+    else:
+        print("LWSD_SCHOOL_URL not set — skipping school site scan.", file=sys.stderr)
+
+    # Scan district site
+    session.navigate(DISTRICT_URL)
+    time.sleep(3)
+    snap = session.snapshot()
+
+    district_events = _parse_events(snap, "lwsd events") if snap else []
+    district_news = _parse_district_news(snap) if snap else []
+
+    # Output
+    print("=== School Events ===" if LWSD_SCHOOL_URL else "=== School Events (skipped) ===")
+    if rms_events:
+        for e in rms_events:
+            print(f"  {e}")
+    else:
+        print("  (none found)")
+
+    print("\n=== School News ===" if LWSD_SCHOOL_URL else "\n=== School News (skipped) ===")
+    if rms_news:
+        for n in rms_news:
+            print(f"  {n}")
+    else:
+        print("  (none found)")
+
+    print("\n=== LWSD District Events ===")
+    if district_events:
+        for e in district_events:
+            print(f"  {e}")
+    else:
+        print("  (none found)")
+
+    print("\n=== LWSD District News ===")
+    if district_news:
+        for n in district_news:
+            print(f"  {n}")
+    else:
+        print("  (none found)")
+
+    print(f"\nScanned: {LWSD_SCHOOL_URL or '(no school URL)'} + {DISTRICT_URL}", file=sys.stderr)
+    return 0
+
+
+def _parse_events(snap, section_heading="RMS events"):
+    """Parse events from an events section on the homepage."""
+    events = []
+    lines = snap.split("\n")
+    in_events = False
+    current_month = ""
+    current_day = ""
+
+    for line in lines:
+        # Start of events section
+        if f'heading "{section_heading}"' in line:
+            in_events = True
+            continue
+        # End of events section (next major section)
+        if in_events and 'heading "' in line and "level=2" in line and section_heading not in line:
+            # Check it's not an event button masquerading as a heading
+            if "events" not in line.lower() and "calendar" not in line.lower():
+                break
+        if not in_events:
+            continue
+
+        # Month (in time elements or generic elements)
+        if "generic [ref=" in line:
+            m = re.search(r'generic \[ref=\w+\]:\s*"?([^"]+)"?', line)
+            if m:
+                text = m.group(1).strip().strip('"')
+                # Month abbreviation
+                if text in ("Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                            "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"):
+                    current_month = text
+                # Day number
+                elif re.match(r'^\d{1,2}$', text):
+                    current_day = text
+
+        # Event title (in button or group elements)
+        if ("button" in line or "group" in line) and "ref=" in line:
+            m = re.search(r'(?:button|group) "([^"]+)"', line)
+            if m:
+                title = m.group(1).strip()
+                if title and len(title) > 5 and "ref=" not in title:
+                    date_str = f"{current_month} {current_day}" if current_month and current_day else ""
+                    events.append(f"{date_str}: {title}" if date_str else title)
+
+        # Time ranges
+        if "time [ref=" in line:
+            m = re.search(r'time \[ref=\w+\]:\s*(.+)', line)
+            if m:
+                time_text = m.group(1).strip()
+                if ":" in time_text and events:
+                    events[-1] += f" ({time_text})"
+
+        # Location
+        if "generic [ref=" in line and "  " in line:
+            m = re.search(r'generic \[ref=\w+\]:\s*(.+)', line)
+            if m:
+                text = m.group(1).strip()
+                if text and ("RMS" in text or "GYM" in text or "Center" in text or "Library" in text):
+                    if events:
+                        events[-1] += f" @ {text}"
+
+    return events
+
+
+def _parse_news(snap):
+    """Parse news items from the RMS news section."""
+    news = []
+    lines = snap.split("\n")
+    in_news = False
+
+    for line in lines:
+        if 'heading "RMS news"' in line:
+            in_news = True
+            continue
+        if not in_news:
+            continue
+
+        # News items as links
+        if "link" in line.lower() and "/url:" not in line:
+            m = re.search(r'link "([^"]+)"', line)
+            if m:
+                title = m.group(1).strip()
+                if title and len(title) > 15:
+                    news.append(title)
+
+        # Or as headings/text
+        if "heading" in line.lower() and "level" in line:
+            m = re.search(r'heading "([^"]+)"', line)
+            if m:
+                title = m.group(1).strip()
+                if title and len(title) > 15:
+                    news.append(title)
+
+    # Deduplicate
+    seen = set()
+    unique = []
+    for n in news:
+        if n not in seen:
+            seen.add(n)
+            unique.append(n)
+    return unique[:10]
+
+
+def _parse_district_news(snap):
+    """Parse news/stories from lwsd.org homepage."""
+    news = []
+    lines = snap.split("\n")
+
+    # District news appears as links with article titles
+    for line in lines:
+        if "link" in line.lower() and "/url:" not in line:
+            m = re.search(r'link "([^"]+)"', line)
+            if m:
+                title = m.group(1).strip()
+                # Filter to actual news articles (skip nav, social, generic)
+                if (title and len(title) > 20
+                        and "opens in new window" not in title
+                        and "News & Stories" not in title
+                        and "newsletter" not in title.lower()
+                        and not title.startswith("LWSD")
+                        and "Skip" not in title):
+                    news.append(title)
+
+    # Deduplicate
+    seen = set()
+    unique = []
+    for n in news:
+        if n not in seen:
+            seen.add(n)
+            unique.append(n)
+    return unique[:10]

--- a/apps/b3t/osp.py
+++ b/apps/b3t/osp.py
@@ -1,0 +1,364 @@
+"""OurSchoolPages CMS archive and site scan commands."""
+import os
+import re
+import sys
+import time
+
+import env
+import session
+from constants import OSP_BASE, OSP_LOGIN, OSP_CREATE_PAGE, OSP_SCAN_PAGES
+
+
+def dispatch(args):
+    action = args.action
+    if not action:
+        print("Usage: b3t osp <login|archive|scan>", file=sys.stderr)
+        return 2
+    if action == "login":
+        return cmd_login(args)
+    elif action == "archive":
+        return cmd_archive(args)
+    elif action == "scan":
+        return cmd_scan(args)
+    return 2
+
+
+def ensure_authenticated():
+    """Check OSP auth, auto-login if needed."""
+    session.ensure_running()
+
+    # Test by navigating to admin
+    session.navigate(f"{OSP_BASE}/Admin/Index")
+    time.sleep(2)
+    url = session.current_url()
+    if url and "/Account/LogOn" not in url:
+        return True
+
+    user = os.environ.get("OURSCHOOLPAGES_USER")
+    passw = os.environ.get("OURSCHOOLPAGES_PASS")
+    if not user or not passw:
+        print("ERROR: Set OURSCHOOLPAGES_USER and OURSCHOOLPAGES_PASS in .env", file=sys.stderr)
+        return False
+
+    print("Logging in to OurSchoolPages...", file=sys.stderr)
+    session.navigate(OSP_LOGIN)
+    time.sleep(2)
+
+    snap = session.snapshot()
+    if not snap:
+        return False
+
+    user_ref = pass_ref = submit_ref = None
+    for line in snap.split("\n"):
+        ll = line.lower()
+        if ("username" in ll or "email" in ll) and "textbox" in ll and not user_ref:
+            m = re.search(r'\[ref=(\w+)\]', line)
+            if m:
+                user_ref = m.group(1)
+        if "password" in ll and "textbox" in ll and not pass_ref:
+            m = re.search(r'\[ref=(\w+)\]', line)
+            if m:
+                pass_ref = m.group(1)
+        if ("log" in ll or "sign" in ll) and "button" in ll and not submit_ref:
+            m = re.search(r'\[ref=(\w+)\]', line)
+            if m:
+                submit_ref = m.group(1)
+
+    if not user_ref or not pass_ref:
+        print("ERROR: Cannot find login fields.", file=sys.stderr)
+        return False
+
+    session.run("fill", user_ref, user)
+    session.run("fill", pass_ref, passw)
+
+    if submit_ref:
+        session.run("click", submit_ref)
+    else:
+        session.run("press", pass_ref, "Enter")
+
+    time.sleep(3)
+    session.save_state()
+    print("OurSchoolPages login successful.", file=sys.stderr)
+    return True
+
+
+def cmd_login(args):
+    if ensure_authenticated():
+        return 0
+    return 1
+
+
+def cmd_archive(args):
+    """Create archive page for an edition."""
+    if not ensure_authenticated():
+        return 1
+
+    html_path = args.html
+    if not os.path.exists(html_path):
+        print(f"ERROR: File not found: {html_path}", file=sys.stderr)
+        return 1
+
+    with open(html_path) as f:
+        html_content = f.read()
+
+    edition_date = args.edition
+    slug = f"{edition_date}-english"
+    heading = f"Bear Tracks - {edition_date}"
+
+    print(f"Creating archive page: {slug}", file=sys.stderr)
+    session.navigate(OSP_CREATE_PAGE)
+    time.sleep(2)
+
+    snap = session.snapshot()
+    if not snap:
+        return 1
+
+    # Find form fields: Name, Heading
+    name_ref = heading_ref = None
+    for line in snap.split("\n"):
+        ll = line.lower()
+        if "name" in ll and "textbox" in ll and not name_ref:
+            m = re.search(r'\[ref=(\w+)\]', line)
+            if m:
+                name_ref = m.group(1)
+        if "heading" in ll and "textbox" in ll and not heading_ref:
+            m = re.search(r'\[ref=(\w+)\]', line)
+            if m:
+                heading_ref = m.group(1)
+
+    if not name_ref:
+        print("ERROR: Cannot find Name field.", file=sys.stderr)
+        return 1
+
+    session.run("fill", name_ref, slug)
+    if heading_ref:
+        session.run("fill", heading_ref, heading)
+
+    # For HTML content, need to use Source Code button in TinyMCE
+    # Store HTML in localStorage, then inject via TinyMCE API
+    session.run("localstorage-set", "_b3t_html", html_content)
+
+    js = '''() => {
+  const html = localStorage.getItem("_b3t_html");
+  const editor = window.tinymce && window.tinymce.activeEditor;
+  if (editor) {
+    editor.setContent(html);
+    return "ok";
+  }
+  return "no-tinymce";
+}'''
+    result = session.run("eval", js)
+
+    session.run("localstorage-set", "_b3t_html", "")
+
+    if "ok" not in result.stdout:
+        print("WARNING: Could not inject HTML via TinyMCE. Use Source button manually.", file=sys.stderr)
+        print("HTML stored in clipboard-ready format.", file=sys.stderr)
+
+    print(f"Page form filled. Review and save manually.", file=sys.stderr)
+    print(f"URL will be: {OSP_BASE}/Page/BearTracks/{slug}")
+    return 0
+
+
+def _parse_page_content(snap):
+    """Extract headings, text, and links from a standard page snapshot."""
+    lines = []
+    for line in snap.split("\n"):
+        if "heading" in line.lower() and "level" in line:
+            m = re.search(r'heading "([^"]+)"', line)
+            if m:
+                text = m.group(1).strip()
+                if text and len(text) > 3 and "Sign in" not in text:
+                    lines.append(f"# {text}")
+        elif "- text:" in line:
+            text = re.sub(r'^\s*- text:\s*', '', line).strip()
+            if text and len(text) > 20:
+                lines.append(text)
+        elif "link" in line.lower() and "/url:" not in line:
+            m = re.search(r'link "([^"]+)"', line)
+            if m:
+                text = m.group(1).strip()
+                if text and len(text) > 10 and "Powered by" not in text:
+                    lines.append(f"[link] {text}")
+
+    seen = set()
+    unique = []
+    for l in lines:
+        if l not in seen:
+            seen.add(l)
+            unique.append(l)
+    return "\n".join(unique[:30])
+
+
+def _parse_calendar(snap):
+    """Extract calendar events from month view.
+
+    Structure: alternating date rows and event rows.
+    Date row: 7 cells with day numbers (Sun-Sat), e.g. "May 31 Jun 1 2 3 4 5 6"
+    Event row: 7 cells, most empty, event text in the column matching its day.
+    """
+    lines = snap.split("\n")
+    events = []
+    current_month = ""
+
+    # Get month/year
+    for line in lines:
+        if "generic [ref=" in line:
+            m = re.search(r':\s*((?:January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{4})', line)
+            if m:
+                current_month = m.group(1).strip()
+                break
+
+    # Parse rows — track date rows and map column positions to dates
+    current_dates = []  # 7 dates for current week (Sun-Sat)
+    for line in lines:
+        # Date row: row text contains the day numbers
+        row_match = re.search(r'row "(.+?)" \[ref=', line)
+        if row_match:
+            row_text = row_match.group(1)
+            # Check if this is a date row (contains mostly numbers)
+            parts = row_text.split()
+            dates_in_row = []
+            i = 0
+            while i < len(parts):
+                # Handle "Jun 1" or "Jul 1" style
+                if re.match(r'^(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)$', parts[i]) and i + 1 < len(parts):
+                    dates_in_row.append(f"{parts[i]} {parts[i+1]}")
+                    i += 2
+                elif re.match(r'^\d{1,2}$', parts[i]):
+                    dates_in_row.append(parts[i])
+                    i += 1
+                else:
+                    # Not a date row — it's an event row
+                    break
+            if len(dates_in_row) == 7:
+                current_dates = dates_in_row
+            continue
+
+        # Event cells within event rows — find non-empty cells by position
+        cell_match = re.search(r'cell "([^"]+)"', line)
+        if cell_match and current_dates:
+            cell_text = cell_match.group(1)
+            # Skip if it's just a date number
+            if re.match(r'^(?:(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+)?\d{1,2}$', cell_text):
+                continue
+            # This is an event — figure out which column it's in
+            # Count preceding empty cells + this cell to determine column
+            # Since we can't easily get column from snapshot, use a different approach:
+            # The event row has the event name in its row header text
+            # Just pair it with the date row above and find which column has content
+            # For simplicity, count cell occurrences in this event row
+            events.append(cell_text)
+
+    # Better approach: parse event rows by matching column position
+    # Re-parse using row-level logic
+    events_with_dates = []
+    current_dates = []
+    in_event_row = False
+    col_idx = 0
+
+    for line in lines:
+        row_match = re.search(r'row "(.*?)" \[ref=', line)
+        if row_match:
+            row_text = row_match.group(1)
+            # Check if date row
+            parts = row_text.split()
+            dates_in_row = []
+            i = 0
+            while i < len(parts):
+                if re.match(r'^(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)$', parts[i]) and i + 1 < len(parts):
+                    dates_in_row.append(f"{parts[i]} {parts[i+1]}")
+                    i += 2
+                elif re.match(r'^\d{1,2}$', parts[i]):
+                    dates_in_row.append(parts[i])
+                    i += 1
+                else:
+                    break
+            if len(dates_in_row) == 7:
+                current_dates = dates_in_row
+                in_event_row = False
+            else:
+                # Event row
+                in_event_row = True
+                col_idx = 0
+            continue
+
+        if in_event_row and "cell" in line:
+            cell_match = re.search(r'cell "([^"]*)"', line)
+            if cell_match:
+                cell_text = cell_match.group(1)
+                if cell_text and not re.match(r'^\d{1,2}$', cell_text):
+                    # Found an event
+                    date_label = current_dates[col_idx] if col_idx < len(current_dates) else "?"
+                    events_with_dates.append(f"  {date_label}: {cell_text}")
+            # Empty cell match (no text)
+            elif re.search(r'cell \[ref=', line):
+                pass
+            col_idx += 1
+
+    header = f"Month: {current_month}" if current_month else "Calendar Events"
+    if events_with_dates:
+        return header + "\n" + "\n".join(events_with_dates)
+    return header + "\n  (no events)"
+
+
+def _scan_pages():
+    """Parse OSP_SCAN_PAGES env: 'Name|/path,Name2|/path2'. Defaults to home only."""
+    if OSP_SCAN_PAGES:
+        pages = []
+        for part in OSP_SCAN_PAGES.split(","):
+            part = part.strip()
+            if "|" in part:
+                name, path = part.split("|", 1)
+                pages.append((name.strip(), path.strip()))
+            elif part:
+                pages.append((part, part if part.startswith("/") else f"/{part}"))
+        if pages:
+            return pages
+    return [("Home", "/")]
+
+
+def cmd_scan(args):
+    """Scan configured site pages for content updates. No auth needed."""
+    if not OSP_BASE:
+        print("ERROR: OSP_BASE must be set in .env", file=sys.stderr)
+        return 1
+
+    session.ensure_running()
+    scan_pages = _scan_pages()
+
+    print(f"Scanning {OSP_BASE} ({len(scan_pages)} pages)...", file=sys.stderr)
+    results = []
+
+    for name, path in scan_pages:
+        url = f"{OSP_BASE}{path}"
+        session.navigate(url)
+        time.sleep(2)
+
+        snap = session.snapshot()
+        if not snap:
+            results.append({"page": name, "url": url, "content": "[ERROR: no snapshot]"})
+            continue
+
+        # Calendar pages need special parsing
+        if name == "Calendar":
+            content = _parse_calendar(snap)
+        else:
+            content = _parse_page_content(snap)
+
+        results.append({"page": name, "url": url, "content": content})
+
+    # Output
+    for r in results:
+        print(f"\n{'='*60}")
+        print(f"PAGE: {r['page']}")
+        print(f"URL: {r['url']}")
+        print(f"{'─'*60}")
+        if r["content"]:
+            print(r["content"])
+        else:
+            print("(empty or no text content)")
+
+    print(f"\n{'='*60}", file=sys.stderr)
+    print(f"Scanned {len(results)} pages.", file=sys.stderr)
+    return 0

--- a/apps/b3t/outlook.py
+++ b/apps/b3t/outlook.py
@@ -1,0 +1,315 @@
+"""Outlook email commands — deterministic folder checking with thread expansion.
+
+Usage:
+    b3t outlook check                    # List Submissions folder messages
+    b3t outlook check --folder Inbox     # List Inbox messages
+    b3t outlook read 1                   # Read message #1 (expand full thread)
+    b3t outlook login                    # Verify M365 auth
+
+Flow:
+    check: Navigate to Outlook → click folder in sidebar → parse message list
+    read:  Click message → expand conversation → output all messages in thread
+"""
+import os
+import re
+import sys
+import time
+
+import session
+from constants import OUTLOOK_URL
+
+
+def dispatch(args):
+    action = args.action
+    if not action:
+        print("Usage: b3t outlook <login|check|read>", file=sys.stderr)
+        return 2
+    if action == "login":
+        return cmd_login(args)
+    elif action == "check":
+        return cmd_check(args)
+    elif action == "read":
+        return cmd_read(args)
+    return 2
+
+
+def _ensure_outlook():
+    """Navigate to Outlook, verify auth. Returns True if authenticated."""
+    session.ensure_running()
+    session.navigate(OUTLOOK_URL)
+    time.sleep(4)
+
+    url = session.current_url()
+    if url and "login.microsoftonline.com" in url:
+        print("ERROR: Not authenticated to M365.", file=sys.stderr)
+        print("Run: b3t open, log into outlook.office.com, b3t close", file=sys.stderr)
+        return False
+    return True
+
+
+def _find_ref(snapshot_text, test_fn):
+    """Find first ref matching test_fn(line) -> bool."""
+    for line in snapshot_text.split("\n"):
+        if test_fn(line):
+            m = re.search(r'\[ref=(\w+)\]', line)
+            if m:
+                return m.group(1)
+    return None
+
+
+def _click_folder(folder_name):
+    """Click a folder in the Outlook sidebar."""
+    snap = session.snapshot()
+    if not snap:
+        return False
+
+    # Look for treeitem with the folder name
+    ref = _find_ref(snap, lambda l: f'"{folder_name}"' in l and "treeitem" in l.lower())
+    if not ref:
+        # Fallback: look for generic with folder name inside a treeitem context
+        ref = _find_ref(snap, lambda l: folder_name in l and "treeitem" in l.lower())
+    if ref:
+        session.run("click", ref)
+        time.sleep(2)
+        return True
+    return False
+
+
+def _parse_messages(snap):
+    """Parse message options from a snapshot. Returns list of dicts."""
+    messages = []
+    for line in snap.split("\n"):
+        # Messages appear as option elements in the listbox
+        if 'option "' in line.lower() and "ref=" in line:
+            m = re.search(r'\[ref=(\w+)\]', line)
+            if not m:
+                continue
+            ref = m.group(1)
+
+            # Extract the full option text
+            text_match = re.search(r'option "([^"]*)"', line)
+            if not text_match:
+                continue
+            full_text = text_match.group(1)
+
+            # Parse out components from the option text
+            # Pattern: "Collapsed/Expanded SENDER SUBJECT DATE PREVIEW"
+            collapsed = "Collapsed" in full_text
+            clean = full_text.replace("Collapsed ", "").replace("Expanded ", "")
+
+            # Remove noise
+            clean = re.sub(r'No conversations selected$', '', clean).strip()
+            clean = re.sub(r'EXTERNAL EMAIL: Use Caution!\s*', '', clean)
+            clean = re.sub(r'IMPORTANT:.*?before sending the reply\.\s*', '', clean)
+
+            messages.append({
+                "ref": ref,
+                "text": clean,
+                "collapsed": collapsed,
+            })
+
+    return messages
+
+
+def cmd_login(args):
+    if _ensure_outlook():
+        print("Outlook authenticated.", file=sys.stderr)
+        return 0
+    return 1
+
+
+def cmd_check(args):
+    """List messages in a folder."""
+    if not _ensure_outlook():
+        return 1
+
+    folder = args.folder if hasattr(args, "folder") else "Submissions"
+
+    if not _click_folder(folder):
+        print(f"ERROR: Could not find folder '{folder}' in sidebar.", file=sys.stderr)
+        return 1
+
+    snap = session.snapshot()
+    if not snap:
+        print("ERROR: Cannot get page snapshot.", file=sys.stderr)
+        return 1
+
+    messages = _parse_messages(snap)
+
+    print(f"Folder: {folder}", file=sys.stderr)
+    print(f"{len(messages)} messages", file=sys.stderr)
+
+    if not messages:
+        print(f"No messages in {folder}.")
+    else:
+        for i, msg in enumerate(messages, 1):
+            print(f"  {i}. {msg['text'][:120]}")
+
+    return 0
+
+
+def cmd_read(args):
+    """Read a specific message by number, expanding the full thread.
+
+    Outputs: subject, sender(s), body text, attachment names.
+    Downloads attachments to --dir if specified.
+    """
+    import shutil
+
+    if not _ensure_outlook():
+        return 1
+
+    folder = args.folder if hasattr(args, "folder") and args.folder else "Submissions"
+    if not _click_folder(folder):
+        print(f"ERROR: Could not find folder '{folder}' in sidebar.", file=sys.stderr)
+        return 1
+
+    msg_num = int(args.number) if hasattr(args, "number") and args.number else 1
+    output_dir = args.dir if hasattr(args, "dir") and args.dir else None
+
+    snap = session.snapshot()
+    if not snap:
+        print("ERROR: Cannot get page snapshot.", file=sys.stderr)
+        return 1
+
+    messages = _parse_messages(snap)
+    if msg_num < 1 or msg_num > len(messages):
+        print(f"ERROR: Message #{msg_num} not found. {len(messages)} messages visible.", file=sys.stderr)
+        return 1
+
+    target = messages[msg_num - 1]
+
+    # Click the message to select it
+    session.run("click", target["ref"])
+    time.sleep(2)
+
+    # Expand the conversation if collapsed
+    if target["collapsed"]:
+        snap = session.snapshot()
+        expand_ref = _find_ref(snap, lambda l: "Expand conversation" in l and "button" in l.lower())
+        if expand_ref:
+            session.run("click", expand_ref)
+            time.sleep(2)
+
+    # Read the full thread from the snapshot
+    snap = session.snapshot()
+    if not snap:
+        print("ERROR: Cannot get snapshot after expanding.", file=sys.stderr)
+        return 1
+
+    # Parse thread messages (listitem elements in expanded conversation)
+    thread_msgs = []
+    for line in snap.split("\n"):
+        if "listitem" in line.lower() and "ref=e" in line:
+            text_match = re.search(r'listitem "([^"]*)"', line)
+            if text_match:
+                text = text_match.group(1)
+                text = re.sub(r'EXTERNAL EMAIL: Use Caution!\s*', '', text)
+                if text and len(text) > 10:
+                    thread_msgs.append(text)
+
+    # Parse reading pane: From headers, message bodies, attachments
+    # Structure: heading "From: X" → attachments listbox → document "Message body"
+    reading_pane = []
+    attachments = []
+    in_body = False
+    for line in snap.split("\n"):
+        # From headers mark a new message in the reading pane
+        if 'heading "From:' in line:
+            in_body = False
+            m = re.search(r'From: ([^"]+)"', line)
+            if m:
+                reading_pane.append(f"\n--- From: {m.group(1)} ---")
+
+        # Attachments: options with file extension + size
+        elif "option" in line.lower() and re.search(r'\.(png|jpg|jpeg|gif|pdf|docx|xlsx|zip|webp)\b', line, re.IGNORECASE):
+            if re.search(r'\d+\s*(KB|MB|GB)', line):
+                m = re.search(r'\[ref=(\w+)\]', line)
+                name_match = re.search(r'option "([^"]+)"', line)
+                if m and name_match:
+                    attachments.append({"ref": m.group(1), "name": name_match.group(1)})
+
+        # "Message body" document is where the actual email content lives
+        elif 'document "Message body"' in line:
+            in_body = True
+
+        # Collect body text from generic elements inside Message body
+        elif in_body and "generic [ref=" in line:
+            # Extract text after "generic [ref=eNNN]: " — may contain quotes
+            text_match = re.search(r'generic \[ref=\w+\]:\s*(.+)$', line)
+            if text_match:
+                text = text_match.group(1).strip().strip('"')
+                if text and "EXTERNAL EMAIL" not in text:
+                    reading_pane.append(text)
+        elif in_body and "- text:" in line:
+            text = re.sub(r'^\s*- text:\s*', '', line).strip()
+            if text and len(text) > 3:
+                reading_pane.append(text)
+
+        # End of message body section (next heading or toolbar)
+        elif in_body and ("toolbar" in line or 'heading "From:' in line):
+            in_body = False
+
+    # Output thread
+    if thread_msgs:
+        print("=== Thread ===")
+        for i, msg in enumerate(thread_msgs, 1):
+            print(f"\n[{i}] {msg}")
+
+    # Output reading pane
+    if reading_pane:
+        print("\n=== Content ===")
+        for line in reading_pane:
+            print(line)
+
+    # Output attachments
+    if attachments:
+        print(f"\n=== Attachments ({len(attachments)}) ===")
+        for att in attachments:
+            print(f"  {att['name']}")
+
+        # Download attachments if --dir specified
+        if output_dir:
+            os.makedirs(output_dir, exist_ok=True)
+            pw_dir = os.path.join(os.getcwd(), ".playwright-cli")
+            existing = set(os.listdir(pw_dir)) if os.path.isdir(pw_dir) else set()
+
+            for att in attachments:
+                # Click attachment to open preview
+                session.run("click", att["ref"])
+                time.sleep(2)
+
+                # Find and click Download in the preview
+                snap2 = session.snapshot()
+                dl_ref = _find_ref(snap2, lambda l: "Download" in l and "menuitem" in l.lower())
+                if dl_ref:
+                    session.run("click", dl_ref)
+                    time.sleep(3)
+
+                    # Close preview
+                    close_ref = _find_ref(session.snapshot() or "", lambda l: "Close" in l and "menuitem" in l.lower())
+                    if close_ref:
+                        session.run("click", close_ref)
+                        time.sleep(1)
+
+            # Move downloaded files to output dir
+            if os.path.isdir(pw_dir):
+                current = set(os.listdir(pw_dir))
+                new_files = [f for f in (current - existing)
+                             if not f.startswith("page-") and not f.endswith(".yml") and not f.endswith(".log")]
+                for f in new_files:
+                    src = os.path.join(pw_dir, f)
+                    dst = os.path.join(output_dir, f)
+                    shutil.move(src, dst)
+                    print(f"  Downloaded: {dst}", file=sys.stderr)
+                    print(dst)
+
+    if not thread_msgs and not reading_pane:
+        print("=== Raw ===")
+        for line in snap.split("\n"):
+            if "- text:" in line:
+                text = re.sub(r'^\s*- text:\s*', '', line).strip()
+                if text and len(text) > 10:
+                    print(f"  {text}")
+
+    return 0

--- a/apps/b3t/parentsquare.py
+++ b/apps/b3t/parentsquare.py
@@ -1,0 +1,227 @@
+"""ParentSquare feed scanning.
+
+Usage:
+    b3t parentsquare login       # Auto-login using env credentials
+    b3t parentsquare scan        # List recent feed posts (titles, dates, authors)
+"""
+import os
+import re
+import sys
+import time
+
+import env
+import session
+from constants import PARENTSQUARE_BASE, PARENTSQUARE_FEED, PARENTSQUARE_LOGIN
+
+
+def dispatch(args):
+    if not PARENTSQUARE_FEED:
+        print("ERROR: PARENTSQUARE_SCHOOL_ID must be set in .env", file=sys.stderr)
+        return 1
+    action = args.action
+    if not action:
+        print("Usage: b3t parentsquare <login|scan>", file=sys.stderr)
+        return 2
+    if action == "login":
+        return cmd_login(args)
+    elif action == "scan":
+        return cmd_scan(args)
+    return 2
+
+
+def ensure_authenticated():
+    """Check ParentSquare auth, auto-login using env credentials if needed."""
+    session.ensure_running()
+
+    session.navigate(PARENTSQUARE_FEED)
+    time.sleep(3)
+    url = session.current_url()
+    if url and "/signin" not in url and "/login" not in url:
+        return True
+
+    # Auto-login
+    user = os.environ.get("PARENTSQUARE_USER")
+    passw = os.environ.get("PARENTSQUARE_PASS")
+    if not user or not passw:
+        print("ERROR: Set PARENTSQUARE_USER and PARENTSQUARE_PASS in .env", file=sys.stderr)
+        return False
+
+    print("Logging in to ParentSquare...", file=sys.stderr)
+    session.navigate(PARENTSQUARE_LOGIN)
+    time.sleep(3)
+
+    snap = session.snapshot()
+    if not snap:
+        return False
+
+    email_ref = pass_ref = submit_ref = None
+    for line in snap.split("\n"):
+        ll = line.lower()
+        if "email" in ll and "textbox" in ll and not email_ref:
+            m = re.search(r'\[ref=(\w+)\]', line)
+            if m:
+                email_ref = m.group(1)
+        if "password" in ll and "textbox" in ll and not pass_ref:
+            m = re.search(r'\[ref=(\w+)\]', line)
+            if m:
+                pass_ref = m.group(1)
+        if ("sign in" in ll or "log in" in ll) and "button" in ll and not submit_ref:
+            m = re.search(r'\[ref=(\w+)\]', line)
+            if m:
+                submit_ref = m.group(1)
+
+    if not email_ref or not pass_ref:
+        print("ERROR: Cannot find login fields.", file=sys.stderr)
+        return False
+
+    session.run("fill", email_ref, user)
+    session.run("fill", pass_ref, passw)
+
+    if submit_ref:
+        session.run("click", submit_ref)
+    else:
+        session.run("press", pass_ref, "Enter")
+
+    time.sleep(4)
+    url = session.current_url()
+    if url and "/signin" in url:
+        print("ERROR: Login failed.", file=sys.stderr)
+        return False
+
+    session.save_state()
+    print("ParentSquare login successful.", file=sys.stderr)
+    return True
+
+
+def cmd_login(args):
+    if ensure_authenticated():
+        print("ParentSquare authenticated.", file=sys.stderr)
+        return 0
+    return 1
+
+
+def cmd_scan(args):
+    """Scan recent feed posts — titles, dates, authors.
+
+    Deterministic: login → navigate → scroll twice → parse → output.
+    Only captures top-level posts (has "Posted by" metadata), not nested
+    sub-headings within posts like the Connections newsletter.
+    """
+    if not ensure_authenticated():
+        return 1
+
+    # Navigate to feed
+    url = session.current_url()
+    if not url or "feeds" not in url:
+        session.navigate(PARENTSQUARE_FEED)
+        time.sleep(3)
+
+    # Scroll to load more posts (feed is lazy-loaded)
+    # mousewheel: first arg is vertical (despite label saying dx)
+    session.run("mousewheel", "3000", "0")
+    time.sleep(2)
+    session.run("mousewheel", "3000", "0")
+    time.sleep(2)
+
+    snap = session.snapshot()
+    if not snap:
+        print("ERROR: Cannot get feed snapshot.", file=sys.stderr)
+        return 1
+
+    posts = _parse_feed(snap)
+
+    print(f"{len(posts)} posts found", file=sys.stderr)
+    for i, post in enumerate(posts, 1):
+        date = post.get("date", "")
+        author = post.get("author", "")
+        title = post.get("title", "")
+        meta = f"{date} | {author}" if date and author else date or author
+        print(f"  {i}. [{meta}] {title}")
+
+    return 0
+
+
+def _parse_feed(snap):
+    """Parse top-level feed posts from snapshot.
+
+    Structure in accessibility tree:
+      region "Posts"
+        ...
+          heading "Post Title" [level=2]
+          ...
+            link "Posted by Author Name"
+          ...
+            text: • N days ago • DayOfWeek, Mon DD at HH:MM PM •
+        ...
+
+    Key insight: real top-level posts have "Posted by" within ~8 lines after
+    their heading. Nested sub-headings (inside article bodies like the
+    Connections newsletter) do NOT have "Posted by" nearby.
+    """
+    posts = []
+    lines = snap.split("\n")
+    in_posts = False
+    skip_titles = {"Communicate", "Explore", "Participate", "Events", "Photos"}
+
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+
+        if 'region "Posts"' in line:
+            in_posts = True
+            i += 1
+            continue
+
+        if not in_posts:
+            i += 1
+            continue
+
+        # Look for h2 headings
+        if 'heading "' in line and "[level=2]" in line:
+            m = re.search(r'heading "([^"]+)"', line)
+            if not m:
+                i += 1
+                continue
+            title = m.group(1).strip()
+            if title in skip_titles or len(title) < 5:
+                i += 1
+                continue
+
+            # Look ahead for "Posted by" (proves this is a top-level post)
+            author = ""
+            date_str = ""
+            is_real_post = False
+
+            for j in range(i + 1, min(i + 12, len(lines))):
+                # Author
+                if "Posted by" in lines[j]:
+                    am = re.search(r'Posted by ([^"]+)"', lines[j])
+                    if am:
+                        author = am.group(1).strip()
+                    is_real_post = True
+
+                # Date: text line with bullet-separated metadata
+                # Format: • N days ago • DayOfWeek, Mon DD at HH:MM PM •
+                if "• " in lines[j] and "days ago" in lines[j]:
+                    dm = re.search(r'(\d+ days?) ago', lines[j])
+                    if dm:
+                        date_str = dm.group(1) + " ago"
+                elif "• " in lines[j] and "at " in lines[j]:
+                    # "• Wednesday, Jun 10 at 12:31 PM •"
+                    dm = re.search(
+                        r'(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)\w*, (\w+ \d+)',
+                        lines[j]
+                    )
+                    if dm:
+                        date_str = dm.group(1)
+
+            if is_real_post:
+                posts.append({
+                    "title": title,
+                    "author": author,
+                    "date": date_str,
+                })
+
+        i += 1
+
+    return posts

--- a/apps/b3t/parentsquare.py
+++ b/apps/b3t/parentsquare.py
@@ -1,17 +1,31 @@
-"""ParentSquare feed scanning.
+"""ParentSquare feed scanning and submission export.
 
 Usage:
-    b3t parentsquare login       # Auto-login using env credentials
-    b3t parentsquare scan        # List recent feed posts (titles, dates, authors)
+    b3t parentsquare login              # Auto-login using env credentials
+    b3t parentsquare scan               # List recent posts with full bodies
+    b3t parentsquare scan --json        # Machine-readable output
+    b3t parentsquare save --dir PATH    # Write parentsquare-*.md submission files
 """
+import json
 import os
 import re
 import sys
 import time
+from datetime import date
 
 import env
 import session
 from constants import PARENTSQUARE_BASE, PARENTSQUARE_FEED, PARENTSQUARE_LOGIN
+
+SKIP_TITLES = {"Communicate", "Explore", "Participate", "Events", "Photos"}
+BODY_STOP_MARKERS = (
+    "Appreciate",
+    "Comment",
+    "Print",
+    "people appreciate this post",
+    "User Preferred Notifications",
+    "Read More about",
+)
 
 
 def dispatch(args):
@@ -20,12 +34,14 @@ def dispatch(args):
         return 1
     action = args.action
     if not action:
-        print("Usage: b3t parentsquare <login|scan>", file=sys.stderr)
+        print("Usage: b3t parentsquare <login|scan|save>", file=sys.stderr)
         return 2
     if action == "login":
         return cmd_login(args)
     elif action == "scan":
         return cmd_scan(args)
+    elif action == "save":
+        return cmd_save(args)
     return 2
 
 
@@ -39,7 +55,6 @@ def ensure_authenticated():
     if url and "/signin" not in url and "/login" not in url:
         return True
 
-    # Auto-login
     user = os.environ.get("PARENTSQUARE_USER")
     passw = os.environ.get("PARENTSQUARE_PASS")
     if not user or not passw:
@@ -58,15 +73,15 @@ def ensure_authenticated():
     for line in snap.split("\n"):
         ll = line.lower()
         if "email" in ll and "textbox" in ll and not email_ref:
-            m = re.search(r'\[ref=(\w+)\]', line)
+            m = re.search(r"\[ref=(\w+)\]", line)
             if m:
                 email_ref = m.group(1)
         if "password" in ll and "textbox" in ll and not pass_ref:
-            m = re.search(r'\[ref=(\w+)\]', line)
+            m = re.search(r"\[ref=(\w+)\]", line)
             if m:
                 pass_ref = m.group(1)
         if ("sign in" in ll or "log in" in ll) and "button" in ll and not submit_ref:
-            m = re.search(r'\[ref=(\w+)\]', line)
+            m = re.search(r"\[ref=(\w+)\]", line)
             if m:
                 submit_ref = m.group(1)
 
@@ -100,128 +115,277 @@ def cmd_login(args):
     return 1
 
 
-def cmd_scan(args):
-    """Scan recent feed posts — titles, dates, authors.
+def _parse_json_result(stdout):
+    for line in stdout.split("\n"):
+        line = line.strip()
+        if not line or line.startswith("###") or line.startswith("```") or line.startswith("await"):
+            continue
+        try:
+            parsed = json.loads(line)
+            if isinstance(parsed, str):
+                try:
+                    return json.loads(parsed)
+                except json.JSONDecodeError:
+                    return parsed
+            return parsed
+        except (json.JSONDecodeError, ValueError, TypeError):
+            continue
+    return None
 
-    Deterministic: login → navigate → scroll twice → parse → output.
-    Only captures top-level posts (has "Posted by" metadata), not nested
-    sub-headings within posts like the Connections newsletter.
-    """
+
+def _scroll_feed():
+    """Scroll lazy-loaded feed."""
+    session.run("mousewheel", "3000", "0")
+    time.sleep(2)
+    session.run("mousewheel", "3000", "0")
+    time.sleep(2)
+
+
+def _expand_all_read_more():
+    """Expand truncated posts so full bodies are visible."""
+    snap = session.snapshot() or ""
+    refs = []
+    for line in snap.split("\n"):
+        if "Read More about" in line and "button" in line.lower():
+            m = re.search(r"\[ref=(\w+)\]", line)
+            if m:
+                refs.append(m.group(1))
+    for ref in refs:
+        session.run("click", ref, timeout=5)
+        time.sleep(0.4)
+    if refs:
+        time.sleep(1)
+
+
+def _parse_feed_bodies(snap):
+    """Extract post bodies from accessibility snapshot (after Read More expanded)."""
+    posts = []
+    lines = snap.split("\n")
+    skip_titles = SKIP_TITLES
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        m = re.match(r'\s*- region "([^"]+)" \[ref=', line)
+        if not m:
+            i += 1
+            continue
+        title = m.group(1).strip()
+        if title in skip_titles or len(title) < 5:
+            i += 1
+            continue
+
+        author = ""
+        date_str = ""
+        body_parts = []
+        feed_url = ""
+        is_post = False
+        i += 1
+
+        while i < len(lines):
+            ln = lines[i]
+            if re.match(r'\s*- region "', ln) and not ln.strip().startswith("- region"):
+                break
+            if re.match(r'\s*- region "', ln):
+                break
+            if re.match(r'^\s{10,}- region "', ln):
+                break
+
+            if "Posted by" in ln:
+                am = re.search(r'Posted by ([^"]+)"', ln)
+                if am:
+                    author = am.group(1).strip()
+                    is_post = True
+            if "/feeds/" in ln and title.replace('"', "") in ln:
+                um = re.search(r'/url: (/feeds/\d+)', ln)
+                if um:
+                    feed_url = PARENTSQUARE_BASE + um.group(1)
+            if "days ago" in ln or re.search(r'(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)\w*, \w+ \d+', ln):
+                if "•" in ln:
+                    dm = re.search(r'(\d+ days? ago)', ln)
+                    if dm:
+                        date_str = dm.group(1)
+                    else:
+                        dm2 = re.search(r'((?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)\w*, \w+ \d+[^•]*)', ln)
+                        if dm2:
+                            date_str = dm2.group(1).strip()
+
+            tm = re.match(r'\s*- text: (.+)$', ln)
+            if tm and is_post:
+                text = tm.group(1).strip()
+                if any(s in text for s in BODY_STOP_MARKERS):
+                    i += 1
+                    break
+                if text and text not in (title, "Read More"):
+                    body_parts.append(text)
+            pm = re.match(r'\s*- paragraph \[ref=', ln)
+            if pm and is_post and i + 1 < len(lines):
+                nm = re.match(r'\s*- text: (.+)$', lines[i + 1])
+                if nm:
+                    text = nm.group(1).strip()
+                    if text and not any(s in text for s in BODY_STOP_MARKERS):
+                        body_parts.append(text)
+
+            if is_post and "Appreciate" in ln and "button" in ln.lower():
+                break
+            i += 1
+
+        if is_post and author:
+            posts.append({
+                "title": title,
+                "author": author,
+                "date": date_str,
+                "feed_url": feed_url,
+                "body": "\n".join(body_parts).strip(),
+                "links": [],
+            })
+        if i < len(lines) and re.match(r'\s*- region "', lines[i]):
+            continue
+    return posts
+
+
+def _fetch_posts(expand=True):
+    """Return list of post dicts with title, author, date, feed_url, body."""
+    if expand:
+        _expand_all_read_more()
+    snap = session.snapshot()
+    if not snap:
+        return []
+    return _parse_feed_bodies(snap)
+
+
+def _days_ago_from_date(date_str):
+    """Parse '6 days ago' or 'Jun 8' style strings; return days ago or None."""
+    if not date_str:
+        return None
+    m = re.search(r"(\d+)\s+days?\s+ago", date_str)
+    if m:
+        return int(m.group(1))
+    return None
+
+
+def _filter_since(posts, since_days):
+    if not since_days:
+        return posts
+    filtered = []
+    for post in posts:
+        days = _days_ago_from_date(post.get("date", ""))
+        if days is None or days <= since_days:
+            filtered.append(post)
+    return filtered
+
+
+def _slugify(title):
+    slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
+    return slug[:72] or "post"
+
+
+def _write_submission(path, post):
+    today = date.today().isoformat()
+    title = post.get("title", "Untitled")
+    author = post.get("author", "")
+    date_str = post.get("date", "")
+    feed_url = post.get("feed_url", "")
+    body = post.get("body", "").strip()
+    links = post.get("links") or []
+
+    lines = [
+        f"# {title}",
+        "",
+        "**Source:** ParentSquare",
+    ]
+    if feed_url:
+        lines.append(f"**URL:** {feed_url}")
+    if author:
+        lines.append(f"**Author:** {author}")
+    if date_str:
+        lines.append(f"**Posted:** {date_str}")
+    lines.append(f"**Gathered:** {today}")
+    lines.append("")
+    lines.append("## Body")
+    lines.append("")
+    lines.append(body or "_(empty)_")
+    if links:
+        lines.append("")
+        lines.append("## Links")
+        lines.append("")
+        seen = set()
+        for link in links:
+            href = link.get("href", "")
+            text = link.get("text", href)
+            if href in seen:
+                continue
+            seen.add(href)
+            lines.append(f"- [{text}]({href})")
+
+    with open(path, "w") as f:
+        f.write("\n".join(lines) + "\n")
+
+
+def cmd_scan(args):
+    """Scan recent feed posts with full bodies."""
     if not ensure_authenticated():
         return 1
 
-    # Navigate to feed
     url = session.current_url()
     if not url or "feeds" not in url:
         session.navigate(PARENTSQUARE_FEED)
         time.sleep(3)
 
-    # Scroll to load more posts (feed is lazy-loaded)
-    # mousewheel: first arg is vertical (despite label saying dx)
-    session.run("mousewheel", "3000", "0")
-    time.sleep(2)
-    session.run("mousewheel", "3000", "0")
-    time.sleep(2)
-
-    snap = session.snapshot()
-    if not snap:
-        print("ERROR: Cannot get feed snapshot.", file=sys.stderr)
-        return 1
-
-    posts = _parse_feed(snap)
+    _scroll_feed()
+    posts = _fetch_posts(expand=True)
+    posts = _filter_since(posts, getattr(args, "since", None))
 
     print(f"{len(posts)} posts found", file=sys.stderr)
+
+    if getattr(args, "json", False):
+        print(json.dumps(posts, indent=2))
+        return 0
+
     for i, post in enumerate(posts, 1):
-        date = post.get("date", "")
+        meta = post.get("date", "")
         author = post.get("author", "")
         title = post.get("title", "")
-        meta = f"{date} | {author}" if date and author else date or author
-        print(f"  {i}. [{meta}] {title}")
-
+        header = f"{meta} | {author}" if meta and author else meta or author
+        print(f"\n{'=' * 60}")
+        print(f"{i}. [{header}] {title}")
+        if post.get("feed_url"):
+            print(f"URL: {post['feed_url']}")
+        print("-" * 60)
+        body = post.get("body", "").strip()
+        if body:
+            preview = body if len(body) <= 1200 else body[:1200] + "\n…"
+            print(preview)
+        else:
+            print("(no body text captured)")
     return 0
 
 
-def _parse_feed(snap):
-    """Parse top-level feed posts from snapshot.
+def cmd_save(args):
+    """Save feed posts as submission markdown files."""
+    if not ensure_authenticated():
+        return 1
 
-    Structure in accessibility tree:
-      region "Posts"
-        ...
-          heading "Post Title" [level=2]
-          ...
-            link "Posted by Author Name"
-          ...
-            text: • N days ago • DayOfWeek, Mon DD at HH:MM PM •
-        ...
+    out_dir = os.path.abspath(args.dir)
+    since_days = getattr(args, "since", None)
 
-    Key insight: real top-level posts have "Posted by" within ~8 lines after
-    their heading. Nested sub-headings (inside article bodies like the
-    Connections newsletter) do NOT have "Posted by" nearby.
-    """
-    posts = []
-    lines = snap.split("\n")
-    in_posts = False
-    skip_titles = {"Communicate", "Explore", "Participate", "Events", "Photos"}
+    url = session.current_url()
+    if not url or "feeds" not in url:
+        session.navigate(PARENTSQUARE_FEED)
+        time.sleep(3)
 
-    i = 0
-    while i < len(lines):
-        line = lines[i]
+    _scroll_feed()
+    posts = _fetch_posts(expand=True)
+    posts = _filter_since(posts, since_days)
 
-        if 'region "Posts"' in line:
-            in_posts = True
-            i += 1
-            continue
+    os.makedirs(out_dir, exist_ok=True)
+    written = 0
+    for post in posts:
+        slug = _slugify(post.get("title", "post"))
+        path = os.path.join(out_dir, f"parentsquare-{slug}.md")
+        _write_submission(path, post)
+        written += 1
+        print(path)
 
-        if not in_posts:
-            i += 1
-            continue
-
-        # Look for h2 headings
-        if 'heading "' in line and "[level=2]" in line:
-            m = re.search(r'heading "([^"]+)"', line)
-            if not m:
-                i += 1
-                continue
-            title = m.group(1).strip()
-            if title in skip_titles or len(title) < 5:
-                i += 1
-                continue
-
-            # Look ahead for "Posted by" (proves this is a top-level post)
-            author = ""
-            date_str = ""
-            is_real_post = False
-
-            for j in range(i + 1, min(i + 12, len(lines))):
-                # Author
-                if "Posted by" in lines[j]:
-                    am = re.search(r'Posted by ([^"]+)"', lines[j])
-                    if am:
-                        author = am.group(1).strip()
-                    is_real_post = True
-
-                # Date: text line with bullet-separated metadata
-                # Format: • N days ago • DayOfWeek, Mon DD at HH:MM PM •
-                if "• " in lines[j] and "days ago" in lines[j]:
-                    dm = re.search(r'(\d+ days?) ago', lines[j])
-                    if dm:
-                        date_str = dm.group(1) + " ago"
-                elif "• " in lines[j] and "at " in lines[j]:
-                    # "• Wednesday, Jun 10 at 12:31 PM •"
-                    dm = re.search(
-                        r'(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)\w*, (\w+ \d+)',
-                        lines[j]
-                    )
-                    if dm:
-                        date_str = dm.group(1)
-
-            if is_real_post:
-                posts.append({
-                    "title": title,
-                    "author": author,
-                    "date": date_str,
-                })
-
-        i += 1
-
-    return posts
+    print(f"Wrote {written} files to {out_dir}", file=sys.stderr)
+    session.save_state()
+    return 0

--- a/apps/b3t/peachjar.py
+++ b/apps/b3t/peachjar.py
@@ -1,0 +1,183 @@
+"""PeachJar school flyer queries via GraphQL (no browser needed)."""
+import json
+import sys
+from datetime import date
+
+import requests
+
+from constants import PEACHJAR_GRAPHQL, PEACHJAR_API_KEY, PEACHJAR_AUDIENCE_ID, PEACHJAR_DISTRICT_ID
+
+
+def _check_config():
+    if not PEACHJAR_API_KEY or not PEACHJAR_AUDIENCE_ID or not PEACHJAR_DISTRICT_ID:
+        print("ERROR: PEACHJAR_API_KEY, PEACHJAR_AUDIENCE_ID, and PEACHJAR_DISTRICT_ID must be set in .env", file=sys.stderr)
+        sys.exit(1)
+
+
+HEADERS = {
+    "Content-Type": "application/json",
+    "X-Api-Key": PEACHJAR_API_KEY,
+}
+
+DISTRICT_ID = PEACHJAR_DISTRICT_ID
+
+FLYERS_QUERY = """
+query($input: GetAllFlyersInput) {
+  getAllFlyers(input: $input) {
+    items {
+      flyerId
+      title
+      startDate
+      endDate
+      categories
+      frontImageUrl
+      criticalDate
+      org { name }
+      ctas { type value isPrimary }
+    }
+    pagination { pageSize pageNumber total }
+  }
+}
+"""
+
+FLYER_QUERY = """
+query($input: GetFlyerInput!) {
+  getFlyer(input: $input) {
+    flyerId
+    title
+    startDate
+    endDate
+    categories
+    grades
+    frontImageUrl
+    criticalDate
+    status
+    org { name orgId description links { call website email } }
+    pages { imageUrl pageNumber userText }
+    ctas { type value isPrimary }
+  }
+}
+"""
+
+
+def dispatch(args):
+    _check_config()
+    action = args.action
+    if not action:
+        print("Usage: b3t peachjar <list|get>", file=sys.stderr)
+        return 2
+    if action == "list":
+        return cmd_list(args)
+    elif action == "get":
+        return cmd_get(args)
+    return 2
+
+
+def _graphql(query, variables):
+    try:
+        resp = requests.post(
+            PEACHJAR_GRAPHQL,
+            json={"query": query, "variables": variables},
+            headers=HEADERS,
+            timeout=15,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        if "errors" in data:
+            print(f"GraphQL errors: {json.dumps(data['errors'][:2])}", file=sys.stderr)
+            return None
+        return data.get("data")
+    except requests.RequestException as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return None
+
+
+def cmd_list(args):
+    """List recent flyers."""
+    since = None
+    if hasattr(args, "since") and args.since:
+        since = date.fromisoformat(args.since)
+
+    variables = {
+        "input": {
+            "pagination": {"pageSize": 30, "pageNumber": 1},
+            "filters": {
+                "districtId": DISTRICT_ID,
+                "schoolIds": [PEACHJAR_AUDIENCE_ID],
+            },
+        }
+    }
+    data = _graphql(FLYERS_QUERY, variables)
+    if not data:
+        return 1
+
+    result = data.get("getAllFlyers", {})
+    items = result.get("items", [])
+    total = result.get("pagination", {}).get("total", len(items))
+
+    flyers = []
+    for f in items:
+        if since and f.get("endDate"):
+            try:
+                end = date.fromisoformat(f["endDate"][:10])
+                if end < since:
+                    continue
+            except (ValueError, TypeError):
+                pass
+        flyers.append(f)
+
+    if hasattr(args, "json") and args.json:
+        json.dump(flyers, sys.stdout, indent=2)
+        print()
+    else:
+        print(f"{len(flyers)} flyers (of {total} total)", file=sys.stderr)
+        for f in flyers:
+            end = f.get("endDate", "")[:10] if f.get("endDate") else "?"
+            org = (f.get("org") or {}).get("name", "?")
+            cats = ", ".join(f.get("categories") or [])
+            print(f"  [{f['flyerId']}] {f['title']}")
+            print(f"         org={org}  ends={end}  cats={cats}")
+
+    return 0
+
+
+def cmd_get(args):
+    """Get flyer details."""
+    flyer_id = int(args.flyer_id)
+    variables = {
+        "input": {
+            "flyerId": flyer_id,
+            "districtId": DISTRICT_ID,
+            "schoolId": PEACHJAR_AUDIENCE_ID,
+        }
+    }
+    data = _graphql(FLYER_QUERY, variables)
+    if not data:
+        return 1
+
+    flyer = data.get("getFlyer")
+    if not flyer:
+        print(f"ERROR: Flyer {flyer_id} not found.", file=sys.stderr)
+        return 1
+
+    if hasattr(args, "json") and args.json:
+        json.dump(flyer, sys.stdout, indent=2)
+        print()
+    else:
+        print(f"Title: {flyer['title']}")
+        print(f"Dates: {(flyer.get('startDate') or '?')[:10]} - {(flyer.get('endDate') or '?')[:10]}")
+        org = flyer.get("org") or {}
+        print(f"Org: {org.get('name', '?')}")
+        print(f"Categories: {', '.join(flyer.get('categories') or [])}")
+        if flyer.get("grades"):
+            print(f"Grades: {', '.join(flyer['grades'])}")
+        if flyer.get("ctas"):
+            print("Links:")
+            for cta in flyer["ctas"]:
+                print(f"  {cta.get('type', '?')}: {cta.get('value', '?')}")
+        if flyer.get("pages"):
+            print("Images:")
+            for p in flyer["pages"]:
+                print(f"  {p.get('imageUrl')}")
+
+    return 0

--- a/apps/b3t/requirements.txt
+++ b/apps/b3t/requirements.txt
@@ -1,0 +1,2 @@
+openpyxl
+requests

--- a/apps/b3t/session.py
+++ b/apps/b3t/session.py
@@ -1,0 +1,203 @@
+"""Browser session management via playwright-cli.
+
+Launches Chrome directly (no automation flags) and attaches playwright-cli via CDP.
+"""
+import os
+import subprocess
+import sys
+import time
+
+from constants import SESSION_NAME, CHROME_PROFILE_DIR, STATE_FILE
+
+CHROME_PATH = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+CDP_PORT = 9222
+
+
+def run(*args, timeout=30):
+    """Run playwright-cli -s=b3t with given args. Returns CompletedProcess."""
+    cmd = ["playwright-cli", f"-s={SESSION_NAME}"] + list(args)
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(cmd, 124, "", "Timeout")
+
+
+def is_running():
+    """Check if browser session is active."""
+    result = run("eval", "() => true")
+    return result.returncode == 0
+
+
+def _chrome_running():
+    """Check if Chrome is listening on CDP port."""
+    import urllib.request
+    try:
+        urllib.request.urlopen(f"http://127.0.0.1:{CDP_PORT}/json/version", timeout=2)
+        return True
+    except Exception:
+        return False
+
+
+def open_browser():
+    """Launch Chrome directly and attach playwright-cli via CDP."""
+    if is_running():
+        print("Browser already running.", file=sys.stderr)
+        return 0
+
+    if not _chrome_running():
+        os.makedirs(CHROME_PROFILE_DIR, exist_ok=True)
+        cmd = [
+            CHROME_PATH,
+            f"--user-data-dir={CHROME_PROFILE_DIR}",
+            f"--remote-debugging-port={CDP_PORT}",
+            "--no-first-run",
+            "--no-default-browser-check",
+            "about:blank",
+        ]
+        subprocess.Popen(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        # Wait for Chrome to start listening
+        for _ in range(30):
+            if _chrome_running():
+                break
+            time.sleep(0.2)
+        else:
+            print("ERROR: Chrome did not start in time.", file=sys.stderr)
+            return 1
+
+    # Attach playwright-cli to the running Chrome via CDP
+    result = run("attach", f"--cdp=http://127.0.0.1:{CDP_PORT}", timeout=15)
+    if result.returncode != 0:
+        print(f"ERROR: Failed to attach: {result.stderr}", file=sys.stderr)
+        return 1
+
+    print("Browser opened.", file=sys.stderr)
+    return 0
+
+
+def close_browser():
+    """Save state and close browser gracefully."""
+    if not is_running():
+        print("Browser not running.", file=sys.stderr)
+        return 0
+
+    state_path = _state_path()
+    if state_path:
+        os.makedirs(os.path.dirname(state_path), exist_ok=True)
+        run("state-save", state_path)
+        print(f"State saved to {state_path}", file=sys.stderr)
+
+    # Detach playwright from Chrome (doesn't kill the process)
+    run("close")
+
+    # Gracefully quit Chrome so it writes "clean exit" to profile
+    import platform
+    if platform.system() == "Darwin":
+        subprocess.run(
+            ["osascript", "-e", 'tell application "Google Chrome" to quit'],
+            capture_output=True, timeout=5,
+        )
+    else:
+        # Linux/Windows: find Chrome process using our profile and send SIGTERM
+        import signal
+        for proc_line in subprocess.run(
+            ["pgrep", "-f", CHROME_PROFILE_DIR],
+            capture_output=True, text=True,
+        ).stdout.strip().split("\n"):
+            if proc_line.strip():
+                try:
+                    os.kill(int(proc_line.strip()), signal.SIGTERM)
+                except (ProcessLookupError, ValueError):
+                    pass
+    # Wait briefly for Chrome to finish writing profile
+    for _ in range(20):
+        if not _chrome_running():
+            break
+        time.sleep(0.25)
+
+    print("Browser closed.", file=sys.stderr)
+    return 0
+
+
+def ensure_running():
+    """Open browser if not already running."""
+    if not is_running():
+        return open_browser()
+    return 0
+
+
+def navigate(url):
+    """Navigate to a URL."""
+    ensure_running()
+    result = run("goto", url)
+    if result.returncode != 0:
+        print(f"ERROR: {result.stderr}", file=sys.stderr)
+        return 1
+    return 0
+
+
+def snapshot():
+    """Take page accessibility snapshot, return text."""
+    result = run("snapshot", timeout=10)
+    if result.returncode != 0:
+        print(f"ERROR: {result.stderr}", file=sys.stderr)
+        return None
+    return result.stdout
+
+
+def _parse_eval_result(stdout):
+    """Extract value from playwright-cli eval/run-code stdout."""
+    import json
+    import re
+
+    if not stdout:
+        return None
+
+    # Prefer ### Result block when present
+    m = re.search(r"### Result\s*\n\"((?:[^\"\\]|\\.)*)\"", stdout, re.DOTALL)
+    if m:
+        try:
+            return json.loads(f'"{m.group(1)}"')
+        except json.JSONDecodeError:
+            pass
+
+    for line in stdout.split("\n"):
+        line = line.strip()
+        if not line or line.startswith("###") or line.startswith("```"):
+            continue
+        try:
+            parsed = json.loads(line)
+            if isinstance(parsed, str):
+                try:
+                    return json.loads(parsed)
+                except json.JSONDecodeError:
+                    return parsed
+            return parsed
+        except json.JSONDecodeError:
+            continue
+    return stdout.strip() or None
+
+
+def current_url():
+    """Get current page URL."""
+    result = run("eval", "() => window.location.href")
+    if result.returncode == 0:
+        url = _parse_eval_result(result.stdout)
+        return url if isinstance(url, str) else None
+    return None
+
+
+def save_state():
+    """Save current browser state."""
+    state_path = _state_path()
+    if state_path:
+        os.makedirs(os.path.dirname(state_path), exist_ok=True)
+        run("state-save", state_path)
+
+
+def _state_path():
+    """Resolve state file path relative to project root (CWD)."""
+    return os.path.join(os.getcwd(), STATE_FILE)

--- a/apps/b3t/session.py
+++ b/apps/b3t/session.py
@@ -11,6 +11,12 @@ from constants import SESSION_NAME, CHROME_PROFILE_DIR, STATE_FILE
 
 CHROME_PATH = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
 CDP_PORT = 9222
+CDP_ATTACH_BASES = (
+    f"http://127.0.0.1:{CDP_PORT}",
+    f"http://localhost:{CDP_PORT}",
+    f"http://[::1]:{CDP_PORT}",
+)
+CHROME_STARTUP_WAIT = 60  # 60 × 0.2s = 12s
 
 
 def run(*args, timeout=30):
@@ -28,14 +34,59 @@ def is_running():
     return result.returncode == 0
 
 
+def _chrome_cdp_base():
+    """Return CDP base URL if Chrome is listening, else None."""
+    import urllib.request
+    for base in CDP_ATTACH_BASES:
+        try:
+            urllib.request.urlopen(f"{base}/json/version", timeout=2)
+            return base
+        except Exception:
+            continue
+    return None
+
+
 def _chrome_running():
     """Check if Chrome is listening on CDP port."""
-    import urllib.request
-    try:
-        urllib.request.urlopen(f"http://127.0.0.1:{CDP_PORT}/json/version", timeout=2)
-        return True
-    except Exception:
-        return False
+    return _chrome_cdp_base() is not None
+
+
+def _profile_process_running():
+    """True if Chrome is already using our profile (may be starting up)."""
+    result = subprocess.run(
+        ["pgrep", "-f", CHROME_PROFILE_DIR],
+        capture_output=True,
+        text=True,
+    )
+    return bool(result.stdout.strip())
+
+
+def _wait_for_cdp():
+    """Wait for CDP to become available. Returns base URL or None."""
+    for _ in range(CHROME_STARTUP_WAIT):
+        base = _chrome_cdp_base()
+        if base:
+            return base
+        time.sleep(0.2)
+    return None
+
+
+def _launch_chrome():
+    """Start Chrome with the b3t profile (first launch only)."""
+    os.makedirs(CHROME_PROFILE_DIR, exist_ok=True)
+    cmd = [
+        CHROME_PATH,
+        f"--user-data-dir={CHROME_PROFILE_DIR}",
+        f"--remote-debugging-port={CDP_PORT}",
+        "--no-first-run",
+        "--no-default-browser-check",
+        "about:blank",
+    ]
+    subprocess.Popen(
+        cmd,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
 
 
 def open_browser():
@@ -44,32 +95,22 @@ def open_browser():
         print("Browser already running.", file=sys.stderr)
         return 0
 
-    if not _chrome_running():
-        os.makedirs(CHROME_PROFILE_DIR, exist_ok=True)
-        cmd = [
-            CHROME_PATH,
-            f"--user-data-dir={CHROME_PROFILE_DIR}",
-            f"--remote-debugging-port={CDP_PORT}",
-            "--no-first-run",
-            "--no-default-browser-check",
-            "about:blank",
-        ]
-        subprocess.Popen(
-            cmd,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
-        # Wait for Chrome to start listening
-        for _ in range(30):
-            if _chrome_running():
-                break
-            time.sleep(0.2)
+    cdp_base = _chrome_cdp_base()
+    if not cdp_base:
+        if _profile_process_running():
+            # Profile Chrome is up but CDP not ready yet — wait, do NOT relaunch
+            # (relaunching with the same profile opens a new about:blank tab).
+            cdp_base = _wait_for_cdp()
         else:
-            print("ERROR: Chrome did not start in time.", file=sys.stderr)
-            return 1
+            _launch_chrome()
+            cdp_base = _wait_for_cdp()
+
+    if not cdp_base:
+        print("ERROR: Chrome did not start in time.", file=sys.stderr)
+        return 1
 
     # Attach playwright-cli to the running Chrome via CDP
-    result = run("attach", f"--cdp=http://127.0.0.1:{CDP_PORT}", timeout=15)
+    result = run("attach", f"--cdp={cdp_base}", timeout=15)
     if result.returncode != 0:
         print(f"ERROR: Failed to attach: {result.stderr}", file=sys.stderr)
         return 1

--- a/b3t
+++ b/b3t
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+echo `# <#` >/dev/null
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$SCRIPT_DIR/apps/b3t"
+VENV_DIR="$APP_DIR/.venv"
+
+# Create venv if missing
+if [ ! -f "$VENV_DIR/bin/python3" ]; then
+    echo "b3t: creating venv..." >&2
+    python3 -m venv "$VENV_DIR"
+    "$VENV_DIR/bin/pip" install -q -r "$APP_DIR/requirements.txt"
+fi
+
+exec "$VENV_DIR/bin/python3" "$APP_DIR/__main__.py" "$@"
+#> > $null
+
+$ScriptPath = $PSCommandPath
+if (-not $ScriptPath) { $ScriptPath = $MyInvocation.MyCommand.Path }
+if (-not $ScriptPath) { $ScriptPath = Join-Path (Get-Location) "b3t" }
+
+$ScriptDir = Split-Path -Parent $ScriptPath
+$AppDir = Join-Path $ScriptDir "apps/b3t"
+$VenvDir = Join-Path $AppDir ".venv"
+$B3tPath = Join-Path $AppDir "__main__.py"
+
+if (-not (Test-Path (Join-Path $VenvDir "Scripts/python.exe"))) {
+    Write-Host "b3t: creating venv..." -ForegroundColor Yellow
+    python -m venv $VenvDir
+    & (Join-Path $VenvDir "Scripts/pip.exe") install -q -r (Join-Path $AppDir "requirements.txt")
+}
+
+$Python = Join-Path $VenvDir "Scripts/python.exe"
+if (Test-Path $Python) { & $Python $B3tPath @args; exit $LASTEXITCODE }
+
+$Python = Get-Command python3 -ErrorAction SilentlyContinue
+if ($Python) { & $Python.Source $B3tPath @args; exit $LASTEXITCODE }
+$Python = Get-Command python -ErrorAction SilentlyContinue
+if ($Python) { & $Python.Source $B3tPath @args; exit $LASTEXITCODE }
+
+Write-Error "Could not find python3 or python on PATH."
+exit 127

--- a/b3t.cmd
+++ b/b3t.cmd
@@ -1,0 +1,10 @@
+@echo off
+setlocal
+set "APP_DIR=%~dp0apps\b3t"
+set "VENV=%APP_DIR%\.venv"
+if not exist "%VENV%\Scripts\python.exe" (
+    echo b3t: creating venv... >&2
+    python -m venv "%VENV%"
+    "%VENV%\Scripts\pip" install -q -r "%APP_DIR%\requirements.txt"
+)
+"%VENV%\Scripts\python.exe" "%APP_DIR%\__main__.py" %*


### PR DESCRIPTION
## Summary

- Adds **`b3t`**, a single-session CLI for Bear Tracks newsletter production — replaces ad-hoc `playwright-cli` sessions and one-off scripts with deterministic commands for each platform.
- All org-specific config (GiveBacks, Forms, PeachJar, ParentSquare, OSP, etc.) loads from a project-root `.env`; source includes `.env.example` with documented variables.
- Browser automation uses a persistent Chrome profile via CDP (`b3t open` / `b3t close`); PeachJar queries run without a browser.

### Commands (high level)

| Group | Examples |
|-------|----------|
| Session | `b3t open`, `close`, `status`, `snap` |
| GiveBacks | `b3t gb login`, `list`, `pull`, `push`, `upload`, `screenshot` |
| M365 | `b3t forms download/list`, `b3t ol check/read` |
| Sources | `b3t pj list/get`, `b3t ps scan/save`, `b3t lwsd scan`, `b3t osp scan` |
| Assets | `b3t gm generate/download` |
| Edition | `b3t ed create/status/manifest` |

Implementation docs live in `apps/b3t/docs/`. Known gaps tracked in `apps/b3t/docs/TODO.md` (raw_html regen, image index listing, SQLite content index, etc.).

Workflow docs consolidated in BearTracks repo: `README.md`, `AGENTS.md`.

## WIP status

This PR is **draft for review**. Not ready to merge until:

- [x] README / workflow documentation consolidated (BearTracks `README.md` + `AGENTS.md`)
- [ ] Manual smoke test on a full edition cycle (Summer Send-Off attempted Jun 2026; board opted not to send — marked `unused` in manifest)
- [x] Review of env var surface and `.env.example` completeness

## Test plan

### Gather / auth
- [x] `b3t ol check --folder Submissions` — lists messages
- [x] `b3t ol read N --folder Submissions` — expands thread (navigates to folder first)
- [x] `b3t forms download` + `forms list` — parses full xlsx
- [x] `b3t status` — clean URL output
- [x] `b3t ps scan` — full post bodies (`--json`, `--since`); expands Read More
- [x] `b3t ps save --dir submissions/` — writes `parentsquare-*.md`
- [x] `b3t pj list` — requires `PEACHJAR_DISTRICT_ID` in `.env`
- [x] `b3t lwsd scan` — requires `LWSD_SCHOOL_URL` in `.env`
- [x] `b3t osp scan`

### GiveBacks edit cycle
- [x] `b3t gb list` — after GiveBacks login
- [x] `b3t gb push --id UUID --design FILE` — API push verified
- [x] `b3t gb upload --id UUID --index N --image FILE` — verified; waits for S3 save (do not navigate away between uploads)
- [x] `b3t gb screenshot --id UUID` — captures messages preview page
- [ ] `b3t gb regen --id UUID` — **not implemented**; manual trivial edit + Save Draft still required
- [ ] `b3t gb images --id UUID` — **not implemented**; agent must guess upload `--index`

### Assets / archive
- [x] `b3t gm generate` — smoke-tested Jun 2026 (template upload, prompt, download → `header-option-1.png`)
- [ ] `b3t osp archive` — **deferred** ([#127](https://github.com/neilobremski/bin/issues/127)); needs org-agnostic design

Made with [Cursor](https://cursor.com)