### PR TITLE
feat(a8s): file-proxy inbox_dir and upload failure diagnostics

### DIFF
--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -352,15 +352,18 @@ cat > file-proxy.json << 'EOF'
 {"proxy": "file", "idle": {"timeout": 30}, "files_ttl_hours": 48}
 EOF
 
+# Optional: custom dirs (absolute paths OK)
+# {"proxy": "file", "inbox_dir": "/mnt/sync/in", "outbox_dir": "mail/out", "files_dir": ".files", ...}
+
 # Register with a mounted root directory
 a8s add my-email /mnt/gdrive/my-email/ file-proxy.json
 ```
 
 ### How it works
 
-- **On message:** A8S moves inbox JSON files into `<root>/.inbox/` instead of invoking a subprocess. The remote side polls `.inbox/`, processes, deletes.
-- **Outbox:** The remote side writes response envelopes to `<root>/.outbox/`. A8S ingests these on its normal routing pass (no change from regular agents).
-- **Files:** Tell copies attachments into `.outbox/<msg_id>/` before writing the envelope (filename only in JSON). Ingest moves the bundle with the JSON; routing delivers into `<files_dir>/<msg_id>/` on each recipient (default `files_dir` is `.files` under the agent root; absolute paths OK). Wake prompts use absolute `ATTACHED FILE: <path>` lines. A8S creates `files_dir` when waking and cleans up files older than `files_ttl_hours` (default 48) on each idle cycle.
+- **On message:** A8S moves inbox JSON files into the definition's `inbox_dir` (default `<root>/.inbox/`) instead of invoking a subprocess. The remote side polls that directory, processes, deletes.
+- **Outbox:** The remote side writes response envelopes to the definition's `outbox_dir` (default `<root>/.outbox/`). A8S ingests these on its normal routing pass (no change from regular agents).
+- **Files:** Tell copies attachments into `.outbox/<msg_id>/` before writing the envelope (filename only in JSON). Ingest moves the bundle with the JSON; routing delivers into `<files_dir>/<msg_id>/` on each recipient (default `files_dir` is `.files` under the agent root; absolute paths OK). Wake prompts use absolute `ATTACHED FILE: <path>` lines. A8S creates `files_dir` when waking CLI agents and cleans up files older than `files_ttl_hours` (default 48) on each idle cycle.
 - **Idle:** The `idle.timeout` controls how often A8S syncs (moves inbox files + runs TTL cleanup). No CLI is invoked.
 
 ### Filesystem layout (agent root)

--- a/apps/a8s/core.py
+++ b/apps/a8s/core.py
@@ -274,6 +274,23 @@ def files_dir(root: Path) -> Path:
     return resolve_files_path(root)
 
 
+def resolve_inbox_path(agent_root: Path, spec: str | None = None) -> Path:
+    """Resolve a file-proxy inbox directory from definition `inbox_dir`.
+
+    Relative paths are under `agent_root`; absolute paths are used as-is.
+    Default / omitted spec is `.inbox` under the agent root."""
+    raw = (spec if spec is not None else ".inbox").strip() or ".inbox"
+    p = Path(raw).expanduser()
+    if p.is_absolute():
+        return p.resolve()
+    return (agent_root / p).resolve()
+
+
+def inbox_dir(root: Path) -> Path:
+    """Default file-proxy inbox path: `<agent-root>/.inbox`."""
+    return resolve_inbox_path(root)
+
+
 def resolve_files_path(agent_root: Path, spec: str | None = None) -> Path:
     """Resolve an incoming-files directory from a definition `files_dir` value.
 
@@ -435,6 +452,7 @@ class Participant:
     safe_dirs: tuple[Path, ...] = ()
     outbox: Path | None = None
     files: Path | None = None
+    inbox: Path | None = None
 
     def outbox_path(self) -> Path:
         if self.outbox is not None:
@@ -445,6 +463,11 @@ class Participant:
         if self.files is not None:
             return self.files
         return files_dir(self.root)
+
+    def inbox_path(self) -> Path:
+        if self.inbox is not None:
+            return self.inbox
+        return inbox_dir(self.root)
 
     def files_bundle_dir(self, msg_id: str) -> Path:
         return inbound_bundle_dir(self.files_path(), msg_id)

--- a/apps/a8s/core.py
+++ b/apps/a8s/core.py
@@ -286,11 +286,6 @@ def resolve_inbox_path(agent_root: Path, spec: str | None = None) -> Path:
     return (agent_root / p).resolve()
 
 
-def inbox_dir(root: Path) -> Path:
-    """Default file-proxy inbox path: `<agent-root>/.inbox`."""
-    return resolve_inbox_path(root)
-
-
 def resolve_files_path(agent_root: Path, spec: str | None = None) -> Path:
     """Resolve an incoming-files directory from a definition `files_dir` value.
 
@@ -467,7 +462,7 @@ class Participant:
     def inbox_path(self) -> Path:
         if self.inbox is not None:
             return self.inbox
-        return inbox_dir(self.root)
+        return resolve_inbox_path(self.root)
 
     def files_bundle_dir(self, msg_id: str) -> Path:
         return inbound_bundle_dir(self.files_path(), msg_id)

--- a/apps/a8s/daemon.py
+++ b/apps/a8s/daemon.py
@@ -136,8 +136,8 @@ def _tell_outbox_env(p: Participant) -> dict[str, str]:
 
 
 def _deliver_file_proxy(p: Participant) -> None:
-    """Move ALL inbox files to <root>/.inbox/ for file-proxy agents."""
-    dest = p.root / ".inbox"
+    """Move ALL inbox files to the agent's file-proxy inbox dir."""
+    dest = p.inbox_path()
     dest.mkdir(parents=True, exist_ok=True)
     src = inbox_dir(p.name)
     if not src.is_dir():

--- a/apps/a8s/definitions.py
+++ b/apps/a8s/definitions.py
@@ -22,6 +22,7 @@ from core import (
     MARKER_FILES,
     SCRIPT_DIR,
     resolve_files_path,
+    resolve_inbox_path,
     resolve_outbox_path,
 )
 from registry import load_registry
@@ -80,6 +81,24 @@ def resolve_files_dir_for_agent(name: str, agent_root: Path) -> Path:
     except (FileNotFoundError, RuntimeError):
         definition = {}
     return resolve_files_dir(agent_root, definition)
+
+
+def resolve_inbox_dir(agent_root: Path, definition: dict) -> Path:
+    """File-proxy delivery dir from definition `inbox_dir` (default `.inbox`)."""
+    spec = definition.get("inbox_dir")
+    if spec is not None and not isinstance(spec, str):
+        raise ValueError("definition inbox_dir must be a string")
+    if isinstance(spec, str) and not spec.strip():
+        raise ValueError("definition inbox_dir must not be empty")
+    return resolve_inbox_path(agent_root, spec if isinstance(spec, str) else None)
+
+
+def resolve_inbox_dir_for_agent(name: str, agent_root: Path) -> Path:
+    try:
+        definition = load_definition(name)
+    except (FileNotFoundError, RuntimeError):
+        definition = {}
+    return resolve_inbox_dir(agent_root, definition)
 
 
 def load_definition(name: str) -> dict:

--- a/apps/a8s/mailbox.py
+++ b/apps/a8s/mailbox.py
@@ -121,27 +121,49 @@ def _msg_id_from_pending_json(name: str) -> str:
     return Path(name).stem
 
 
-def _resolve_pending_attachment(sender_name: str, msg_id: str, entry: dict) -> Path | None:
+def _pending_attachment_status(
+    sender_name: str, msg_id: str, entry: dict
+) -> tuple[Path | None, str]:
+    """Resolve a pending-bundle attachment for upload or local delivery.
+
+    Returns `(path, "")` on success or `(None, reason)` with a specific
+    diagnostic when the bytes cannot be read."""
+    if not (msg_id or "").strip():
+        return None, "missing message id"
     if (entry.get("path") or "").strip():
-        return None
+        return None, "files entry has path field (expected filename-only pending shape)"
     filename = (entry.get("filename") or "").strip()
-    if not filename or filename != Path(filename).name:
-        return None
+    if not filename:
+        return None, "missing filename in files entry"
+    if filename != Path(filename).name:
+        return None, f"filename {filename!r} is not a basename"
     bundle = pending_bundle_dir(sender_name, msg_id).resolve()
     try:
         src = (bundle / filename).resolve()
         src.relative_to(bundle)
-    except (ValueError, OSError, RuntimeError):
-        return None
+    except ValueError:
+        return None, f"path escapes pending bundle {bundle}"
+    except (OSError, RuntimeError) as e:
+        return None, f"cannot resolve {bundle / filename}: {e}"
+    if not src.exists():
+        return None, f"not found: {src}"
+    if src.is_dir():
+        return None, f"is a directory, not a file: {src}"
     if not src.is_file():
-        return None
+        return None, f"not a regular file: {src}"
     try:
         size = src.stat().st_size
-    except OSError:
-        return None
-    if size > _max_file_bytes():
-        return None
-    return src
+    except OSError as e:
+        return None, f"cannot stat {src}: {e}"
+    max_bytes = _max_file_bytes()
+    if size > max_bytes:
+        return None, f"size {size} bytes exceeds max_file_bytes ({max_bytes})"
+    return src, ""
+
+
+def _resolve_pending_attachment(sender_name: str, msg_id: str, entry: dict) -> Path | None:
+    path, _ = _pending_attachment_status(sender_name, msg_id, entry)
+    return path
 
 
 def _transfer_file_to_recipient(
@@ -160,9 +182,12 @@ def _transfer_file_to_recipient(
     filename = (entry.get("filename") or "").strip()
     if not filename:
         return None
-    src_resolved = _resolve_pending_attachment(sender_name, msg_id, entry)
+    src_resolved, reason = _pending_attachment_status(sender_name, msg_id, entry)
     if src_resolved is None:
-        out_agent(sender_name, f"FILE: staged attachment missing or invalid: {filename!r}")
+        out_agent(
+            sender_name,
+            f"FILE: staged attachment missing or invalid: {filename!r} ({reason})",
+        )
         return None
     dest_dir = recipient.files_bundle_dir(msg_id)
     dest_dir.mkdir(parents=True, exist_ok=True)
@@ -365,13 +390,23 @@ def _upload_files_for_remote(
         if not filename:
             continue
         per_file = uploaded.setdefault(filename, {})
-        src = _resolve_file_source(sender.name, msg_id, entry) if msg_id else None
+        src, src_reason = (
+            _pending_attachment_status(sender.name, msg_id, entry)
+            if msg_id
+            else (None, "missing message id")
+        )
         if src is None and any(s.id not in per_file for s in services):
             out_agent(
                 sender.name,
-                f"FILE: cannot read source for upload (filename={filename!r}); will retry",
+                f"FILE: cannot read source for upload (filename={filename!r}): {src_reason}; will retry",
             )
-            txlog.log("FILE_UPLOAD_FAILED", msg_id=msg.get("id", ""), sender=sender.name, files=[filename], detail="source unreadable")
+            txlog.log(
+                "FILE_UPLOAD_FAILED",
+                msg_id=msg.get("id", ""),
+                sender=sender.name,
+                files=[filename],
+                detail=src_reason,
+            )
             all_done = False
             continue
         for service in services:

--- a/apps/a8s/registry.py
+++ b/apps/a8s/registry.py
@@ -193,9 +193,16 @@ def participants_from_registry() -> list[Participant]:
                 safe_dirs=tuple(safe_dirs),
                 outbox=_participant_outbox(name, root),
                 files=_participant_files(name, root),
+                inbox=_participant_inbox(name, root),
             )
         )
     return parts
+
+
+def _participant_inbox(name: str, root: Path) -> Path:
+    from definitions import resolve_inbox_dir_for_agent
+
+    return resolve_inbox_dir_for_agent(name, root)
 
 
 def _participant_files(name: str, root: Path) -> Path:

--- a/apps/a8s/settings.py
+++ b/apps/a8s/settings.py
@@ -72,6 +72,7 @@ KNOBS: tuple[Knob, ...] = (
     Knob("definition.invoke", None, "definition", False, note="Required argv template for message wakes"),
     Knob("definition.outbox_dir", ".outbox", "definition", False, note="Tell outbox under agent root (absolute OK); a8s injects TELL_OUTBOX_DIR on wake"),
     Knob("definition.files_dir", ".files", "definition", False, note="Inbound attachment root (absolute OK)"),
+    Knob("definition.inbox_dir", ".inbox", "definition", False, note="File-proxy only: where wake moves inbox JSON for remote polling"),
     Knob("definition.files_ttl_hours", 48, "definition", False, note="Attachment TTL cleanup on idle (hours)"),
     Knob("definition.pause", 0, "definition", False, note="Debounce seconds before waking on a message burst"),
     Knob("definition.batch.invoke", None, "definition", False, note="Argv when 2+ inbox messages waiting"),

--- a/apps/a8s/tests/test_definitions.py
+++ b/apps/a8s/tests/test_definitions.py
@@ -17,6 +17,7 @@ from definitions import (
     default_definition_path,
     load_definition,
     resolve_files_dir,
+    resolve_inbox_dir,
     resolve_outbox_dir,
 )
 
@@ -337,6 +338,39 @@ class TestResolveFilesDir:
     def test_rejects_empty(self, tmp_path):
         with pytest.raises(ValueError, match="must not be empty"):
             resolve_files_dir(tmp_path, {"files_dir": "  "})
+
+
+# ---------- resolve_inbox_dir ----------
+
+class TestResolveInboxDir:
+    def test_default_relative(self, tmp_path):
+        root = tmp_path / "agent"
+        root.mkdir()
+        assert resolve_inbox_dir(root, {"proxy": "file"}) == (root / ".inbox").resolve()
+
+    def test_explicit_relative(self, tmp_path):
+        root = tmp_path / "agent"
+        root.mkdir()
+        assert resolve_inbox_dir(root, {"proxy": "file", "inbox_dir": "sync/in"}) == (
+            root / "sync" / "in"
+        ).resolve()
+
+    def test_absolute(self, tmp_path):
+        root = tmp_path / "agent"
+        root.mkdir()
+        external = tmp_path / "external-inbox"
+        external.mkdir()
+        assert resolve_inbox_dir(
+            root, {"proxy": "file", "inbox_dir": str(external)}
+        ) == external.resolve()
+
+    def test_rejects_non_string(self, tmp_path):
+        with pytest.raises(ValueError, match="inbox_dir must be a string"):
+            resolve_inbox_dir(tmp_path, {"inbox_dir": 1})
+
+    def test_rejects_empty(self, tmp_path):
+        with pytest.raises(ValueError, match="must not be empty"):
+            resolve_inbox_dir(tmp_path, {"inbox_dir": "  "})
 
 
 # ---------- load_definition ----------

--- a/apps/a8s/tests/test_file_proxy.py
+++ b/apps/a8s/tests/test_file_proxy.py
@@ -18,18 +18,31 @@ from core import (
 from daemon import attached_loop, maybe_run_idle, wake_once
 from definitions import files_ttl_seconds, is_file_proxy
 from mailbox import _write_outbox, ensure_mailboxes
-from registry import save_registry
+from registry import participants_from_registry, save_registry
 
 
 def _read_log(name: str) -> str:
     return agent_log_path(name).read_text() if agent_log_path(name).is_file() else ""
 
 
-def _write_file_proxy_def(path: Path, *, timeout: int = 30, ttl_hours: int | None = None) -> None:
+def _write_file_proxy_def(
+    path: Path,
+    *,
+    timeout: int = 30,
+    ttl_hours: int | None = None,
+    inbox_dir: str | None = None,
+) -> None:
     defn: dict = {"proxy": "file", "idle": {"timeout": timeout}}
     if ttl_hours is not None:
         defn["files_ttl_hours"] = ttl_hours
+    if inbox_dir is not None:
+        defn["inbox_dir"] = inbox_dir
     path.write_text(json.dumps(defn))
+
+
+def _proxy_participant(name: str, root: Path, defp: Path) -> Participant:
+    save_registry({name: {"root": str(root.resolve()), "definition": str(defp.resolve())}})
+    return next(p for p in participants_from_registry() if p.name == name)
 
 
 class TestIsFileProxy:
@@ -82,6 +95,25 @@ class TestWakeOnceFileProxy:
         assert delivered.is_file()
         assert json.loads(delivered.read_text())["content"] == "hello"
         assert "proxy: delivered test1.json" in _read_log("PROXY")
+
+    def test_delivers_to_custom_inbox_dir(self, fake_home, tmp_path):
+        d = tmp_path / "agent"
+        d.mkdir()
+        external = tmp_path / "sync-inbox"
+        defp = tmp_path / "proxy.json"
+        _write_file_proxy_def(defp, inbox_dir=str(external))
+        p = _proxy_participant("PROXY", d, defp)
+        ensure_mailboxes(p)
+
+        msg = {"id": "test1", "from": "ALICE", "to": "PROXY", "content": "hello", "files": []}
+        msg_file = inbox_dir("PROXY") / "test1.json"
+        msg_file.write_text(json.dumps(msg))
+
+        wake_once(p, msg_file)
+
+        delivered = external / "test1.json"
+        assert delivered.is_file()
+        assert not (d / ".inbox" / "test1.json").exists()
 
     def test_batch_delivers_all_inbox_files(self, fake_home, tmp_path):
         d = tmp_path / "agent"
@@ -189,6 +221,33 @@ class TestIdleFileProxy:
         log = _read_log("PROXY")
         assert "TTL cleanup removed 1 file(s)" in log
 
+    def test_idle_uses_custom_files_dir_for_ttl(self, fake_home, tmp_path):
+        d = tmp_path / "agent"
+        d.mkdir()
+        external_files = tmp_path / "attachment-store"
+        defp = tmp_path / "proxy.json"
+        defp.write_text(
+            json.dumps(
+                {
+                    "proxy": "file",
+                    "idle": {"timeout": 1},
+                    "files_ttl_hours": 1,
+                    "files_dir": str(external_files),
+                }
+            )
+        )
+        p = _proxy_participant("PROXY", d, defp)
+        ensure_mailboxes(p)
+
+        external_files.mkdir(parents=True, exist_ok=True)
+        old_file = external_files / "old.txt"
+        old_file.write_text("expired")
+        os.utime(old_file, (time.time() - 7200, time.time() - 7200))
+
+        touch_last_active("PROXY", datetime.now(timezone.utc) - timedelta(seconds=60))
+        assert maybe_run_idle(p) is True
+        assert not old_file.is_file()
+
     def test_idle_skips_when_not_yet_expired(self, fake_home, tmp_path):
         d = tmp_path / "agent"
         d.mkdir()
@@ -233,3 +292,30 @@ class TestAttachedLoopFileProxy:
         content = json.loads(delivered[0].read_text())
         assert content["content"] == "file-proxy test"
         assert "proxy: delivered" in _read_log("PROXY")
+
+    def test_custom_inbox_dir_via_attached_loop(self, fake_home, tmp_path, fixtures_dir):
+        sender_root = tmp_path / "sender"
+        proxy_root = tmp_path / "proxy"
+        inbox_external = tmp_path / "drive-inbox"
+        sender_root.mkdir()
+        proxy_root.mkdir()
+
+        defp = tmp_path / "proxy.json"
+        _write_file_proxy_def(defp, inbox_dir=str(inbox_external))
+
+        save_registry({
+            "SENDER": {"root": str(sender_root), "definition": str(fixtures_dir / "mock.json")},
+            "PROXY": {"root": str(proxy_root), "definition": str(defp)},
+        })
+        ensure_mailboxes(Participant("SENDER", sender_root))
+        ensure_mailboxes(Participant("PROXY", proxy_root))
+
+        _write_outbox("SENDER", sender_root, "PROXY", "custom inbox", [])
+
+        rc = attached_loop(["SENDER", "PROXY"], 0.1, single_pass=True)
+        assert rc == 0
+
+        delivered = list(inbox_external.glob("*.json"))
+        assert len(delivered) == 1
+        assert json.loads(delivered[0].read_text())["content"] == "custom inbox"
+        assert not (proxy_root / ".inbox").exists()

--- a/apps/a8s/tests/test_mailbox.py
+++ b/apps/a8s/tests/test_mailbox.py
@@ -21,13 +21,79 @@ from core import (
     trash_dir,
 )
 from mailbox import (
+    _pending_attachment_status,
     _split_content_and_files,
+    _upload_files_for_remote,
     _write_outbox,
     ensure_mailboxes,
     next_inbox_message,
     route_outboxes,
 )
 from registry import participants_from_registry, save_aliases, save_registry
+
+
+class TestPendingAttachmentStatus:
+    def test_missing_bundle_file(self, fake_home):
+        path, reason = _pending_attachment_status(
+            "A",
+            "01TEST",
+            {"filename": "missing.tif"},
+        )
+        assert path is None
+        assert reason.startswith("not found:")
+
+    def test_oversize_file(self, fake_home, tmp_path, monkeypatch):
+        monkeypatch.setenv("A8S_MAX_FILE_BYTES", "10")
+        bundle = pending_dir("A") / "01TEST"
+        bundle.mkdir(parents=True)
+        big = bundle / "huge.tif"
+        big.write_bytes(b"x" * 20)
+        path, reason = _pending_attachment_status(
+            "A",
+            "01TEST",
+            {"filename": "huge.tif"},
+        )
+        assert path is None
+        assert "exceeds max_file_bytes" in reason
+
+    def test_path_field_rejected(self, fake_home):
+        path, reason = _pending_attachment_status(
+            "A",
+            "01TEST",
+            {"filename": "x.tif", "path": "/tmp/x.tif"},
+        )
+        assert path is None
+        assert "path field" in reason
+
+    def test_upload_logs_specific_reason(self, fake_home, tmp_path):
+        from txlog import _txlog_path
+
+        a_root = tmp_path / "a"
+        a_root.mkdir()
+        save_registry({"A": {"root": str(a_root)}})
+        a = Participant("A", a_root)
+        ensure_mailboxes(a)
+        pending = pending_dir("A") / "01UPLOAD"
+        pending.mkdir(parents=True)
+        (pending / "01UPLOAD.json").write_text(
+            json.dumps(
+                {
+                    "id": "01UPLOAD",
+                    "from": "A",
+                    "to": "REMOTE",
+                    "content": "see file",
+                    "files": [{"filename": "Scan.TIF"}],
+                }
+            )
+        )
+        sidecar = {"attempts": 0, "uploaded": {}}
+        msg = json.loads((pending / "01UPLOAD.json").read_text())
+        ok = _upload_files_for_remote(msg, a, [_StubStorage("svc")], sidecar)
+        assert ok is False
+        lines = _txlog_path().read_text().splitlines()
+        failed = [ln for ln in lines if "\tFILE_UPLOAD_FAILED\t" in ln]
+        assert len(failed) == 1
+        assert "not found:" in failed[0].split("\t")[-1]
 
 
 def _write_staged(sender_name: str, sender_root: Path, to: str, content: str, *sources: Path) -> Path:

--- a/apps/a8s/tests/test_registry.py
+++ b/apps/a8s/tests/test_registry.py
@@ -279,6 +279,21 @@ class TestParticipantsFromRegistry:
         assert len(parts) == 1
         assert parts[0].files_path() == external.resolve()
 
+    def test_resolves_inbox_dir_from_definition(self, fake_home, tmp_path):
+        import json
+
+        root = tmp_path / "agent"
+        root.mkdir()
+        external = tmp_path / "external-inbox"
+        defn = tmp_path / "def.json"
+        defn.write_text(
+            json.dumps({"proxy": "file", "inbox_dir": str(external)})
+        )
+        save_registry({"A": {"root": str(root), "definition": str(defn)}})
+        parts = participants_from_registry()
+        assert len(parts) == 1
+        assert parts[0].inbox_path() == external.resolve()
+
 
 # ---------- parse_name + _scan_for_markers ----------
 


### PR DESCRIPTION
## PR Checklist

### Code Quality
- [x] No `__pycache__` or `.pyc` files in git
- [x] No hardcoded secrets (API keys, passwords, bridge URLs, MQTT creds)
- [x] No PII in committed code or PR description (real emails, phone numbers — use example.com)
- [x] No SQL string interpolation (all queries use `?` parameters)
- [x] No raw `except:` without specific exception types
- [x] No dead imports or unused variables
- [x] Runtime artifacts gitignored (`.db`, `.log`, `.count`, `health.txt`, `stimulus.txt`)

### Testing
- [ ] Integration tests pass (`lifetime.sh`)
- [x] Unit tests pass (if applicable: `pytest`)
- [ ] Manual verification of new features

### Documentation
- [ ] Textbook updated if architecture changed
- [x] README updated if organ/CLI interface changed

### Review
- [ ] Critic agent reviewed before merge

## Summary

- **File-proxy `inbox_dir`:** definition field (default `.inbox`, absolute OK) resolved via registry into `Participant.inbox_path()` — replaces hardcoded `<root>/.inbox/` for wake/idle delivery.
- **Upload diagnostics:** `FILE_UPLOAD_FAILED` and agent logs now report why pending-bundle reads fail (`not found`, `cannot stat`, oversize, bad envelope shape) instead of generic `source unreadable`.

## Test plan

- [x] `pytest apps/a8s/tests/test_file_proxy.py`
- [x] `pytest apps/a8s/tests/test_definitions.py::TestResolveInboxDir`
- [x] `pytest apps/a8s/tests/test_mailbox.py::TestPendingAttachmentStatus`
- [x] `pytest apps/a8s/tests/test_registry.py::TestParticipantsFromRegistry::test_resolves_inbox_dir_from_definition`


Made with [Cursor](https://cursor.com)