### PR TITLE
refactor(a8s): TELL_OUTBOX_DIR lock and definition outbox_dir

### DIFF
--- a/apps/a8s/DEVELOPMENT.md
+++ b/apps/a8s/DEVELOPMENT.md
@@ -25,6 +25,7 @@ Read `README.md` first for concept and usage.
 - **Recipient-CWD-relative attachment paths.** Delivered messages append `ATTACHED FILE: ./.files/<filename>` lines (not bare `FILE:`).
 - **Outbox attachments are staged.** Tell copies sources into `.outbox/<msg_id>/`; outbox envelopes carry `filename` only. Ingest moves the bundle with the JSON. Routing delivers into `.files/<msg_id>/`. Delivered wakes append `ATTACHED FILE:` lines (not bare `FILE:`).
 - **Definition `outbox_dir`.** Optional; defaults to `.outbox` under agent root. Absolute paths allowed. Harness ingests from the resolved path; wakes inject `TELL_OUTBOX_DIR` into the invoke subprocess so tell writes there without the agent seeing the outbox in its workspace.
+- **Tell requires `TELL_OUTBOX_DIR`.** No CWD tree walk — a8s sets the env on wake; manual tell must export it explicitly.
 - **Persistent MQTT sessions.** `clean_session=False` + QoS 1, hash-derived `client_id`.
 - **`publish` waits for readiness event before raising.** Don't drop the
   disconnect handler.

--- a/apps/a8s/DEVELOPMENT.md
+++ b/apps/a8s/DEVELOPMENT.md
@@ -24,6 +24,7 @@ Read `README.md` first for concept and usage.
 - **Storage services are stateless.** No start/stop lifecycle.
 - **Recipient-CWD-relative attachment paths.** Delivered messages append `ATTACHED FILE: ./.files/<filename>` lines (not bare `FILE:`).
 - **Outbox attachments are staged.** Tell copies sources into `.outbox/<msg_id>/`; outbox envelopes carry `filename` only. Ingest moves the bundle with the JSON. Routing delivers into `.files/<msg_id>/`. Delivered wakes append `ATTACHED FILE:` lines (not bare `FILE:`).
+- **Definition `outbox_dir`.** Optional; defaults to `.outbox` under agent root. Absolute paths allowed. Harness ingests from the resolved path; wakes inject `TELL_OUTBOX_DIR` into the invoke subprocess so tell writes there without the agent seeing the outbox in its workspace.
 - **Persistent MQTT sessions.** `clean_session=False` + QoS 1, hash-derived `client_id`.
 - **`publish` waits for readiness event before raising.** Don't drop the
   disconnect handler.

--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -77,9 +77,8 @@ a8s ls
 #   CLAUDE  PID 12345  /Users/me/projects/code-review
 #   GEMINI  PID 12345  /Users/me/projects/research
 
-# Send messages. `tell` writes a JSON file to the nearest enclosing
-# `.outbox/` directory (the agent root, walking up from CWD), so you
-# must `cd` into one of your agents first.
+# Send messages. Woken agents get `TELL_OUTBOX_DIR` from a8s; manual tell
+# requires `export TELL_OUTBOX_DIR=…/.outbox` (see docs/tell.md).
 cd ~/projects/code-review
 tell GEMINI "look at lines 40-80 of foo.py"
 tell devs   "stand-up at 3pm"
@@ -125,8 +124,8 @@ That's the full loop. Members don't know they're "in a8s" — they just see a `t
 ### Messaging
 | | |
 |---|---|
-| `a8s tell <name> <msg>` | Routed message. `<name>` may be an agent or alias (fans out at routing time). Sender = agent whose `.outbox/` encloses CWD (walks up); errors if no `.outbox/` is found. There is no senderless channel — every message has a force-stamped agent `from` (the router stamps it from the outbox's owning agent, regardless of what the client wrote). |
-| `tell <name> <msg>` (top-level shim, [`~/bin/tell`](/Users/neilo/bin/tell)) | Delegates to `a8s tell` (`apps/a8s/tell.py`). Walks up CWD to find any `.outbox/`, drops a JSON envelope — no `~/.a8s` access required. When the registry is reachable, recipient validation and `from` stamping apply. Windows: `tell.cmd`. Operator internals: [`docs/tell.md`](docs/tell.md). |
+| `a8s tell <name> <msg>` | Routed message via `_write_outbox` into the sender's configured outbox. `<name>` may be an agent or alias (fans out at routing time). Sender = agent whose root encloses CWD; router force-stamps `from` from outbox ownership. |
+| `tell <name> <msg>` (top-level shim, [`~/bin/tell`](/Users/neilo/bin/tell)) | Delegates to `a8s tell` (`apps/a8s/tell.py`). Requires `TELL_OUTBOX_DIR` (a8s injects it on wake). Drops a JSON envelope — no `~/.a8s` access required. When the registry is reachable, recipient validation and `from` stamping apply. Windows: `tell.cmd`. Operator internals: [`docs/tell.md`](docs/tell.md). |
 | `a8s logs <name>... [--tail N] [-f]` | Read per-agent log files; one agent in append order, multiple merge by ISO timestamp. `-f` follows. |
 
 ### Skills

--- a/apps/a8s/core.py
+++ b/apps/a8s/core.py
@@ -51,6 +51,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 SKILLS_DIR = SCRIPT_DIR / "skills"
 BIN_ROOT = SCRIPT_DIR.parent.parent
 DEFINITIONS_DIR = SCRIPT_DIR / "definitions"
+TELL_OUTBOX_DIR_ENV = "TELL_OUTBOX_DIR"
 # Explicit path for `cmd_start`'s re-exec. After the modular split, `__file__`
 # resolved inside any module would point at that module — not the entry script.
 ENTRYPOINT = SCRIPT_DIR / "a8s.py"
@@ -245,16 +246,21 @@ def retry_sidecar_path(pending_file: Path) -> Path:
     return pending_file.with_suffix(pending_file.suffix + ".retry")
 
 
-def outbox_dir(root: Path) -> Path:
-    """Outbox lives **inside the agent's own dir** so the agent can write to it
-    even under a strict workspace sandbox (codex --full-auto). Inbox and trash
-    stay isolated under ~/.a8s/agents/<NAME>/ where the agent never sees them.
+def resolve_outbox_path(agent_root: Path, spec: str | None = None) -> Path:
+    """Resolve an outbox directory from a definition `outbox_dir` value.
 
-    `route_outboxes()` re-stamps the `from` field to the enclosing participant's
-    name on every read, so an agent can't spoof a senderless prompt by writing
-    a JSON with `from: ""`.
-    """
-    return root / ".outbox"
+    Relative paths are under `agent_root`; absolute paths are used as-is.
+    Default / omitted spec is `.outbox` under the agent root."""
+    raw = (spec if spec is not None else ".outbox").strip() or ".outbox"
+    p = Path(raw).expanduser()
+    if p.is_absolute():
+        return p.resolve()
+    return (agent_root / p).resolve()
+
+
+def outbox_dir(root: Path) -> Path:
+    """Default outbox path: `<agent-root>/.outbox`."""
+    return resolve_outbox_path(root)
 
 
 def outbox_bundle_dir(outbox: Path, msg_id: str) -> Path:
@@ -405,3 +411,9 @@ class Participant:
     name: str
     root: Path
     safe_dirs: tuple[Path, ...] = ()
+    outbox: Path | None = None
+
+    def outbox_path(self) -> Path:
+        if self.outbox is not None:
+            return self.outbox
+        return outbox_dir(self.root)

--- a/apps/a8s/daemon.py
+++ b/apps/a8s/daemon.py
@@ -32,6 +32,7 @@ from pathlib import Path
 import core
 from core import (
     Participant,
+    TELL_OUTBOX_DIR_ENV,
     _pid_alive,
     _preview,
     agent_dir,
@@ -82,16 +83,26 @@ _CURRENT_WAKE_PROC: subprocess.Popen | None = None
 _CURRENT_WAKE_NAME: str | None = None
 
 
-def run_with_prefix(name: str, cmd: list[str], cwd: Path) -> int:
+def run_with_prefix(
+    name: str,
+    cmd: list[str],
+    cwd: Path,
+    *,
+    env: dict[str, str] | None = None,
+) -> int:
     """Run the wake subprocess in its own session so SIGKILL can target the
     whole process group (LLM CLI + any helpers it spawns). Tracks the live
     process in `_CURRENT_WAKE_PROC` and the agent in `_CURRENT_WAKE_NAME` so
     signal handlers can identify which agent's wake is in-flight."""
     global _CURRENT_WAKE_PROC, _CURRENT_WAKE_NAME
+    proc_env = os.environ.copy()
+    if env:
+        proc_env.update(env)
     try:
         proc = subprocess.Popen(
             cmd,
             cwd=str(cwd),
+            env=proc_env,
             stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
@@ -118,6 +129,10 @@ def run_with_prefix(name: str, cmd: list[str], cwd: Path) -> int:
     finally:
         _CURRENT_WAKE_PROC = None
         _CURRENT_WAKE_NAME = None
+
+
+def _tell_outbox_env(p: Participant) -> dict[str, str]:
+    return {TELL_OUTBOX_DIR_ENV: str(p.outbox_path())}
 
 
 def _deliver_file_proxy(p: Participant) -> None:
@@ -193,7 +208,7 @@ def wake_once(p: Participant, msg_path: Path) -> None:
     out_agent(p.name, f"[{p.name}] waking from {trashed.name}: {_preview(msg.get('content', ''))}")
     cmd = build_command(definition, msg)
     out_agent(p.name, f"[{p.name}] exec: {shlex.join(cmd)}")
-    run_with_prefix(p.name, cmd, p.root)
+    run_with_prefix(p.name, cmd, p.root, env=_tell_outbox_env(p))
     # And again after the wake returns — a long-running LLM call shouldn't
     # leave last-active stuck at the pre-wake timestamp.
     touch_last_active(p.name)
@@ -228,7 +243,7 @@ def wake_batch(p: Participant, msg_paths: list[Path], definition: dict) -> None:
     )
     cmd = build_batch_command(definition, p.name, trashed)
     out_agent(p.name, f"[{p.name}] batch exec: {shlex.join(cmd)}")
-    run_with_prefix(p.name, cmd, p.root)
+    run_with_prefix(p.name, cmd, p.root, env=_tell_outbox_env(p))
     touch_last_active(p.name)
 
 
@@ -304,7 +319,7 @@ def maybe_run_idle(p: Participant) -> bool:
     )
     out_agent(p.name, f"[{p.name}] idle exec: {shlex.join(cmd)}")
     try:
-        run_with_prefix(p.name, cmd, p.root)
+        run_with_prefix(p.name, cmd, p.root, env=_tell_outbox_env(p))
     finally:
         touch_last_active(p.name)
     return True

--- a/apps/a8s/definitions.py
+++ b/apps/a8s/definitions.py
@@ -21,6 +21,7 @@ from core import (
     DEFINITIONS_DIR,
     MARKER_FILES,
     SCRIPT_DIR,
+    resolve_outbox_path,
 )
 from registry import load_registry
 
@@ -42,6 +43,24 @@ def files_ttl_seconds(definition: dict) -> float:
     except (TypeError, ValueError):
         h = 48.0
     return max(0.0, h * 3600)
+
+
+def resolve_outbox_dir(agent_root: Path, definition: dict) -> Path:
+    """Outbox path from definition `outbox_dir` (default `.outbox` under root)."""
+    spec = definition.get("outbox_dir")
+    if spec is not None and not isinstance(spec, str):
+        raise ValueError("definition outbox_dir must be a string")
+    if isinstance(spec, str) and not spec.strip():
+        raise ValueError("definition outbox_dir must not be empty")
+    return resolve_outbox_path(agent_root, spec if isinstance(spec, str) else None)
+
+
+def resolve_outbox_dir_for_agent(name: str, agent_root: Path) -> Path:
+    try:
+        definition = load_definition(name)
+    except (FileNotFoundError, RuntimeError):
+        definition = {}
+    return resolve_outbox_dir(agent_root, definition)
 
 
 def load_definition(name: str) -> dict:

--- a/apps/a8s/docs/tell.md
+++ b/apps/a8s/docs/tell.md
@@ -14,12 +14,11 @@ Operator documentation for how `tell` works under the hood. Agent-facing usage l
 
 ## Send path (async)
 
-0. **`tell --check`** — optional self-test: verifies a writable `.outbox/` is available (walk from CWD / `TELL_DEFAULT_DIR`, or `$TELL_DIR/.outbox` — creating that directory when `TELL_DIR` is set and `.outbox` is missing). Optional recipient name validates registry routing. No envelope written.
-1. If `TELL_DIR` is set, use `$TELL_DIR/.outbox` directly (no CWD or parent walk).
-2. Else walk up from CWD for the first `.outbox/` directory.
-3. If none found, walk up from `TELL_DEFAULT_DIR` (agent root or any path under it).
-4. Build message body (argv, stdin, or `-`); parse trailing `FILE:` lines via `mailbox._split_content_and_files`. `--attach` / `--file` append to the same `files` array. Any source path tell can read is attachable. Allocate `msg_id`, copy each file into `.outbox/<msg_id>/<basename>`, then write `.outbox/<msg_id>.json` with **filename-only** `files` entries (no `path` field).
-5. Optionally read `~/.a8s` (or `A8S_HOME`) to validate recipient and stamp `from` when CWD sits inside a registered agent root.
+0. **`tell --check`** — optional self-test: verifies a writable outbox is available (`TELL_OUTBOX_DIR`, or tree walk from CWD). Creates the path when `TELL_OUTBOX_DIR` is set and missing. Optional recipient name validates registry routing. No envelope written.
+1. If `TELL_OUTBOX_DIR` is set, use that path directly as the outbox (no CWD walk). Created when missing.
+2. Else walk up from CWD for the first **writable** `.outbox/` directory.
+3. Build message body (argv, stdin, or `-`); parse trailing `FILE:` lines via `mailbox._split_content_and_files`. `--attach` / `--file` append to the same `files` array. Any source path tell can read is attachable. Allocate `msg_id`, copy each file into `.outbox/<msg_id>/<basename>`, then write `.outbox/<msg_id>.json` with **filename-only** `files` entries (no `path` field).
+4. Optionally read `~/.a8s` (or `A8S_HOME`) to validate recipient and stamp `from` when CWD sits inside a registered agent root.
 
 Envelope shape:
 
@@ -45,28 +44,19 @@ On disk alongside the JSON:
 
 `from` is omitted when registry is unreachable; the router **force-overwrites** `from` based on which agent owns the outbox directory.
 
-6. **Ingest** — move `<msg_id>.json` and `.outbox/<msg_id>/` together into `~/.a8s/agents/<SENDER>/pending/`.
-7. **Route** — copy pending bundle bytes into each recipient's `.files/<msg_id>/`. Inbox JSON keeps filename-only `files`. Wake `$MESSAGE` appends `ATTACHED FILE: ./.files/<msg_id>/<filename>` lines.
+5. **Ingest** — move `<msg_id>.json` and `.outbox/<msg_id>/` together into `~/.a8s/agents/<SENDER>/pending/`.
+6. **Route** — copy pending bundle bytes into each recipient's `.files/<msg_id>/`. Inbox JSON keeps filename-only `files`. Wake `$MESSAGE` appends `ATTACHED FILE: ./.files/<msg_id>/<filename>` lines.
 
-### `TELL_DIR`
+### `TELL_OUTBOX_DIR`
 
-Hard lock to a mailbox root. When set, `tell` always writes to `$TELL_DIR/.outbox` — no walk from CWD, no fallback to `TELL_DEFAULT_DIR`. Use for isolated agent sandboxes where the mailbox tree (`.outbox/`, `.temp/`, etc.) lives in a dedicated directory:
-
-```bash
-export TELL_DIR=/var/mailboxes/agent-one
-cd /anywhere && tell GEMINI "locked to this mailbox"
-```
-
-If `$TELL_DIR/.outbox` is missing, send fails. `tell --check` creates it when probing a `TELL_DIR` mailbox. Sync session files use `$TELL_DIR/.temp/`.
-
-### `TELL_DEFAULT_DIR`
-
-Set on an agent process (systemd, wrapper script, `.env`) to an agent root or any directory beneath it. When CWD is outside the agent tree — e.g. `/tmp` — `tell` still finds `.outbox/` via this fallback. Ignored when `TELL_DIR` is set. CWD wins over this fallback when it already encloses an outbox.
+Hard lock to an explicit outbox directory. When set, `tell` always writes there — no walk from CWD. The path **is** the outbox (typically `…/agent/.outbox`); it is created when missing.
 
 ```bash
-export TELL_DEFAULT_DIR=/home/agent/my-agent
-cd /tmp && tell GEMINI "works from anywhere"
+export TELL_OUTBOX_DIR=/var/mailboxes/agent-one/.outbox
+cd /anywhere && tell GEMINI "locked to this outbox"
 ```
+
+Sync session files use `<outbox-parent>/.temp/` (parent of the outbox path).
 
 Does not affect `sender_from_cwd()`; the router still force-stamps `from` from outbox ownership.
 

--- a/apps/a8s/docs/tell.md
+++ b/apps/a8s/docs/tell.md
@@ -14,11 +14,10 @@ Operator documentation for how `tell` works under the hood. Agent-facing usage l
 
 ## Send path (async)
 
-0. **`tell --check`** — optional self-test: verifies a writable outbox is available (`TELL_OUTBOX_DIR`, or tree walk from CWD). Creates the path when `TELL_OUTBOX_DIR` is set and missing. Optional recipient name validates registry routing. No envelope written.
-1. If `TELL_OUTBOX_DIR` is set, use that path directly as the outbox (no CWD walk). Created when missing.
-2. Else walk up from CWD for the first **writable** `.outbox/` directory.
-3. Build message body (argv, stdin, or `-`); parse trailing `FILE:` lines via `mailbox._split_content_and_files`. `--attach` / `--file` append to the same `files` array. Any source path tell can read is attachable. Allocate `msg_id`, copy each file into `.outbox/<msg_id>/<basename>`, then write `.outbox/<msg_id>.json` with **filename-only** `files` entries (no `path` field).
-4. Optionally read `~/.a8s` (or `A8S_HOME`) to validate recipient and stamp `from` when CWD sits inside a registered agent root.
+0. **`tell --check`** — optional self-test: verifies `TELL_OUTBOX_DIR` points at a writable outbox (creates the path when missing). Optional recipient name validates registry routing. No envelope written.
+1. **`TELL_OUTBOX_DIR` required** — tell writes only to this path. a8s sets it on every wake/idle/batch invoke from the agent definition's `outbox_dir` (default `<agent-root>/.outbox`). Manual use: export it explicitly.
+2. Build message body (argv, stdin, or `-`); parse trailing `FILE:` lines via `mailbox._split_content_and_files`. `--attach` / `--file` append to the same `files` array. Any source path tell can read is attachable. Allocate `msg_id`, copy each file into `<outbox>/<msg_id>/<basename>`, then write `<outbox>/<msg_id>.json` with **filename-only** `files` entries (no `path` field).
+3. Optionally read `~/.a8s` (or `A8S_HOME`) to validate recipient and stamp `from` when CWD sits inside a registered agent root.
 
 Envelope shape:
 
@@ -36,7 +35,7 @@ Envelope shape:
 On disk alongside the JSON:
 
 ```
-.outbox/
+<outbox>/
   01J….json
   01J…/
     avatar.jpg
@@ -44,23 +43,23 @@ On disk alongside the JSON:
 
 `from` is omitted when registry is unreachable; the router **force-overwrites** `from` based on which agent owns the outbox directory.
 
-5. **Ingest** — move `<msg_id>.json` and `.outbox/<msg_id>/` together into `~/.a8s/agents/<SENDER>/pending/`.
-6. **Route** — copy pending bundle bytes into each recipient's `.files/<msg_id>/`. Inbox JSON keeps filename-only `files`. Wake `$MESSAGE` appends `ATTACHED FILE: ./.files/<msg_id>/<filename>` lines.
+4. **Ingest** — move `<msg_id>.json` and `<outbox>/<msg_id>/` together into `~/.a8s/agents/<SENDER>/pending/`.
+5. **Route** — copy pending bundle bytes into each recipient's `.files/<msg_id>/`. Inbox JSON keeps filename-only `files`. Wake `$MESSAGE` appends `ATTACHED FILE: ./.files/<msg_id>/<filename>` lines.
 
 ### `TELL_OUTBOX_DIR`
 
-Hard lock to an explicit outbox directory. When set, `tell` always writes there — no walk from CWD. The path **is** the outbox (typically `…/agent/.outbox`); it is created when missing.
+The outbox path tell writes to. **Required** — no CWD walk or implicit discovery.
 
 ```bash
 export TELL_OUTBOX_DIR=/var/mailboxes/agent-one/.outbox
-cd /anywhere && tell GEMINI "locked to this outbox"
+tell GEMINI "hello"
 ```
 
-Sync session files use `<outbox-parent>/.temp/` (parent of the outbox path).
-
-Does not affect `sender_from_cwd()`; the router still force-stamps `from` from outbox ownership.
+Created when missing. Sync session files use `<outbox-parent>/.temp/`.
 
 When a8s wakes an agent, it sets `TELL_OUTBOX_DIR` in the invoke subprocess environment to the agent definition's resolved `outbox_dir` (default `<agent-root>/.outbox`). Use a separate absolute `outbox_dir` to keep outgoing tell traffic outside the agent workspace.
+
+Does not affect `sender_from_cwd()`; the router still force-stamps `from` from outbox ownership.
 
 ## `--sync`
 

--- a/apps/a8s/docs/tell.md
+++ b/apps/a8s/docs/tell.md
@@ -60,6 +60,8 @@ Sync session files use `<outbox-parent>/.temp/` (parent of the outbox path).
 
 Does not affect `sender_from_cwd()`; the router still force-stamps `from` from outbox ownership.
 
+When a8s wakes an agent, it sets `TELL_OUTBOX_DIR` in the invoke subprocess environment to the agent definition's resolved `outbox_dir` (default `<agent-root>/.outbox`). Use a separate absolute `outbox_dir` to keep outgoing tell traffic outside the agent workspace.
+
 ## `--sync`
 
 Client side (`tell.py` + `sync_listen.py`):

--- a/apps/a8s/mailbox.py
+++ b/apps/a8s/mailbox.py
@@ -94,7 +94,7 @@ def ensure_mailboxes(p: Participant) -> None:
         trash_dir(p.name),
     ):
         d.mkdir(parents=True, exist_ok=True)
-    outbox_dir(p.root).mkdir(parents=True, exist_ok=True)
+    p.outbox_path().mkdir(parents=True, exist_ok=True)
     files_dir(p.root).mkdir(parents=True, exist_ok=True)
 
 
@@ -226,7 +226,7 @@ def _ingest_outboxes(senders: list[Participant]) -> None:
     `<root>/.outbox/<id>/` attachment bundle into pending."""
     for sender in senders:
         ensure_mailboxes(sender)
-        outbox = outbox_dir(sender.root)
+        outbox = sender.outbox_path()
         if not outbox.is_dir():
             continue
         dest_dir = pending_dir(sender.name)

--- a/apps/a8s/registry.py
+++ b/apps/a8s/registry.py
@@ -186,8 +186,21 @@ def participants_from_registry() -> list[Participant]:
                     safe_dirs.append(Path(item).expanduser().resolve())
                 except (OSError, RuntimeError):
                     continue
-        parts.append(Participant(name=name, root=root, safe_dirs=tuple(safe_dirs)))
+        parts.append(
+            Participant(
+                name=name,
+                root=root,
+                safe_dirs=tuple(safe_dirs),
+                outbox=_participant_outbox(name, root),
+            )
+        )
     return parts
+
+
+def _participant_outbox(name: str, root: Path) -> Path:
+    from definitions import resolve_outbox_dir_for_agent
+
+    return resolve_outbox_dir_for_agent(name, root)
 
 
 # ---------- discovery (suggestions only) ----------

--- a/apps/a8s/tell.py
+++ b/apps/a8s/tell.py
@@ -1,8 +1,7 @@
-"""tell — drop a JSON envelope in the nearest `.outbox/`.
+"""tell — drop a JSON envelope in the outbox directory.
 
-Walks up from CWD for the first **writable** `.outbox/`; `TELL_OUTBOX_DIR` locks
-to an explicit outbox path (created when missing). No registry required.
-`~/.a8s` is reachable and CWD sits inside a registered agent, validates the
+Requires `TELL_OUTBOX_DIR` (set by a8s on agent wake). No filesystem
+discovery. `~/.a8s` reachable and CWD inside a registered agent validates the
 recipient (with remote fallback), stamps `from`, and logs to the agent log.
 
 Attachments: any path tell can read is copied into `.outbox/<msg_id>/` before
@@ -50,17 +49,6 @@ def _probe_outbox_writable(outbox: Path) -> str | None:
     return None
 
 
-def _walk_writable_outbox_from(start: Path) -> Path | None:
-    cur = start.resolve()
-    for d in (cur, *cur.parents):
-        candidate = d / ".outbox"
-        if not candidate.is_dir():
-            continue
-        if _probe_outbox_writable(candidate) is None:
-            return candidate
-    return None
-
-
 def _outbox_from_env() -> Path | None:
     raw = os.environ.get(TELL_OUTBOX_DIR_ENV, "").strip()
     if not raw:
@@ -76,12 +64,15 @@ def _outbox_from_env() -> Path | None:
 
 
 def find_outbox() -> Path | None:
-    locked = _outbox_from_env()
-    if locked is not None:
-        return locked
+    return _outbox_from_env()
+
+
+def _report_outbox_unavailable() -> None:
+    print("tell: cannot send from this directory", file=sys.stderr)
     if os.environ.get(TELL_OUTBOX_DIR_ENV, "").strip():
-        return None
-    return _walk_writable_outbox_from(Path.cwd())
+        print(f"tell: {TELL_OUTBOX_DIR_ENV} is set but outbox is unavailable", file=sys.stderr)
+    else:
+        print(f"tell: {TELL_OUTBOX_DIR_ENV} is not set", file=sys.stderr)
 
 
 def agent_root_from_outbox(outbox: Path) -> Path:
@@ -454,9 +445,7 @@ def _run_sync(
 def run_check(recipient: str | None) -> int:
     outbox = find_outbox()
     if outbox is None:
-        print("tell: cannot send from this directory", file=sys.stderr)
-        if os.environ.get(TELL_OUTBOX_DIR_ENV, "").strip():
-            print(f"tell: {TELL_OUTBOX_DIR_ENV} is set but outbox is unavailable", file=sys.stderr)
+        _report_outbox_unavailable()
         return 1
 
     lines = ["tell: ok", f"  outbox: {outbox}"]
@@ -512,7 +501,7 @@ def tell_main(argv: list[str]) -> int:
 
     outbox = find_outbox()
     if outbox is None:
-        print("tell: cannot send from this directory", file=sys.stderr)
+        _report_outbox_unavailable()
         return 1
 
     rc = _validate_attachment_sources(files)

--- a/apps/a8s/tell.py
+++ b/apps/a8s/tell.py
@@ -25,7 +25,7 @@ from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
 
-from core import _preview, out_agent, outbox_bundle_dir
+from core import _preview, out_agent, outbox_bundle_dir, TELL_OUTBOX_DIR_ENV
 from mailbox import _split_content_and_files
 from sync_listen import (
     DEFAULT_SYNC_TIMEOUT_SEC,
@@ -38,7 +38,6 @@ from ulid import new as new_ulid
 DEFAULT_SYNC_TIMEOUT = DEFAULT_SYNC_TIMEOUT_SEC
 SYNC_ACK_TIMEOUT = 30.0
 SYNC_POLL_INTERVAL = 0.25
-TELL_OUTBOX_DIR_ENV = "TELL_OUTBOX_DIR"
 
 
 def _probe_outbox_writable(outbox: Path) -> str | None:

--- a/apps/a8s/tell.py
+++ b/apps/a8s/tell.py
@@ -1,8 +1,7 @@
 """tell — drop a JSON envelope in the nearest `.outbox/`.
 
-Walks up from CWD for `.outbox/` and writes; `TELL_DIR` locks to a fixed
-mailbox root (`$TELL_DIR/.outbox`, no scan). Falls back to `TELL_DEFAULT_DIR`
-(walks up from that path) when CWD has no outbox. No registry required.
+Walks up from CWD for the first **writable** `.outbox/`; `TELL_OUTBOX_DIR` locks
+to an explicit outbox path (created when missing). No registry required.
 `~/.a8s` is reachable and CWD sits inside a registered agent, validates the
 recipient (with remote fallback), stamps `from`, and logs to the agent log.
 
@@ -39,72 +38,51 @@ from ulid import new as new_ulid
 DEFAULT_SYNC_TIMEOUT = DEFAULT_SYNC_TIMEOUT_SEC
 SYNC_ACK_TIMEOUT = 30.0
 SYNC_POLL_INTERVAL = 0.25
-TELL_DIR_ENV = "TELL_DIR"
-TELL_DEFAULT_DIR_ENV = "TELL_DEFAULT_DIR"
+TELL_OUTBOX_DIR_ENV = "TELL_OUTBOX_DIR"
 
 
-def _outbox_at(root: Path) -> Path | None:
-    candidate = root / ".outbox"
-    return candidate if candidate.is_dir() else None
-
-
-def _outbox_from_tell_dir() -> Path | None:
-    tell_dir = os.environ.get(TELL_DIR_ENV, "").strip()
-    if not tell_dir:
-        return None
+def _probe_outbox_writable(outbox: Path) -> str | None:
+    probe = outbox / f".tell-check-{os.getpid()}.tmp"
     try:
-        return _outbox_at(Path(tell_dir).expanduser().resolve())
-    except OSError:
-        return None
-
-
-def _walk_outbox_from(start: Path) -> Path | None:
-    cur = start.resolve()
-    for d in (cur, *cur.parents):
-        found = _outbox_at(d)
-        if found is not None:
-            return found
+        probe.write_text("{}", encoding="utf-8")
+        probe.unlink()
+    except OSError as e:
+        return str(e)
     return None
 
 
-def find_outbox() -> Path | None:
-    outbox, _source = resolve_outbox()
-    return outbox
+def _walk_writable_outbox_from(start: Path) -> Path | None:
+    cur = start.resolve()
+    for d in (cur, *cur.parents):
+        candidate = d / ".outbox"
+        if not candidate.is_dir():
+            continue
+        if _probe_outbox_writable(candidate) is None:
+            return candidate
+    return None
 
 
-def resolve_outbox() -> tuple[Path | None, str]:
-    if os.environ.get(TELL_DIR_ENV, "").strip():
-        return _outbox_from_tell_dir(), TELL_DIR_ENV
-    found = _walk_outbox_from(Path.cwd())
-    if found is not None:
-        return found, "cwd"
-    default_dir = os.environ.get(TELL_DEFAULT_DIR_ENV, "").strip()
-    if not default_dir:
-        return None, "none"
-    try:
-        found = _walk_outbox_from(Path(default_dir).expanduser())
-    except OSError:
-        return None, TELL_DEFAULT_DIR_ENV
-    return (found, TELL_DEFAULT_DIR_ENV) if found is not None else (None, TELL_DEFAULT_DIR_ENV)
-
-
-def _ensure_tell_dir_outbox() -> Path | None:
-    tell_dir = os.environ.get(TELL_DIR_ENV, "").strip()
-    if not tell_dir:
+def _outbox_from_env() -> Path | None:
+    raw = os.environ.get(TELL_OUTBOX_DIR_ENV, "").strip()
+    if not raw:
         return None
     try:
-        outbox = Path(tell_dir).expanduser().resolve() / ".outbox"
+        outbox = Path(raw).expanduser().resolve()
         outbox.mkdir(parents=True, exist_ok=True)
+        if _probe_outbox_writable(outbox) is not None:
+            return None
         return outbox
     except OSError:
         return None
 
 
-def resolve_outbox_for_check() -> Path | None:
-    if os.environ.get(TELL_DIR_ENV, "").strip():
-        return _ensure_tell_dir_outbox()
-    outbox, _source = resolve_outbox()
-    return outbox
+def find_outbox() -> Path | None:
+    locked = _outbox_from_env()
+    if locked is not None:
+        return locked
+    if os.environ.get(TELL_OUTBOX_DIR_ENV, "").strip():
+        return None
+    return _walk_writable_outbox_from(Path.cwd())
 
 
 def agent_root_from_outbox(outbox: Path) -> Path:
@@ -474,29 +452,12 @@ def _run_sync(
             )
 
 
-def _probe_outbox_writable(outbox: Path) -> str | None:
-    probe = outbox / f".tell-check-{os.getpid()}.tmp"
-    try:
-        probe.write_text("{}", encoding="utf-8")
-        probe.unlink()
-    except OSError as e:
-        return str(e)
-    return None
-
-
 def run_check(recipient: str | None) -> int:
-    outbox = resolve_outbox_for_check()
+    outbox = find_outbox()
     if outbox is None:
         print("tell: cannot send from this directory", file=sys.stderr)
-        if os.environ.get(TELL_DIR_ENV, "").strip():
-            print(f"tell: {TELL_DIR_ENV} is set but send directory is unavailable", file=sys.stderr)
-        elif os.environ.get(TELL_DEFAULT_DIR_ENV, "").strip():
-            print(f"tell: {TELL_DEFAULT_DIR_ENV} is set but has no .outbox", file=sys.stderr)
-        return 1
-
-    err = _probe_outbox_writable(outbox)
-    if err is not None:
-        print(f"tell: .outbox not writable: {err}", file=sys.stderr)
+        if os.environ.get(TELL_OUTBOX_DIR_ENV, "").strip():
+            print(f"tell: {TELL_OUTBOX_DIR_ENV} is set but outbox is unavailable", file=sys.stderr)
         return 1
 
     lines = ["tell: ok", f"  outbox: {outbox}"]

--- a/apps/a8s/tests/test_commands.py
+++ b/apps/a8s/tests/test_commands.py
@@ -23,7 +23,7 @@ from commands import (
     cmd_unremote,
     cmd_unstorage,
 )
-from core import Participant, agent_dir, agent_log_path, files_dir, kill_request_path, outbox_bundle_dir, outbox_dir, pid_path
+from core import Participant, TELL_OUTBOX_DIR_ENV, agent_dir, agent_log_path, files_dir, kill_request_path, outbox_bundle_dir, outbox_dir, pid_path
 from mailbox import ensure_mailboxes
 from network import load_network_config, save_network_config
 from registry import load_aliases, load_registry, save_registry
@@ -427,10 +427,11 @@ class TestCmdTellRemoteRecipient:
     def _setup_sender(self, fake_home, tmp_path, monkeypatch):
         sender_root = tmp_path / "sender"
         sender_root.mkdir()
+        (sender_root / ".outbox").mkdir()
         save_registry({"sender": {"root": str(sender_root)}})
         ensure_mailboxes(Participant("sender", sender_root))
-        # cmd_tell uses sender_from_cwd() — chdir into the sender's root.
         monkeypatch.chdir(sender_root)
+        monkeypatch.setenv(TELL_OUTBOX_DIR_ENV, str(sender_root / ".outbox"))
         return sender_root
 
     def test_unknown_recipient_with_no_remotes_rejected(self, fake_home, tmp_path, monkeypatch, capsys):
@@ -614,10 +615,12 @@ class TestCmdTellWithSplitFileArg:
     def test_split_file_arg_extracts_attachment(self, fake_home, tmp_path, monkeypatch):
         sender_root = tmp_path / "sender"
         sender_root.mkdir()
+        (sender_root / ".outbox").mkdir()
         save_registry({"sender": {"root": str(sender_root)}, "alice": {"root": str(tmp_path / "alice")}})
         (tmp_path / "alice").mkdir()
         ensure_mailboxes(Participant("sender", sender_root))
         monkeypatch.chdir(sender_root)
+        monkeypatch.setenv(TELL_OUTBOX_DIR_ENV, str(sender_root / ".outbox"))
         (sender_root / "report.pdf").write_text("doc")
 
         rc = cmd_tell(["alice", "Here is the doc.", "FILE: ./report.pdf"])

--- a/apps/a8s/tests/test_daemon.py
+++ b/apps/a8s/tests/test_daemon.py
@@ -293,6 +293,38 @@ def _read_log(name: str) -> str:
     return agent_log_path(name).read_text() if agent_log_path(name).is_file() else ""
 
 
+class TestTellOutboxEnv:
+    def test_run_with_prefix_sets_tell_outbox_dir(self, tmp_path, monkeypatch):
+        from core import TELL_OUTBOX_DIR_ENV
+
+        agent_root = tmp_path / "a"
+        agent_root.mkdir()
+        external = tmp_path / "out"
+        external.mkdir()
+        p = Participant("X", agent_root, outbox=external)
+        captured: dict = {}
+
+        class FakeProc:
+            stdout = iter([])
+            returncode = 0
+
+            def wait(self):
+                return 0
+
+            def poll(self):
+                return 0
+
+        def fake_popen(cmd, **kwargs):
+            captured["env"] = kwargs["env"]
+            return FakeProc()
+
+        monkeypatch.setattr("daemon.subprocess.Popen", fake_popen)
+        from daemon import _tell_outbox_env, run_with_prefix
+
+        run_with_prefix("X", ["true"], agent_root, env=_tell_outbox_env(p))
+        assert captured["env"][TELL_OUTBOX_DIR_ENV] == str(external.resolve())
+
+
 class TestWakeOnce:
     """End-to-end wake_once exercise via the mock CLI. With the single-`invoke`
     verb every wake produces the same argv shape — the wake line surfaces

--- a/apps/a8s/tests/test_daemon.py
+++ b/apps/a8s/tests/test_daemon.py
@@ -19,6 +19,7 @@ import pytest
 
 from core import (
     Participant,
+    TELL_OUTBOX_DIR_ENV,
     agent_log_path,
     clear_inbox_waiting_since,
     detach_request_path,
@@ -323,6 +324,17 @@ class TestTellOutboxEnv:
 
         run_with_prefix("X", ["true"], agent_root, env=_tell_outbox_env(p))
         assert captured["env"][TELL_OUTBOX_DIR_ENV] == str(external.resolve())
+
+    def test_wake_env_matches_participant_outbox_path(self, tmp_path):
+        from daemon import _tell_outbox_env
+
+        agent_root = tmp_path / "agent"
+        agent_root.mkdir()
+        external = tmp_path / "mail" / ".outbox"
+        p = Participant("X", agent_root, outbox=external)
+        assert _tell_outbox_env(p) == {
+            TELL_OUTBOX_DIR_ENV: str(external.resolve()),
+        }
 
 
 class TestWakeOnce:

--- a/apps/a8s/tests/test_definitions.py
+++ b/apps/a8s/tests/test_definitions.py
@@ -16,6 +16,7 @@ from definitions import (
     build_command,
     default_definition_path,
     load_definition,
+    resolve_outbox_dir,
 )
 
 
@@ -241,6 +242,37 @@ class TestAutodiscoverDefinition:
         path, note = _autodiscover_definition(tmp_path)
         assert path == str(default_definition_path("cursor"))
         assert "auto-detected via CURSOR.md" in note
+
+
+# ---------- resolve_outbox_dir ----------
+
+class TestResolveOutboxDir:
+    def test_default_relative(self, tmp_path):
+        root = tmp_path / "agent"
+        root.mkdir()
+        assert resolve_outbox_dir(root, {}) == (root / ".outbox").resolve()
+
+    def test_explicit_relative(self, tmp_path):
+        root = tmp_path / "agent"
+        root.mkdir()
+        assert resolve_outbox_dir(root, {"outbox_dir": "mail/out"}) == (
+            root / "mail" / "out"
+        ).resolve()
+
+    def test_absolute(self, tmp_path):
+        root = tmp_path / "agent"
+        root.mkdir()
+        external = tmp_path / "external"
+        external.mkdir()
+        assert resolve_outbox_dir(root, {"outbox_dir": str(external)}) == external.resolve()
+
+    def test_rejects_non_string(self, tmp_path):
+        with pytest.raises(ValueError, match="outbox_dir must be a string"):
+            resolve_outbox_dir(tmp_path, {"outbox_dir": 1})
+
+    def test_rejects_empty(self, tmp_path):
+        with pytest.raises(ValueError, match="must not be empty"):
+            resolve_outbox_dir(tmp_path, {"outbox_dir": "  "})
 
 
 # ---------- load_definition ----------

--- a/apps/a8s/tests/test_install_client.py
+++ b/apps/a8s/tests/test_install_client.py
@@ -89,6 +89,7 @@ def test_installed_tell_writes_outbox(tmp_path, monkeypatch):
     proc = subprocess.run(
         [str(bin_dir / "tell"), "GEMINI", "hello from client"],
         cwd=str(agent),
+        env={**os.environ, "TELL_OUTBOX_DIR": str(outbox)},
         capture_output=True,
         text=True,
         check=False,

--- a/apps/a8s/tests/test_mailbox.py
+++ b/apps/a8s/tests/test_mailbox.py
@@ -510,6 +510,35 @@ class TestIngestPhase:
         # Trashed.
         assert any("lost" in f.read_text() for f in trash_dir("SOLO").iterdir())
 
+    def test_ingest_from_custom_outbox_dir(self, fake_home, tmp_path):
+        a_root = tmp_path / "agent"
+        a_root.mkdir()
+        b_root = tmp_path / "b"
+        b_root.mkdir()
+        external = tmp_path / "external-outbox"
+        external.mkdir()
+        save_registry({"A": {"root": str(a_root)}, "B": {"root": str(b_root)}})
+        a = Participant("A", a_root, outbox=external)
+        b = Participant("B", b_root)
+        ensure_mailboxes(a)
+        ensure_mailboxes(b)
+        msg_path = external / "01TEST.json"
+        msg_path.write_text(
+            json.dumps(
+                {
+                    "id": "01TEST",
+                    "date": "2026-01-01T00:00:00Z",
+                    "from": "A",
+                    "to": "B",
+                    "content": "from external",
+                    "files": [],
+                }
+            )
+        )
+        route_outboxes([a, b], all_agents=[a, b])
+        assert list(external.iterdir()) == []
+        assert (inbox_dir("B") / "01TEST.json").is_file()
+
 
 class TestRetrySidecar:
     """Per-message retry sidecar. With no remotes configured, the happy path

--- a/apps/a8s/tests/test_registry.py
+++ b/apps/a8s/tests/test_registry.py
@@ -249,6 +249,21 @@ class TestParticipantsFromRegistry:
         assert len(parts) == 1
         assert parts[0].safe_dirs == (drop.resolve(),)
 
+    def test_resolves_outbox_dir_from_definition(self, fake_home, tmp_path):
+        import json
+
+        root = tmp_path / "agent"
+        root.mkdir()
+        external = tmp_path / "external-outbox"
+        defn = tmp_path / "def.json"
+        defn.write_text(
+            json.dumps({"invoke": ["echo", "x"], "outbox_dir": str(external)})
+        )
+        save_registry({"A": {"root": str(root), "definition": str(defn)}})
+        parts = participants_from_registry()
+        assert len(parts) == 1
+        assert parts[0].outbox_path() == external.resolve()
+
 
 # ---------- parse_name + _scan_for_markers ----------
 

--- a/apps/a8s/tests/test_sync_listen.py
+++ b/apps/a8s/tests/test_sync_listen.py
@@ -5,7 +5,7 @@ import json
 import time
 from pathlib import Path
 
-from core import Participant, inbox_dir, outbox_dir
+from core import TELL_OUTBOX_DIR_ENV, Participant, inbox_dir, outbox_dir
 from mailbox import _write_outbox, ensure_mailboxes, route_outboxes
 from registry import save_registry
 from sync_listen import (
@@ -35,6 +35,10 @@ def _setup_agents(fake_home, tmp_path):
     ensure_mailboxes(alice)
     ensure_mailboxes(bob)
     return alice, bob
+
+
+def _bind_tell_outbox(monkeypatch, p: Participant) -> None:
+    monkeypatch.setenv(TELL_OUTBOX_DIR_ENV, str(outbox_dir(p.root)))
 
 
 class TestSyncListenCommand:
@@ -320,6 +324,7 @@ class TestTellSyncE2E:
     def test_tell_sync_round_trip(self, fake_home, tmp_path, monkeypatch, capsys):
         alice, bob = _setup_agents(fake_home, tmp_path)
         monkeypatch.chdir(alice.root)
+        _bind_tell_outbox(monkeypatch, alice)
 
         import tell as tell_mod
 
@@ -351,6 +356,7 @@ class TestTellSyncE2E:
     def test_tell_sync_timeout_cancels_listener(self, fake_home, tmp_path, monkeypatch, capsys):
         alice, bob = _setup_agents(fake_home, tmp_path)
         monkeypatch.chdir(alice.root)
+        _bind_tell_outbox(monkeypatch, alice)
 
         import tell as tell_mod
 
@@ -376,6 +382,7 @@ class TestTellSyncE2E:
     def test_tell_sync_interrupt_drops_cancel(self, fake_home, tmp_path, monkeypatch, capsys):
         alice, bob = _setup_agents(fake_home, tmp_path)
         monkeypatch.chdir(alice.root)
+        _bind_tell_outbox(monkeypatch, alice)
 
         import signal
         import tell as tell_mod

--- a/apps/a8s/tests/test_tell.py
+++ b/apps/a8s/tests/test_tell.py
@@ -1,7 +1,7 @@
 """Tests for `tell` — invoked as a subprocess via the ~/bin/tell shim.
 
-The shim delegates to `a8s tell`, which writes JSON envelopes into the
-nearest `.outbox/` without requiring registry access.
+The shim delegates to `a8s tell`, which requires `TELL_OUTBOX_DIR` (a8s sets
+this on wake). Tests pass it explicitly when exercising tell directly.
 """
 from __future__ import annotations
 
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import pytest
 
-from core import files_dir, inbound_bundle_dir, outbox_bundle_dir, outbox_dir
+from core import TELL_OUTBOX_DIR_ENV, files_dir, inbound_bundle_dir, outbox_bundle_dir, outbox_dir
 
 TELL = Path(__file__).resolve().parent.parent.parent.parent / "tell"
 A8S_TELL = [
@@ -24,29 +24,52 @@ A8S_TELL = [
 ]
 
 
+def _merge_tell_env(
+    cwd: Path,
+    env: dict[str, str] | None = None,
+    *,
+    outbox: Path | None = None,
+) -> dict[str, str]:
+    merged = dict(os.environ)
+    extra = dict(env or {})
+    if TELL_OUTBOX_DIR_ENV not in extra:
+        target = outbox if outbox is not None else cwd / ".outbox"
+        if outbox is not None or target.is_dir():
+            extra[TELL_OUTBOX_DIR_ENV] = str(target.resolve() if outbox is None else target)
+    merged.update(extra)
+    return merged
+
+
 def _run(
     cwd: Path,
     *args: str,
     stdin: str | None = None,
     env: dict[str, str] | None = None,
+    outbox: Path | None = None,
 ) -> subprocess.CompletedProcess:
     kw: dict = {
         "cwd": str(cwd),
         "capture_output": True,
         "text": True,
+        "env": _merge_tell_env(cwd, env, outbox=outbox),
     }
     if stdin is not None:
         kw["input"] = stdin
-    if env is not None:
-        kw["env"] = {**os.environ, **env}
     return subprocess.run([str(TELL), *args], **kw)
 
 
-def _run_a8s(cwd: Path, *args: str, stdin: str | None = None) -> subprocess.CompletedProcess:
+def _run_a8s(
+    cwd: Path,
+    *args: str,
+    stdin: str | None = None,
+    env: dict[str, str] | None = None,
+    outbox: Path | None = None,
+) -> subprocess.CompletedProcess:
     kw: dict = {
         "cwd": str(cwd),
         "capture_output": True,
         "text": True,
+        "env": _merge_tell_env(cwd, env, outbox=outbox),
     }
     if stdin is not None:
         kw["input"] = stdin
@@ -89,13 +112,18 @@ def test_a8s_tell_writes_outbox_without_registry(tmp_path):
     assert msg["content"] == "via a8s tell"
 
 
-def test_tell_walks_up_from_subdir(tmp_path):
-    (tmp_path / ".outbox").mkdir()
+def test_tell_requires_tell_outbox_dir_from_subdir(tmp_path):
+    outbox = tmp_path / ".outbox"
+    outbox.mkdir()
     sub = tmp_path / "deep" / "nested"
     sub.mkdir(parents=True)
     res = _run(sub, "codex", "from below")
+    assert res.returncode != 0
+    assert "TELL_OUTBOX_DIR is not set" in res.stderr
+
+    res = _run(sub, "codex", "from below", outbox=outbox)
     assert res.returncode == 0, res.stderr
-    _name, msg = _read_outbox(tmp_path / ".outbox")
+    _name, msg = _read_outbox(outbox)
     assert msg["to"] == "codex"
     assert msg["content"] == "from below"
 
@@ -103,7 +131,7 @@ def test_tell_walks_up_from_subdir(tmp_path):
 def test_tell_errors_when_no_outbox(tmp_path):
     res = _run(tmp_path, "anyone", "should fail")
     assert res.returncode != 0
-    assert "cannot send from this directory" in res.stderr
+    assert "TELL_OUTBOX_DIR is not set" in res.stderr
 
 
 def test_tell_help_is_opaque(tmp_path):
@@ -145,33 +173,14 @@ def test_tell_outbox_dir_creates_when_missing(tmp_path):
     assert msg["content"] == "created"
 
 
-def test_tell_skips_non_writable_outbox_in_tree(tmp_path):
-    outer = tmp_path / "outer"
-    inner = outer / "inner"
-    inner.mkdir(parents=True)
-    bad_outbox = outer / ".outbox"
-    bad_outbox.mkdir()
-    bad_outbox.chmod(0o555)
-    good_outbox = inner / ".outbox"
-    good_outbox.mkdir()
-    try:
-        res = _run(inner, "gerry", "hello")
-        assert res.returncode == 0, res.stderr
-        _name, msg = _read_outbox(good_outbox)
-        assert msg["content"] == "hello"
-        assert list(bad_outbox.glob("*.json")) == []
-    finally:
-        bad_outbox.chmod(0o755)
-
-
 def test_tell_fails_when_outbox_not_writable(tmp_path):
     outbox = tmp_path / ".outbox"
     outbox.mkdir()
     outbox.chmod(0o555)
     try:
-        res = _run(tmp_path, "gerry", "nope")
+        res = _run(tmp_path, "gerry", "nope", outbox=outbox)
         assert res.returncode != 0
-        assert "cannot send from this directory" in res.stderr
+        assert "outbox is unavailable" in res.stderr
     finally:
         outbox.chmod(0o755)
 
@@ -325,7 +334,7 @@ def test_tell_absolutizes_attach_relative_to_cwd_not_outbox_root(tmp_path):
     (agent_root / ".outbox").mkdir()
     payload = work / "report.pdf"
     payload.write_text("payload")
-    res = _run(work, "bob", "--attach", "report.pdf", "see attached")
+    res = _run(work, "bob", "--attach", "report.pdf", "see attached", outbox=agent_root / ".outbox")
     assert res.returncode == 0, res.stderr
     _name, msg = _read_outbox(agent_root / ".outbox")
     _assert_staged_files(agent_root / ".outbox", msg, ["report.pdf"])
@@ -347,7 +356,14 @@ def test_tell_absolutized_attach_delivers_after_routing(fake_home, tmp_path):
     save_registry(
         {"SENDER": {"root": str(sender_root)}, "BOB": {"root": str(recipient_root)}}
     )
-    res = _run_a8s(work, "BOB", "--attach", "data.txt", "see attached")
+    res = _run_a8s(
+        work,
+        "BOB",
+        "--attach",
+        "data.txt",
+        "see attached",
+        outbox=sender_root / ".outbox",
+    )
     assert res.returncode == 0, res.stderr
     _name, out_msg = _read_outbox(sender_root / ".outbox")
     msg_id = out_msg["id"]
@@ -485,7 +501,7 @@ def test_tell_check_unknown_recipient_fails(fake_home, tmp_path, monkeypatch):
 def test_tell_check_fails_without_outbox(tmp_path):
     res = _run(tmp_path, "--check")
     assert res.returncode == 1
-    assert "cannot send from this directory" in res.stderr
+    assert "TELL_OUTBOX_DIR is not set" in res.stderr
 
 
 def test_tell_check_reports_outbox_dir(tmp_path):

--- a/apps/a8s/tests/test_tell.py
+++ b/apps/a8s/tests/test_tell.py
@@ -113,102 +113,67 @@ def test_tell_help_is_opaque(tmp_path):
     assert ".temp" not in res.stderr
 
 
-def test_tell_uses_tell_default_dir(tmp_path):
-    agent = tmp_path / "agent"
-    (agent / ".outbox").mkdir(parents=True)
-    elsewhere = tmp_path / "elsewhere"
-    elsewhere.mkdir()
-    res = _run(
-        elsewhere,
-        "gerry",
-        "via default dir",
-        env={"TELL_DEFAULT_DIR": str(agent)},
-    )
-    assert res.returncode == 0, res.stderr
-    _name, msg = _read_outbox(agent / ".outbox")
-    assert msg["content"] == "via default dir"
-
-
-def test_tell_cwd_outbox_wins_over_tell_default_dir(tmp_path):
-    cwd_agent = tmp_path / "here"
-    other_agent = tmp_path / "there"
-    (cwd_agent / ".outbox").mkdir(parents=True)
-    (other_agent / ".outbox").mkdir(parents=True)
-    res = _run(
-        cwd_agent,
-        "gerry",
-        "from cwd",
-        env={"TELL_DEFAULT_DIR": str(other_agent)},
-    )
-    assert res.returncode == 0, res.stderr
-    assert list((other_agent / ".outbox").glob("*.json")) == []
-    _name, msg = _read_outbox(cwd_agent / ".outbox")
-    assert msg["content"] == "from cwd"
-
-
-def test_tell_default_dir_walks_up(tmp_path):
-    agent = tmp_path / "agent"
-    (agent / ".outbox").mkdir(parents=True)
-    sub = agent / "src" / "pkg"
-    sub.mkdir(parents=True)
-    elsewhere = tmp_path / "elsewhere"
-    elsewhere.mkdir()
-    res = _run(
-        elsewhere,
-        "gerry",
-        "default subdir",
-        env={"TELL_DEFAULT_DIR": str(sub)},
-    )
-    assert res.returncode == 0, res.stderr
-    _name, msg = _read_outbox(agent / ".outbox")
-    assert msg["content"] == "default subdir"
-
-
-def test_tell_dir_locks_mailbox(tmp_path):
-    locked = tmp_path / "mailbox"
+def test_tell_outbox_dir_locks_over_cwd_outbox(tmp_path):
+    locked = tmp_path / "mailbox" / ".outbox"
+    locked.mkdir(parents=True)
     cwd_agent = tmp_path / "cwd-agent"
-    (locked / ".outbox").mkdir(parents=True)
     (cwd_agent / ".outbox").mkdir(parents=True)
     res = _run(
         cwd_agent,
         "gerry",
         "locked send",
-        env={"TELL_DIR": str(locked)},
+        env={"TELL_OUTBOX_DIR": str(locked)},
     )
     assert res.returncode == 0, res.stderr
     assert list((cwd_agent / ".outbox").glob("*.json")) == []
-    _name, msg = _read_outbox(locked / ".outbox")
+    _name, msg = _read_outbox(locked)
     assert msg["content"] == "locked send"
 
 
-def test_tell_dir_missing_outbox_fails(tmp_path):
-    mailbox = tmp_path / "mailbox"
-    mailbox.mkdir()
+def test_tell_outbox_dir_creates_when_missing(tmp_path):
+    outbox = tmp_path / "mailbox" / ".outbox"
+    assert not outbox.exists()
     res = _run(
         tmp_path,
         "gerry",
-        "nope",
-        env={"TELL_DIR": str(mailbox)},
-    )
-    assert res.returncode != 0
-    assert "cannot send from this directory" in res.stderr
-
-
-def test_tell_dir_overrides_tell_default_dir(tmp_path):
-    locked = tmp_path / "locked"
-    other = tmp_path / "other"
-    (locked / ".outbox").mkdir(parents=True)
-    (other / ".outbox").mkdir(parents=True)
-    res = _run(
-        tmp_path,
-        "gerry",
-        "dir wins",
-        env={"TELL_DIR": str(locked), "TELL_DEFAULT_DIR": str(other)},
+        "created",
+        env={"TELL_OUTBOX_DIR": str(outbox)},
     )
     assert res.returncode == 0, res.stderr
-    assert list((other / ".outbox").glob("*.json")) == []
-    _name, msg = _read_outbox(locked / ".outbox")
-    assert msg["content"] == "dir wins"
+    assert outbox.is_dir()
+    _name, msg = _read_outbox(outbox)
+    assert msg["content"] == "created"
+
+
+def test_tell_skips_non_writable_outbox_in_tree(tmp_path):
+    outer = tmp_path / "outer"
+    inner = outer / "inner"
+    inner.mkdir(parents=True)
+    bad_outbox = outer / ".outbox"
+    bad_outbox.mkdir()
+    bad_outbox.chmod(0o555)
+    good_outbox = inner / ".outbox"
+    good_outbox.mkdir()
+    try:
+        res = _run(inner, "gerry", "hello")
+        assert res.returncode == 0, res.stderr
+        _name, msg = _read_outbox(good_outbox)
+        assert msg["content"] == "hello"
+        assert list(bad_outbox.glob("*.json")) == []
+    finally:
+        bad_outbox.chmod(0o755)
+
+
+def test_tell_fails_when_outbox_not_writable(tmp_path):
+    outbox = tmp_path / ".outbox"
+    outbox.mkdir()
+    outbox.chmod(0o555)
+    try:
+        res = _run(tmp_path, "gerry", "nope")
+        assert res.returncode != 0
+        assert "cannot send from this directory" in res.stderr
+    finally:
+        outbox.chmod(0o755)
 
 
 def test_tell_lifts_file_lines_into_files_array(tmp_path):
@@ -414,9 +379,9 @@ def test_tell_rejects_missing_attachment(tmp_path):
     assert "not found" in res.stderr
 
 
-def test_tell_stages_attach_from_cwd_when_outbox_via_tell_dir(tmp_path):
-    mailbox = tmp_path / "mailbox"
-    (mailbox / ".outbox").mkdir(parents=True)
+def test_tell_stages_attach_from_cwd_when_outbox_via_tell_outbox_dir(tmp_path):
+    outbox = tmp_path / "mailbox" / ".outbox"
+    outbox.mkdir(parents=True)
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     note = workspace / "note.txt"
@@ -427,12 +392,12 @@ def test_tell_stages_attach_from_cwd_when_outbox_via_tell_dir(tmp_path):
         "--attach",
         "./note.txt",
         "hi",
-        env={"TELL_DIR": str(mailbox)},
+        env={"TELL_OUTBOX_DIR": str(outbox)},
     )
     assert res.returncode == 0, res.stderr
-    _name, msg = _read_outbox(mailbox / ".outbox")
-    _assert_staged_files(mailbox / ".outbox", msg, ["note.txt"])
-    assert (outbox_bundle_dir(mailbox / ".outbox", msg["id"]) / "note.txt").read_text() == "x"
+    _name, msg = _read_outbox(outbox)
+    _assert_staged_files(outbox, msg, ["note.txt"])
+    assert (outbox_bundle_dir(outbox, msg["id"]) / "note.txt").read_text() == "x"
 
 
 def test_tell_stdin_dash(tmp_path):
@@ -523,30 +488,29 @@ def test_tell_check_fails_without_outbox(tmp_path):
     assert "cannot send from this directory" in res.stderr
 
 
-def test_tell_check_reports_tell_dir(tmp_path):
-    locked = tmp_path / "mailbox"
-    (locked / ".outbox").mkdir(parents=True)
+def test_tell_check_reports_outbox_dir(tmp_path):
+    outbox = tmp_path / "mailbox" / ".outbox"
+    outbox.mkdir(parents=True)
     res = _run(
         tmp_path,
         "--check",
-        env={"TELL_DIR": str(locked)},
+        env={"TELL_OUTBOX_DIR": str(outbox)},
     )
     assert res.returncode == 0, res.stderr
-    assert f"outbox: {locked.resolve() / '.outbox'}" in res.stdout
+    assert f"outbox: {outbox.resolve()}" in res.stdout
 
 
-def test_tell_check_creates_outbox_when_tell_dir_set(tmp_path):
-    locked = tmp_path / "mailbox"
-    locked.mkdir()
-    assert not (locked / ".outbox").exists()
+def test_tell_check_creates_outbox_when_outbox_dir_set(tmp_path):
+    outbox = tmp_path / "mailbox" / ".outbox"
+    assert not outbox.exists()
     res = _run(
         tmp_path,
         "--check",
-        env={"TELL_DIR": str(locked)},
+        env={"TELL_OUTBOX_DIR": str(outbox)},
     )
     assert res.returncode == 0, res.stderr
-    assert (locked / ".outbox").is_dir()
-    assert list((locked / ".outbox").glob("*.json")) == []
+    assert outbox.is_dir()
+    assert list(outbox.glob("*.json")) == []
 
 
 def test_tell_check_rejects_message_body(tmp_path):

--- a/apps/a8s/tests/test_tell.py
+++ b/apps/a8s/tests/test_tell.py
@@ -540,3 +540,53 @@ def test_tell_help_omits_check(tmp_path):
     res = _run(tmp_path, "--help")
     assert res.returncode == 0
     assert "--check" not in res.stderr
+
+
+def _strip_tell_outbox_env(extra: dict[str, str] | None = None) -> dict[str, str]:
+    env = {k: v for k, v in os.environ.items() if k != TELL_OUTBOX_DIR_ENV}
+    if extra:
+        env.update(extra)
+    return env
+
+
+def _run_raw(
+    cwd: Path,
+    *args: str,
+    stdin: str | None = None,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess:
+    kw: dict = {
+        "cwd": str(cwd),
+        "capture_output": True,
+        "text": True,
+        "env": _strip_tell_outbox_env(env),
+    }
+    if stdin is not None:
+        kw["input"] = stdin
+    return subprocess.run([str(TELL), *args], **kw)
+
+
+class TestTellOutboxDirContract:
+    """PR #136 test plan — replaces manual checklist items for tell outbox resolution."""
+
+    def test_without_tell_outbox_dir_fails_clearly(self, tmp_path):
+        res = _run_raw(tmp_path, "bob", "hi")
+        assert res.returncode == 1
+        assert "cannot send from this directory" in res.stderr
+        assert "TELL_OUTBOX_DIR is not set" in res.stderr
+
+    def test_wake_injected_env_sufficient_without_cwd_outbox(self, tmp_path):
+        """Simulates a8s wake: only TELL_OUTBOX_DIR set, CWD has no .outbox."""
+        outbox = tmp_path / "external-outbox"
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        res = _run_raw(
+            workspace,
+            "bob",
+            "from wake env",
+            env={TELL_OUTBOX_DIR_ENV: str(outbox)},
+        )
+        assert res.returncode == 0, res.stderr
+        assert outbox.is_dir()
+        _name, msg = _read_outbox(outbox)
+        assert msg["content"] == "from wake env"

--- a/tests/test_pii.py
+++ b/tests/test_pii.py
@@ -32,7 +32,7 @@ def test_pii_check_catches_example_agent_name_in_added_line():
         [
             "diff --git a/example.md b/example.md",
             "+++ b/example.md",
-            "+export TELL_DIR=/var/mailboxes/example-agent-name",
+            "+export TELL_OUTBOX_DIR=/var/mailboxes/example-agent-name/.outbox",
         ]
     )
     hits = check_diff(diff, parse_patterns(SAMPLE_PATTERNS))


### PR DESCRIPTION
## Summary

Unifies tell outbox resolution and lets agents decouple their workspace from where outgoing messages land.

### Tell CLI — `TELL_OUTBOX_DIR` only

- Renames **`TELL_DIR` → `TELL_OUTBOX_DIR`** — points **directly** at the outbox directory
- **Removes `TELL_DEFAULT_DIR`** and **CWD tree walk** — no implicit `.outbox` discovery
- **`TELL_OUTBOX_DIR` required** for tell; a8s injects it on every wake/idle/batch invoke
- Path created when missing (send and `--check`)
- Clear error when unset: `TELL_OUTBOX_DIR is not set`

### Harness (`outbox_dir` in definition JSON)

- Optional definition field **`outbox_dir`** (default `.outbox` under agent root; absolute paths allowed)
- **`participants_from_registry()`** resolves it into `Participant.outbox`
- **Ingest/routing** monitors the resolved path
- **Wake, batch wake, and idle invoke** inject `TELL_OUTBOX_DIR` into the subprocess environment

Example — sandboxed agent home, external outbox:

```json
{
  "invoke": ["claude", "-p", "$MESSAGE"],
  "outbox_dir": "/var/mailboxes/neil-phone/.outbox"
}
```

## Commits

| Commit | What |
|--------|------|
| `71358d2` | `TELL_OUTBOX_DIR` replaces `TELL_DIR` / `TELL_DEFAULT_DIR` |
| `19be601` | Definition `outbox_dir`; harness ingest + wake env injection |
| `8eeb908` | Drop CWD tree walk; tell requires `TELL_OUTBOX_DIR` |

## Migration

```bash
# Before
export TELL_DIR=/path/to/agent
# (or rely on CWD walk)

# After — a8s agents: automatic on wake
# Manual / scripts:
export TELL_OUTBOX_DIR=/path/to/agent/.outbox
```

Remove `TELL_DEFAULT_DIR`. Nested CWD no longer finds a parent `.outbox`.

## Test plan

- [x] `pytest apps/a8s/tests/ -q --ignore=apps/a8s/tests/test_install.py` (509 passed)
- [x] Woken agent `tell` works without manual env — `TestTellOutboxDirContract::test_wake_injected_env_sufficient_without_cwd_outbox` + `TestTellOutboxEnv` (daemon injects `TELL_OUTBOX_DIR` on invoke)
- [x] Bare shell without `TELL_OUTBOX_DIR` fails clearly — `TestTellOutboxDirContract::test_without_tell_outbox_dir_fails_clearly`
