### PR TITLE
fix(a8s): align tell --check with outbox-only bundle model

### DIFF
--- a/apps/a8s/docs/tell.md
+++ b/apps/a8s/docs/tell.md
@@ -14,7 +14,7 @@ Operator documentation for how `tell` works under the hood. Agent-facing usage l
 
 ## Send path (async)
 
-0. **`tell --check`** — optional self-test: resolves send directory, probes writability, reports `send-from` / `via` / `sender`; with a recipient name, validates registry routing. No envelope written.
+0. **`tell --check`** — optional self-test: verifies a writable `.outbox/` is available (walk from CWD / `TELL_DEFAULT_DIR`, or `$TELL_DIR/.outbox` — creating that directory when `TELL_DIR` is set and `.outbox` is missing). Optional recipient name validates registry routing. No envelope written.
 1. If `TELL_DIR` is set, use `$TELL_DIR/.outbox` directly (no CWD or parent walk).
 2. Else walk up from CWD for the first `.outbox/` directory.
 3. If none found, walk up from `TELL_DEFAULT_DIR` (agent root or any path under it).
@@ -57,7 +57,7 @@ export TELL_DIR=/var/mailboxes/agent-one
 cd /anywhere && tell GEMINI "locked to this mailbox"
 ```
 
-If `$TELL_DIR/.outbox` is missing, send fails. Sync session files use `$TELL_DIR/.temp/`.
+If `$TELL_DIR/.outbox` is missing, send fails. `tell --check` creates it when probing a `TELL_DIR` mailbox. Sync session files use `$TELL_DIR/.temp/`.
 
 ### `TELL_DEFAULT_DIR`
 

--- a/apps/a8s/tell.py
+++ b/apps/a8s/tell.py
@@ -88,6 +88,25 @@ def resolve_outbox() -> tuple[Path | None, str]:
     return (found, TELL_DEFAULT_DIR_ENV) if found is not None else (None, TELL_DEFAULT_DIR_ENV)
 
 
+def _ensure_tell_dir_outbox() -> Path | None:
+    tell_dir = os.environ.get(TELL_DIR_ENV, "").strip()
+    if not tell_dir:
+        return None
+    try:
+        outbox = Path(tell_dir).expanduser().resolve() / ".outbox"
+        outbox.mkdir(parents=True, exist_ok=True)
+        return outbox
+    except OSError:
+        return None
+
+
+def resolve_outbox_for_check() -> Path | None:
+    if os.environ.get(TELL_DIR_ENV, "").strip():
+        return _ensure_tell_dir_outbox()
+    outbox, _source = resolve_outbox()
+    return outbox
+
+
 def agent_root_from_outbox(outbox: Path) -> Path:
     return outbox.parent.resolve()
 
@@ -466,28 +485,21 @@ def _probe_outbox_writable(outbox: Path) -> str | None:
 
 
 def run_check(recipient: str | None) -> int:
-    outbox, source = resolve_outbox()
+    outbox = resolve_outbox_for_check()
     if outbox is None:
         print("tell: cannot send from this directory", file=sys.stderr)
-        if source == TELL_DIR_ENV:
-            print(f"tell: {TELL_DIR_ENV} is set but has no send directory", file=sys.stderr)
-        elif source == TELL_DEFAULT_DIR_ENV:
-            print(f"tell: {TELL_DEFAULT_DIR_ENV} is set but has no send directory", file=sys.stderr)
+        if os.environ.get(TELL_DIR_ENV, "").strip():
+            print(f"tell: {TELL_DIR_ENV} is set but send directory is unavailable", file=sys.stderr)
+        elif os.environ.get(TELL_DEFAULT_DIR_ENV, "").strip():
+            print(f"tell: {TELL_DEFAULT_DIR_ENV} is set but has no .outbox", file=sys.stderr)
         return 1
 
     err = _probe_outbox_writable(outbox)
     if err is not None:
-        print(f"tell: send directory not writable: {err}", file=sys.stderr)
+        print(f"tell: .outbox not writable: {err}", file=sys.stderr)
         return 1
 
-    agent_root = agent_root_from_outbox(outbox)
-    lines = ["tell: ok", f"  send-from: {agent_root}", f"  via: {source}"]
-
-    sender = _optional_sender()
-    if sender is not None:
-        lines.append(f"  sender: {sender[0]}")
-    else:
-        lines.append("  sender: (registry unavailable)")
+    lines = ["tell: ok", f"  outbox: {outbox}"]
 
     if recipient is not None:
         rc, canonical, kind = _validate_recipient(recipient)

--- a/apps/a8s/tests/test_tell.py
+++ b/apps/a8s/tests/test_tell.py
@@ -481,8 +481,7 @@ def test_tell_check_ok_without_recipient(tmp_path):
     res = _run(tmp_path, "--check")
     assert res.returncode == 0, res.stderr
     assert res.stdout.splitlines()[0] == "tell: ok"
-    assert f"send-from: {tmp_path.resolve()}" in res.stdout
-    assert "via: cwd" in res.stdout
+    assert f"outbox: {tmp_path.resolve() / '.outbox'}" in res.stdout
     assert list((tmp_path / ".outbox").glob("*.json")) == []
 
 
@@ -500,7 +499,6 @@ def test_tell_check_validates_recipient(fake_home, tmp_path, monkeypatch):
     res = _run_a8s(agent_root, "--check", "bob")
     assert res.returncode == 0, res.stderr
     assert "recipient 'bob': ok" in res.stdout
-    assert "sender: SENDER" in res.stdout
     assert list((agent_root / ".outbox").glob("*.json")) == []
 
 
@@ -534,8 +532,21 @@ def test_tell_check_reports_tell_dir(tmp_path):
         env={"TELL_DIR": str(locked)},
     )
     assert res.returncode == 0, res.stderr
-    assert "via: TELL_DIR" in res.stdout
-    assert f"send-from: {locked.resolve()}" in res.stdout
+    assert f"outbox: {locked.resolve() / '.outbox'}" in res.stdout
+
+
+def test_tell_check_creates_outbox_when_tell_dir_set(tmp_path):
+    locked = tmp_path / "mailbox"
+    locked.mkdir()
+    assert not (locked / ".outbox").exists()
+    res = _run(
+        tmp_path,
+        "--check",
+        env={"TELL_DIR": str(locked)},
+    )
+    assert res.returncode == 0, res.stderr
+    assert (locked / ".outbox").is_dir()
+    assert list((locked / ".outbox").glob("*.json")) == []
 
 
 def test_tell_check_rejects_message_body(tmp_path):


### PR DESCRIPTION
## Summary

- **`tell --check`** now only verifies a writable `.outbox/` is available — the only prerequisite for send under the message-scoped attachment model
- Drops `send-from` / `via` / `sender` reporting (agent identity and routing roots are irrelevant to the check)
- When **`TELL_DIR`** is set and `.outbox` is missing, `--check` creates it so operators can bootstrap a locked mailbox before first send
- Actual send path unchanged: still requires an existing `.outbox` unless bootstrapped via `--check`

## Test plan

- [x] `pytest apps/a8s/tests/test_tell.py -k check` (8 passed)
- [ ] Manual: `TELL_DIR=/tmp/mailbox tell --check` with no `.outbox` — directory created, `tell: ok`
- [ ] Manual: `tell --check bob` from registered agent root — recipient line present


Made with [Cursor](https://cursor.com)