### PR TITLE
feat(a8s): install-client for system-wide tell deployment

### DIFF
--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -126,7 +126,7 @@ That's the full loop. Members don't know they're "in a8s" — they just see a `t
 | | |
 |---|---|
 | `a8s tell <name> <msg>` | Routed message. `<name>` may be an agent or alias (fans out at routing time). Sender = agent whose `.outbox/` encloses CWD (walks up); errors if no `.outbox/` is found. There is no senderless channel — every message has a force-stamped agent `from` (the router stamps it from the outbox's owning agent, regardless of what the client wrote). |
-| `tell <name> <msg>` (top-level shim, [`~/bin/tell`](/Users/neilo/bin/tell)) | Delegates to `a8s tell` (`apps/a8s/tell.py`). Walks up CWD to find any `.outbox/`, drops a JSON envelope — no `~/.a8s` access required. When the registry is reachable, recipient validation and `from` stamping apply. Windows: `tell.cmd`. |
+| `tell <name> <msg>` (top-level shim, [`~/bin/tell`](/Users/neilo/bin/tell)) | Delegates to `a8s tell` (`apps/a8s/tell.py`). Walks up CWD to find any `.outbox/`, drops a JSON envelope — no `~/.a8s` access required. When the registry is reachable, recipient validation and `from` stamping apply. Windows: `tell.cmd`. Operator internals: [`docs/tell.md`](docs/tell.md). |
 | `a8s logs <name>... [--tail N] [-f]` | Read per-agent log files; merge-sort by ISO timestamp across multiple agents. `-f` follows. |
 
 ### Skills

--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -133,6 +133,7 @@ That's the full loop. Members don't know they're "in a8s" — they just see a `t
 | | |
 |---|---|
 | `a8s install` | Install bundled skills into the current agent dir (or `--global` for user home). |
+| `a8s install-client` | Copy `apps/a8s` to `/usr/local/lib/a8s/apps/a8s` and install `/usr/local/bin/tell` (`sudo`). Re-run to upgrade. |
 
 ### Remotes (issue #63)
 | | |

--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -133,7 +133,7 @@ That's the full loop. Members don't know they're "in a8s" — they just see a `t
 | | |
 |---|---|
 | `a8s install` | Install bundled skills into the current agent dir (or `--global` for user home). |
-| `a8s install-client` | Copy `apps/a8s` to `/usr/local/lib/a8s/apps/a8s` and install `/usr/local/bin/tell` (`sudo`). Re-run to upgrade. |
+| `a8s install-client` | Copy `apps/a8s` to `/usr/local/lib/a8s/` and install `/usr/local/bin/tell` (`sudo`). Re-run to upgrade. |
 
 ### Remotes (issue #63)
 | | |

--- a/apps/a8s/a8s.py
+++ b/apps/a8s/a8s.py
@@ -23,6 +23,7 @@ Surface (CLI):
   stop / kill / exit / ls     handler control
   prompt / tell / clear       message queueing
   install                     install canonical skills
+  install-client              install standalone tell to /usr/local
   logs <name>... [--tail N] [-f]   per-agent log readout (merge-sorted)
 
 `a8s` with no command prints help. There is no auto-discovery — agents must

--- a/apps/a8s/cli.py
+++ b/apps/a8s/cli.py
@@ -15,6 +15,7 @@ from commands import (
     cmd_exit,
     cmd_health,
     cmd_install,
+    cmd_install_client,
     cmd_kill,
     cmd_logs,
     cmd_ls,
@@ -56,6 +57,7 @@ COMMANDS: list[tuple[str, str, str]] = [
     ("storage",  "[<name> [<url> [--<k> <v> ...]]]",            "List, show, or set a cross-cluster file storage service."),
     ("unstorage","<name>",                    "Remove a configured storage service."),
     ("install",  "[path] [--global]",        "Install skills into an agent dir (default CWD) or user home."),
+    ("install-client", "[dest] [--bin-dir]", "Copy a8s to dest (default /usr/local/lib/a8s) and install tell."),
     ("health",   "",                          "Test connectivity of remotes and storage services."),
 ]
 
@@ -111,6 +113,8 @@ def dispatch(cmd: str, args: list[str], interval: float) -> int:
         return cmd_drain(args)
     if cmd == "install":
         return cmd_install(args)
+    if cmd == "install-client":
+        return cmd_install_client(args)
     if cmd == "logs":
         return cmd_logs(args)
     if cmd == "remote":

--- a/apps/a8s/commands.py
+++ b/apps/a8s/commands.py
@@ -422,6 +422,123 @@ def cmd_install(args: list[str]) -> int:
     return _install_skills_into(base)
 
 
+DEFAULT_CLIENT_BIN = Path("/usr/local/bin")
+DEFAULT_CLIENT_LIB = Path("/usr/local/lib/a8s")
+_A8S_SOURCE = Path(__file__).resolve().parent
+
+
+def _install_ignore(_dir: str, names: list[str]) -> set[str]:
+    skip = {"__pycache__", ".pytest_cache", "tests"}
+    return {n for n in names if n in skip or n.endswith(".pyc")}
+
+
+def _install_client_wrapper(bin_path: Path, a8s_entry: Path) -> None:
+    entry = a8s_entry.resolve()
+    wrapper = (
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        f'exec python3 "{entry}" tell "$@"\n'
+    )
+    bin_path.parent.mkdir(parents=True, exist_ok=True)
+    bin_path.write_text(wrapper, encoding="utf-8")
+    bin_path.chmod(0o755)
+
+
+def _chmod_install_tree(root: Path) -> None:
+    for dirpath, dirnames, filenames in os.walk(root):
+        Path(dirpath).chmod(0o755)
+        for name in filenames:
+            (Path(dirpath) / name).chmod(0o644)
+
+
+def _install_a8s_tree(lib_dir: Path) -> Path:
+    dest = lib_dir / "apps" / "a8s"
+    if lib_dir.exists():
+        shutil.rmtree(lib_dir)
+    dest.parent.mkdir(parents=True, mode=0o755)
+    shutil.copytree(_A8S_SOURCE, dest, ignore=_install_ignore)
+    _chmod_install_tree(lib_dir)
+    entry = dest / "a8s.py"
+    if not entry.is_file():
+        raise FileNotFoundError(f"missing {entry}")
+    return entry
+
+
+def cmd_install_client(args: list[str]) -> int:
+    """Install a8s tree + tell wrapper to /usr/local for unprivileged agent users."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="a8s install-client",
+        description=(
+            "Install a copy of apps/a8s for agent users. "
+            "Copies the a8s package to --lib-dir/apps/a8s (excluding tests) "
+            "and writes a tell wrapper to --bin-dir/tell. Re-running overwrites "
+            "any previous install."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "examples:\n"
+            "  sudo a8s install-client\n"
+            "  sudo a8s install-client /opt/a8s\n"
+            "  a8s install-client --bin-dir /tmp/bin --lib-dir /tmp/lib/a8s\n"
+        ),
+    )
+    parser.add_argument(
+        "dest",
+        nargs="?",
+        type=Path,
+        help=f"install root (default: {DEFAULT_CLIENT_LIB})",
+    )
+    parser.add_argument(
+        "--bin-dir",
+        type=Path,
+        default=DEFAULT_CLIENT_BIN,
+        help=f"directory for tell wrapper (default: {DEFAULT_CLIENT_BIN})",
+    )
+    parser.add_argument(
+        "--lib-dir",
+        type=Path,
+        default=None,
+        help=f"install root (same as positional dest; default: {DEFAULT_CLIENT_LIB})",
+    )
+    try:
+        parsed = parser.parse_args(args)
+        if parsed.dest is not None and parsed.lib_dir is not None:
+            parser.error("dest argument conflicts with --lib-dir")
+    except SystemExit as e:
+        return int(e.code if e.code is not None else 0)
+
+    bin_dir = parsed.bin_dir.expanduser().resolve()
+    lib_dir = (parsed.dest or parsed.lib_dir or DEFAULT_CLIENT_LIB).expanduser().resolve()
+    system_install = (
+        str(bin_dir).startswith("/usr/local")
+        or str(lib_dir).startswith("/usr/local")
+    )
+    if system_install and os.geteuid() != 0:
+        print(
+            "a8s install-client: must run as root for /usr/local "
+            "(sudo a8s install-client)",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not _A8S_SOURCE.is_dir():
+        print(f"a8s install-client: source missing: {_A8S_SOURCE}", file=sys.stderr)
+        return 1
+
+    try:
+        a8s_entry = _install_a8s_tree(lib_dir)
+        _install_client_wrapper(bin_dir / "tell", a8s_entry)
+    except OSError as e:
+        print(f"a8s install-client: {e}", file=sys.stderr)
+        return 1
+
+    print(f"installed tell -> {bin_dir / 'tell'}")
+    print(f"installed a8s -> {a8s_entry}")
+    return 0
+
+
 # ---------- alias commands ----------
 
 def cmd_alias(args: list[str]) -> int:

--- a/apps/a8s/commands.py
+++ b/apps/a8s/commands.py
@@ -440,6 +440,8 @@ def _install_client_wrapper(bin_path: Path, a8s_entry: Path) -> None:
         f'exec python3 "{entry}" tell "$@"\n'
     )
     bin_path.parent.mkdir(parents=True, exist_ok=True)
+    if bin_path.is_symlink() or bin_path.exists():
+        bin_path.unlink()
     bin_path.write_text(wrapper, encoding="utf-8")
     bin_path.chmod(0o755)
 
@@ -452,13 +454,11 @@ def _chmod_install_tree(root: Path) -> None:
 
 
 def _install_a8s_tree(lib_dir: Path) -> Path:
-    dest = lib_dir / "apps" / "a8s"
     if lib_dir.exists():
         shutil.rmtree(lib_dir)
-    dest.parent.mkdir(parents=True, mode=0o755)
-    shutil.copytree(_A8S_SOURCE, dest, ignore=_install_ignore)
+    shutil.copytree(_A8S_SOURCE, lib_dir, ignore=_install_ignore)
     _chmod_install_tree(lib_dir)
-    entry = dest / "a8s.py"
+    entry = lib_dir / "a8s.py"
     if not entry.is_file():
         raise FileNotFoundError(f"missing {entry}")
     return entry
@@ -472,7 +472,7 @@ def cmd_install_client(args: list[str]) -> int:
         prog="a8s install-client",
         description=(
             "Install a copy of apps/a8s for agent users. "
-            "Copies the a8s package to --lib-dir/apps/a8s (excluding tests) "
+            "Copies the a8s package to --lib-dir (excluding tests) "
             "and writes a tell wrapper to --bin-dir/tell. Re-running overwrites "
             "any previous install."
         ),

--- a/apps/a8s/docs/tell.md
+++ b/apps/a8s/docs/tell.md
@@ -15,9 +15,10 @@ Operator documentation for how `tell` works under the hood. Agent-facing usage l
 ## Send path (async)
 
 1. Walk up from CWD for the first `.outbox/` directory.
-2. Build message body (argv, stdin, or `-`); parse trailing `FILE:` lines via `mailbox._split_content_and_files`.
-3. Optionally read `~/.a8s` (or `A8S_HOME`) to validate recipient and stamp `from` when CWD is inside a registered agent root.
-4. Write a JSON envelope atomically into `.outbox/` (`.{id}.tmp` → `{id}.json`).
+2. If none found, walk up from `TELL_DEFAULT_DIR` (agent root or any path under it).
+3. Build message body (argv, stdin, or `-`); parse trailing `FILE:` lines via `mailbox._split_content_and_files`.
+4. Optionally read `~/.a8s` (or `A8S_HOME`) to validate recipient and stamp `from` when CWD sits inside a registered agent root.
+5. Write a JSON envelope atomically into `.outbox/` (`.{id}.tmp` → `{id}.json`).
 
 Envelope shape:
 
@@ -34,7 +35,18 @@ Envelope shape:
 
 `from` is omitted when registry is unreachable; the router **force-overwrites** `from` based on which agent owns the outbox directory.
 
-5. `route_outboxes` ingests outbox files into `~/.a8s/agents/<NAME>/pending/`, routes to recipient inboxes (or alias fan-out), and handles remotes.
+6. `route_outboxes` ingests outbox files into `~/.a8s/agents/<NAME>/pending/`, routes to recipient inboxes (or alias fan-out), and handles remotes.
+
+### `TELL_DEFAULT_DIR`
+
+Set on an agent process (systemd, wrapper script, `.env`) to an agent root or any directory beneath it. When CWD is outside the agent tree — e.g. `/tmp` — `tell` still finds `.outbox/` via this fallback. CWD wins when it already encloses an outbox.
+
+```bash
+export TELL_DEFAULT_DIR=/home/knobert/my-agent
+cd /tmp && tell GEMINI "works from anywhere"
+```
+
+Does not affect `sender_from_cwd()`; the router still force-stamps `from` from outbox ownership.
 
 ## `--sync`
 

--- a/apps/a8s/docs/tell.md
+++ b/apps/a8s/docs/tell.md
@@ -1,0 +1,74 @@
+# tell — internals
+
+Operator documentation for how `tell` works under the hood. Agent-facing usage lives in [`skills/tell/SKILL.md`](../skills/tell/SKILL.md).
+
+## Surface
+
+| Entry | Path |
+|-------|------|
+| Operator shim | `~/bin/tell` → `~/bin/a8s tell` |
+| System client | `sudo a8s install-client` → `/usr/local/bin/tell` + `/usr/local/lib/a8s/` |
+| Implementation | `apps/a8s/tell.py` (`tell_main`) |
+| Router | `apps/a8s/mailbox.py` (`route_outboxes`) |
+| Sync protocol | `apps/a8s/sync_listen.py` |
+
+## Send path (async)
+
+1. Walk up from CWD for the first `.outbox/` directory.
+2. Build message body (argv, stdin, or `-`); parse trailing `FILE:` lines via `mailbox._split_content_and_files`.
+3. Optionally read `~/.a8s` (or `A8S_HOME`) to validate recipient and stamp `from` when CWD is inside a registered agent root.
+4. Write a JSON envelope atomically into `.outbox/` (`.{id}.tmp` → `{id}.json`).
+
+Envelope shape:
+
+```json
+{
+  "id": "<ulid>",
+  "date": "<iso8601 Z>",
+  "to": "<recipient>",
+  "content": "...",
+  "files": [{"filename": "...", "path": "..."}],
+  "from": "<sender>"
+}
+```
+
+`from` is omitted when registry is unreachable; the router **force-overwrites** `from` based on which agent owns the outbox directory.
+
+5. `route_outboxes` ingests outbox files into `~/.a8s/agents/<NAME>/pending/`, routes to recipient inboxes (or alias fan-out), and handles remotes.
+
+## `--sync`
+
+Client side (`tell.py` + `sync_listen.py`):
+
+1. Write the user message envelope as usual.
+2. Write a control envelope to `!a8s` with `command: sync_listen` and session paths under `<agent-root>/.temp/`.
+3. Poll for `listen.ack`, then `{session}.reply.json`, then drop `sync_cancel` on exit.
+
+Server side (`sync_listen.py` via a8s handler):
+
+- Registers listeners in `~/.a8s/agents/<NAME>/sync-listeners.json`.
+- When a matching reply is routed, writes the reply JSON to the agent-root path `tell` polls.
+
+Designed for containers and file-proxy mounts where only the agent tree is shared.
+
+## install-client
+
+`a8s install-client [dest]` copies this `apps/a8s` tree (minus `tests/`) to `/usr/local/lib/a8s/` by default and installs `/usr/local/bin/tell`:
+
+```bash
+exec python3 "/usr/local/lib/a8s/a8s.py" tell "$@"
+```
+
+Re-run to upgrade; replaces existing wrapper (including symlinks). Requires root for `/usr/local`.
+
+Use case: agent OS users who must not read the operator's `~/bin` tree — they get `tell` only on PATH.
+
+## User-visible opacity
+
+CLI help and the agent skill intentionally avoid mentioning `.outbox/`, `.temp/`, or JSON. Errors use generic messages (`cannot send from this directory`) so curious agents are not steered toward bypassing the tool.
+
+## Related
+
+- [a8s README](../README.md) — mental model diagram, routing invariants
+- `apps/a8s/tests/test_tell.py` — CLI behavior
+- `apps/a8s/tests/test_sync_listen.py` — sync round-trip

--- a/apps/a8s/skills/tell/SKILL.md
+++ b/apps/a8s/skills/tell/SKILL.md
@@ -3,49 +3,48 @@ name: "tell"
 description: "Send a message to a recipient by name using the `tell` shell command. Delivery is asynchronous and may take seconds, minutes, or longer for the recipient to receive and act on the message; do not wait for or expect an immediate reply. Attach files with `--attach` or `--file`."
 ---
 
-# /tell — send a message to a recipient by name
+# tell — send a message by name
 
-Use the `tell` shell command (available on PATH) to send a message to a recipient by name.
+Use the `tell` shell command (on PATH) to send a message to a recipient by name.
 
 ```
 tell [--sync] [--timeout SEC] [--attach PATH] <name> [<message...>]
 ```
 
-**`tell` is a shell command — invoke it via your bash/shell tool.** Printing `tell <name> "..."` as your final assistant text is *not* a reply; it is just narration and the message will not be sent. The recipient hears you only when you actually execute `tell` through the shell tool.
+**Invoke `tell` through your shell tool.** Printing `tell BOB "hello"` as assistant text does not send anything — only a real shell invocation delivers the message.
 
-**Run from inside an agent's directory tree.** `tell` walks up from CWD to find the first `.outbox/` directory and drops the message JSON there. If no `.outbox/` exists in CWD or any parent, the command errors with `tell: no .outbox/ found in CWD or any parent`.
+## Recipients and tone
 
-- `<name>` is the recipient's name. Treat it as opaque — do not assume whether the recipient is a person or another assistant, and do not change your tone based on a guess.
+- `<name>` is opaque. Do not assume the recipient is a person, another assistant, or a group — and do not change tone based on a guess.
 - `<message>` is the body. Omit it when piping stdin (see below).
-- **Attachments:** use `--attach PATH` or `--file PATH` (same flag, repeatable). Flags may appear before or after the recipient name, but before the message body.
-- **`--sync`:** block until the recipient replies (or `--timeout`, default 300s). Uses a file-drop protocol under `<agent-root>/.temp/` — compatible with containers and file-proxy mounts where only the filesystem is shared. Requires a running a8s handler to route messages. Reply body is printed to stdout. Ctrl-C drops a cancel envelope and exits 130. a8s expires listeners automatically when `--timeout` elapses so stale sessions never capture replies forever.
 
-**Stdin:** pass `-` as the message to read stdin explicitly, or pipe a payload with no message argument:
+## Options
+
+- **`--attach PATH` / `--file PATH`** — attach a file (repeatable). Flags may appear before or after the recipient name, before the message body.
+- **`--sync`** — block until the recipient replies (or until `--timeout`, default 300s). Reply body is printed to stdout. Ctrl-C aborts and exits 130.
+- **Stdin** — pass `-` to read stdin explicitly, or pipe with no message argument:
 
 ```
 echo "summarize this" | tell GEMINI
 cat report.md | tell GEMINI -
 ```
 
-**Legacy `FILE:` lines** (still supported): append trailing `FILE: <path>` lines at the end of the body, or pass `FILE: ./path` as a separate shell argument.
+**Legacy `FILE:` lines** (still supported): trailing `FILE: <path>` lines at the end of the body, or `FILE: ./path` as a separate shell argument.
 
-The command returns immediately. Delivery and processing are asynchronous: the recipient may receive the message seconds, minutes, hours, or longer after you send it, and may take additional time to read and act on it. Don't make assumptions about what causes the delay — it isn't necessarily mechanical. Do not block waiting for a reply; if you need a response, send the message and continue with other work. If a reply is essential, ask the user how to proceed rather than polling.
+## Timing
+
+The command returns immediately (except with `--sync`). Delivery is asynchronous — the recipient may act seconds, minutes, or longer later. Do not block waiting for a reply unless you used `--sync`. If a reply is essential without `--sync`, ask the user how to proceed.
 
 ## Examples
 
 ```
 tell GEMINI --attach /tmp/note.txt please summarize the attached note
-```
-
-```
 tell w heads up — running the migration tonight
-```
-
-```
 git diff | tell CLAUDE review these changes
+tell NEIL --sync "ping" --timeout 60
 ```
 
 ## Failures
 
-- **"tell: no .outbox/ found in CWD or any parent"** — you ran `tell` outside any agent's directory tree. Report this to the user and stop; do not try to work around it (e.g. don't `cd` somewhere unusual to make the error go away).
-- **The recipient name is not validated.** `tell` accepts any `<name>` and the routing layer decides what to do with it. If the name is unknown to the router and no remote clusters are configured, the message is logged + trashed silently. Use names you actually know.
+- **`tell: cannot send from this directory`** — you are not in a context where sending works. Report this to the user; do not `cd` elsewhere to work around it.
+- **Unknown recipient names** are not rejected at the CLI. Routing decides what happens; use names you actually know.

--- a/apps/a8s/tell.py
+++ b/apps/a8s/tell.py
@@ -176,7 +176,7 @@ _USAGE = (
 def _print_usage() -> None:
     print(_USAGE, file=sys.stderr)
     print("       message may be `-` to read stdin; stdin is used when piped", file=sys.stderr)
-    print("       --sync waits for a reply via .temp/ files (default timeout 300s)", file=sys.stderr)
+    print("       --sync block until the recipient replies (default timeout 300s)", file=sys.stderr)
 
 
 def _optional_sender() -> tuple[str, dict] | None:
@@ -357,11 +357,7 @@ def tell_main(argv: list[str]) -> int:
 
     outbox = find_outbox()
     if outbox is None:
-        print(
-            "tell: no .outbox/ found in CWD or any parent "
-            "(run from inside an agent root)",
-            file=sys.stderr,
-        )
+        print("tell: cannot send from this directory", file=sys.stderr)
         return 1
 
     agent_root = agent_root_from_outbox(outbox)

--- a/apps/a8s/tell.py
+++ b/apps/a8s/tell.py
@@ -1,6 +1,7 @@
 """tell — drop a JSON envelope in the nearest `.outbox/`.
 
-Walks up from CWD for `.outbox/` and writes; no registry required. When
+Walks up from CWD for `.outbox/` and writes; falls back to `TELL_DEFAULT_DIR`
+(walks up from that path too) when CWD has no outbox. No registry required.
 `~/.a8s` is reachable and CWD sits inside a registered agent, validates the
 recipient (with remote fallback), stamps `from`, and logs to the agent log.
 
@@ -31,15 +32,34 @@ from ulid import new as new_ulid
 DEFAULT_SYNC_TIMEOUT = DEFAULT_SYNC_TIMEOUT_SEC
 SYNC_ACK_TIMEOUT = 30.0
 SYNC_POLL_INTERVAL = 0.25
+TELL_DEFAULT_DIR_ENV = "TELL_DEFAULT_DIR"
+
+
+def _outbox_at(root: Path) -> Path | None:
+    candidate = root / ".outbox"
+    return candidate if candidate.is_dir() else None
+
+
+def _walk_outbox_from(start: Path) -> Path | None:
+    cur = start.resolve()
+    for d in (cur, *cur.parents):
+        found = _outbox_at(d)
+        if found is not None:
+            return found
+    return None
 
 
 def find_outbox() -> Path | None:
-    cur = Path.cwd().resolve()
-    for d in (cur, *cur.parents):
-        candidate = d / ".outbox"
-        if candidate.is_dir():
-            return candidate
-    return None
+    found = _walk_outbox_from(Path.cwd())
+    if found is not None:
+        return found
+    default_dir = os.environ.get(TELL_DEFAULT_DIR_ENV, "").strip()
+    if not default_dir:
+        return None
+    try:
+        return _walk_outbox_from(Path(default_dir).expanduser())
+    except OSError:
+        return None
 
 
 def agent_root_from_outbox(outbox: Path) -> Path:

--- a/apps/a8s/tests/test_install.py
+++ b/apps/a8s/tests/test_install.py
@@ -23,7 +23,10 @@ def test_install_local_creates_claude_skill_symlink(tmp_path):
     skill = agent / ".claude" / "skills" / "tell" / "SKILL.md"
     assert skill.is_symlink()
     assert skill.resolve().name == "SKILL.md"
-    assert "tell" in skill.read_text()
+    text = skill.read_text()
+    assert "tell" in text
+    assert ".outbox" not in text
+    assert ".temp" not in text
     cursor = agent / ".cursor" / "skills" / "tell" / "SKILL.md"
     assert cursor.is_symlink()
     assert cursor.resolve() == skill.resolve()

--- a/apps/a8s/tests/test_install_client.py
+++ b/apps/a8s/tests/test_install_client.py
@@ -1,0 +1,82 @@
+"""Tests for `a8s install-client`."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+from commands import cmd_install_client
+
+
+def test_install_client_help(capsys):
+    rc = cmd_install_client(["--help"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "install-client" in out
+    assert "/usr/local/lib/a8s" in out
+
+
+def test_install_client_requires_root_for_usr_local(monkeypatch):
+    monkeypatch.setattr(os, "geteuid", lambda: 1000)
+    rc = cmd_install_client([])
+    assert rc == 1
+
+
+def test_install_client_positional_dest(tmp_path, monkeypatch):
+    monkeypatch.setattr(os, "geteuid", lambda: 0)
+    lib_dir = tmp_path / "opt" / "a8s"
+    bin_dir = tmp_path / "bin"
+    assert cmd_install_client([str(lib_dir), "--bin-dir", str(bin_dir)]) == 0
+    assert (lib_dir / "apps" / "a8s" / "a8s.py").is_file()
+    assert (bin_dir / "tell").is_file()
+
+
+def test_install_client_dest_conflicts_with_lib_dir(capsys):
+    rc = cmd_install_client(["/tmp/a", "--lib-dir", "/tmp/b"])
+    assert rc != 0
+
+
+def test_install_client_copies_a8s_and_overwrites(tmp_path, monkeypatch):
+    monkeypatch.setattr(os, "geteuid", lambda: 0)
+    bin_dir = tmp_path / "bin"
+    lib_dir = tmp_path / "lib" / "a8s"
+    a8s_dest = lib_dir / "apps" / "a8s"
+
+    assert cmd_install_client(["--bin-dir", str(bin_dir), "--lib-dir", str(lib_dir)]) == 0
+    tell_bin = bin_dir / "tell"
+    assert tell_bin.is_file()
+    assert tell_bin.stat().st_mode & 0o777 == 0o755
+    assert (a8s_dest / "a8s.py").is_file()
+    assert (a8s_dest / "tell.py").is_file()
+    assert not (a8s_dest / "tests").exists()
+    assert (a8s_dest / "tell.py").stat().st_mode & 0o777 == 0o644
+
+    (a8s_dest / "tell.py").write_text("# stale\n", encoding="utf-8")
+    assert cmd_install_client(["--bin-dir", str(bin_dir), "--lib-dir", str(lib_dir)]) == 0
+    assert "stale" not in (a8s_dest / "tell.py").read_text(encoding="utf-8")
+
+
+def test_installed_tell_writes_outbox(tmp_path, monkeypatch):
+    monkeypatch.setattr(os, "geteuid", lambda: 0)
+    bin_dir = tmp_path / "bin"
+    lib_dir = tmp_path / "lib" / "a8s"
+    assert cmd_install_client(["--bin-dir", str(bin_dir), "--lib-dir", str(lib_dir)]) == 0
+
+    agent = tmp_path / "agent"
+    outbox = agent / ".outbox"
+    outbox.mkdir(parents=True)
+    proc = subprocess.run(
+        [str(bin_dir / "tell"), "GEMINI", "hello from client"],
+        cwd=str(agent),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    files = list(outbox.glob("*.json"))
+    assert len(files) == 1
+    msg = json.loads(files[0].read_text(encoding="utf-8"))
+    assert msg["to"] == "GEMINI"
+    assert msg["content"] == "hello from client"
+    assert "from" not in msg

--- a/apps/a8s/tests/test_install_client.py
+++ b/apps/a8s/tests/test_install_client.py
@@ -28,7 +28,7 @@ def test_install_client_positional_dest(tmp_path, monkeypatch):
     lib_dir = tmp_path / "opt" / "a8s"
     bin_dir = tmp_path / "bin"
     assert cmd_install_client([str(lib_dir), "--bin-dir", str(bin_dir)]) == 0
-    assert (lib_dir / "apps" / "a8s" / "a8s.py").is_file()
+    assert (lib_dir / "a8s.py").is_file()
     assert (bin_dir / "tell").is_file()
 
 
@@ -41,20 +41,40 @@ def test_install_client_copies_a8s_and_overwrites(tmp_path, monkeypatch):
     monkeypatch.setattr(os, "geteuid", lambda: 0)
     bin_dir = tmp_path / "bin"
     lib_dir = tmp_path / "lib" / "a8s"
-    a8s_dest = lib_dir / "apps" / "a8s"
 
     assert cmd_install_client(["--bin-dir", str(bin_dir), "--lib-dir", str(lib_dir)]) == 0
     tell_bin = bin_dir / "tell"
     assert tell_bin.is_file()
+    assert not tell_bin.is_symlink()
     assert tell_bin.stat().st_mode & 0o777 == 0o755
-    assert (a8s_dest / "a8s.py").is_file()
-    assert (a8s_dest / "tell.py").is_file()
-    assert not (a8s_dest / "tests").exists()
-    assert (a8s_dest / "tell.py").stat().st_mode & 0o777 == 0o644
+    assert (lib_dir / "a8s.py").is_file()
+    assert (lib_dir / "tell.py").is_file()
+    assert not (lib_dir / "tests").exists()
+    assert (lib_dir / "tell.py").stat().st_mode & 0o777 == 0o644
 
-    (a8s_dest / "tell.py").write_text("# stale\n", encoding="utf-8")
+    (lib_dir / "tell.py").write_text("# stale\n", encoding="utf-8")
     assert cmd_install_client(["--bin-dir", str(bin_dir), "--lib-dir", str(lib_dir)]) == 0
-    assert "stale" not in (a8s_dest / "tell.py").read_text(encoding="utf-8")
+    assert "stale" not in (lib_dir / "tell.py").read_text(encoding="utf-8")
+
+
+def test_install_client_replaces_symlink_tell(tmp_path, monkeypatch):
+    monkeypatch.setattr(os, "geteuid", lambda: 0)
+    bin_dir = tmp_path / "bin"
+    lib_dir = tmp_path / "lib" / "a8s"
+    other = tmp_path / "old-tell.sh"
+    other.write_text("#!/bin/sh\necho old\n", encoding="utf-8")
+    other.chmod(0o755)
+    bin_dir.mkdir()
+    tell_bin = bin_dir / "tell"
+    tell_bin.symlink_to(other)
+
+    assert cmd_install_client(["--bin-dir", str(bin_dir), "--lib-dir", str(lib_dir)]) == 0
+    assert tell_bin.is_file()
+    assert not tell_bin.is_symlink()
+    assert "a8s.py" in tell_bin.read_text(encoding="utf-8")
+    proc = subprocess.run([str(tell_bin), "--help"], capture_output=True, text=True, check=False)
+    assert proc.returncode == 0
+    assert "old" not in proc.stdout
 
 
 def test_installed_tell_writes_outbox(tmp_path, monkeypatch):

--- a/apps/a8s/tests/test_tell.py
+++ b/apps/a8s/tests/test_tell.py
@@ -6,6 +6,7 @@ nearest `.outbox/` without requiring registry access.
 from __future__ import annotations
 
 import json
+import os
 import re
 import subprocess
 import sys
@@ -21,7 +22,12 @@ A8S_TELL = [
 ]
 
 
-def _run(cwd: Path, *args: str, stdin: str | None = None) -> subprocess.CompletedProcess:
+def _run(
+    cwd: Path,
+    *args: str,
+    stdin: str | None = None,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess:
     kw: dict = {
         "cwd": str(cwd),
         "capture_output": True,
@@ -29,6 +35,8 @@ def _run(cwd: Path, *args: str, stdin: str | None = None) -> subprocess.Complete
     }
     if stdin is not None:
         kw["input"] = stdin
+    if env is not None:
+        kw["env"] = {**os.environ, **env}
     return subprocess.run([str(TELL), *args], **kw)
 
 
@@ -93,6 +101,57 @@ def test_tell_help_is_opaque(tmp_path):
     assert res.returncode == 0
     assert ".outbox" not in res.stderr
     assert ".temp" not in res.stderr
+
+
+def test_tell_uses_tell_default_dir(tmp_path):
+    agent = tmp_path / "agent"
+    (agent / ".outbox").mkdir(parents=True)
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    res = _run(
+        elsewhere,
+        "gerry",
+        "via default dir",
+        env={"TELL_DEFAULT_DIR": str(agent)},
+    )
+    assert res.returncode == 0, res.stderr
+    _name, msg = _read_outbox(agent / ".outbox")
+    assert msg["content"] == "via default dir"
+
+
+def test_tell_cwd_outbox_wins_over_tell_default_dir(tmp_path):
+    cwd_agent = tmp_path / "here"
+    other_agent = tmp_path / "there"
+    (cwd_agent / ".outbox").mkdir(parents=True)
+    (other_agent / ".outbox").mkdir(parents=True)
+    res = _run(
+        cwd_agent,
+        "gerry",
+        "from cwd",
+        env={"TELL_DEFAULT_DIR": str(other_agent)},
+    )
+    assert res.returncode == 0, res.stderr
+    assert list((other_agent / ".outbox").glob("*.json")) == []
+    _name, msg = _read_outbox(cwd_agent / ".outbox")
+    assert msg["content"] == "from cwd"
+
+
+def test_tell_default_dir_walks_up(tmp_path):
+    agent = tmp_path / "agent"
+    (agent / ".outbox").mkdir(parents=True)
+    sub = agent / "src" / "pkg"
+    sub.mkdir(parents=True)
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    res = _run(
+        elsewhere,
+        "gerry",
+        "default subdir",
+        env={"TELL_DEFAULT_DIR": str(sub)},
+    )
+    assert res.returncode == 0, res.stderr
+    _name, msg = _read_outbox(agent / ".outbox")
+    assert msg["content"] == "default subdir"
 
 
 def test_tell_lifts_file_lines_into_files_array(tmp_path):

--- a/apps/a8s/tests/test_tell.py
+++ b/apps/a8s/tests/test_tell.py
@@ -85,7 +85,14 @@ def test_tell_walks_up_from_subdir(tmp_path):
 def test_tell_errors_when_no_outbox(tmp_path):
     res = _run(tmp_path, "anyone", "should fail")
     assert res.returncode != 0
-    assert "no .outbox/" in res.stderr
+    assert "cannot send from this directory" in res.stderr
+
+
+def test_tell_help_is_opaque(tmp_path):
+    res = _run(tmp_path, "--help")
+    assert res.returncode == 0
+    assert ".outbox" not in res.stderr
+    assert ".temp" not in res.stderr
 
 
 def test_tell_lifts_file_lines_into_files_array(tmp_path):


### PR DESCRIPTION
## Summary

- Add `a8s install-client` to copy `apps/a8s` to a configurable install root (default `/usr/local/lib/a8s/`) and install a `/usr/local/bin/tell` wrapper for agent users who cannot access the operator's `~/bin` tree
- Flatten lib layout, replace existing tell symlinks on reinstall, and support positional `dest` override
- Make tell UX opaque for agents (CLI help + skill); move internals to `apps/a8s/docs/tell.md`
- Add `TELL_DEFAULT_DIR` env fallback so agents can `tell` from any CWD when the var points at their agent root

## Test plan

- [x] `pytest apps/a8s/tests/test_install_client.py`
- [x] `pytest apps/a8s/tests/test_tell.py` (help opacity, `TELL_DEFAULT_DIR`, error message)
- [x] `pytest apps/a8s/tests/test_install.py` (skill opacity)
- [ ] Manual: `sudo a8s install-client` on server; verify `/usr/local/bin/tell --help` and outbox write from agent user
- [ ] Manual: re-run install over existing symlink at `/usr/local/bin/tell`
- [ ] Manual: set `TELL_DEFAULT_DIR` on agent process; `tell` from `/tmp` succeeds

## PR Checklist

### Code Quality
- [x] No `__pycache__` or `.pyc` files in git
- [x] No hardcoded secrets (API keys, passwords, bridge URLs, MQTT creds)
- [x] No PII in committed code or PR description (real emails, phone numbers — use example.com)
- [x] No SQL string interpolation (all queries use `?` parameters)
- [x] No raw `except:` without specific exception types
- [x] No dead imports or unused variables
- [x] Runtime artifacts gitignored (`.db`, `.log`, `.count`, `health.txt`, `stimulus.txt`)

### Testing
- [ ] Integration tests pass (`lifetime.sh`)
- [x] Unit tests pass (if applicable: `pytest`)
- [ ] Manual verification of new features

### Documentation
- [ ] Textbook updated if architecture changed
- [x] README updated if organ/CLI interface changed

### Review
- [ ] Critic agent reviewed before merge