### PR TITLE
fix(a8s): MQTT publish reliability and convo outbound archive

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install pytest
+      - name: Install a8s test dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mosquitto
+          pip install pytest -r apps/a8s/tests/requirements.txt
       - run: python -m pytest tests/test_pii.py apps/a8s/tests/ -x -q
 
   k7e:

--- a/apps/a8s/convo.py
+++ b/apps/a8s/convo.py
@@ -91,7 +91,10 @@ def load_entries() -> list[dict[str, Any]]:
 
 
 def record(msg: dict[str, Any], *, recipients: list[str]) -> None:
-    """Append one logical message if at least one local recipient exists."""
+    """Append one logical message when delivery completes (local inbox, remote
+    receive, or outbound remote publish). `recipients` lists local deliverees
+    for routed/RECEIVED_REMOTE rows, or the logical `to` name for outbound
+    remote-only sends."""
     if not recipients:
         return
     entry = _entry_from_message(msg, recipients=recipients)

--- a/apps/a8s/mailbox.py
+++ b/apps/a8s/mailbox.py
@@ -655,6 +655,14 @@ def _process_pending(
             and (not local_target_known or sidecar["local_delivered"])
         )
         if all_done:
+            remote_published = bool(sidecar["succeeded_remotes"])
+            if has_files and not (services or []):
+                # v1 fallback: remotes marked succeeded without a wire publish.
+                remote_published = False
+            if remote_published:
+                import convo
+
+                convo.record(msg, recipients=[recipient_name])
             _finalize_pending(sender, f)
             continue
         # Still pending — schedule a retry with backoff.

--- a/apps/a8s/network.py
+++ b/apps/a8s/network.py
@@ -259,10 +259,10 @@ def seen_id_append(ulid: str) -> None:
 
 def make_publish_remotes(remotes: list[Transport]) -> Callable:
     """Build the `publish_remotes` callable that `route_outboxes` invokes.
-    For each not-yet-succeeded remote, attempts a publish; on failure logs
-    a warning to the sender's per-agent log and leaves the remote in the
-    `pending_remotes` set for the next pass. Returns the updated
-    `succeeded_remotes` list."""
+    For each not-yet-succeeded remote, attempts a publish; on success logs to
+    the sender's per-agent log (and stdout under `a8s run`); on failure logs
+    a warning and leaves the remote in the `pending_remotes` set for the next
+    pass. Returns the updated `succeeded_remotes` list."""
 
     def publish_with_backoff(
         msg: dict,
@@ -271,6 +271,8 @@ def make_publish_remotes(remotes: list[Transport]) -> Callable:
         attempt_count: int,
     ) -> list[str]:
         envelope = json.dumps(msg).encode("utf-8")
+        recipient = (msg.get("to") or "").strip() or "?"
+        preview = _preview(msg.get("content", ""))
         succeeded = list(succeeded_so_far)
         for remote in remotes:
             if remote.id in succeeded:
@@ -278,6 +280,10 @@ def make_publish_remotes(remotes: list[Transport]) -> Callable:
             try:
                 remote.publish(envelope)
                 succeeded.append(remote.id)
+                out_agent(
+                    sender_name,
+                    f"remote {remote.id}: published -> {recipient}: {preview}",
+                )
             except TransportError as e:
                 out_agent(
                     sender_name,

--- a/apps/a8s/tests/cluster_runner.py
+++ b/apps/a8s/tests/cluster_runner.py
@@ -1,0 +1,16 @@
+"""Subprocess entry: `attached_loop` for one A8S_HOME (integration tests only)."""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+_PKG = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PKG))
+
+if __name__ == "__main__":
+    home, agent, interval, drain = sys.argv[1:5]
+    os.environ["A8S_HOME"] = home
+    from daemon import attached_loop
+
+    raise SystemExit(attached_loop([agent], float(interval), drain_seconds=float(drain)))

--- a/apps/a8s/tests/conftest.py
+++ b/apps/a8s/tests/conftest.py
@@ -18,6 +18,8 @@ import pytest
 _PKG_DIR = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_PKG_DIR))
 
+from mqtt_cluster import mqtt_broker  # noqa: E402 — re-export for pytest
+
 
 @pytest.fixture
 def fake_home(tmp_path, monkeypatch):

--- a/apps/a8s/tests/mqtt_cluster.py
+++ b/apps/a8s/tests/mqtt_cluster.py
@@ -1,0 +1,220 @@
+"""Shared helpers for two-cluster MQTT integration tests."""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Callable, Iterator
+
+import pytest
+
+_PKG_DIR = Path(__file__).resolve().parent.parent
+_RUNNER = Path(__file__).resolve().parent / "cluster_runner.py"
+
+
+def free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture
+def mqtt_broker(tmp_path):
+    """Local mosquitto on a random port. Skips when `mosquitto` is absent."""
+    if shutil.which("mosquitto") is None:
+        pytest.skip("mosquitto binary not on PATH")
+    port = free_port()
+    conf = tmp_path / "mosquitto.conf"
+    conf.write_text(
+        f"listener {port} 127.0.0.1\nallow_anonymous true\npersistence false\n"
+    )
+    proc = subprocess.Popen(
+        ["mosquitto", "-c", str(conf)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    deadline = time.time() + 5.0
+    while time.time() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                break
+        except OSError:
+            time.sleep(0.05)
+    else:
+        proc.terminate()
+        pytest.fail("mosquitto failed to start within 5s")
+    yield port
+    proc.terminate()
+    try:
+        proc.wait(timeout=3)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+
+def write_network_json(
+    a8s_home: Path,
+    port: int,
+    topic: str,
+    client_id: str,
+    *,
+    storage_url: str | None = None,
+) -> None:
+    a8s_home.mkdir(parents=True, exist_ok=True)
+    cfg: dict = {
+        "remotes": {
+            "hub": {
+                "transport": "mqtt",
+                "broker": f"mqtt://127.0.0.1:{port}",
+                "topic": topic,
+                "client_id": client_id,
+            }
+        }
+    }
+    if storage_url is not None:
+        cfg["services"] = {
+            "fake": {"service": "tempfile_org", "url": storage_url},
+        }
+    (a8s_home / "network.json").write_text(json.dumps(cfg))
+
+
+def setup_cluster(
+    a8s_home: Path,
+    *,
+    port: int,
+    topic: str,
+    client_id: str,
+    agents: dict[str, Path],
+) -> None:
+    """Write network.json + registry for one isolated A8S_HOME."""
+    write_network_json(a8s_home, port, topic, client_id)
+    from registry import save_registry
+
+    with using_a8s_home(a8s_home):
+        reg: dict[str, dict] = {}
+        for name, root in agents.items():
+            def_path = root / "a8s-proxy.json"
+            def_path.write_text(json.dumps({"proxy": "file", "idle": {"timeout": 30}}))
+            reg[name] = {
+                "root": str(root.resolve()),
+                "definition": str(def_path.resolve()),
+            }
+        save_registry(reg)
+
+
+@contextmanager
+def using_a8s_home(home: Path) -> Iterator[None]:
+    prev = os.environ.get("A8S_HOME")
+    os.environ["A8S_HOME"] = str(home)
+    try:
+        yield
+    finally:
+        if prev is None:
+            os.environ.pop("A8S_HOME", None)
+        else:
+            os.environ["A8S_HOME"] = prev
+
+
+def ensure_agent_mailboxes(home: Path, agents: dict[str, Path]) -> None:
+    from core import Participant
+    from mailbox import ensure_mailboxes
+
+    with using_a8s_home(home):
+        for name, root in agents.items():
+            ensure_mailboxes(Participant(name, root))
+
+
+def write_outbox(home: Path, sender: str, sender_root: Path, to: str, content: str) -> None:
+    from mailbox import _write_outbox
+
+    with using_a8s_home(home):
+        _write_outbox(sender, sender_root, to, content, [])
+
+
+def wait_inbox(
+    home: Path,
+    agent: str,
+    *,
+    timeout: float = 8.0,
+    predicate: Callable[[dict], bool] | None = None,
+) -> dict:
+    from core import inbox_dir
+
+    deadline = time.time() + timeout
+    with using_a8s_home(home):
+        while time.time() < deadline:
+            for path in sorted(inbox_dir(agent).glob("*.json")):
+                body = json.loads(path.read_text())
+                if predicate is None or predicate(body):
+                    return body
+            time.sleep(0.05)
+    raise AssertionError(f"no matching inbox message for {agent!r} within {timeout}s")
+
+
+def wait_convo(
+    home: Path,
+    *,
+    timeout: float = 8.0,
+    predicate: Callable[[list[dict]], bool],
+) -> list[dict]:
+    from convo import load_entries
+
+    deadline = time.time() + timeout
+    with using_a8s_home(home):
+        while time.time() < deadline:
+            rows = load_entries()
+            if predicate(rows):
+                return rows
+            time.sleep(0.05)
+    raise AssertionError(f"conversations.jsonl condition not met within {timeout}s")
+
+
+def wait_agent_log(
+    a8s_home: Path,
+    agent: str,
+    substring: str,
+    *,
+    timeout: float = 8.0,
+) -> str:
+    path = a8s_home / "agents" / agent / "log.txt"
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if path.is_file():
+            text = path.read_text()
+            if substring in text:
+                return text
+        time.sleep(0.05)
+    raise AssertionError(f"log line {substring!r} not found for {agent!r} within {timeout}s")
+
+
+def start_attached_loop(a8s_home: Path, agent: str, *, drain_seconds: float = 0.0) -> subprocess.Popen:
+    env = os.environ.copy()
+    env["A8S_HOME"] = str(a8s_home)
+    env["PYTHONPATH"] = str(_PKG_DIR)
+    return subprocess.Popen(
+        [
+            sys.executable,
+            str(_RUNNER),
+            str(a8s_home),
+            agent,
+            "0.05",
+            str(drain_seconds),
+        ],
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def stop_attached_loop(proc: subprocess.Popen) -> None:
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=3)

--- a/apps/a8s/tests/test_mailbox.py
+++ b/apps/a8s/tests/test_mailbox.py
@@ -701,6 +701,28 @@ class TestRemotePublishHook:
         # Nothing in trash either.
         assert list(trash_dir("A").iterdir()) == []
 
+    def test_remote_only_records_convo(self, two_agents, fake_home):
+        from convo import load_entries
+
+        a, b = two_agents
+
+        def stub_publish(msg, sender_name, succeeded_so_far, attempt_count):
+            return list(succeeded_so_far) + ["hub"]
+
+        _write_outbox("A", a.root, "GHOST", "remote-only", [])
+        route_outboxes(
+            [a, b],
+            all_agents=[a, b],
+            publish_remotes=stub_publish,
+            configured_remote_ids=["hub"],
+        )
+        rows = load_entries()
+        assert len(rows) == 1
+        assert rows[0]["from"] == "A"
+        assert rows[0]["to"] == "GHOST"
+        assert rows[0]["recipients"] == ["GHOST"]
+        assert rows[0]["content"] == "remote-only"
+
     def test_backoff_exhaustion_trashes(self, two_agents):
         a, b = two_agents
 

--- a/apps/a8s/tests/test_network.py
+++ b/apps/a8s/tests/test_network.py
@@ -13,6 +13,7 @@ import pytest
 from core import (
     MAX_SEEN_IDS,
     Participant,
+    agent_log_path,
     inbox_dir,
     network_config_path,
     seen_ids_path,
@@ -184,6 +185,9 @@ class TestPublishWithBackoff:
         assert len(r2.published) == 1
         # Envelope is JSON-serialized msg.
         assert json.loads(r1.published[0])["to"] == "X"
+        log = agent_log_path("A").read_text()
+        assert "remote r1: published -> X: hi" in log
+        assert "remote r2: published -> X: hi" in log
 
     def test_failure_warns_and_returns_partial(self, fake_home, tmp_path):
         a_root = tmp_path / "A"; a_root.mkdir()

--- a/apps/a8s/tests/test_remote_dual_cluster.py
+++ b/apps/a8s/tests/test_remote_dual_cluster.py
@@ -1,0 +1,173 @@
+"""Two-cluster MQTT integration — sender and recipient on opposite A8S_HOME
+trees with real mosquitto, exercising publish/receive, conversations.jsonl,
+and `a8s convo` end to end."""
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+
+pytest.importorskip("paho.mqtt.client")
+
+from commands import cmd_convo
+from convo import load_entries
+from core import inbox_dir
+from mqtt_cluster import (
+    ensure_agent_mailboxes,
+    setup_cluster,
+    start_attached_loop,
+    stop_attached_loop,
+    using_a8s_home,
+    wait_agent_log,
+    wait_convo,
+    write_outbox,
+)
+
+
+def _unique_topic(prefix: str) -> str:
+    return f"a8s/{prefix}-{os.getpid()}-{int(time.time() * 1000)}"
+
+
+class TestDualClusterRemote:
+    def test_bidirectional_delivery_convo_and_cmd(self, tmp_path, mqtt_broker, capsys):
+        """Two handlers on separate A8S_HOME dirs share one broker topic.
+        Messages published from each side arrive at the other; both
+        conversations.jsonl archives and `a8s convo` show inbound/outbound."""
+        topic = _unique_topic("dual")
+        alice_a8s = tmp_path / "alice_a8s"
+        bob_a8s = tmp_path / "bob_a8s"
+        alice_root = tmp_path / "alice_root"
+        bob_root = tmp_path / "bob_root"
+        alice_root.mkdir(parents=True)
+        bob_root.mkdir(parents=True)
+
+        setup_cluster(
+            alice_a8s,
+            port=mqtt_broker,
+            topic=topic,
+            client_id=f"a8s-test-alice-{os.getpid()}",
+            agents={"ALICE": alice_root},
+        )
+        setup_cluster(
+            bob_a8s,
+            port=mqtt_broker,
+            topic=topic,
+            client_id=f"a8s-test-bob-{os.getpid()}",
+            agents={"BOB": bob_root},
+        )
+        ensure_agent_mailboxes(alice_a8s, {"ALICE": alice_root})
+        ensure_agent_mailboxes(bob_a8s, {"BOB": bob_root})
+
+        alice_proc = start_attached_loop(alice_a8s, "ALICE")
+        bob_proc = start_attached_loop(bob_a8s, "BOB")
+        try:
+            time.sleep(0.8)
+
+            write_outbox(alice_a8s, "ALICE", alice_root, "BOB", "hello from alice")
+            wait_agent_log(alice_a8s, "ALICE", "remote hub: published -> BOB: hello from alice")
+            wait_agent_log(bob_a8s, "BOB", "received from ALICE (via remote): hello from alice")
+
+            wait_convo(
+                alice_a8s,
+                predicate=lambda rows: any(
+                    r.get("from") == "ALICE"
+                    and r.get("to") == "BOB"
+                    and r.get("content") == "hello from alice"
+                    for r in rows
+                ),
+            )
+            wait_convo(
+                bob_a8s,
+                predicate=lambda rows: any(
+                    r.get("from") == "ALICE"
+                    and r.get("to") == "BOB"
+                    and "BOB" in (r.get("recipients") or [])
+                    for r in rows
+                ),
+            )
+
+            write_outbox(bob_a8s, "BOB", bob_root, "ALICE", "hello from bob")
+            wait_agent_log(bob_a8s, "BOB", "remote hub: published -> ALICE: hello from bob")
+            wait_agent_log(alice_a8s, "ALICE", "received from BOB (via remote): hello from bob")
+
+            wait_convo(
+                bob_a8s,
+                predicate=lambda rows: any(
+                    r.get("from") == "BOB"
+                    and r.get("to") == "ALICE"
+                    and r.get("content") == "hello from bob"
+                    for r in rows
+                ),
+            )
+
+            with using_a8s_home(alice_a8s):
+                assert cmd_convo(["ALICE", "--limit", "10"]) == 0
+            alice_out = capsys.readouterr().out
+            assert "## from ALICE to BOB" in alice_out
+            assert "### from BOB to ALICE" in alice_out
+            assert "hello from alice" in alice_out
+            assert "hello from bob" in alice_out
+
+            with using_a8s_home(bob_a8s):
+                assert cmd_convo(["BOB", "--limit", "10"]) == 0
+            bob_out = capsys.readouterr().out
+            assert "### from ALICE to BOB" in bob_out
+            assert "## from BOB to ALICE" in bob_out
+
+            wait_agent_log(alice_a8s, "ALICE", "remote hub: published -> BOB: hello from alice")
+            wait_agent_log(bob_a8s, "BOB", "remote hub: published -> ALICE: hello from bob")
+        finally:
+            stop_attached_loop(alice_proc)
+            stop_attached_loop(bob_proc)
+
+    def test_mismatched_topics_do_not_cross_deliver(self, tmp_path, mqtt_broker):
+        """Subscribe and publish both use the configured topic — a typo on
+        one cluster means MQTT connects fine but envelopes never arrive."""
+        topic_a = _unique_topic("topic-a")
+        topic_b = _unique_topic("topic-b")
+        alice_a8s = tmp_path / "alice_a8s"
+        bob_a8s = tmp_path / "bob_a8s"
+        alice_root = tmp_path / "alice_root"
+        bob_root = tmp_path / "bob_root"
+        alice_root.mkdir(parents=True)
+        bob_root.mkdir(parents=True)
+
+        setup_cluster(
+            alice_a8s,
+            port=mqtt_broker,
+            topic=topic_a,
+            client_id=f"a8s-test-alice-mismatch-{os.getpid()}",
+            agents={"ALICE": alice_root},
+        )
+        setup_cluster(
+            bob_a8s,
+            port=mqtt_broker,
+            topic=topic_b,
+            client_id=f"a8s-test-bob-mismatch-{os.getpid()}",
+            agents={"BOB": bob_root},
+        )
+        ensure_agent_mailboxes(alice_a8s, {"ALICE": alice_root})
+        ensure_agent_mailboxes(bob_a8s, {"BOB": bob_root})
+
+        alice_proc = start_attached_loop(alice_a8s, "ALICE")
+        bob_proc = start_attached_loop(bob_a8s, "BOB")
+        try:
+            time.sleep(0.8)
+            write_outbox(alice_a8s, "ALICE", alice_root, "BOB", "wrong topic")
+
+            with using_a8s_home(bob_a8s):
+                deadline = time.time() + 2.0
+                while time.time() < deadline:
+                    if list(inbox_dir("BOB").glob("*.json")):
+                        pytest.fail("BOB received message despite topic mismatch")
+                    time.sleep(0.05)
+
+            with using_a8s_home(alice_a8s):
+                rows = load_entries()
+                assert any(r.get("content") == "wrong topic" for r in rows), (
+                    "sender should still archive outbound remote publish"
+                )
+        finally:
+            stop_attached_loop(alice_proc)
+            stop_attached_loop(bob_proc)

--- a/apps/a8s/tests/test_remote_e2e.py
+++ b/apps/a8s/tests/test_remote_e2e.py
@@ -13,79 +13,14 @@ from __future__ import annotations
 
 import json
 import os
-import shutil
-import socket
-import subprocess
 import time
 from pathlib import Path
 
 import pytest
 
+from mqtt_cluster import write_network_json
+
 pytest.importorskip("paho.mqtt.client")
-
-
-def _free_port() -> int:
-    with socket.socket() as s:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
-
-
-@pytest.fixture
-def mqtt_broker(tmp_path):
-    if shutil.which("mosquitto") is None:
-        pytest.skip("mosquitto binary not on PATH")
-    port = _free_port()
-    conf = tmp_path / "mosquitto.conf"
-    conf.write_text(
-        f"listener {port} 127.0.0.1\nallow_anonymous true\npersistence false\n"
-    )
-    proc = subprocess.Popen(
-        ["mosquitto", "-c", str(conf)],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
-    deadline = time.time() + 5.0
-    while time.time() < deadline:
-        try:
-            with socket.create_connection(("127.0.0.1", port), timeout=0.2):
-                break
-        except OSError:
-            time.sleep(0.05)
-    else:
-        proc.terminate()
-        pytest.fail("mosquitto failed to start within 5s")
-    yield port
-    proc.terminate()
-    try:
-        proc.wait(timeout=3)
-    except subprocess.TimeoutExpired:
-        proc.kill()
-
-
-def _write_network_json(
-    home: Path,
-    port: int,
-    topic: str,
-    client_id: str,
-    storage_url: str | None = None,
-) -> None:
-    a8s_dir = home / ".a8s"
-    a8s_dir.mkdir(parents=True, exist_ok=True)
-    cfg: dict = {
-        "remotes": {
-            "hub": {
-                "transport": "mqtt",
-                "broker": f"mqtt://127.0.0.1:{port}",
-                "topic": topic,
-                "client_id": client_id,
-            }
-        }
-    }
-    if storage_url is not None:
-        cfg["services"] = {
-            "fake": {"service": "tempfile_org", "url": storage_url},
-        }
-    (a8s_dir / "network.json").write_text(json.dumps(cfg))
 
 
 def test_remote_round_trip(tmp_path, mqtt_broker, monkeypatch):
@@ -97,8 +32,8 @@ def test_remote_round_trip(tmp_path, mqtt_broker, monkeypatch):
     cluster_a_home.mkdir()
     cluster_b_home = tmp_path / "clusterB"
     cluster_b_home.mkdir()
-    _write_network_json(cluster_a_home, mqtt_broker, topic, "a8s-test-clusterA")
-    _write_network_json(cluster_b_home, mqtt_broker, topic, "a8s-test-clusterB")
+    write_network_json(cluster_a_home / ".a8s", mqtt_broker, topic, "a8s-test-clusterA")
+    write_network_json(cluster_b_home / ".a8s", mqtt_broker, topic, "a8s-test-clusterB")
 
     import core
     core.PRINT_LOCK = None
@@ -181,8 +116,20 @@ def test_remote_round_trip_with_file_via_storage(tmp_path, mqtt_broker, monkeypa
         topic = f"a8s/test-storage-{os.getpid()}-{int(time.time() * 1000)}"
         cluster_a_home = tmp_path / "clusterA"; cluster_a_home.mkdir()
         cluster_b_home = tmp_path / "clusterB"; cluster_b_home.mkdir()
-        _write_network_json(cluster_a_home, mqtt_broker, topic, "a8s-test-storage-A", storage_url)
-        _write_network_json(cluster_b_home, mqtt_broker, topic, "a8s-test-storage-B", storage_url)
+        write_network_json(
+            cluster_a_home / ".a8s",
+            mqtt_broker,
+            topic,
+            "a8s-test-storage-A",
+            storage_url=storage_url,
+        )
+        write_network_json(
+            cluster_b_home / ".a8s",
+            mqtt_broker,
+            topic,
+            "a8s-test-storage-B",
+            storage_url=storage_url,
+        )
 
         import core
         core.PRINT_LOCK = None

--- a/apps/a8s/tests/test_transport_mqtt.py
+++ b/apps/a8s/tests/test_transport_mqtt.py
@@ -182,6 +182,29 @@ def test_publish_waits_for_reconnect_before_raising(mqtt_broker):
         t.stop()
 
 
+def test_publish_survives_slow_receive_on_same_client(mqtt_broker):
+    """One client publishes and subscribes on the same topic. receive_envelope
+    can do real work; if on_message runs on paho's network thread the broker
+    echo blocks PUBACK and publish fails with 'not acknowledged'."""
+    import time as _time
+
+    def slow_cb(_b: bytes) -> None:
+        _time.sleep(0.3)
+
+    t = MqttTransport(
+        remote_id="hub",
+        broker=mqtt_broker,
+        topic="a8s/test-slow-same-client",
+        client_id="a8s-test-slow-same-client",
+        connect_timeout_s=1.0,
+    )
+    t.start(slow_cb)
+    try:
+        t.publish(b'{"id":"01SLOW","to":"remote","content":"hi"}')
+    finally:
+        t.stop()
+
+
 def test_persistent_session_replays_on_reconnect(mqtt_broker):
     """The whole point of clean_session=False + QoS 1: an offline subscriber
     catches up when it reconnects under the same client_id. We simulate by
@@ -277,3 +300,9 @@ class TestMqttTransportOptions:
     def test_connect_timeout_coerced_from_string(self):
         t = MqttTransport(remote_id="hub", broker="mqtt://x", topic="t", connect_timeout_s="0.5")
         assert t._connect_timeout_s == 0.5
+
+    def test_publish_qos_must_be_0_or_1(self):
+        with pytest.raises(ValueError, match="publish_qos"):
+            MqttTransport(remote_id="hub", broker="mqtt://x", topic="t", publish_qos=2)
+        t = MqttTransport(remote_id="hub", broker="mqtt://x", topic="t", publish_qos="0")
+        assert t._publish_qos == 0

--- a/apps/a8s/transports/mqtt.py
+++ b/apps/a8s/transports/mqtt.py
@@ -19,6 +19,7 @@ anything left over so an obvious typo in `network.json` fails loud.
 from __future__ import annotations
 
 import hashlib
+import queue
 import socket
 import threading
 from typing import Any, Optional
@@ -42,6 +43,7 @@ _KNOWN_OPTS: set[str] = {
     "client_id",
     "keepalive",
     "connect_timeout_s",
+    "publish_qos",
 }
 
 
@@ -61,7 +63,11 @@ class MqttTransport(Transport):
         topic: the broadcast topic both publish and subscribe target.
         **opts: per-remote options forwarded from `network.json`. Recognized:
             username / password (aliased from `user` / `pass`), client_id,
-            keepalive (seconds, default 60), connect_timeout_s (default 5.0).
+            keepalive (seconds, default 60), connect_timeout_s (default 5.0),
+            publish_qos (0 or 1, default 1). Subscribe stays at QoS 1.
+            a8s-android (Java Paho) publishes asynchronously and never waits
+            for PUBACK; this client waits, and the broker echo runs through
+            `on_message` on the same connection — see `_worker_loop`.
             Unknown keys raise ValueError so a typo in the config doesn't
             silently produce a broken remote.
     """
@@ -94,11 +100,17 @@ class MqttTransport(Transport):
         client_id: Optional[str] = opts.get("client_id")
         keepalive: int = int(opts.get("keepalive", 60))
         connect_timeout_s: float = float(opts.get("connect_timeout_s", 5.0))
+        publish_qos: int = int(opts.get("publish_qos", 1))
+        if publish_qos not in (0, 1):
+            raise ValueError(
+                f"remote {remote_id!r}: publish_qos must be 0 or 1, got {publish_qos!r}"
+            )
 
         self._remote_id = remote_id
         self._topic = topic
         self._keepalive = keepalive
         self._connect_timeout_s = connect_timeout_s
+        self._publish_qos = publish_qos
         parsed = urlparse(broker)
         if parsed.scheme not in ("mqtt", "mqtts"):
             raise ValueError(
@@ -120,6 +132,9 @@ class MqttTransport(Transport):
             self._client.tls_set()
         self._connected = threading.Event()
         self._on_message: Optional[OnMessage] = None
+        self._msg_queue: queue.SimpleQueue[bytes | None] = queue.SimpleQueue()
+        self._worker_stop = threading.Event()
+        self._worker_thread: threading.Thread | None = None
         self._started = False
 
     @property
@@ -138,20 +153,41 @@ class MqttTransport(Transport):
         self._connected.clear()
 
     def _on_message_cb(self, client, userdata, msg):
-        cb = self._on_message
-        if cb is not None:
+        # Never run the user callback on paho's network thread. a8s uses one
+        # client for both publish and subscribe on the same topic; the broker
+        # echoes our publishes back through on_message, and receive_envelope
+        # can do real work (registry I/O, file downloads, convo archive).
+        # Blocking here delays PUBACK for the in-flight outbound publish and
+        # surfaces as "publish not acknowledged" at the routing layer.
+        self._msg_queue.put(msg.payload)
+
+    def _worker_loop(self) -> None:
+        while not self._worker_stop.is_set():
             try:
-                cb(msg.payload)
+                payload = self._msg_queue.get(timeout=0.1)
+            except queue.Empty:
+                continue
+            if payload is None:
+                break
+            cb = self._on_message
+            if cb is None:
+                continue
+            try:
+                cb(payload)
             except Exception:
-                # The user's on_message must not bubble exceptions back into
-                # paho's network thread (it would tear the loop down). Log via
-                # core if needed, but never re-raise here.
                 pass
 
     def start(self, on_message: OnMessage) -> None:
         if self._started:
             raise TransportError(f"{self._remote_id}: already started")
         self._on_message = on_message
+        self._worker_stop.clear()
+        self._worker_thread = threading.Thread(
+            target=self._worker_loop,
+            name=f"a8s-mqtt-{self._remote_id}",
+            daemon=True,
+        )
+        self._worker_thread.start()
         self._client.on_connect = self._on_connect
         self._client.on_disconnect = self._on_disconnect
         self._client.on_message = self._on_message_cb
@@ -179,6 +215,12 @@ class MqttTransport(Transport):
         except OSError:
             pass
         self._client.loop_stop()
+        self._worker_stop.set()
+        self._msg_queue.put(None)
+        worker = self._worker_thread
+        if worker is not None:
+            worker.join(timeout=5.0)
+            self._worker_thread = None
         self._started = False
 
     def publish(self, envelope: bytes) -> None:
@@ -192,10 +234,12 @@ class MqttTransport(Transport):
             self._connected.wait(timeout=self._connect_timeout_s)
         if not self._client.is_connected():
             raise TransportError(f"{self._remote_id}: broker not connected")
-        info = self._client.publish(self._topic, payload=envelope, qos=1)
+        info = self._client.publish(self._topic, payload=envelope, qos=self._publish_qos)
         rc = info.rc
         if rc != mqtt.MQTT_ERR_SUCCESS:
             raise TransportError(f"{self._remote_id}: publish rc={rc}")
+        if self._publish_qos == 0:
+            return
         try:
             info.wait_for_publish(timeout=self._connect_timeout_s)
         except (RuntimeError, ValueError) as e:


### PR DESCRIPTION
## Summary

- **MQTT publish:** defer `receive_envelope` off paho's network thread so broker echo cannot block outbound PUBACK processing; add optional `publish_qos` remote knob; log `remote <id>: published -> <to>: …` on success (mirrors existing failure WARN lines).
- **convo:** record outbound remote-only sends in `~/.a8s/conversations.jsonl` when all configured remotes accept the envelope — previously only local ROUTED and RECEIVED_REMOTE rows were archived, so sends like knobert → neil-phone appeared in `transactions.tsv` as PUBLISHED but not in `a8s convo`.

## Test plan

- [x] `pytest apps/a8s/tests/test_transport_mqtt.py`
- [x] `pytest apps/a8s/tests/test_network.py::TestPublishWithBackoff`
- [x] `pytest apps/a8s/tests/test_convo.py`
- [x] `pytest apps/a8s/tests/test_mailbox.py::TestRemotePublishHook`
- [x] `pytest apps/a8s/tests/test_remote_dual_cluster.py` — real mosquitto, two concurrent `A8S_HOME` handlers on one broker: bidirectional remote delivery, publish-success agent logs, `conversations.jsonl`, `a8s convo` `##`/`###` headings, and mismatched-topic regression (no cross-delivery when subscribe/publish topics diverge)
- [x] `a8s run <agent>` — send to remote recipient; confirm success line in stdout and row in `conversations.jsonl` (covered by `test_bidirectional_delivery_convo_and_cmd` via `wait_agent_log` on `remote hub: published -> …` and convo archive assertions)
- [x] `a8s convo <agent>` — verify outbound remote sends appear with `## from …` headings (covered by same dual-cluster test via `cmd_convo` output)

Made with [Cursor](https://cursor.com)