### PR TITLE
feat(a8s): convo history, settings.json, and config catalog

### DIFF
--- a/apps/a8s/DEVELOPMENT.md
+++ b/apps/a8s/DEVELOPMENT.md
@@ -31,6 +31,13 @@ Read `README.md` first for concept and usage.
   disconnect handler.
 - **Per-message backoff retry.** BACKOFF_SCHEDULE drives `.retry` sidecars.
 - **Local routing claims the ULID in `seen-ids`** to prevent MQTT round-trip dupes.
+- **`settings.json` is the stable operator config.** `a8s config set` persists
+  machine-wide keys; `a8s config` (no args) catalogs every knob including
+  definition, registry, and network fields. Env vars apply only when a key
+  is absent from the file. `A8S_HOME` relocates the whole state dir.
+- **`conversations.jsonl` is machine-wide.** One routed row per logical message
+  (alias fan-out is one row). Rotates at `convo_max_limit` (default 1000).
+  Queried by `a8s convo <agent>` — not per-agent storage.
 
 ## Per-tool quirks
 

--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -19,17 +19,17 @@ The win at scale: a team of agents that share knowledge through ordinary convers
 
 ```mermaid
 flowchart LR
-    subgraph A["Agent's own dir &nbsp;<i>(~/projects/foo/)</i>"]
+    subgraph A["Agent's own dir  <i>(~/projects/foo/)</i>"]
         direction TB
         marker["CLAUDE.md / GEMINI.md / CODEX.md<br/><i>marker file</i>"]
         outbox[".outbox/<br/><i>agent writes here</i>"]
     end
 
-    subgraph H["~/.a8s/ &nbsp;<i>(a8s-managed state)</i>"]
+    subgraph H["~/.a8s/  <i>(a8s-managed state)</i>"]
         direction TB
         reg["a8s.json<br/><i>registry — agents + aliases</i>"]
         slog["log.txt<br/><i>process-scoped supervisor log</i>"]
-        subgraph AG["agents/&lt;NAME&gt;/"]
+        subgraph AG["agents/<NAME>/"]
             direction TB
             ib["inbox/"]
             tr["trash/"]
@@ -45,6 +45,8 @@ flowchart LR
     pid -.-|"holds attachment"| handler
     handler -.-|"writes"| alog
 ```
+
+
 
 Three concepts:
 
@@ -95,52 +97,85 @@ That's the full loop. Members don't know they're "in a8s" — they just see a `t
 ## Commands
 
 ### Registration
-| | |
-|---|---|
-| `a8s add <name> <dir> [<def>]` | Register an agent. Auto-detects definition from `<dir>`'s marker file unless `<def>` is given. |
-| `a8s remove <name>` | Unregister an agent. Wipes `~/.a8s/agents/<NAME>/` and prunes the agent from any alias's member list (deletes empty aliases). Refuses if a handler is running. |
-| `a8s define <name> [<path>]` | Show or set the agent's definition file. |
-| `a8s discover <path>` | Walk a path for marker files; print suggested `add`+`define` commands. Read-only. |
-| `a8s agents` | List every registered agent and its definition. |
+
+
+|                                |                                                                                                                                                                |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `a8s add <name> <dir> [<def>]` | Register an agent. Auto-detects definition from `<dir>`'s marker file unless `<def>` is given.                                                                 |
+| `a8s remove <name>`            | Unregister an agent. Wipes `~/.a8s/agents/<NAME>/` and prunes the agent from any alias's member list (deletes empty aliases). Refuses if a handler is running. |
+| `a8s define <name> [<path>]`   | Show or set the agent's definition file.                                                                                                                       |
+| `a8s discover <path>`          | Walk a path for marker files; print suggested `add`+`define` commands. Read-only.                                                                              |
+| `a8s agents`                   | List every registered agent and its definition.                                                                                                                |
+
 
 ### Aliases
-| | |
-|---|---|
-| `a8s alias <alias> <member>` | Create or extend an alias. Members can be agents or other aliases (cycles rejected). |
-| `a8s unalias <alias> [<member>]` | Remove a single member, or the whole alias. |
-| `a8s aliases` | List every alias and its resolved members. |
+
+
+|                                  |                                                                                      |
+| -------------------------------- | ------------------------------------------------------------------------------------ |
+| `a8s alias <alias> <member>`     | Create or extend an alias. Members can be agents or other aliases (cycles rejected). |
+| `a8s unalias <alias> [<member>]` | Remove a single member, or the whole alias.                                          |
+| `a8s aliases`                    | List every alias and its resolved members.                                           |
+
 
 ### Handlers
-| | |
-|---|---|
-| `a8s start <name>` | Spawn a detached background process to handle the agent (or every member of an alias, in one process). |
-| `a8s run <name>` | Foreground attached loop. Aliases produce one process with interleaved output. Ctrl+C: graceful detach. 2nd Ctrl+C: kill the wake subprocess group. |
-| `a8s step <name>` | Attach, do one route+drain pass, release. Heavyweight: detaches the current handler if any. |
-| `a8s stop <name>` | SIGTERM the handler. Aliases dedupe by PID — one signal per multi-agent handler. Graceful detach. |
-| `a8s kill <name>` | Per-agent force-detach: writes a kill-request, SIGUSR1s the holder. Holder kills the in-flight wake subprocess iff it's for that agent and releases the attachment; siblings keep running. Falls back to whole-process SIGTERM only if the holder doesn't honor the request in 10s. |
-| `a8s exit` | SIGTERM every running handler. |
-| `a8s ls` | List only running agents and their handler PIDs. |
+
+
+|                    |                                                                                                                                                                                                                                                                                     |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `a8s start <name>` | Spawn a detached background process to handle the agent (or every member of an alias, in one process).                                                                                                                                                                              |
+| `a8s run <name>`   | Foreground attached loop. Aliases produce one process with interleaved output. Ctrl+C: graceful detach. 2nd Ctrl+C: kill the wake subprocess group.                                                                                                                                 |
+| `a8s step <name>`  | Attach, do one route+drain pass, release. Heavyweight: detaches the current handler if any.                                                                                                                                                                                         |
+| `a8s stop <name>`  | SIGTERM the handler. Aliases dedupe by PID — one signal per multi-agent handler. Graceful detach.                                                                                                                                                                                   |
+| `a8s kill <name>`  | Per-agent force-detach: writes a kill-request, SIGUSR1s the holder. Holder kills the in-flight wake subprocess iff it's for that agent and releases the attachment; siblings keep running. Falls back to whole-process SIGTERM only if the holder doesn't honor the request in 10s. |
+| `a8s exit`         | SIGTERM every running handler.                                                                                                                                                                                                                                                      |
+| `a8s ls`           | List only running agents and their handler PIDs.                                                                                                                                                                                                                                    |
+
 
 ### Messaging
+
+
+|                                                                             |                                                                                                                                                                                                                                                                                                                           |
+| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `a8s tell <name> <msg>`                                                     | Routed message via `_write_outbox` into the sender's configured outbox. `<name>` may be an agent or alias (fans out at routing time). Sender = agent whose root encloses CWD; router force-stamps `from` from outbox ownership.                                                                                           |
+| `tell <name> <msg>` (top-level shim, `[~/bin/tell](/Users/neilo/bin/tell)`) | Delegates to `a8s tell` (`apps/a8s/tell.py`). Requires `TELL_OUTBOX_DIR` (a8s injects it on wake). Drops a JSON envelope — no `~/.a8s` access required. When the registry is reachable, recipient validation and `from` stamping apply. Windows: `tell.cmd`. Operator internals: `[docs/tell.md](docs/tell.md)`.          |
+| `a8s logs <name>... [--tail N] [-f]`                                        | Read per-agent log files; one agent in append order, multiple merge by ISO timestamp. `-f` follows.                                                                                                                                                                                                                       |
+| `a8s convo <name> [--limit N]`                                              | Markdown conversation history for an agent (messages to or from). Default `--limit 10`. Outbound headings use `##`, inbound use `###`. Archive: `~/.a8s/conversations.jsonl` (machine-wide; rotates at `convo_max_limit`, default 1000 — `a8s config`). |
+| `a8s drain <name>`                                                          | Move pending inbox JSON to trash without waking the agent.                                                                                                                                                                                                                                                                |
+
+
+### Configuration
+
+
 | | |
 |---|---|
-| `a8s tell <name> <msg>` | Routed message via `_write_outbox` into the sender's configured outbox. `<name>` may be an agent or alias (fans out at routing time). Sender = agent whose root encloses CWD; router force-stamps `from` from outbox ownership. |
-| `tell <name> <msg>` (top-level shim, [`~/bin/tell`](/Users/neilo/bin/tell)) | Delegates to `a8s tell` (`apps/a8s/tell.py`). Requires `TELL_OUTBOX_DIR` (a8s injects it on wake). Drops a JSON envelope — no `~/.a8s` access required. When the registry is reachable, recipient validation and `from` stamping apply. Windows: `tell.cmd`. Operator internals: [`docs/tell.md`](docs/tell.md). |
-| `a8s logs <name>... [--tail N] [-f]` | Read per-agent log files; one agent in append order, multiple merge by ISO timestamp. `-f` follows. |
+| `a8s config` | List settings with effective values and source (`settings.json`, `env`, or default). |
+| `a8s config get <key>` | Print one setting. |
+| `a8s config set <key> <value>` | Persist to `~/.a8s/settings.json`. |
+| `a8s config unset <key>` | Remove key from settings.json; fall back to env then default. |
+
+Env vars apply only when a key is absent from `settings.json` (e.g. `A8S_CONVO_MAX_LIMIT`, `A8S_LOOP_INTERVAL`). `a8s config` with no arguments lists every knob — machine-wide, per-agent definition, registry, network, env, and constants — even read-only ones.
+
 
 ### Skills
-| | |
-|---|---|
-| `a8s install` | Install bundled skills into the current agent dir (or `--global` for user home). |
+
+
+|                      |                                                                                                         |
+| -------------------- | ------------------------------------------------------------------------------------------------------- |
+| `a8s install`        | Install bundled skills into the current agent dir (or `--global` for user home).                        |
 | `a8s install-client` | Copy `apps/a8s` to `/usr/local/lib/a8s/` and install `/usr/local/bin/tell` (`sudo`). Re-run to upgrade. |
 
+
 ### Remotes (issue #63)
-| | |
-|---|---|
-| `a8s remote` | List configured remotes (transport, broker, topic, opts; passwords masked). |
-| `a8s remote <name>` | Show one remote's spec. |
+
+
+|                                                                |                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `a8s remote`                                                   | List configured remotes (transport, broker, topic, opts; passwords masked).                                                                                                                                                                                                                                                                                                                                                            |
+| `a8s remote <name>`                                            | Show one remote's spec.                                                                                                                                                                                                                                                                                                                                                                                                                |
 | `a8s remote <name> <broker-url> <topic> [--<opt> <value> ...]` | Register or overwrite a remote. Broker URL is `mqtt://host[:1883]` or `mqtts://host[:8883]`. Persistent session + QoS 1 are wired automatically so an offline cluster catches up on reconnect. Any `--<opt> <value>` past the broker and topic is forwarded verbatim to the transport — common ones are `--user U --pass P`, `--client_id ID`, `--keepalive N`. The transport rejects unknown options at load time so typos fail loud. |
-| `a8s unremote <name>` | Forget a remote. Running daemons keep using the prior config until restart. |
+| `a8s unremote <name>`                                          | Forget a remote. Running daemons keep using the prior config until restart.                                                                                                                                                                                                                                                                                                                                                            |
+
 
 Remotes are git-shaped: an explicit list of places to fan messages out to. a8s only crosses cluster boundaries on `tell` / `prompt` — everything else (`a8s logs`, `a8s ls`, `a8s agents`) is strictly local. If you want cross-cluster log access, register an a8s connector that turns inbound tells into local `a8s logs` calls; a8s itself just enables the message + invocation path.
 
@@ -164,28 +199,32 @@ Take-over has a 60-second timeout (kill is 10s). If the holder is wedged on a lo
 
 Each agent has a definition file: a JSON document describing how to invoke its CLI for each verb. Built-in defaults ship in `apps/a8s/definitions/`:
 
-| File | Purpose |
-|---|---|
-| `claude.json` | Claude Code with `--permission-mode dontAsk` allowlist + `--continue` |
-| `agy.json` | Antigravity (agy) with `--sandbox` + `--dangerously-skip-permissions` + `--continue` for headless operation |
-| `codex.json` | Codex CLI with `--full-auto` workspace-write sandbox + `resume --last` |
-| `copilot.json` | GitHub Copilot CLI with `--allow-all-tools` (required for non-interactive `-p` mode) + `--continue`. Marker is `.github/copilot-instructions.md` (Copilot's native repo-instructions location). |
-| `cursor.json` | Cursor Agent CLI (`agent`) with `-p --trust --force --approve-mcps --continue` for headless tool use. Marker is `CURSOR.md`. |
+
+| File            | Purpose                                                                                                                                                                                                                                            |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `claude.json`   | Claude Code with `--permission-mode dontAsk` allowlist + `--continue`                                                                                                                                                                              |
+| `agy.json`      | Antigravity (agy) with `--sandbox` + `--dangerously-skip-permissions` + `--continue` for headless operation                                                                                                                                        |
+| `codex.json`    | Codex CLI with `--full-auto` workspace-write sandbox + `resume --last`                                                                                                                                                                             |
+| `copilot.json`  | GitHub Copilot CLI with `--allow-all-tools` (required for non-interactive `-p` mode) + `--continue`. Marker is `.github/copilot-instructions.md` (Copilot's native repo-instructions location).                                                    |
+| `cursor.json`   | Cursor Agent CLI (`agent`) with `-p --trust --force --approve-mcps --continue` for headless tool use. Marker is `CURSOR.md`.                                                                                                                       |
 | `opencode.json` | [OpenCode](https://opencode.ai/) — BYO model. `opencode run --continue --dangerously-skip-permissions`. Operator picks the provider/model in each agent's own `opencode.json` (e.g. `{"model": "ollama/gpt-oss:20b"}`), not in the a8s definition. |
-| `default.json` | Fallback — runs `dummy-cli` and prints "no real CLI configured" |
+| `default.json`  | Fallback — runs `dummy-cli` and prints "no real CLI configured"                                                                                                                                                                                    |
+
 
 ### Marker files & auto-discovery
 
 `a8s discover <path>` and `a8s add <name> <dir>` (without an explicit definition) figure out which CLI an agent uses by scanning for one of these marker files at the agent's root, in order:
 
-| Marker | Kind | Where the CLI itself looks |
-|---|---|---|
-| `CLAUDE.md` | claude | [Claude Code memory](https://docs.claude.com/en/docs/claude-code/memory) |
-| `GEMINI.md` | agy | [Antigravity (agy) context files](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/configuration.md) |
-| `CODEX.md` | codex | [Codex CLI configuration](https://github.com/openai/codex) |
-| `.github/copilot-instructions.md` | copilot | [Copilot CLI repository custom instructions](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions/add-repository-instructions) — the same file Copilot itself auto-loads |
-| `CURSOR.md` | cursor | a8s marker for [Cursor Agent CLI](https://cursor.com/docs/cli/using) agents. Cursor also loads `AGENTS.md` and `.cursor/rules/`; use `CURSOR.md` when this directory is a Cursor CLI agent in a8s. |
-| `AGENTS.md` (fallback) | opencode | [The agents.md standard](https://agents.md/) — tool-agnostic instructions stewarded by the [Agentic AI Foundation](https://agentic.foundation/) under the Linux Foundation |
+
+| Marker                            | Kind     | Where the CLI itself looks                                                                                                                                                                         |
+| --------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CLAUDE.md`                       | claude   | [Claude Code memory](https://docs.claude.com/en/docs/claude-code/memory)                                                                                                                           |
+| `GEMINI.md`                       | agy      | [Antigravity (agy) context files](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/configuration.md)                                                                                 |
+| `CODEX.md`                        | codex    | [Codex CLI configuration](https://github.com/openai/codex)                                                                                                                                         |
+| `.github/copilot-instructions.md` | copilot  | [Copilot CLI repository custom instructions](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions/add-repository-instructions) — the same file Copilot itself auto-loads       |
+| `CURSOR.md`                       | cursor   | a8s marker for [Cursor Agent CLI](https://cursor.com/docs/cli/using) agents. Cursor also loads `AGENTS.md` and `.cursor/rules/`; use `CURSOR.md` when this directory is a Cursor CLI agent in a8s. |
+| `AGENTS.md` (fallback)            | opencode | [The agents.md standard](https://agents.md/) — tool-agnostic instructions stewarded by the [Agentic AI Foundation](https://agentic.foundation/) under the Linux Foundation                         |
+
 
 The first four are **kind-specific** locations — for the tools that have a distinct native instruction file, a8s uses that location directly. For Copilot we use its repo-instructions location (`.github/copilot-instructions.md`) rather than inventing a `COPILOT.md` — same file serves both a8s discovery and Copilot's own persona loading.
 
@@ -208,6 +247,7 @@ Strict opacity (issues #69, #70) still holds: a routed message looks identical w
 ```
 
 Argv elements run through six substitutions:
+
 - `$SENDER` → sender's canonical name (always non-empty — every message has a force-stamped agent `from`).
 - `$RECIPIENT` → what the sender wrote in `to` (alias name for fanned messages, agent name for direct ones).
 - `$MESSAGE` → the message body (`content`, with any `ATTACHED FILE: <path>` lines appended for inbound attachments).
@@ -266,8 +306,10 @@ The state root is `$HOME/.a8s` by default; set `A8S_HOME` to relocate it. This i
 ```
 ~/.a8s/                       (or wherever A8S_HOME points)
 ├── a8s.json                  registry: { agents: {...}, aliases: {...} }
+├── settings.json             operator settings (`a8s config`; env fills gaps)
 ├── network.json              configured remotes (absent → local-only)
 ├── seen-ids                  cluster-wide ULID ring for receive-side dedup
+├── conversations.jsonl       routed message archive for `a8s convo` (see convo_max_limit)
 ├── log.txt                   process-scoped supervisor log
 └── agents/
     └── <NAME>/

--- a/apps/a8s/cli.py
+++ b/apps/a8s/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import sys
 
+import settings as sm
 from commands import (
     cmd_add,
     cmd_agents,
@@ -12,6 +13,8 @@ from commands import (
     cmd_define,
     cmd_discover,
     cmd_drain,
+    cmd_config,
+    cmd_convo,
     cmd_exit,
     cmd_health,
     cmd_install,
@@ -51,6 +54,8 @@ COMMANDS: list[tuple[str, str, str]] = [
     ("ls",       "",                          "List running agents."),
     ("tell",     "<name> [<message>]",       "Send a message to an agent or alias."),
     ("drain",    "<name>",                   "Move local inbox to trash without invoking."),
+    ("config",   "[get|set|unset ...]",      "List all knobs or edit ~/.a8s/settings.json."),
+    ("convo",    "<name> [--limit N]",       "Show markdown conversation history for an agent."),
     ("logs",     "<name>... [--tail N] [-f]", "Show per-agent logs."),
     ("remote",   "[<name> [<broker> <topic> [--<k> <v> ...]]]", "List, show, or set a cross-machine remote."),
     ("unremote", "<name>",                    "Remove a configured remote."),
@@ -111,6 +116,10 @@ def dispatch(cmd: str, args: list[str], interval: float) -> int:
         return cmd_tell(args)
     if cmd == "drain":
         return cmd_drain(args)
+    if cmd == "config":
+        return cmd_config(args)
+    if cmd == "convo":
+        return cmd_convo(args)
     if cmd == "install":
         return cmd_install(args)
     if cmd == "install-client":
@@ -137,7 +146,12 @@ def main(argv: list[str]) -> int:
         epilog=CLI_EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.add_argument("--interval", type=float, default=1.0, help="loop poll interval seconds (default: 1.0)")
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=None,
+        help=f"loop poll interval seconds (default from settings: {sm.DEFAULTS['loop_interval']})",
+    )
     parser.add_argument("command", nargs="?", help=argparse.SUPPRESS)
     parser.add_argument("rest", nargs=argparse.REMAINDER, help=argparse.SUPPRESS)
     args = parser.parse_args(argv)
@@ -146,8 +160,10 @@ def main(argv: list[str]) -> int:
         parser.print_help()
         return 0
 
+    interval = args.interval if args.interval is not None else sm.get_float("loop_interval")
+
     if args.command in KNOWN_COMMANDS:
-        return dispatch(args.command, args.rest, args.interval)
+        return dispatch(args.command, args.rest, interval)
 
     print(f"unknown command: {args.command!r}", file=sys.stderr)
     return 2

--- a/apps/a8s/commands.py
+++ b/apps/a8s/commands.py
@@ -992,6 +992,169 @@ def cmd_drain(args: list[str]) -> int:
     return 0
 
 
+# ---------- config ----------
+
+def cmd_config(args: list[str]) -> int:
+    """`a8s config` — read or write `~/.a8s/settings.json`; list all knobs."""
+    import settings as sm
+
+    if not args:
+        machine = {r[0]: r for r in sm.list_settings()}
+        for group_label, knobs in sm.list_catalog():
+            print(f"\n{group_label}")
+            for knob in knobs:
+                if knob.writable:
+                    _key, _stored, effective, default, source = machine[knob.key]
+                    print(f"  {knob.key}: {effective}  ({source}; default {default})")
+                    if knob.note:
+                        print(f"    {knob.note}")
+                else:
+                    default = knob.default if knob.default is not None else "—"
+                    print(f"  {knob.key}: {default}")
+                    if knob.note:
+                        print(f"    {knob.note}")
+        print()
+        return 0
+
+    sub = args[0]
+    if sub == "get":
+        if len(args) != 2:
+            print("usage: a8s config get <key>", file=sys.stderr)
+            return 2
+        key = args[1]
+        if sm.is_writable(key):
+            print(sm.get_setting(key))
+            return 0
+        knob = sm.knob_by_key(key)
+        if knob is not None:
+            val = knob.default if knob.default is not None else ""
+            print(val)
+            if knob.note:
+                print(f"({knob.note})", file=sys.stderr)
+            return 0
+        print(f"unknown setting {key!r}", file=sys.stderr)
+        return 1
+
+    if sub == "set":
+        if len(args) != 3:
+            print("usage: a8s config set <key> <value>", file=sys.stderr)
+            return 2
+        try:
+            sm.set_setting(args[1], args[2])
+        except KeyError:
+            print(f"unknown setting {args[1]!r}", file=sys.stderr)
+            return 1
+        except ValueError as e:
+            print(str(e), file=sys.stderr)
+            return 2
+        print(f"{args[1]}={sm.get_setting(args[1])}")
+        return 0
+
+    if sub == "unset":
+        if len(args) != 2:
+            print("usage: a8s config unset <key>", file=sys.stderr)
+            return 2
+        try:
+            removed = sm.unset_setting(args[1])
+        except KeyError:
+            print(f"unknown setting {args[1]!r}", file=sys.stderr)
+            return 1
+        if not removed:
+            print(f"{args[1]}: not set in settings.json")
+        else:
+            print(f"{args[1]} unset (effective {sm.get_setting(args[1])})")
+        return 0
+
+    print(
+        "usage: a8s config [get <key> | set <key> <value> | unset <key>]",
+        file=sys.stderr,
+    )
+    return 2
+
+
+# ---------- convo ----------
+
+def cmd_convo(args: list[str]) -> int:
+    """`a8s convo <name> [--limit N] [--heading-out T] [--heading-in T]` —
+    markdown history of messages to or from an agent."""
+    from convo import (
+        DEFAULT_HEADING_IN,
+        DEFAULT_HEADING_OUT,
+        format_conversation,
+    )
+
+    if not args:
+        print(
+            "usage: a8s convo <name> [--limit N] [--heading-out TEMPLATE] [--heading-in TEMPLATE]",
+            file=sys.stderr,
+        )
+        return 2
+
+    name: str | None = None
+    limit = 10
+    heading_out = DEFAULT_HEADING_OUT
+    heading_in = DEFAULT_HEADING_IN
+    i = 0
+    while i < len(args):
+        a = args[i]
+        if a == "--limit":
+            if i + 1 >= len(args):
+                print("--limit requires a number", file=sys.stderr)
+                return 2
+            try:
+                limit = int(args[i + 1])
+            except ValueError:
+                print("--limit requires a number", file=sys.stderr)
+                return 2
+            i += 2
+            continue
+        if a == "--heading-out":
+            if i + 1 >= len(args):
+                print("--heading-out requires a template", file=sys.stderr)
+                return 2
+            heading_out = args[i + 1]
+            i += 2
+            continue
+        if a == "--heading-in":
+            if i + 1 >= len(args):
+                print("--heading-in requires a template", file=sys.stderr)
+                return 2
+            heading_in = args[i + 1]
+            i += 2
+            continue
+        if a.startswith("-"):
+            print(f"unknown convo arg: {a!r}", file=sys.stderr)
+            return 2
+        if name is not None:
+            print(f"unexpected argument: {a!r}", file=sys.stderr)
+            return 2
+        name = a
+        i += 1
+
+    if name is None:
+        print(
+            "usage: a8s convo <name> [--limit N] [--heading-out TEMPLATE] [--heading-in TEMPLATE]",
+            file=sys.stderr,
+        )
+        return 2
+
+    match = resolve_recipient(name)
+    if match is None:
+        print(f"no agent named {name!r}", file=sys.stderr)
+        return 1
+    agent_name = match[0]
+
+    text = format_conversation(
+        agent_name,
+        limit=limit,
+        heading_out=heading_out,
+        heading_in=heading_in,
+    )
+    if text:
+        print(text)
+    return 0
+
+
 # ---------- logs ----------
 
 def _parse_log_line_ts(line: str) -> datetime | None:

--- a/apps/a8s/convo.py
+++ b/apps/a8s/convo.py
@@ -1,0 +1,155 @@
+"""Conversation archive — append-only jsonl of routed messages for `a8s convo`.
+
+One record per logical message (alias fan-out stores the alias in `to` and
+lists local deliverees in `recipients`). Rotates to `convo_max_limit` entries
+from `~/.a8s/settings.json` (default 1000).
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+from core import conversations_path
+from settings import get_int
+
+__all__ = [
+    "DEFAULT_HEADING_IN",
+    "DEFAULT_HEADING_OUT",
+    "format_conversation",
+    "involves_agent",
+    "load_entries",
+    "record",
+]
+
+DEFAULT_HEADING_OUT = "## from {from} to {to} at {timestamp}"
+DEFAULT_HEADING_IN = "### from {from} to {to} at {timestamp}"
+
+
+def _max_limit() -> int:
+    return get_int("convo_max_limit")
+
+
+def _name_key(name: str) -> str:
+    return (name or "").strip().lower()
+
+
+def involves_agent(entry: dict[str, Any], agent: str) -> bool:
+    key = _name_key(agent)
+    if not key:
+        return False
+    if _name_key(entry.get("from", "")) == key:
+        return True
+    if _name_key(entry.get("to", "")) == key:
+        return True
+    recipients = entry.get("recipients") or []
+    return any(_name_key(r) == key for r in recipients)
+
+
+def _entry_from_message(msg: dict[str, Any], *, recipients: list[str]) -> dict[str, Any]:
+    files = msg.get("files") or []
+    filenames = [
+        (e.get("filename") or "").strip()
+        for e in files
+        if isinstance(e, dict) and (e.get("filename") or "").strip()
+    ]
+    return {
+        "date": (msg.get("date") or "").strip() or _now_iso(),
+        "from": (msg.get("from") or "").strip(),
+        "to": (msg.get("to") or "").strip(),
+        "content": msg.get("content", ""),
+        "files": filenames,
+        "id": (msg.get("id") or "").strip(),
+        "recipients": list(recipients),
+    }
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def load_entries() -> list[dict[str, Any]]:
+    path = conversations_path()
+    if not path.is_file():
+        return []
+    out: list[dict[str, Any]] = []
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(row, dict):
+                    out.append(row)
+    except OSError:
+        return []
+    return out
+
+
+def record(msg: dict[str, Any], *, recipients: list[str]) -> None:
+    """Append one logical message if at least one local recipient exists."""
+    if not recipients:
+        return
+    entry = _entry_from_message(msg, recipients=recipients)
+    msg_id = entry.get("id") or ""
+    try:
+        rows = load_entries()
+        if msg_id and any(r.get("id") == msg_id for r in rows):
+            return
+        rows.append(entry)
+        cap = _max_limit()
+        if len(rows) > cap:
+            rows = rows[-cap:]
+        path = conversations_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as f:
+            for row in rows:
+                f.write(json.dumps(row, ensure_ascii=False) + "\n")
+    except OSError:
+        pass
+
+
+def _format_heading(template: str, entry: dict[str, Any]) -> str:
+    ts = (entry.get("date") or "").strip()
+    return template.format(
+        **{
+            "from": entry.get("from", ""),
+            "to": entry.get("to", ""),
+            "timestamp": ts,
+            "date": ts,
+        }
+    )
+
+
+def format_conversation(
+    agent: str,
+    *,
+    limit: int = 10,
+    heading_out: str = DEFAULT_HEADING_OUT,
+    heading_in: str = DEFAULT_HEADING_IN,
+) -> str:
+    """Return markdown for the last `limit` messages involving `agent`."""
+    if limit < 1:
+        return ""
+    rows = [e for e in load_entries() if involves_agent(e, agent)]
+    rows = rows[-limit:]
+    parts: list[str] = []
+    agent_key = _name_key(agent)
+    for entry in rows:
+        sent = _name_key(entry.get("from", "")) == agent_key
+        heading = _format_heading(heading_out if sent else heading_in, entry)
+        content = entry.get("content", "")
+        block = heading
+        if content:
+            block = f"{heading}\n\n{content}"
+        files = entry.get("files") or []
+        if files:
+            file_lines = "\n".join(f"- attachment: {name}" for name in files)
+            block = f"{block}\n\n{file_lines}" if block else file_lines
+        parts.append(block)
+    return "\n\n".join(parts)
+

--- a/apps/a8s/core.py
+++ b/apps/a8s/core.py
@@ -305,6 +305,16 @@ def network_config_path() -> Path:
     return _a8s_dir() / "network.json"
 
 
+def settings_path() -> Path:
+    """`~/.a8s/settings.json` — operator settings (`a8s config`)."""
+    return _a8s_dir() / "settings.json"
+
+
+def conversations_path() -> Path:
+    """`~/.a8s/conversations.jsonl` — routed message archive for `a8s convo`."""
+    return _a8s_dir() / "conversations.jsonl"
+
+
 def seen_ids_path() -> Path:
     """Single cluster-wide ring file holding the last MAX_SEEN_IDS message
     IDs the receive loops have written into local inboxes. Receive-side dedup

--- a/apps/a8s/mailbox.py
+++ b/apps/a8s/mailbox.py
@@ -50,7 +50,6 @@ from typing import Callable, Optional
 from core import (
     BACKOFF_SCHEDULE,
     MAX_ATTEMPTS,
-    MAX_FILE_BYTES,
     Participant,
     _preview,
     inbound_bundle_dir,
@@ -71,6 +70,12 @@ from sync_listen import A8S_CONTROL, expire_stale_listeners_for_participants, ha
 from services import StorageError, StorageService
 import txlog
 from ulid import new as new_ulid
+
+
+def _max_file_bytes() -> int:
+    from settings import get_int
+
+    return get_int("max_file_bytes")
 
 # A function that publishes one routed-and-from-stamped message envelope to
 # every configured remote that hasn't yet accepted it. Returns the updated
@@ -134,7 +139,7 @@ def _resolve_pending_attachment(sender_name: str, msg_id: str, entry: dict) -> P
         size = src.stat().st_size
     except OSError:
         return None
-    if size > MAX_FILE_BYTES:
+    if size > _max_file_bytes():
         return None
     return src
 
@@ -578,6 +583,13 @@ def _process_pending(
                                         out_agent(recipient.name, f"received from {sender.name}: {preview}")
                                     txlog.log("ROUTED", msg_id=msg_id, sender=sender.name, recipient=recipient.name, files=msg_files or None, detail=preview)
                                     routed += delivered
+                                import convo
+
+                                delivered_names = [
+                                    r.name for r in recipients
+                                    if (inbox_dir(r.name) / f.name).is_file()
+                                ]
+                                convo.record(msg, recipients=delivered_names)
                         except OSError as e:
                             out_agent(sender.name, f"commit failed on {f.name}: {e}")
                             # leave for retry

--- a/apps/a8s/network.py
+++ b/apps/a8s/network.py
@@ -30,7 +30,6 @@ from pathlib import Path
 from typing import Callable
 
 from core import (
-    MAX_SEEN_IDS,
     Participant,
     _preview,
     inbox_dir,
@@ -221,8 +220,14 @@ def seen_id_contains(ulid: str) -> bool:
     return False
 
 
+def _max_seen_ids() -> int:
+    from settings import get_int
+
+    return get_int("max_seen_ids")
+
+
 def seen_id_append(ulid: str) -> None:
-    """Append a ULID to the ring, rotating to the last MAX_SEEN_IDS entries
+    """Append a ULID to the ring, rotating to the last max_seen_ids entries
     when the file grows past the cap. Best-effort — disk failures don't
     propagate (a missed append just means we might re-deliver a duplicate)."""
     with _SEEN_IDS_LOCK:
@@ -239,11 +244,11 @@ def seen_id_append(ulid: str) -> None:
                 lines = [ln.rstrip("\n") for ln in f if ln.strip()]
         except OSError:
             return
-        if len(lines) > MAX_SEEN_IDS:
+        if len(lines) > _max_seen_ids():
             tmp = p.with_suffix(p.suffix + ".tmp")
             try:
                 with tmp.open("w", encoding="utf-8") as out_f:
-                    for u in lines[-MAX_SEEN_IDS:]:
+                    for u in lines[-_max_seen_ids():]:
                         out_f.write(u + "\n")
                 os.replace(str(tmp), str(p))
             except OSError:
@@ -352,6 +357,7 @@ def receive_envelope(
         msg["files"] = []
     sender_label = msg.get("from") or "?"
     preview = _preview(msg.get("content", ""))
+    delivered_names: list[str] = []
     for recipient in recipients:
         # Per-recipient download: each recipient has its own `.files/`, so
         # the bytes land in the right place even on alias fan-out. Imported
@@ -383,6 +389,7 @@ def receive_envelope(
                 remote="remote",
                 detail=f"sync capture: {preview}",
             )
+            delivered_names.append(recipient.name)
             continue
         # ensure_mailboxes lives in mailbox.py; importing it here would form
         # a cycle. Just create dirs.
@@ -390,7 +397,8 @@ def receive_envelope(
         inbox_tmp_dir(recipient.name).mkdir(parents=True, exist_ok=True)
         final = inbox_dir(recipient.name) / f"{msg_id}.json"
         if final.is_file():
-            continue  # already there
+            delivered_names.append(recipient.name)
+            continue
         staging = inbox_tmp_dir(recipient.name) / f"{msg_id}.json"
         try:
             with staging.open("w", encoding="utf-8") as f:
@@ -402,6 +410,11 @@ def receive_envelope(
         out_agent(recipient.name, f"received from {sender_label} (via remote): {preview}")
         file_names = [e.get("filename", "") for e in (msg_for_recipient.get("files") or []) if e.get("filename")]
         txlog.log("RECEIVED_REMOTE", msg_id=msg_id, sender=sender_label, recipient=recipient.name, files=file_names or None, remote="remote", detail=preview)
+        delivered_names.append(recipient.name)
+    if delivered_names:
+        import convo
+
+        convo.record(msg, recipients=delivered_names)
     seen_id_append(msg_id)
 
 

--- a/apps/a8s/settings.py
+++ b/apps/a8s/settings.py
@@ -1,0 +1,292 @@
+"""a8s settings — operator config at `~/.a8s/settings.json` plus knob catalog.
+
+Writable machine-wide keys resolve:
+  1. settings.json (`a8s config set`)
+  2. env var when absent from settings.json
+  3. bundled default
+
+`a8s config` with no args lists every known knob — including per-agent
+definition fields, registry, and network — so operators can see the full
+surface even when a knob is not stored in settings.json.
+
+`A8S_HOME` relocates the entire state dir (including settings.json).
+"""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from core import BACKOFF_SCHEDULE, _a8s_dir
+
+Group = Literal["machine", "definition", "registry", "network", "env", "constant"]
+
+
+@dataclass(frozen=True)
+class Knob:
+    key: str
+    default: Any
+    group: Group
+    writable: bool
+    env_var: str | None = None
+    note: str = ""
+
+
+KNOBS: tuple[Knob, ...] = (
+    # --- machine-wide (settings.json) ---
+    Knob(
+        "convo_max_limit",
+        1000,
+        "machine",
+        True,
+        "A8S_CONVO_MAX_LIMIT",
+        "Max rows in ~/.a8s/conversations.jsonl before rotation",
+    ),
+    Knob(
+        "loop_interval",
+        1.0,
+        "machine",
+        True,
+        "A8S_LOOP_INTERVAL",
+        "Default attached_loop poll seconds; a8s --interval overrides per invocation",
+    ),
+    Knob(
+        "max_file_bytes",
+        50 * 1024 * 1024,
+        "machine",
+        True,
+        "A8S_MAX_FILE_BYTES",
+        "Attachment size cap at routing time (bytes)",
+    ),
+    Knob(
+        "max_seen_ids",
+        10000,
+        "machine",
+        True,
+        "A8S_MAX_SEEN_IDS",
+        "Cluster-wide receive dedup ring size (~/.a8s/seen-ids)",
+    ),
+    # --- per-agent definition (a8s define) ---
+    Knob("definition.invoke", None, "definition", False, note="Required argv template for message wakes"),
+    Knob("definition.outbox_dir", ".outbox", "definition", False, note="Tell outbox under agent root (absolute OK); a8s injects TELL_OUTBOX_DIR on wake"),
+    Knob("definition.files_dir", ".files", "definition", False, note="Inbound attachment root (absolute OK)"),
+    Knob("definition.files_ttl_hours", 48, "definition", False, note="Attachment TTL cleanup on idle (hours)"),
+    Knob("definition.pause", 0, "definition", False, note="Debounce seconds before waking on a message burst"),
+    Knob("definition.batch.invoke", None, "definition", False, note="Argv when 2+ inbox messages waiting"),
+    Knob("definition.batch.limit", 5, "definition", False, note="Max messages per batch wake"),
+    Knob("definition.idle.timeout", None, "definition", False, note="Seconds idle before idle.invoke (0 disables)"),
+    Knob("definition.idle.invoke", None, "definition", False, note="Argv for idle/sync hooks"),
+    Knob("definition.proxy", None, "definition", False, note='Set to "file" for file-proxy agents (no CLI wake)'),
+    # --- registry (a8s add / a8s alias) ---
+    Knob("registry.agents.<name>.root", None, "registry", False, note="Agent workspace directory"),
+    Knob("registry.agents.<name>.definition", None, "registry", False, note="Path to wake JSON (optional)"),
+    Knob("registry.agents.<name>.safe_dirs", None, "registry", False, note="Legacy extra attachment roots (unused for routing)"),
+    Knob("registry.aliases.<name>", None, "registry", False, note="Alias member list"),
+    # --- network (a8s remote / a8s storage) ---
+    Knob("network.remotes.<name>", None, "network", False, note="Cross-machine MQTT transport config"),
+    Knob("network.services.<name>", None, "network", False, note="Shared file storage for cross-cluster attachments"),
+    # --- runtime environment ---
+    Knob("A8S_HOME", None, "env", False, note="Relocate entire ~/.a8s state tree (tests, sandboxes)"),
+    Knob("TELL_OUTBOX_DIR", None, "env", False, note="Tell write path; a8s sets on wake from definition.outbox_dir"),
+    # --- code constants (not in settings.json) ---
+    Knob(
+        "remote.backoff_schedule",
+        list(BACKOFF_SCHEDULE),
+        "constant",
+        False,
+        note="Remote publish retry delays in seconds (fixed schedule)",
+    ),
+)
+
+DEFAULTS: dict[str, Any] = {
+    k.key: k.default for k in KNOBS if k.group == "machine" and k.writable
+}
+
+ENV_VARS: dict[str, str] = {
+    k.key: k.env_var for k in KNOBS if k.group == "machine" and k.env_var
+}
+
+_WRITABLE = frozenset(DEFAULTS)
+
+
+__all__ = [
+    "DEFAULTS",
+    "ENV_VARS",
+    "KNOBS",
+    "Knob",
+    "get_float",
+    "get_int",
+    "get_setting",
+    "is_writable",
+    "knob_by_key",
+    "list_catalog",
+    "list_settings",
+    "load_settings_file",
+    "save_settings_file",
+    "settings_path",
+    "set_setting",
+    "unset_setting",
+]
+
+
+def settings_path() -> Path:
+    return _a8s_dir() / "settings.json"
+
+
+def is_writable(key: str) -> bool:
+    return key in _WRITABLE
+
+
+def knob_by_key(key: str) -> Knob | None:
+    for k in KNOBS:
+        if k.key == key:
+            return k
+    return None
+
+
+def load_settings_file() -> dict[str, Any]:
+    path = settings_path()
+    if not path.is_file():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return {k: v for k, v in data.items() if k in _WRITABLE}
+
+
+def save_settings_file(data: dict[str, Any]) -> None:
+    path = settings_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    cleaned = {k: data[k] for k in sorted(data) if k in _WRITABLE}
+    path.write_text(json.dumps(cleaned, indent=2) + "\n", encoding="utf-8")
+
+
+def _coerce(key: str, raw: str) -> Any:
+    if key in ("convo_max_limit", "max_file_bytes", "max_seen_ids"):
+        return int(raw)
+    if key == "loop_interval":
+        return float(raw)
+    return raw
+
+
+def _validate(key: str, value: Any) -> Any:
+    if key == "convo_max_limit":
+        n = int(value)
+        if n < 1:
+            raise ValueError("convo_max_limit must be a positive integer")
+        return n
+    if key == "max_file_bytes":
+        n = int(value)
+        if n < 1:
+            raise ValueError("max_file_bytes must be a positive integer")
+        return n
+    if key == "max_seen_ids":
+        n = int(value)
+        if n < 1:
+            raise ValueError("max_seen_ids must be a positive integer")
+        return n
+    if key == "loop_interval":
+        f = float(value)
+        if f <= 0:
+            raise ValueError("loop_interval must be a positive number")
+        return f
+    return value
+
+
+def get_setting(key: str) -> Any:
+    if key not in _WRITABLE:
+        knob = knob_by_key(key)
+        if knob is not None:
+            return knob.default
+        raise KeyError(key)
+    stored = load_settings_file()
+    if key in stored:
+        return stored[key]
+    env_name = ENV_VARS.get(key)
+    if env_name:
+        raw = os.environ.get(env_name, "")
+        if raw:
+            return _coerce(key, raw)
+    return DEFAULTS[key]
+
+
+def get_int(key: str) -> int:
+    value = get_setting(key)
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        n = int(DEFAULTS[key])
+    return max(1, n)
+
+
+def get_float(key: str) -> float:
+    value = get_setting(key)
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        f = float(DEFAULTS[key])
+    return max(1e-9, f)
+
+
+def set_setting(key: str, value: Any) -> None:
+    if key not in _WRITABLE:
+        raise KeyError(key)
+    value = _validate(key, value)
+    data = load_settings_file()
+    data[key] = value
+    save_settings_file(data)
+
+
+def unset_setting(key: str) -> bool:
+    if key not in _WRITABLE:
+        raise KeyError(key)
+    data = load_settings_file()
+    if key not in data:
+        return False
+    del data[key]
+    save_settings_file(data)
+    return True
+
+
+def _machine_source(key: str, stored: dict[str, Any]) -> str:
+    if key in stored:
+        return "settings.json"
+    env_name = ENV_VARS.get(key)
+    if env_name and os.environ.get(env_name, ""):
+        return "env"
+    return "default"
+
+
+def list_settings() -> list[tuple[str, Any, Any, Any, str]]:
+    """Return (key, stored, effective, default, source) for writable keys."""
+    stored = load_settings_file()
+    rows: list[tuple[str, Any, Any, Any, str]] = []
+    for key, default in DEFAULTS.items():
+        file_val = stored.get(key)
+        effective = get_setting(key)
+        rows.append((key, file_val, effective, default, _machine_source(key, stored)))
+    return rows
+
+
+_GROUP_ORDER: tuple[Group, ...] = ("machine", "definition", "registry", "network", "env", "constant")
+_GROUP_LABELS = {
+    "machine": "Machine-wide (a8s config set)",
+    "definition": "Per-agent definition (a8s define)",
+    "registry": "Registry (~/.a8s/a8s.json)",
+    "network": "Network (~/.a8s/network.json)",
+    "env": "Runtime environment",
+    "constant": "Code constants (not in settings.json)",
+}
+
+
+def list_catalog() -> list[tuple[str, list[Knob]]]:
+    by_group: dict[str, list[Knob]] = {g: [] for g in _GROUP_ORDER}
+    for knob in KNOBS:
+        by_group[knob.group].append(knob)
+    return [( _GROUP_LABELS[g], by_group[g]) for g in _GROUP_ORDER if by_group[g]]
+

--- a/apps/a8s/tests/test_convo.py
+++ b/apps/a8s/tests/test_convo.py
@@ -1,0 +1,267 @@
+"""Tests for convo.py — conversation archive and `a8s convo` formatting."""
+from __future__ import annotations
+
+import pytest
+
+from convo import (
+    format_conversation,
+    involves_agent,
+    load_entries,
+    record,
+)
+from core import conversations_path
+from commands import cmd_convo
+from settings import DEFAULTS
+
+
+class TestInvolvesAgent:
+    def test_from(self):
+        entry = {"from": "Bob", "to": "Alice", "recipients": ["Alice"]}
+        assert involves_agent(entry, "bob")
+
+    def test_to(self):
+        entry = {"from": "Alice", "to": "Bob", "recipients": ["Bob"]}
+        assert involves_agent(entry, "bob")
+
+    def test_alias_recipient(self):
+        entry = {"from": "Alice", "to": "devs", "recipients": ["Bob", "Carol"]}
+        assert involves_agent(entry, "bob")
+        assert involves_agent(entry, "carol")
+        assert not involves_agent(entry, "dave")
+
+
+class TestRecord:
+    def test_appends_entry(self, fake_home):
+        record(
+            {
+                "id": "01JTEST000000000000000000",
+                "date": "2026-06-18T12:00:00.000000Z",
+                "from": "Alice",
+                "to": "Bob",
+                "content": "hello",
+                "files": [{"filename": "x.txt"}],
+            },
+            recipients=["Bob"],
+        )
+        rows = load_entries()
+        assert len(rows) == 1
+        assert rows[0]["from"] == "Alice"
+        assert rows[0]["to"] == "Bob"
+        assert rows[0]["content"] == "hello"
+        assert rows[0]["files"] == ["x.txt"]
+        assert rows[0]["recipients"] == ["Bob"]
+
+    def test_skips_empty_recipients(self, fake_home):
+        record({"id": "01JTEST000000000000000001", "from": "A", "to": "B", "content": "x"}, recipients=[])
+        assert load_entries() == []
+
+    def test_dedupes_by_msg_id(self, fake_home):
+        msg = {
+            "id": "01JTEST000000000000000002",
+            "from": "A",
+            "to": "B",
+            "content": "once",
+        }
+        record(msg, recipients=["B"])
+        record(msg, recipients=["B"])
+        assert len(load_entries()) == 1
+
+    def test_rotates_to_max_limit(self, fake_home, monkeypatch):
+        monkeypatch.setenv("A8S_CONVO_MAX_LIMIT", "3")
+        for i in range(5):
+            record(
+                {
+                    "id": f"01JTEST00000000000000000{i}",
+                    "date": f"2026-06-18T12:00:0{i}.000000Z",
+                    "from": "A",
+                    "to": "B",
+                    "content": f"m{i}",
+                },
+                recipients=["B"],
+            )
+        rows = load_entries()
+        assert len(rows) == 3
+        assert rows[0]["content"] == "m2"
+        assert rows[-1]["content"] == "m4"
+
+
+class TestFormatConversation:
+    def test_outbound_uses_heading_out(self, fake_home):
+        record(
+            {
+                "id": "01JOUT0000000000000000000",
+                "date": "2026-06-18T14:00:00.000000Z",
+                "from": "Bob",
+                "to": "Alice",
+                "content": "ping",
+            },
+            recipients=["Alice"],
+        )
+        text = format_conversation("Bob", limit=10)
+        assert "## from Bob to Alice at 2026-06-18T14:00:00.000000Z" in text
+        assert "ping" in text
+        assert "###" not in text
+
+    def test_inbound_uses_heading_in(self, fake_home):
+        record(
+            {
+                "id": "01JIN00000000000000000000",
+                "date": "2026-06-18T15:00:00.000000Z",
+                "from": "Alice",
+                "to": "Bob",
+                "content": "pong",
+            },
+            recipients=["Bob"],
+        )
+        text = format_conversation("Bob", limit=10)
+        assert "### from Alice to Bob at 2026-06-18T15:00:00.000000Z" in text
+        assert "pong" in text
+
+    def test_alias_inbound_for_member(self, fake_home):
+        record(
+            {
+                "id": "01JALIAS00000000000000000",
+                "date": "2026-06-18T16:00:00.000000Z",
+                "from": "Alice",
+                "to": "devs",
+                "content": "standup",
+            },
+            recipients=["Bob", "Carol"],
+        )
+        text = format_conversation("Bob", limit=10)
+        assert "### from Alice to devs at 2026-06-18T16:00:00.000000Z" in text
+        assert "standup" in text
+
+    def test_limit_returns_last_n_chronologically(self, fake_home):
+        for i in range(3):
+            record(
+                {
+                    "id": f"01JSEQ00000000000000000{i}",
+                    "date": f"2026-06-18T10:00:0{i}.000000Z",
+                    "from": "Alice",
+                    "to": "Bob",
+                    "content": f"msg{i}",
+                },
+                recipients=["Bob"],
+            )
+        text = format_conversation("Bob", limit=2)
+        assert "msg1" in text
+        assert "msg2" in text
+        assert "msg0" not in text
+
+    def test_custom_headings(self, fake_home):
+        record(
+            {
+                "id": "01JCUST00000000000000000",
+                "date": "2026-06-18T17:00:00.000000Z",
+                "from": "Bob",
+                "to": "Alice",
+                "content": "hi",
+            },
+            recipients=["Alice"],
+        )
+        text = format_conversation(
+            "Bob",
+            limit=10,
+            heading_out="OUT {from}->{to} @ {timestamp}",
+            heading_in="IN",
+        )
+        assert "OUT Bob->Alice @ 2026-06-18T17:00:00.000000Z" in text
+
+
+class TestCmdConvo:
+    def test_unknown_agent(self, fake_home, capsys):
+        assert cmd_convo(["nope"]) == 1
+        assert "no agent named" in capsys.readouterr().err
+
+    def test_prints_formatted_history(self, fake_home, tmp_path, capsys):
+        from registry import save_registry
+
+        root = tmp_path / "bob"
+        root.mkdir()
+        save_registry({"Bob": {"root": str(root)}})
+        record(
+            {
+                "id": "01JCMD000000000000000000",
+                "date": "2026-06-18T18:00:00.000000Z",
+                "from": "Alice",
+                "to": "Bob",
+                "content": "for harness",
+            },
+            recipients=["Bob"],
+        )
+        assert cmd_convo(["bob", "--limit", "5"]) == 0
+        out = capsys.readouterr().out
+        assert "for harness" in out
+        assert "Alice" in out
+
+
+class TestConversationsPath:
+    def test_default_under_a8s_home(self, fake_home):
+        assert conversations_path() == fake_home / ".a8s" / "conversations.jsonl"
+
+    def test_respects_a8s_home(self, fake_home, monkeypatch, tmp_path):
+        custom = tmp_path / "custom"
+        monkeypatch.setenv("A8S_HOME", str(custom))
+        custom.mkdir()
+        assert conversations_path() == custom / "conversations.jsonl"
+
+
+class TestRoutingIntegration:
+    """Archive hooks on local route — one logical row per alias fan-out."""
+
+    def test_alias_fanout_records_once(self, fake_home, tmp_path):
+        from core import Participant
+        from mailbox import _write_outbox, ensure_mailboxes, route_outboxes
+        from registry import save_aliases, save_registry
+
+        agents = {}
+        for n in ("A", "B", "C"):
+            d = tmp_path / n.lower()
+            d.mkdir()
+            agents[n] = Participant(n, d)
+        save_registry({n: {"root": str(p.root)} for n, p in agents.items()})
+        save_aliases({"devs": ["B", "C"]})
+        for p in agents.values():
+            ensure_mailboxes(p)
+        payload = agents["A"].root / "x.txt"
+        payload.write_text("x")
+        _write_outbox("A", agents["A"].root, "devs", "team note", [], attachment_sources=[payload])
+        route_outboxes(list(agents.values()), all_agents=list(agents.values()))
+
+        rows = load_entries()
+        assert len(rows) == 1
+        assert rows[0]["to"] == "devs"
+        assert sorted(rows[0]["recipients"]) == ["B", "C"]
+        assert rows[0]["content"] == "team note"
+
+    def test_bob_convo_after_routed_thread(self, fake_home, tmp_path):
+        from core import Participant
+        from mailbox import _write_outbox, ensure_mailboxes, route_outboxes
+        from registry import save_registry
+
+        a_root = tmp_path / "alice"
+        b_root = tmp_path / "bob"
+        a_root.mkdir()
+        b_root.mkdir()
+        save_registry({"Alice": {"root": str(a_root)}, "Bob": {"root": str(b_root)}})
+        alice = Participant("Alice", a_root)
+        bob = Participant("Bob", b_root)
+        ensure_mailboxes(alice)
+        ensure_mailboxes(bob)
+
+        _write_outbox("Alice", a_root, "Bob", "question", [])
+        route_outboxes([alice, bob], all_agents=[alice, bob])
+        _write_outbox("Bob", b_root, "Alice", "answer", [])
+        route_outboxes([alice, bob], all_agents=[alice, bob])
+
+        text = format_conversation("Bob", limit=10)
+        assert "### from Alice to Bob" in text
+        assert "question" in text
+        assert "## from Bob to Alice" in text
+        assert "answer" in text
+        assert text.index("question") < text.index("answer")
+
+
+def test_default_max_limit_is_1000():
+    assert DEFAULTS["convo_max_limit"] == 1000

--- a/apps/a8s/tests/test_network.py
+++ b/apps/a8s/tests/test_network.py
@@ -155,7 +155,7 @@ class TestSeenIdsRing:
 
     def test_rotation_at_cap(self, fake_home, monkeypatch):
         # Lower the cap so we don't have to write 10k lines.
-        monkeypatch.setattr("network.MAX_SEEN_IDS", 5)
+        monkeypatch.setenv("A8S_MAX_SEEN_IDS", "5")
         ids = [new_ulid() for _ in range(8)]
         for u in ids:
             seen_id_append(u)

--- a/apps/a8s/tests/test_settings.py
+++ b/apps/a8s/tests/test_settings.py
@@ -1,0 +1,98 @@
+"""Tests for settings.py and `a8s config`."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import settings as sm
+from commands import cmd_config
+
+
+class TestSettingsResolution:
+    def test_default_when_file_and_env_missing(self, fake_home):
+        assert sm.get_int("convo_max_limit") == 1000
+        assert sm.get_float("loop_interval") == 1.0
+        assert sm.get_int("max_file_bytes") == 50 * 1024 * 1024
+        assert sm.get_int("max_seen_ids") == 10000
+
+    def test_settings_file_takes_precedence_over_env(self, fake_home, monkeypatch):
+        monkeypatch.setenv("A8S_CONVO_MAX_LIMIT", "50")
+        sm.set_setting("convo_max_limit", 200)
+        assert sm.get_int("convo_max_limit") == 200
+
+    def test_env_used_when_key_absent_from_file(self, fake_home, monkeypatch):
+        monkeypatch.setenv("A8S_LOOP_INTERVAL", "2.5")
+        assert sm.get_float("loop_interval") == 2.5
+
+    def test_unset_falls_back_to_env_then_default(self, fake_home, monkeypatch):
+        sm.set_setting("convo_max_limit", 200)
+        sm.unset_setting("convo_max_limit")
+        monkeypatch.setenv("A8S_CONVO_MAX_LIMIT", "75")
+        assert sm.get_int("convo_max_limit") == 75
+        monkeypatch.delenv("A8S_CONVO_MAX_LIMIT", raising=False)
+        assert sm.get_int("convo_max_limit") == 1000
+
+    def test_set_rejects_non_positive(self, fake_home):
+        with pytest.raises(ValueError, match="positive"):
+            sm.set_setting("convo_max_limit", 0)
+        with pytest.raises(ValueError, match="positive"):
+            sm.set_setting("loop_interval", 0)
+
+    def test_persists_to_settings_json(self, fake_home):
+        sm.set_setting("convo_max_limit", 1500)
+        sm.set_setting("loop_interval", 0.5)
+        raw = json.loads(sm.settings_path().read_text())
+        assert raw == {"convo_max_limit": 1500, "loop_interval": 0.5}
+
+    def test_cannot_set_read_only_knob(self, fake_home):
+        with pytest.raises(KeyError):
+            sm.set_setting("definition.invoke", ["echo"])
+
+    def test_get_read_only_returns_catalog_default(self, fake_home):
+        assert sm.get_setting("definition.files_ttl_hours") == 48
+
+
+class TestCatalog:
+    def test_lists_all_groups(self):
+        groups = [label for label, _ in sm.list_catalog()]
+        assert any("Machine-wide" in g for g in groups)
+        assert any("definition" in g for g in groups)
+        assert any("Registry" in g for g in groups)
+        assert any("Network" in g for g in groups)
+
+    def test_machine_knobs_are_writable(self):
+        for knob in sm.KNOBS:
+            if knob.group == "machine":
+                assert knob.writable
+
+
+class TestCmdConfig:
+    def test_list_shows_catalog(self, fake_home, capsys):
+        assert cmd_config([]) == 0
+        out = capsys.readouterr().out
+        assert "convo_max_limit: 1000" in out
+        assert "definition.invoke" in out
+        assert "registry.agents" in out
+        assert "network.remotes" in out
+        assert "TELL_OUTBOX_DIR" in out
+        assert "remote.backoff_schedule" in out
+
+    def test_get_set_unset_writable(self, fake_home, capsys):
+        assert cmd_config(["set", "convo_max_limit", "2500"]) == 0
+        assert "convo_max_limit=2500" in capsys.readouterr().out
+        capsys.readouterr()
+        assert cmd_config(["get", "convo_max_limit"]) == 0
+        assert capsys.readouterr().out.strip() == "2500"
+        assert cmd_config(["unset", "convo_max_limit"]) == 0
+        assert "effective 1000" in capsys.readouterr().out
+
+    def test_get_read_only_knob(self, fake_home, capsys):
+        assert cmd_config(["get", "definition.batch.limit"]) == 0
+        captured = capsys.readouterr()
+        assert captured.out.strip() == "5"
+        assert "batch" in captured.err.lower()
+
+    def test_unknown_setting(self, fake_home, capsys):
+        assert cmd_config(["get", "bogus"]) == 1
+        assert "unknown setting" in capsys.readouterr().err


### PR DESCRIPTION
## Summary
- Add `a8s convo <agent> [--limit N]` — markdown conversation history from `~/.a8s/conversations.jsonl` (machine-wide archive, one row per logical message including alias fan-out).
- Archive on local route and remote delivery; rotates at `convo_max_limit` (default 1000).
- Add `~/.a8s/settings.json` and `a8s config` — persist four machine-wide knobs and catalog definition/registry/network/env/constant surfaces.
- Wire `loop_interval`, `max_file_bytes`, and `max_seen_ids` from settings (env fills gaps when absent from file).

## Test plan
- [x] `python3 -m pytest apps/a8s/tests/ -q --ignore=apps/a8s/tests/test_install.py` (554 passed)
- [x] `a8s config` lists machine-wide, definition, registry, network, env, and constant knobs
- [x] `a8s convo` shows inbound/outbound markdown headings after routed tells
- [ ] Manual: `a8s config set convo_max_limit 5000` persists across sessions

## PR Checklist

### Code Quality
- [x] No `__pycache__` or `.pyc` files in git
- [x] No hardcoded secrets (API keys, passwords, bridge URLs, MQTT creds)
- [x] No PII in committed code or PR description (real emails, phone numbers — use example.com)
- [x] No SQL string interpolation (all queries use `?` parameters)
- [x] No raw `except:` without specific exception types
- [x] No dead imports or unused variables
- [x] Runtime artifacts gitignored (`.db`, `.log`, `.count`, `health.txt`, `stimulus.txt`)

### Testing
- [ ] Integration tests pass (`lifetime.sh`)
- [x] Unit tests pass (if applicable: `pytest`)
- [ ] Manual verification of new features

### Documentation
- [ ] Textbook updated if architecture changed
- [x] README updated if organ/CLI interface changed

### Review
- [ ] Critic agent reviewed before merge


Made with [Cursor](https://cursor.com)