### PR TITLE
feat(a8s): internal tell --check self-test

### DIFF
--- a/apps/a8s/docs/tell.md
+++ b/apps/a8s/docs/tell.md
@@ -14,6 +14,7 @@ Operator documentation for how `tell` works under the hood. Agent-facing usage l
 
 ## Send path (async)
 
+0. **`tell --check`** — optional self-test: resolves send directory, probes writability, reports `send-from` / `via` / `sender`; with a recipient name, validates registry routing. No envelope written.
 1. If `TELL_DIR` is set, use `$TELL_DIR/.outbox` directly (no CWD or parent walk).
 2. Else walk up from CWD for the first `.outbox/` directory.
 3. If none found, walk up from `TELL_DEFAULT_DIR` (agent root or any path under it).

--- a/apps/a8s/tell.py
+++ b/apps/a8s/tell.py
@@ -62,18 +62,24 @@ def _walk_outbox_from(start: Path) -> Path | None:
 
 
 def find_outbox() -> Path | None:
+    outbox, _source = resolve_outbox()
+    return outbox
+
+
+def resolve_outbox() -> tuple[Path | None, str]:
     if os.environ.get(TELL_DIR_ENV, "").strip():
-        return _outbox_from_tell_dir()
+        return _outbox_from_tell_dir(), TELL_DIR_ENV
     found = _walk_outbox_from(Path.cwd())
     if found is not None:
-        return found
+        return found, "cwd"
     default_dir = os.environ.get(TELL_DEFAULT_DIR_ENV, "").strip()
     if not default_dir:
-        return None
+        return None, "none"
     try:
-        return _walk_outbox_from(Path(default_dir).expanduser())
+        found = _walk_outbox_from(Path(default_dir).expanduser())
     except OSError:
-        return None
+        return None, TELL_DEFAULT_DIR_ENV
+    return (found, TELL_DEFAULT_DIR_ENV) if found is not None else (None, TELL_DEFAULT_DIR_ENV)
 
 
 def agent_root_from_outbox(outbox: Path) -> Path:
@@ -94,12 +100,13 @@ def join_args(args: list[str]) -> str:
 
 def parse_tell_argv(
     argv: list[str],
-) -> tuple[str, list[str], list[str], bool, float]:
-    """Return `(recipient, attachments, message_argv, sync, timeout_sec)`."""
+) -> tuple[str | None, list[str], list[str], bool, float, bool]:
+    """Return `(recipient, attachments, message_argv, sync, timeout_sec, check)`."""
     attachments: list[str] = []
     recipient: str | None = None
     message_argv: list[str] = []
     sync = False
+    check = False
     timeout = DEFAULT_SYNC_TIMEOUT
     i = 0
     while i < len(argv):
@@ -111,6 +118,8 @@ def parse_tell_argv(
             attachments.append(argv[i])
         elif arg == "--sync":
             sync = True
+        elif arg == "--check":
+            check = True
         elif arg == "--timeout":
             i += 1
             if i >= len(argv):
@@ -130,9 +139,9 @@ def parse_tell_argv(
         else:
             message_argv.append(arg)
         i += 1
-    if recipient is None:
+    if recipient is None and not check:
         raise TellUsageError("recipient name required")
-    return recipient, attachments, message_argv, sync, timeout
+    return recipient, attachments, message_argv, sync, timeout, check
 
 
 def resolve_message_body(message_argv: list[str]) -> str | None:
@@ -369,9 +378,58 @@ def _run_sync(
             )
 
 
+def _probe_outbox_writable(outbox: Path) -> str | None:
+    probe = outbox / f".tell-check-{os.getpid()}.tmp"
+    try:
+        probe.write_text("{}", encoding="utf-8")
+        probe.unlink()
+    except OSError as e:
+        return str(e)
+    return None
+
+
+def run_check(recipient: str | None) -> int:
+    outbox, source = resolve_outbox()
+    if outbox is None:
+        print("tell: cannot send from this directory", file=sys.stderr)
+        if source == TELL_DIR_ENV:
+            print(f"tell: {TELL_DIR_ENV} is set but has no send directory", file=sys.stderr)
+        elif source == TELL_DEFAULT_DIR_ENV:
+            print(f"tell: {TELL_DEFAULT_DIR_ENV} is set but has no send directory", file=sys.stderr)
+        return 1
+
+    err = _probe_outbox_writable(outbox)
+    if err is not None:
+        print(f"tell: send directory not writable: {err}", file=sys.stderr)
+        return 1
+
+    agent_root = agent_root_from_outbox(outbox)
+    lines = ["tell: ok", f"  send-from: {agent_root}", f"  via: {source}"]
+
+    sender = _optional_sender()
+    if sender is not None:
+        lines.append(f"  sender: {sender[0]}")
+    else:
+        lines.append("  sender: (registry unavailable)")
+
+    if recipient is not None:
+        rc, canonical, kind = _validate_recipient(recipient)
+        if rc != 0:
+            return rc
+        assert canonical is not None
+        if kind == "alias":
+            lines.append(f"  recipient {recipient!r}: ok (alias -> {canonical})")
+        else:
+            lines.append(f"  recipient {recipient!r}: ok")
+
+    for line in lines:
+        print(line)
+    return 0
+
+
 def tell_main(argv: list[str]) -> int:
     try:
-        recipient, attachments, message_argv, sync, timeout = parse_tell_argv(argv)
+        recipient, attachments, message_argv, sync, timeout, check = parse_tell_argv(argv)
     except TellHelp:
         _print_usage()
         return 0
@@ -379,6 +437,17 @@ def tell_main(argv: list[str]) -> int:
         print(f"tell: {e}", file=sys.stderr)
         _print_usage()
         return 2
+
+    if check:
+        if sync:
+            print("tell: --check cannot be used with --sync", file=sys.stderr)
+            return 2
+        if attachments or message_argv:
+            print("tell: --check does not accept a message or attachments", file=sys.stderr)
+            return 2
+        return run_check(recipient)
+
+    assert recipient is not None
 
     body = resolve_message_body(message_argv)
     if body is None:

--- a/apps/a8s/tests/test_tell.py
+++ b/apps/a8s/tests/test_tell.py
@@ -356,7 +356,83 @@ def test_tell_stamps_from_when_registered(fake_home, tmp_path, monkeypatch):
     assert msg["to"] == "bob"
 
 
+def test_tell_attach_requires_path(tmp_path):
     (tmp_path / ".outbox").mkdir()
     res = _run(tmp_path, "gerry", "--attach")
     assert res.returncode == 2
     assert "--attach requires a path" in res.stderr
+
+
+def test_tell_check_ok_without_recipient(tmp_path):
+    (tmp_path / ".outbox").mkdir()
+    res = _run(tmp_path, "--check")
+    assert res.returncode == 0, res.stderr
+    assert res.stdout.splitlines()[0] == "tell: ok"
+    assert f"send-from: {tmp_path.resolve()}" in res.stdout
+    assert "via: cwd" in res.stdout
+    assert list((tmp_path / ".outbox").glob("*.json")) == []
+
+
+def test_tell_check_validates_recipient(fake_home, tmp_path, monkeypatch):
+    from registry import save_registry
+
+    agent_root = tmp_path / "agent"
+    agent_root.mkdir()
+    (agent_root / ".outbox").mkdir()
+    bob_root = tmp_path / "bob"
+    bob_root.mkdir()
+    save_registry({"SENDER": {"root": str(agent_root)}, "bob": {"root": str(bob_root)}})
+    monkeypatch.chdir(agent_root)
+
+    res = _run_a8s(agent_root, "--check", "bob")
+    assert res.returncode == 0, res.stderr
+    assert "recipient 'bob': ok" in res.stdout
+    assert "sender: SENDER" in res.stdout
+    assert list((agent_root / ".outbox").glob("*.json")) == []
+
+
+def test_tell_check_unknown_recipient_fails(fake_home, tmp_path, monkeypatch):
+    from registry import save_registry
+
+    agent_root = tmp_path / "agent"
+    agent_root.mkdir()
+    (agent_root / ".outbox").mkdir()
+    save_registry({"SENDER": {"root": str(agent_root)}})
+    monkeypatch.chdir(agent_root)
+
+    res = _run_a8s(agent_root, "--check", "ghost")
+    assert res.returncode == 1
+    assert "no agent or alias named 'ghost'" in res.stderr
+    assert list((agent_root / ".outbox").glob("*.json")) == []
+
+
+def test_tell_check_fails_without_outbox(tmp_path):
+    res = _run(tmp_path, "--check")
+    assert res.returncode == 1
+    assert "cannot send from this directory" in res.stderr
+
+
+def test_tell_check_reports_tell_dir(tmp_path):
+    locked = tmp_path / "mailbox"
+    (locked / ".outbox").mkdir(parents=True)
+    res = _run(
+        tmp_path,
+        "--check",
+        env={"TELL_DIR": str(locked)},
+    )
+    assert res.returncode == 0, res.stderr
+    assert "via: TELL_DIR" in res.stdout
+    assert f"send-from: {locked.resolve()}" in res.stdout
+
+
+def test_tell_check_rejects_message_body(tmp_path):
+    (tmp_path / ".outbox").mkdir()
+    res = _run(tmp_path, "--check", "bob", "hello")
+    assert res.returncode == 2
+    assert "does not accept a message" in res.stderr
+
+
+def test_tell_help_omits_check(tmp_path):
+    res = _run(tmp_path, "--help")
+    assert res.returncode == 0
+    assert "--check" not in res.stderr


### PR DESCRIPTION
## Summary

- **`tell --check`** — operator-only self-test: verifies send-directory resolution, writability, registry sender identity, and optional recipient validation without writing an envelope
- **Intentionally hidden** from agent skill (`docs/tell.md`, `skills/tell/SKILL.md`) and `tell --help` — documented only in `apps/a8s/docs/tell.md`
- Fixes orphaned `test_tell_attach_requires_path` at end of `test_tell.py`

Example (operator use):

```bash
tell --check
tell --check GEMINI
```

## PR Checklist

### Code Quality
- [x] No `__pycache__` or `.pyc` files in git
- [x] No hardcoded secrets (API keys, passwords, bridge URLs, MQTT creds)
- [x] No PII in committed code or PR description (real emails, phone numbers — use example.com)
- [x] No SQL string interpolation (all queries use `?` parameters)
- [x] No raw `except:` without specific exception types
- [x] No dead imports or unused variables
- [x] Runtime artifacts gitignored (`.db`, `.log`, `.count`, `health.txt`, `stimulus.txt`)

### Testing
- [ ] Integration tests pass (`lifetime.sh`)
- [x] Unit tests pass (if applicable: `pytest`)
- [ ] Manual verification of new features

### Documentation
- [ ] Textbook updated if architecture changed
- [x] README updated if organ/CLI interface changed

### Review
- [ ] Critic agent reviewed before merge

## Test plan

- [x] `python -m pytest apps/a8s/tests/test_tell.py -q`
- [ ] `tell --check` on server agent sandbox confirms `send-from` / `via` / `sender`
- [ ] `tell --help` does not mention `--check`


Made with [Cursor](https://cursor.com)