### PR TITLE
feat(a8s): definition files_dir and absolute ATTACHED FILE paths

### DIFF
--- a/apps/a8s/DEVELOPMENT.md
+++ b/apps/a8s/DEVELOPMENT.md
@@ -22,8 +22,8 @@ Read `README.md` first for concept and usage.
 - **Cross-cluster `FILE:` payloads ride storage services.** Configured under
   `network.json`'s `services` map (separate from `remotes`).
 - **Storage services are stateless.** No start/stop lifecycle.
-- **Recipient-CWD-relative attachment paths.** Delivered messages append `ATTACHED FILE: ./.files/<filename>` lines (not bare `FILE:`).
-- **Outbox attachments are staged.** Tell copies sources into `.outbox/<msg_id>/`; outbox envelopes carry `filename` only. Ingest moves the bundle with the JSON. Routing delivers into `.files/<msg_id>/`. Delivered wakes append `ATTACHED FILE:` lines (not bare `FILE:`).
+- **Absolute attachment paths in wake prompts.** Delivered messages append `ATTACHED FILE: <absolute-path>` lines (not bare `FILE:`). Path comes from definition `files_dir` (default `.files` under agent root) plus `<msg_id>/<filename>`.
+- **Outbox attachments are staged.** Tell copies sources into `.outbox/<msg_id>/`; outbox envelopes carry `filename` only. Ingest moves the bundle with the JSON. Routing delivers into `<files_dir>/<msg_id>/`. Delivered wakes append `ATTACHED FILE:` lines (not bare `FILE:`).
 - **Definition `outbox_dir`.** Optional; defaults to `.outbox` under agent root. Absolute paths allowed. Harness ingests from the resolved path; wakes inject `TELL_OUTBOX_DIR` into the invoke subprocess so tell writes there without the agent seeing the outbox in its workspace.
 - **Tell requires `TELL_OUTBOX_DIR`.** No CWD tree walk — a8s sets the env on wake; manual tell must export it explicitly.
 - **Persistent MQTT sessions.** `clean_session=False` + QoS 1, hash-derived `client_id`.

--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -318,7 +318,7 @@ a8s add my-email /mnt/gdrive/my-email/ file-proxy.json
 
 - **On message:** A8S moves inbox JSON files into `<root>/.inbox/` instead of invoking a subprocess. The remote side polls `.inbox/`, processes, deletes.
 - **Outbox:** The remote side writes response envelopes to `<root>/.outbox/`. A8S ingests these on its normal routing pass (no change from regular agents).
-- **Files:** Tell copies attachments into `.outbox/<msg_id>/` before writing the envelope (filename only in JSON). Ingest moves the bundle with the JSON; routing delivers into `.files/<msg_id>/` on each recipient. Wake prompts use `ATTACHED FILE: ./.files/<msg_id>/<name>`. A8S cleans up files older than `files_ttl_hours` (default 48) on each idle cycle.
+- **Files:** Tell copies attachments into `.outbox/<msg_id>/` before writing the envelope (filename only in JSON). Ingest moves the bundle with the JSON; routing delivers into `<files_dir>/<msg_id>/` on each recipient (default `files_dir` is `.files` under the agent root; absolute paths OK). Wake prompts use absolute `ATTACHED FILE: <path>` lines. A8S creates `files_dir` when waking and cleans up files older than `files_ttl_hours` (default 48) on each idle cycle.
 - **Idle:** The `idle.timeout` controls how often A8S syncs (moves inbox files + runs TTL cleanup). No CLI is invoked.
 
 ### Filesystem layout (agent root)

--- a/apps/a8s/core.py
+++ b/apps/a8s/core.py
@@ -270,13 +270,25 @@ def outbox_bundle_dir(outbox: Path, msg_id: str) -> Path:
 
 
 def files_dir(root: Path) -> Path:
-    """Incoming attachment root. Routing copies delivered files into
-    `.files/<msg_id>/<filename>`; wake prompts reference those paths."""
-    return root / ".files"
+    """Default incoming attachment root: `<agent-root>/.files`."""
+    return resolve_files_path(root)
 
 
-def inbound_bundle_dir(root: Path, msg_id: str) -> Path:
-    return files_dir(root) / msg_id
+def resolve_files_path(agent_root: Path, spec: str | None = None) -> Path:
+    """Resolve an incoming-files directory from a definition `files_dir` value.
+
+    Relative paths are under `agent_root`; absolute paths are used as-is.
+    Default / omitted spec is `.files` under the agent root."""
+    raw = (spec if spec is not None else ".files").strip() or ".files"
+    p = Path(raw).expanduser()
+    if p.is_absolute():
+        return p.resolve()
+    return (agent_root / p).resolve()
+
+
+def inbound_bundle_dir(files_root: Path, msg_id: str) -> Path:
+    """`<files_root>/<msg_id>/` — one bundle per message."""
+    return files_root / msg_id
 
 
 def pending_bundle_dir(name: str, msg_id: str) -> Path:
@@ -412,8 +424,17 @@ class Participant:
     root: Path
     safe_dirs: tuple[Path, ...] = ()
     outbox: Path | None = None
+    files: Path | None = None
 
     def outbox_path(self) -> Path:
         if self.outbox is not None:
             return self.outbox
         return outbox_dir(self.root)
+
+    def files_path(self) -> Path:
+        if self.files is not None:
+            return self.files
+        return files_dir(self.root)
+
+    def files_bundle_dir(self, msg_id: str) -> Path:
+        return inbound_bundle_dir(self.files_path(), msg_id)

--- a/apps/a8s/daemon.py
+++ b/apps/a8s/daemon.py
@@ -206,7 +206,8 @@ def wake_once(p: Participant, msg_path: Path) -> None:
     trashed = unique_path(trash_dir(p.name) / msg_path.name)
     msg_path.rename(trashed)
     out_agent(p.name, f"[{p.name}] waking from {trashed.name}: {_preview(msg.get('content', ''))}")
-    cmd = build_command(definition, msg)
+    p.files_path().mkdir(parents=True, exist_ok=True)
+    cmd = build_command(definition, msg, p.root)
     out_agent(p.name, f"[{p.name}] exec: {shlex.join(cmd)}")
     run_with_prefix(p.name, cmd, p.root, env=_tell_outbox_env(p))
     # And again after the wake returns — a long-running LLM call shouldn't
@@ -241,6 +242,7 @@ def wake_batch(p: Participant, msg_paths: list[Path], definition: dict) -> None:
         p.name,
         f"[{p.name}] batch waking ({len(trashed)}): {summary}",
     )
+    p.files_path().mkdir(parents=True, exist_ok=True)
     cmd = build_batch_command(definition, p.name, trashed)
     out_agent(p.name, f"[{p.name}] batch exec: {shlex.join(cmd)}")
     run_with_prefix(p.name, cmd, p.root, env=_tell_outbox_env(p))
@@ -248,9 +250,9 @@ def wake_batch(p: Participant, msg_paths: list[Path], definition: dict) -> None:
 
 
 def _file_proxy_ttl_cleanup(p: Participant, definition: dict) -> None:
-    """Delete files in <root>/.files/ older than files_ttl_hours."""
+    """Delete files in the agent files dir older than files_ttl_hours."""
     ttl = files_ttl_seconds(definition)
-    files_path = p.root / ".files"
+    files_path = p.files_path()
     if not files_path.is_dir():
         return
     cutoff = _time.time() - ttl

--- a/apps/a8s/definitions.py
+++ b/apps/a8s/definitions.py
@@ -21,6 +21,7 @@ from core import (
     DEFINITIONS_DIR,
     MARKER_FILES,
     SCRIPT_DIR,
+    resolve_files_path,
     resolve_outbox_path,
 )
 from registry import load_registry
@@ -63,6 +64,24 @@ def resolve_outbox_dir_for_agent(name: str, agent_root: Path) -> Path:
     return resolve_outbox_dir(agent_root, definition)
 
 
+def resolve_files_dir(agent_root: Path, definition: dict) -> Path:
+    """Incoming attachment root from definition `files_dir` (default `.files`)."""
+    spec = definition.get("files_dir")
+    if spec is not None and not isinstance(spec, str):
+        raise ValueError("definition files_dir must be a string")
+    if isinstance(spec, str) and not spec.strip():
+        raise ValueError("definition files_dir must not be empty")
+    return resolve_files_path(agent_root, spec if isinstance(spec, str) else None)
+
+
+def resolve_files_dir_for_agent(name: str, agent_root: Path) -> Path:
+    try:
+        definition = load_definition(name)
+    except (FileNotFoundError, RuntimeError):
+        definition = {}
+    return resolve_files_dir(agent_root, definition)
+
+
 def load_definition(name: str) -> dict:
     """Load the JSON definition for `name`. Every agent always has one — if
     the registry lacks an explicit `definition` field, falls back to the
@@ -85,7 +104,7 @@ def load_definition(name: str) -> dict:
         raise RuntimeError(f"definition load failed for {path}: {e}") from e
 
 
-def _file_lines(msg: dict) -> list[str]:
+def _file_lines(msg: dict, files_root: Path) -> list[str]:
     files = msg.get("files") or []
     if not files:
         return []
@@ -99,14 +118,15 @@ def _file_lines(msg: dict) -> list[str]:
         filename = (entry.get("filename") or "").strip()
         if not filename:
             continue
-        out.append(f"{ATTACHED_FILE_PREFIX}./.files/{msg_id}/{filename}")
+        path = (files_root / msg_id / filename).resolve()
+        out.append(f"{ATTACHED_FILE_PREFIX}{path}")
     return out
 
 
-def _message_body(msg: dict) -> str:
+def _message_body(msg: dict, files_root: Path) -> str:
     """Compose the `$MESSAGE` body: content plus any ATTACHED FILE: lines."""
     content = msg.get("content", "")
-    lines = _file_lines(msg)
+    lines = _file_lines(msg, files_root)
     if not lines:
         return content
     return "\n".join([content, *lines])
@@ -181,7 +201,7 @@ def _expand_argv(
     return out
 
 
-def build_command(definition: dict, msg: dict) -> list[str]:
+def build_command(definition: dict, msg: dict, agent_root: Path) -> list[str]:
     """Pick the `invoke` argv from `definition` and expand interpolation
     variables. There is one verb — every routed message is a `tell` — so
     no dispatch table is needed.
@@ -194,7 +214,8 @@ def build_command(definition: dict, msg: dict) -> list[str]:
         raise ValueError("definition missing 'invoke'")
     sender = (msg.get("from") or "").strip()
     recipient = (msg.get("to") or "").strip()
-    body = _message_body(msg)
+    files_root = resolve_files_dir(agent_root, definition)
+    body = _message_body(msg, files_root)
     date_str = (msg.get("date") or "").strip()
     age = _format_age(date_str)
     return _expand_argv(list(argv), sender, recipient, body, date_str, age)

--- a/apps/a8s/docs/tell.md
+++ b/apps/a8s/docs/tell.md
@@ -44,7 +44,7 @@ On disk alongside the JSON:
 `from` is omitted when registry is unreachable; the router **force-overwrites** `from` based on which agent owns the outbox directory.
 
 4. **Ingest** — move `<msg_id>.json` and `<outbox>/<msg_id>/` together into `~/.a8s/agents/<SENDER>/pending/`.
-5. **Route** — copy pending bundle bytes into each recipient's `.files/<msg_id>/`. Inbox JSON keeps filename-only `files`. Wake `$MESSAGE` appends `ATTACHED FILE: ./.files/<msg_id>/<filename>` lines.
+5. **Route** — copy pending bundle bytes into each recipient's `<files_dir>/<msg_id>/` (default `.files`). Inbox JSON keeps filename-only `files`. Wake `$MESSAGE` appends absolute `ATTACHED FILE:` lines.
 
 ### `TELL_OUTBOX_DIR`
 

--- a/apps/a8s/mailbox.py
+++ b/apps/a8s/mailbox.py
@@ -53,7 +53,6 @@ from core import (
     MAX_FILE_BYTES,
     Participant,
     _preview,
-    files_dir,
     inbound_bundle_dir,
     inbox_dir,
     inbox_tmp_dir,
@@ -84,9 +83,9 @@ PublishRemotes = Callable[[dict, str, list[str], int], list[str]]
 
 def ensure_mailboxes(p: Participant) -> None:
     """Create mailbox dirs for `p`. Inbox, inbox.tmp, pending, and trash live
-    under ~/.a8s/ (hidden from the agent); outbox and .files live in the
-    agent's own root (so the agent can write to outbox and read from .files
-    under a workspace sandbox)."""
+    under ~/.a8s/ (hidden from the agent); outbox lives at the resolved
+    `outbox_dir` (default `.outbox` under agent root). Incoming attachments
+    use `files_dir` (default `.files`); that directory is created on wake."""
     for d in (
         inbox_dir(p.name),
         inbox_tmp_dir(p.name),
@@ -95,12 +94,6 @@ def ensure_mailboxes(p: Participant) -> None:
     ):
         d.mkdir(parents=True, exist_ok=True)
     p.outbox_path().mkdir(parents=True, exist_ok=True)
-    files_dir(p.root).mkdir(parents=True, exist_ok=True)
-
-
-def _attached_file_relative_path(msg_id: str, filename: str) -> str:
-    """Recipient-local path for `$MESSAGE` ATTACHED FILE: lines."""
-    return f"./.files/{msg_id}/{filename}"
 
 
 def _move_dir(src: Path, dest: Path) -> None:
@@ -149,10 +142,10 @@ def _resolve_pending_attachment(sender_name: str, msg_id: str, entry: dict) -> P
 def _transfer_file_to_recipient(
     sender_name: str,
     msg_id: str,
-    recipient_root: Path,
+    recipient: Participant,
     entry: dict,
 ) -> dict | None:
-    """Copy one attachment from pending into `<recipient>/.files/<msg_id>/`."""
+    """Copy one attachment from pending into the recipient's files bundle."""
     if (entry.get("path") or "").strip():
         out_agent(
             sender_name,
@@ -166,7 +159,7 @@ def _transfer_file_to_recipient(
     if src_resolved is None:
         out_agent(sender_name, f"FILE: staged attachment missing or invalid: {filename!r}")
         return None
-    dest_dir = inbound_bundle_dir(recipient_root, msg_id)
+    dest_dir = recipient.files_bundle_dir(msg_id)
     dest_dir.mkdir(parents=True, exist_ok=True)
     dest = dest_dir / filename
     try:
@@ -200,7 +193,7 @@ def _build_routed_message(
         new_files: list[dict] = []
         for entry in src_files:
             rewritten = _transfer_file_to_recipient(
-                sender.name, msg_id, recipient.root, entry
+                sender.name, msg_id, recipient, entry
             )
             if rewritten is not None:
                 new_files.append(rewritten)
@@ -424,7 +417,7 @@ def _download_files_to_recipient(
     if not msg_id:
         out_msg["files"] = []
         return out_msg
-    dest_root = inbound_bundle_dir(recipient.root, msg_id)
+    dest_root = recipient.files_bundle_dir(msg_id)
     dest_root.mkdir(parents=True, exist_ok=True)
     for entry in src_files:
         filename = entry.get("filename") or ""

--- a/apps/a8s/registry.py
+++ b/apps/a8s/registry.py
@@ -192,9 +192,16 @@ def participants_from_registry() -> list[Participant]:
                 root=root,
                 safe_dirs=tuple(safe_dirs),
                 outbox=_participant_outbox(name, root),
+                files=_participant_files(name, root),
             )
         )
     return parts
+
+
+def _participant_files(name: str, root: Path) -> Path:
+    from definitions import resolve_files_dir_for_agent
+
+    return resolve_files_dir_for_agent(name, root)
 
 
 def _participant_outbox(name: str, root: Path) -> Path:

--- a/apps/a8s/tests/test_daemon.py
+++ b/apps/a8s/tests/test_daemon.py
@@ -23,6 +23,7 @@ from core import (
     agent_log_path,
     clear_inbox_waiting_since,
     detach_request_path,
+    files_dir,
     inbox_dir,
     kill_request_path,
     pid_path,
@@ -391,6 +392,101 @@ class TestWakeOnce:
             assert "|MSG:all-hands" in log
             assert "OTHERS:" not in log
             assert "ALIAS:" not in log
+
+
+class TestFilesDirContract:
+    """PR #137 checklist — wake prompts and files_dir bootstrap."""
+
+    def _mock_def(self, tmp_path: Path, fixtures_dir: Path, *, files_dir: str | None = None) -> Path:
+        invoke = [
+            "$A8S_DIR/tests/fixtures/mock-cli",
+            "FROM:$SENDER|TO:$RECIPIENT|TS:$TIMESTAMP|AGE:$AGE|MSG:$MESSAGE",
+        ]
+        body: dict = {"invoke": invoke}
+        if files_dir is not None:
+            body["files_dir"] = files_dir
+        path = tmp_path / "mock-def.json"
+        path.write_text(json.dumps(body))
+        return path
+
+    def test_wake_prompt_includes_absolute_attached_file_path(
+        self, fake_home, tmp_path, fixtures_dir
+    ):
+        a_root = tmp_path / "a"
+        b_root = tmp_path / "b"
+        a_root.mkdir()
+        b_root.mkdir()
+        defn = self._mock_def(tmp_path, fixtures_dir)
+        save_registry({
+            "A": {"root": str(a_root), "definition": str(defn)},
+            "B": {"root": str(b_root), "definition": str(defn)},
+        })
+        a = Participant("A", a_root)
+        b = Participant("B", b_root)
+        ensure_mailboxes(a)
+        ensure_mailboxes(b)
+        payload = a_root / "avatar.jpg"
+        payload.write_text("bytes")
+        out_path = _write_outbox(
+            "A", a_root, "B", "see attached", [],
+            attachment_sources=[payload],
+        )
+        msg_id = out_path.stem
+        rc = attached_loop(["A", "B"], 0.1, single_pass=True)
+        assert rc == 0
+        expected = (b_root / ".files" / msg_id / "avatar.jpg").resolve()
+        log_b = _read_log("B")
+        assert f"ATTACHED FILE: {expected}" in log_b
+        assert "ATTACHED FILE: ./.files" not in log_b
+
+    def test_wake_custom_files_dir_in_attached_file_path(
+        self, fake_home, tmp_path, fixtures_dir
+    ):
+        a_root = tmp_path / "a"
+        b_root = tmp_path / "b"
+        external = tmp_path / "var" / "attachments" / "bob"
+        a_root.mkdir()
+        b_root.mkdir()
+        defn = self._mock_def(tmp_path, fixtures_dir, files_dir=str(external))
+        save_registry({
+            "A": {"root": str(a_root), "definition": str(defn)},
+            "B": {"root": str(b_root), "definition": str(defn)},
+        })
+        ensure_mailboxes(Participant("A", a_root))
+        ensure_mailboxes(Participant("B", b_root))
+        payload = a_root / "avatar.jpg"
+        payload.write_text("bytes")
+        out_path = _write_outbox(
+            "A", a_root, "B", "see attached", [],
+            attachment_sources=[payload],
+        )
+        msg_id = out_path.stem
+        rc = attached_loop(["A", "B"], 0.1, single_pass=True)
+        assert rc == 0
+        expected = (external / msg_id / "avatar.jpg").resolve()
+        log_b = _read_log("B")
+        assert f"ATTACHED FILE: {expected}" in log_b
+        assert (external / msg_id / "avatar.jpg").is_file()
+
+    def test_wake_creates_files_dir_when_missing(
+        self, fake_home, tmp_path, fixtures_dir
+    ):
+        a_root = tmp_path / "a"
+        b_root = tmp_path / "b"
+        a_root.mkdir()
+        b_root.mkdir()
+        defn = self._mock_def(tmp_path, fixtures_dir)
+        save_registry({
+            "A": {"root": str(a_root), "definition": str(defn)},
+            "B": {"root": str(b_root), "definition": str(defn)},
+        })
+        ensure_mailboxes(Participant("A", a_root))
+        ensure_mailboxes(Participant("B", b_root))
+        _write_outbox("A", a_root, "B", "text only", [])
+        assert not files_dir(b_root).exists()
+        rc = attached_loop(["A", "B"], 0.1, single_pass=True)
+        assert rc == 0
+        assert files_dir(b_root).is_dir()
 
 
 class TestAttachedLoopLifecycle:

--- a/apps/a8s/tests/test_definitions.py
+++ b/apps/a8s/tests/test_definitions.py
@@ -16,6 +16,7 @@ from definitions import (
     build_command,
     default_definition_path,
     load_definition,
+    resolve_files_dir,
     resolve_outbox_dir,
 )
 
@@ -74,72 +75,104 @@ class TestFormatAge:
 # ---------- _message_body ----------
 
 class TestMessageBody:
-    def test_content_only(self):
-        assert _message_body({"content": "hello"}) == "hello"
+    @pytest.fixture
+    def files_root(self, tmp_path):
+        root = tmp_path / "agent"
+        root.mkdir()
+        return root / ".files"
 
-    def test_content_with_files(self):
+    def test_content_only(self, files_root):
+        assert _message_body({"content": "hello"}, files_root) == "hello"
+
+    def test_content_with_files(self, files_root):
         msg = {
             "content": "see attached",
             "id": "01JTESTATTACH000000000000",
             "files": [{"filename": "build.log"}, {"filename": "data.csv"}],
         }
-        assert _message_body(msg) == (
+        base = files_root / "01JTESTATTACH000000000000"
+        assert _message_body(msg, files_root) == (
             "see attached\n\n"
-            "ATTACHED FILE: ./.files/01JTESTATTACH000000000000/build.log\n"
-            "ATTACHED FILE: ./.files/01JTESTATTACH000000000000/data.csv"
+            f"ATTACHED FILE: {(base / 'build.log').resolve()}\n"
+            f"ATTACHED FILE: {(base / 'data.csv').resolve()}"
         )
 
-    def test_empty(self):
-        assert _message_body({}) == ""
+    def test_empty(self, files_root):
+        assert _message_body({}, files_root) == ""
 
 
 # ---------- build_command + _expand_argv ----------
 
 class TestBuildCommand:
-    def test_substitutes_sender_recipient_message(self):
+    @pytest.fixture
+    def agent_root(self, tmp_path):
+        root = tmp_path / "agent"
+        root.mkdir()
+        return root
+
+    def test_substitutes_sender_recipient_message(self, agent_root):
         defn = {"invoke": ["claude", "--continue", "-p", "$SENDER tells $RECIPIENT: $MESSAGE"]}
         msg = {"from": "GERRY", "to": "CLAUDE", "content": "fix this"}
-        argv = build_command(defn, msg)
+        argv = build_command(defn, msg, agent_root)
         assert argv == ["claude", "--continue", "-p", "GERRY tells CLAUDE: fix this"]
 
-    def test_alias_routed_keeps_alias_in_recipient(self):
+    def test_alias_routed_keeps_alias_in_recipient(self, agent_root):
         # Strict opacity / mailing-list semantics: when the sender wrote
         # `to: devs`, the recipient's $RECIPIENT resolves to "devs".
         defn = {"invoke": ["claude", "-p", "$SENDER tells $RECIPIENT: $MESSAGE"]}
         msg = {"from": "GERRY", "to": "devs", "content": "standup"}
-        argv = build_command(defn, msg)
+        argv = build_command(defn, msg, agent_root)
         assert argv == ["claude", "-p", "GERRY tells devs: standup"]
 
-    def test_missing_invoke_raises(self):
+    def test_missing_invoke_raises(self, agent_root):
         with pytest.raises(ValueError, match="invoke"):
-            build_command({}, {"from": "G", "to": "C"})
+            build_command({}, {"from": "G", "to": "C"}, agent_root)
 
-    def test_a8s_dir_substitution(self):
+    def test_a8s_dir_substitution(self, agent_root):
         from core import SCRIPT_DIR
         defn = {"invoke": ["$A8S_DIR/dummy-cli", "$MESSAGE"]}
         msg = {"from": "A", "to": "B", "content": "hi"}
-        argv = build_command(defn, msg)
+        argv = build_command(defn, msg, agent_root)
         assert argv == [f"{SCRIPT_DIR}/dummy-cli", "hi"]
 
-    def test_does_not_mutate_original_argv(self):
+    def test_does_not_mutate_original_argv(self, agent_root):
         defn = {"invoke": ["claude", "-p", "$MESSAGE"]}
         original = list(defn["invoke"])
-        build_command(defn, {"from": "A", "to": "B", "content": "hello"})
+        build_command(defn, {"from": "A", "to": "B", "content": "hello"}, agent_root)
         assert defn["invoke"] == original
 
-    def test_message_body_includes_files(self):
+    def test_message_body_includes_files(self, agent_root):
         defn = {"invoke": ["x", "$MESSAGE"]}
+        msg_id = "01JTESTATTACH000000000000"
         msg = {
             "from": "GERRY",
             "to": "CLAUDE",
             "content": "review",
-            "id": "01JTESTATTACH000000000000",
+            "id": msg_id,
             "files": [{"filename": "x"}],
         }
-        argv = build_command(defn, msg)
-        assert argv == ["x", "review\n\nATTACHED FILE: ./.files/01JTESTATTACH000000000000/x"]
+        argv = build_command(defn, msg, agent_root)
+        path = (agent_root / ".files" / msg_id / "x").resolve()
+        assert argv == ["x", f"review\n\nATTACHED FILE: {path}"]
 
-    def test_timestamp_substitution_from_msg_date(self):
+    def test_message_body_uses_custom_files_dir(self, tmp_path):
+        agent_root = tmp_path / "agent"
+        agent_root.mkdir()
+        external = tmp_path / "attachments"
+        msg_id = "01JTESTATTACH000000000000"
+        defn = {"invoke": ["x", "$MESSAGE"], "files_dir": str(external)}
+        msg = {
+            "from": "GERRY",
+            "to": "CLAUDE",
+            "content": "review",
+            "id": msg_id,
+            "files": [{"filename": "x"}],
+        }
+        argv = build_command(defn, msg, agent_root)
+        path = (external / msg_id / "x").resolve()
+        assert argv == ["x", f"review\n\nATTACHED FILE: {path}"]
+
+    def test_timestamp_substitution_from_msg_date(self, agent_root):
         defn = {"invoke": ["x", "[$TIMESTAMP] $SENDER: $MESSAGE"]}
         msg = {
             "from": "GERRY",
@@ -147,10 +180,10 @@ class TestBuildCommand:
             "date": "2026-04-28T14:30:00.000000Z",
             "content": "hi",
         }
-        argv = build_command(defn, msg)
+        argv = build_command(defn, msg, agent_root)
         assert argv == ["x", "[2026-04-28T14:30:00.000000Z] GERRY: hi"]
 
-    def test_age_substitution_relative_to_now(self, monkeypatch):
+    def test_age_substitution_relative_to_now(self, agent_root, monkeypatch):
         from datetime import timedelta
         import definitions as dmod
         frozen = datetime(2026, 4, 28, 14, 35, 0, tzinfo=timezone.utc)
@@ -164,13 +197,13 @@ class TestBuildCommand:
 
         defn = {"invoke": ["x", "($AGE) $MESSAGE"]}
         msg = {"from": "G", "to": "C", "date": msg_date, "content": "hi"}
-        argv = build_command(defn, msg)
+        argv = build_command(defn, msg, agent_root)
         assert argv == ["x", "(5 minutes ago) hi"]
 
-    def test_missing_date_yields_empty_age_and_timestamp(self):
+    def test_missing_date_yields_empty_age_and_timestamp(self, agent_root):
         defn = {"invoke": ["x", "TS:$TIMESTAMP", "AGE:$AGE", "$MESSAGE"]}
         msg = {"from": "G", "to": "C", "content": "hi"}
-        argv = build_command(defn, msg)
+        argv = build_command(defn, msg, agent_root)
         assert argv == ["x", "TS:", "AGE:", "hi"]
 
 
@@ -273,6 +306,37 @@ class TestResolveOutboxDir:
     def test_rejects_empty(self, tmp_path):
         with pytest.raises(ValueError, match="must not be empty"):
             resolve_outbox_dir(tmp_path, {"outbox_dir": "  "})
+
+
+# ---------- resolve_files_dir ----------
+
+class TestResolveFilesDir:
+    def test_default_relative(self, tmp_path):
+        root = tmp_path / "agent"
+        root.mkdir()
+        assert resolve_files_dir(root, {}) == (root / ".files").resolve()
+
+    def test_explicit_relative(self, tmp_path):
+        root = tmp_path / "agent"
+        root.mkdir()
+        assert resolve_files_dir(root, {"files_dir": "incoming"}) == (
+            root / "incoming"
+        ).resolve()
+
+    def test_absolute(self, tmp_path):
+        root = tmp_path / "agent"
+        root.mkdir()
+        external = tmp_path / "attachments"
+        external.mkdir()
+        assert resolve_files_dir(root, {"files_dir": str(external)}) == external.resolve()
+
+    def test_rejects_non_string(self, tmp_path):
+        with pytest.raises(ValueError, match="files_dir must be a string"):
+            resolve_files_dir(tmp_path, {"files_dir": 1})
+
+    def test_rejects_empty(self, tmp_path):
+        with pytest.raises(ValueError, match="must not be empty"):
+            resolve_files_dir(tmp_path, {"files_dir": "  "})
 
 
 # ---------- load_definition ----------

--- a/apps/a8s/tests/test_mailbox.py
+++ b/apps/a8s/tests/test_mailbox.py
@@ -27,7 +27,7 @@ from mailbox import (
     next_inbox_message,
     route_outboxes,
 )
-from registry import save_aliases, save_registry
+from registry import participants_from_registry, save_aliases, save_registry
 
 
 def _write_staged(sender_name: str, sender_root: Path, to: str, content: str, *sources: Path) -> Path:
@@ -371,25 +371,6 @@ class TestFileTransfer:
         assert delivered["files"] == [{"filename": "report.txt"}]
         assert delivered["id"] == msg_id
 
-    def test_routes_to_custom_files_dir(self, fake_home, tmp_path):
-        a_root = tmp_path / "a"
-        b_root = tmp_path / "b"
-        external = tmp_path / "attachments"
-        a_root.mkdir()
-        b_root.mkdir()
-        save_registry({"A": {"root": str(a_root)}, "B": {"root": str(b_root)}})
-        a = Participant("A", a_root)
-        b = Participant("B", b_root, files=external)
-        ensure_mailboxes(a)
-        ensure_mailboxes(b)
-        payload = a.root / "report.txt"
-        payload.write_text("hello payload")
-        out_path = _write_staged("A", a.root, "B", "see attached", payload)
-        msg_id = out_path.stem
-        route_outboxes([a, b], all_agents=[a, b])
-        assert (external / msg_id / "report.txt").read_text() == "hello payload"
-        assert not files_dir(b.root).exists()
-
     def test_alias_fanout_copies_to_each_recipient(self, fake_home, tmp_path):
         agents = {}
         for n in ("A", "B", "C"):
@@ -465,6 +446,61 @@ class TestFileTransfer:
         assert len(msg_ids) == 2
         for mid, expected in zip(msg_ids, ("v0", "v1"), strict=True):
             assert (b.files_bundle_dir(mid) / "doc.txt").read_text() == expected
+
+
+class TestFilesDirContract:
+    """PR #137 checklist — inbound attachment routing via files_dir."""
+
+    @pytest.fixture
+    def file_agents(self, fake_home, tmp_path):
+        a_root = tmp_path / "a"
+        b_root = tmp_path / "b"
+        a_root.mkdir()
+        b_root.mkdir()
+        save_registry({"A": {"root": str(a_root)}, "B": {"root": str(b_root)}})
+        a = Participant("A", a_root)
+        b = Participant("B", b_root)
+        ensure_mailboxes(a)
+        ensure_mailboxes(b)
+        return a, b
+
+    def test_default_delivers_under_dot_files_msg_id(self, file_agents):
+        a, b = file_agents
+        payload = a.root / "avatar.jpg"
+        payload.write_text("image bytes")
+        out_path = _write_staged("A", a.root, "B", "here", payload)
+        msg_id = out_path.stem
+        route_outboxes([a, b], all_agents=[a, b])
+        bundle = b.files_bundle_dir(msg_id)
+        assert bundle == (b.root / ".files" / msg_id).resolve()
+        assert (bundle / "avatar.jpg").read_text() == "image bytes"
+
+    def test_definition_files_dir_routes_via_registry(self, fake_home, tmp_path):
+        a_root = tmp_path / "a"
+        b_root = tmp_path / "b"
+        external = tmp_path / "var" / "attachments" / "bob"
+        a_root.mkdir()
+        b_root.mkdir()
+        defn = tmp_path / "b-def.json"
+        defn.write_text(
+            json.dumps({"invoke": ["echo", "x"], "files_dir": str(external)})
+        )
+        save_registry({
+            "A": {"root": str(a_root)},
+            "B": {"root": str(b_root), "definition": str(defn)},
+        })
+        agents = participants_from_registry()
+        by_name = {p.name: p for p in agents}
+        for p in agents:
+            ensure_mailboxes(p)
+        payload = a_root / "avatar.jpg"
+        payload.write_text("bob avatar")
+        out_path = _write_staged("A", a_root, "B", "see attached", payload)
+        msg_id = out_path.stem
+        route_outboxes(agents, all_agents=agents)
+        assert by_name["B"].files_path() == external.resolve()
+        assert (external / msg_id / "avatar.jpg").read_text() == "bob avatar"
+        assert not files_dir(b_root).exists()
 
 
 class TestNextInboxMessage:

--- a/apps/a8s/tests/test_mailbox.py
+++ b/apps/a8s/tests/test_mailbox.py
@@ -365,11 +365,30 @@ class TestFileTransfer:
         out_path = _write_staged("A", a.root, "B", "see attached", payload)
         msg_id = out_path.stem
         route_outboxes([a, b], all_agents=[a, b])
-        bundle = inbound_bundle_dir(b.root, msg_id)
+        bundle = b.files_bundle_dir(msg_id)
         assert (bundle / "report.txt").read_text() == "hello payload"
         delivered = json.loads(next(inbox_dir("B").iterdir()).read_text())
         assert delivered["files"] == [{"filename": "report.txt"}]
         assert delivered["id"] == msg_id
+
+    def test_routes_to_custom_files_dir(self, fake_home, tmp_path):
+        a_root = tmp_path / "a"
+        b_root = tmp_path / "b"
+        external = tmp_path / "attachments"
+        a_root.mkdir()
+        b_root.mkdir()
+        save_registry({"A": {"root": str(a_root)}, "B": {"root": str(b_root)}})
+        a = Participant("A", a_root)
+        b = Participant("B", b_root, files=external)
+        ensure_mailboxes(a)
+        ensure_mailboxes(b)
+        payload = a.root / "report.txt"
+        payload.write_text("hello payload")
+        out_path = _write_staged("A", a.root, "B", "see attached", payload)
+        msg_id = out_path.stem
+        route_outboxes([a, b], all_agents=[a, b])
+        assert (external / msg_id / "report.txt").read_text() == "hello payload"
+        assert not files_dir(b.root).exists()
 
     def test_alias_fanout_copies_to_each_recipient(self, fake_home, tmp_path):
         agents = {}
@@ -387,7 +406,7 @@ class TestFileTransfer:
         msg_id = out_path.stem
         route_outboxes(list(agents.values()), all_agents=list(agents.values()))
         for n in ("B", "C"):
-            assert (inbound_bundle_dir(agents[n].root, msg_id) / "data.csv").read_text() == "col1,col2\n1,2\n"
+            assert (agents[n].files_bundle_dir(msg_id) / "data.csv").read_text() == "col1,col2\n1,2\n"
 
     def test_envelope_path_field_is_rejected(self, fake_home, tmp_path, file_agents):
         a, b = file_agents
@@ -395,7 +414,7 @@ class TestFileTransfer:
             {"filename": "secrets.txt", "path": "/outside/secrets.txt"},
         ])
         route_outboxes([a, b], all_agents=[a, b])
-        assert list(files_dir(b.root).iterdir()) == []
+        assert not files_dir(b.root).exists()
         delivered = json.loads(next(inbox_dir("B").iterdir()).read_text())
         assert delivered["files"] == []
 
@@ -416,13 +435,13 @@ class TestFileTransfer:
         out_path = _write_staged("A", a.root, "B", "drop attach", payload)
         msg_id = out_path.stem
         route_outboxes([a, b], all_agents=[a, b])
-        assert (inbound_bundle_dir(b.root, msg_id) / "note.txt").read_text() == "from drop folder"
+        assert (b.files_bundle_dir(msg_id) / "note.txt").read_text() == "from drop folder"
 
     def test_missing_staged_file_is_dropped(self, file_agents):
         a, b = file_agents
         _write_outbox("A", a.root, "B", "ghost", [{"filename": "ghost.txt"}])
         route_outboxes([a, b], all_agents=[a, b])
-        assert list(files_dir(b.root).iterdir()) == []
+        assert not files_dir(b.root).exists()
         delivered = json.loads(next(inbox_dir("B").iterdir()).read_text())
         assert delivered["files"] == []
 
@@ -432,7 +451,7 @@ class TestFileTransfer:
         big.write_bytes(b"x" * (MAX_FILE_BYTES + 1))
         _write_staged("A", a.root, "B", "huge", big)
         route_outboxes([a, b], all_agents=[a, b])
-        assert list(files_dir(b.root).iterdir()) == []
+        assert not files_dir(b.root).exists()
 
     def test_same_basename_different_messages_both_deliver(self, file_agents):
         a, b = file_agents
@@ -445,7 +464,7 @@ class TestFileTransfer:
             route_outboxes([a, b], all_agents=[a, b])
         assert len(msg_ids) == 2
         for mid, expected in zip(msg_ids, ("v0", "v1"), strict=True):
-            assert (inbound_bundle_dir(b.root, mid) / "doc.txt").read_text() == expected
+            assert (b.files_bundle_dir(mid) / "doc.txt").read_text() == expected
 
 
 class TestNextInboxMessage:
@@ -900,7 +919,7 @@ class TestStorageDownload:
             }],
         }).encode()
         receive_envelope(envelope, [b], services=[s_first, s_second])
-        assert (inbound_bundle_dir(b_root, msg_id) / "doc.txt").read_bytes() == b"the-payload"
+        assert (b.files_bundle_dir(msg_id) / "doc.txt").read_bytes() == b"the-payload"
         inbox_msg = json.loads(next(inbox_dir("B").iterdir()).read_text())
         assert inbox_msg["files"] == [{"filename": "doc.txt"}]
 

--- a/apps/a8s/tests/test_registry.py
+++ b/apps/a8s/tests/test_registry.py
@@ -264,6 +264,21 @@ class TestParticipantsFromRegistry:
         assert len(parts) == 1
         assert parts[0].outbox_path() == external.resolve()
 
+    def test_resolves_files_dir_from_definition(self, fake_home, tmp_path):
+        import json
+
+        root = tmp_path / "agent"
+        root.mkdir()
+        external = tmp_path / "attachments"
+        defn = tmp_path / "def.json"
+        defn.write_text(
+            json.dumps({"invoke": ["echo", "x"], "files_dir": str(external)})
+        )
+        save_registry({"A": {"root": str(root), "definition": str(defn)}})
+        parts = participants_from_registry()
+        assert len(parts) == 1
+        assert parts[0].files_path() == external.resolve()
+
 
 # ---------- parse_name + _scan_for_markers ----------
 

--- a/apps/a8s/tests/test_remote_e2e.py
+++ b/apps/a8s/tests/test_remote_e2e.py
@@ -193,7 +193,7 @@ def test_remote_round_trip_with_file_via_storage(tmp_path, mqtt_broker, monkeypa
         monkeypatch.delenv("USERPROFILE", raising=False)
         target_root = cluster_b_home / "target"
         target_root.mkdir()
-        from core import Participant, inbound_bundle_dir, inbox_dir
+        from core import Participant, files_dir, inbox_dir
         from mailbox import ensure_mailboxes
         from registry import save_registry
         save_registry({"TARGET": {"root": str(target_root)}})
@@ -249,7 +249,7 @@ def test_remote_round_trip_with_file_via_storage(tmp_path, mqtt_broker, monkeypa
             # File materialized into TARGET's .files/, path rewritten to local.
             assert len(body["files"]) == 1
             assert body["files"][0]["filename"] == "report.txt"
-            local_files = inbound_bundle_dir(target_root, msg_id)
+            local_files = files_dir(target_root) / msg_id
             assert (local_files / "report.txt").read_text() == "hello from cluster A\n"
         finally:
             stop_remotes(rx_remotes)

--- a/apps/a8s/tests/test_tell.py
+++ b/apps/a8s/tests/test_tell.py
@@ -341,7 +341,7 @@ def test_tell_absolutizes_attach_relative_to_cwd_not_outbox_root(tmp_path):
 
 
 def test_tell_absolutized_attach_delivers_after_routing(fake_home, tmp_path):
-    from core import Participant, inbound_bundle_dir, inbox_dir
+    from core import Participant, inbox_dir
     from mailbox import ensure_mailboxes, route_outboxes
     from registry import save_registry
 
@@ -372,7 +372,7 @@ def test_tell_absolutized_attach_delivers_after_routing(fake_home, tmp_path):
     ensure_mailboxes(sender)
     ensure_mailboxes(bob)
     route_outboxes([sender, bob], all_agents=[sender, bob])
-    assert (inbound_bundle_dir(bob.root, msg_id) / "data.txt").read_text() == "hello file"
+    assert (bob.files_bundle_dir(msg_id) / "data.txt").read_text() == "hello file"
     delivered = json.loads(next(inbox_dir("BOB").iterdir()).read_text())
     assert delivered["files"] == [{"filename": "data.txt"}]
 


### PR DESCRIPTION
## Summary
- Add optional `files_dir` to agent definitions (default `.files` under agent root; absolute paths supported), mirroring the `outbox_dir` pattern.
- Route inbound attachments to `<files_dir>/<msg_id>/<filename>`; create `files_dir` on wake; TTL cleanup respects the resolved path.
- Wake `$MESSAGE` appends absolute `ATTACHED FILE:` lines (no env var — agents read the path given in the prompt).

## Test plan
- [x] `python3 -m pytest apps/a8s/tests/ -q --ignore=apps/a8s/tests/test_install.py` (521 passed)
- [x] Custom `files_dir` in definition routes attachments to external path — `TestFilesDirContract::test_definition_files_dir_routes_via_registry`
- [x] Default agents still receive files under `.files/<msg_id>/` — `TestFilesDirContract::test_default_delivers_under_dot_files_msg_id`
- [x] Wake prompt shows absolute paths for attachments — `TestFilesDirContract::test_wake_prompt_includes_absolute_attached_file_path`, `test_wake_custom_files_dir_in_attached_file_path`


Made with [Cursor](https://cursor.com)