### PR TITLE
fix(a8s): show single-agent logs in append order

### DIFF
--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -127,7 +127,7 @@ That's the full loop. Members don't know they're "in a8s" — they just see a `t
 |---|---|
 | `a8s tell <name> <msg>` | Routed message. `<name>` may be an agent or alias (fans out at routing time). Sender = agent whose `.outbox/` encloses CWD (walks up); errors if no `.outbox/` is found. There is no senderless channel — every message has a force-stamped agent `from` (the router stamps it from the outbox's owning agent, regardless of what the client wrote). |
 | `tell <name> <msg>` (top-level shim, [`~/bin/tell`](/Users/neilo/bin/tell)) | Delegates to `a8s tell` (`apps/a8s/tell.py`). Walks up CWD to find any `.outbox/`, drops a JSON envelope — no `~/.a8s` access required. When the registry is reachable, recipient validation and `from` stamping apply. Windows: `tell.cmd`. Operator internals: [`docs/tell.md`](docs/tell.md). |
-| `a8s logs <name>... [--tail N] [-f]` | Read per-agent log files; merge-sort by ISO timestamp across multiple agents. `-f` follows. |
+| `a8s logs <name>... [--tail N] [-f]` | Read per-agent log files; one agent in append order, multiple merge by ISO timestamp. `-f` follows. |
 
 ### Skills
 | | |

--- a/apps/a8s/commands.py
+++ b/apps/a8s/commands.py
@@ -21,6 +21,7 @@ import signal
 import subprocess
 import sys
 import time
+from datetime import datetime
 from pathlib import Path
 
 from core import (
@@ -993,11 +994,52 @@ def cmd_drain(args: list[str]) -> int:
 
 # ---------- logs ----------
 
+def _parse_log_line_ts(line: str) -> datetime | None:
+    if not line:
+        return None
+    head = line.split(" ", 1)[0]
+    if head.endswith("Z"):
+        head = head[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(head)
+    except ValueError:
+        return None
+
+
+def _read_agent_log(path: Path) -> list[str]:
+    if not path.is_file():
+        return []
+    with path.open("r", encoding="utf-8", errors="replace") as f:
+        return f.readlines()
+
+
+def _merge_log_lines(paths: list[Path]) -> list[str]:
+    tagged: list[tuple[tuple, str]] = []
+    for fi, path in enumerate(paths):
+        for li, line in enumerate(_read_agent_log(path)):
+            ts = _parse_log_line_ts(line)
+            key = (0, ts, fi, li) if ts is not None else (1, fi, li)
+            tagged.append((key, line))
+    tagged.sort(key=lambda item: item[0])
+    return [line for _key, line in tagged]
+
+
+def _dump_logs(paths: list[Path], tail_n: int | None) -> None:
+    existing = [p for p in paths if p.is_file()]
+    if not existing:
+        return
+    lines = _read_agent_log(existing[0]) if len(existing) == 1 else _merge_log_lines(existing)
+    if tail_n is not None:
+        lines = lines[-tail_n:]
+    for line in lines:
+        sys.stdout.write(line)
+    sys.stdout.flush()
+
+
 def cmd_logs(args: list[str]) -> int:
-    """Read each named agent's log.txt and emit lines merge-sorted by ISO
-    timestamp prefix. -f follows each file; new lines from any source are
-    interleaved using a small ordering buffer so multi-file output stays
-    roughly chronological."""
+    """Read each named agent's log.txt. One agent: append order (file order).
+    Multiple agents: merge by leading ISO timestamp. -f follows; multi-agent
+    follow uses a short ordering buffer."""
     if not args:
         print("usage: a8s logs <name> [<name>...] [--tail N] [-f|--follow]", file=sys.stderr)
         return 2
@@ -1060,48 +1102,51 @@ def cmd_logs(args: list[str]) -> int:
             print(f"no log yet at {p}", file=sys.stderr)
         return 1
 
-    # Initial dump: read all existing lines, merge-sort by leading timestamp.
-    lines: list[str] = []
-    for p in paths:
-        if p.is_file():
-            with p.open("r", encoding="utf-8", errors="replace") as f:
-                lines.extend(f)
-    lines.sort(key=lambda ln: ln.split(" ", 1)[0] if ln else "")
-    if tail_n is not None:
-        lines = lines[-tail_n:]
-    for ln in lines:
-        sys.stdout.write(ln)
-    sys.stdout.flush()
+    # Initial dump: one file in append order; multiple files merge by timestamp.
+    _dump_logs(paths, tail_n)
 
     if not follow:
         return 0
 
-    # Follow: poll each file's tail, emit new lines in chronological order
-    # using a ~1s ordering window. Cheap and correct enough for v1.
-    handles: list[tuple[Path, "os.IOBase"]] = []
+    handles: list[tuple[int, Path, "os.IOBase"]] = []
     try:
-        for p in paths:
+        for fi, p in enumerate(paths):
             p.parent.mkdir(parents=True, exist_ok=True)
             p.touch(exist_ok=True)
             f = p.open("r", encoding="utf-8", errors="replace")
             f.seek(0, 2)
-            handles.append((p, f))
-        buf: list[str] = []
+            handles.append((fi, p, f))
+        if len(handles) == 1:
+            try:
+                while True:
+                    ln = handles[0][2].readline()
+                    if not ln:
+                        time.sleep(0.25)
+                        continue
+                    sys.stdout.write(ln)
+                    sys.stdout.flush()
+            except KeyboardInterrupt:
+                return 0
+        buf: list[tuple[tuple, str]] = []
+        seq = 0
         last_emit = time.time()
         try:
             while True:
                 progress = False
-                for _path, f in handles:
+                for fi, _path, f in handles:
                     while True:
                         ln = f.readline()
                         if not ln:
                             break
-                        buf.append(ln)
+                        ts = _parse_log_line_ts(ln)
+                        key = (0, ts, fi, seq) if ts is not None else (1, fi, seq)
+                        buf.append((key, ln))
+                        seq += 1
                         progress = True
                 now = time.time()
                 if buf and (not progress or now - last_emit >= 1.0):
-                    buf.sort(key=lambda ln: ln.split(" ", 1)[0] if ln else "")
-                    for ln in buf:
+                    buf.sort(key=lambda item: item[0])
+                    for _key, ln in buf:
                         sys.stdout.write(ln)
                     sys.stdout.flush()
                     buf.clear()
@@ -1110,13 +1155,13 @@ def cmd_logs(args: list[str]) -> int:
                     time.sleep(0.25)
         except KeyboardInterrupt:
             if buf:
-                buf.sort(key=lambda ln: ln.split(" ", 1)[0] if ln else "")
-                for ln in buf:
+                buf.sort(key=lambda item: item[0])
+                for _key, ln in buf:
                     sys.stdout.write(ln)
                 sys.stdout.flush()
             return 0
     finally:
-        for _p, f in handles:
+        for _fi, _p, f in handles:
             try:
                 f.close()
             except Exception:

--- a/apps/a8s/tests/test_commands.py
+++ b/apps/a8s/tests/test_commands.py
@@ -14,6 +14,7 @@ from commands import (
     cmd_add,
     cmd_alias,
     cmd_kill,
+    cmd_logs,
     cmd_remote,
     cmd_remove,
     cmd_storage,
@@ -22,7 +23,7 @@ from commands import (
     cmd_unremote,
     cmd_unstorage,
 )
-from core import Participant, agent_dir, kill_request_path, outbox_dir, pid_path
+from core import Participant, agent_dir, agent_log_path, kill_request_path, outbox_dir, pid_path
 from mailbox import ensure_mailboxes
 from network import load_network_config, save_network_config
 from registry import load_aliases, load_registry, save_registry
@@ -626,5 +627,49 @@ class TestCmdTellWithSplitFileArg:
         msg = _json.loads(outbox_files[0].read_text())
         assert msg["content"] == "Here is the doc."
         assert msg["files"] == [{"filename": "report.pdf", "path": "./report.pdf"}]
+
+
+class TestCmdLogs:
+    def test_single_agent_preserves_append_order(self, fake_home, tmp_path, capsys):
+        root = tmp_path / "x"; root.mkdir()
+        save_registry({"claude": {"root": str(root)}})
+        log = agent_log_path("claude")
+        log.parent.mkdir(parents=True, exist_ok=True)
+        log.write_text(
+            "2026-01-01T12:00:02Z later timestamp first in file\n"
+            "2026-01-01T12:00:01Z earlier timestamp second in file\n"
+            "legacy line without timestamp prefix\n"
+        )
+        assert cmd_logs(["claude"]) == 0
+        out = capsys.readouterr().out
+        assert out.splitlines() == [
+            "2026-01-01T12:00:02Z later timestamp first in file",
+            "2026-01-01T12:00:01Z earlier timestamp second in file",
+            "legacy line without timestamp prefix",
+        ]
+
+    def test_multi_agent_merge_sorts_by_timestamp(self, fake_home, tmp_path, capsys):
+        a_root = tmp_path / "a"; a_root.mkdir()
+        b_root = tmp_path / "b"; b_root.mkdir()
+        save_registry({"claude": {"root": str(a_root)}, "gemini": {"root": str(b_root)}})
+        agent_log_path("claude").parent.mkdir(parents=True, exist_ok=True)
+        agent_log_path("gemini").parent.mkdir(parents=True, exist_ok=True)
+        agent_log_path("claude").write_text("2026-01-01T12:00:03Z from claude\n")
+        agent_log_path("gemini").write_text("2026-01-01T12:00:01Z from gemini\n")
+        assert cmd_logs(["claude", "gemini"]) == 0
+        out = capsys.readouterr().out.splitlines()
+        assert out == [
+            "2026-01-01T12:00:01Z from gemini",
+            "2026-01-01T12:00:03Z from claude",
+        ]
+
+    def test_tail_keeps_last_lines_of_single_agent_log(self, fake_home, tmp_path, capsys):
+        root = tmp_path / "x"; root.mkdir()
+        save_registry({"claude": {"root": str(root)}})
+        log = agent_log_path("claude")
+        log.parent.mkdir(parents=True, exist_ok=True)
+        log.write_text("line1\nline2\nline3\n")
+        assert cmd_logs(["claude", "--tail", "2"]) == 0
+        assert capsys.readouterr().out.splitlines() == ["line2", "line3"]
 
 


### PR DESCRIPTION
## Summary

- **`a8s logs <name>`** — single-agent output now reads `log.txt` in append order instead of re-sorting every line by timestamp prefix
- **`--tail N`** — returns the last N lines of the file (not the N lines with the latest timestamps after a global sort)
- **`-f`** — single-agent follow emits lines immediately with no reorder buffer
- **Multi-agent** — still merge-sorts by parsed ISO timestamp when interleaving several log files

## PR Checklist

### Code Quality
- [x] No `__pycache__` or `.pyc` files in git
- [x] No hardcoded secrets (API keys, passwords, bridge URLs, MQTT creds)
- [x] No PII in committed code or PR description (real emails, phone numbers — use example.com)
- [x] No SQL string interpolation (all queries use `?` parameters)
- [x] No raw `except:` without specific exception types
- [x] No dead imports or unused variables
- [x] Runtime artifacts gitignored (`.db`, `.log`, `.count`, `health.txt`, `stimulus.txt`)

### Testing
- [ ] Integration tests pass (`lifetime.sh`)
- [x] Unit tests pass (if applicable: `pytest`)
- [x] Manual verification of new features

### Documentation
- [ ] Textbook updated if architecture changed
- [x] README updated if organ/CLI interface changed

### Review
- [ ] Critic agent reviewed before merge

## Test plan

- [x] `python -m pytest apps/a8s/tests/test_commands.py::TestCmdLogs -q`
- [ ] `a8s logs knobert` on server shows events in the order they occurred


Made with [Cursor](https://cursor.com)