### PR TITLE
feat(n0b): quota command for Antigravity (agy) rate limits

### DIFF
--- a/apps/n0b/README.md
+++ b/apps/n0b/README.md
@@ -26,6 +26,7 @@ Detailed docs live in [`docs/`](docs/):
 | [secrets.md](docs/secrets.md) | `n0b secrets` | Get/set secrets — env, `~/lib`, Keychain, dotenv |
 | [ai-speak.md](docs/ai-speak.md) | `n0b ai speak` | Local Kokoro text-to-speech, markdown-aware |
 | [transcribe.md](docs/transcribe.md) | `n0b ai transcribe` | Local Whisper speech-to-text, hints + replacement files |
+| [quota.md](docs/quota.md) | `n0b quota` | Live AI tool rate limits (Antigravity / `agy`) |
 
 ### Quick reference (no separate doc yet)
 
@@ -37,6 +38,7 @@ Detailed docs live in [`docs/`](docs/):
 | `mqtt` | `pub`, `sub` | `mosquitto_*` with `MQTT_HOST`, `MQTT_PORT`, `MQTT_USER`, `MQTT_PASS` |
 | `ai` | `image`, `video`, `audio`, `research`, `speak`, `transcribe` | See [ltx-video.md](docs/ltx-video.md) for video; [research.md](docs/research.md) for deep research; [ai-speak.md](docs/ai-speak.md) for text-to-speech; [transcribe.md](docs/transcribe.md) for speech-to-text |
 | `video` | `last-frame` | Extract last frame with `ffmpeg` |
+| `quota` | `[agy]` | Live AI tool quotas (`agy` = Antigravity language-server API) |
 
 ### AI model defaults
 

--- a/apps/n0b/cli.py
+++ b/apps/n0b/cli.py
@@ -10,6 +10,7 @@ from commands.gpu_cmd import cmd_cuda, cmd_mb_free, cmd_mlx, cmd_mps
 from commands.json_cmd import cmd_json
 from commands.mqtt_cmd import cmd_pub, cmd_sub
 from commands.ports_cmd import cmd_free, cmd_listen
+from commands.quota_cmd import cmd_quota
 from commands.secrets_cmd import cmd_get, cmd_set
 from commands.video_cmd import cmd_last_frame
 
@@ -159,6 +160,20 @@ def build_parser() -> argparse.ArgumentParser:
     last_frame.add_argument("video")
     last_frame.add_argument("-o", "--output")
 
+    quota_p = sub.add_parser("quota", help="Check AI tool usage quotas")
+    quota_p.add_argument(
+        "tools",
+        nargs="*",
+        metavar="TOOL",
+        help="Tool id(s) to query (default: all installed). Supported: agy",
+    )
+    quota_p.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    quota_p.add_argument(
+        "--raw",
+        action="store_true",
+        help="Include raw Antigravity API payload in JSON output",
+    )
+
     return parser
 
 
@@ -228,6 +243,8 @@ def dispatch(args: argparse.Namespace) -> int:
     if group == "video":
         if args.video_cmd == "last-frame":
             return cmd_last_frame(args.video, args.output)
+    if group == "quota":
+        return cmd_quota(args.tools, as_json=args.json, raw=args.raw)
     print(f"n0b: unhandled command group {group!r}", file=sys.stderr)
     return 2
 

--- a/apps/n0b/commands/quota_cmd.py
+++ b/apps/n0b/commands/quota_cmd.py
@@ -17,11 +17,9 @@ LIVE_ENDPOINTS = {
     "userStatus": "/exa.language_server_pb.LanguageServerService/GetUserStatus",
     "commandModelConfigs": "/exa.language_server_pb.LanguageServerService/GetCommandModelConfigs",
     "userQuotaSummary": "/exa.language_server_pb.LanguageServerService/GetUserQuotaSummary",
-    "unleash": "/exa.language_server_pb.LanguageServerService/GetUnleashData",
 }
 
 REQUEST_TIMEOUT_S = 8
-PROBE_TIMEOUT_S = 1.5
 
 _SSL_CTX = ssl.create_default_context()
 _SSL_CTX.check_hostname = False
@@ -112,23 +110,28 @@ def detect_antigravity_process() -> dict[str, Any]:
     return candidates[0][1]
 
 
-def _cli_log_ports_for_pid(pid: int) -> list[int]:
+def _cli_log_port_map(pid: int) -> dict[str, int]:
     log_dir = Path.home() / ".gemini" / "antigravity-cli" / "log"
     if not log_dir.is_dir():
-        return []
+        return {}
 
-    ports: list[int] = []
     for log_path in sorted(log_dir.glob("cli-*.log"), key=lambda p: p.stat().st_mtime, reverse=True)[:5]:
         text = log_path.read_text(encoding="utf-8", errors="replace")
         if f"language server process with pid {pid}" not in text:
             continue
-        ports.extend(int(m.group(1)) for m in re.finditer(r"listening on random port at (\d+)", text))
+        ports: dict[str, int] = {}
+        for match in re.finditer(r"listening on random port at (\d+) for (HTTPS \(gRPC\)|HTTP)", text):
+            port = int(match.group(1))
+            if "HTTPS" in match.group(2):
+                ports["https"] = port
+            else:
+                ports["http"] = port
         if ports:
-            break
-    return sorted({p for p in ports if p > 0}, reverse=True)
+            return ports
+    return {}
 
 
-def get_listening_ports(pid: int) -> list[int]:
+def _lsof_listen_ports(pid: int) -> list[int]:
     lsof = next((p for p in ("/usr/bin/lsof", "/usr/sbin/lsof") if shutil.which(p)), None)
     if not lsof:
         raise RuntimeError("lsof is required to discover Antigravity's local API port.")
@@ -139,14 +142,38 @@ def get_listening_ports(pid: int) -> list[int]:
         text=True,
         check=False,
     )
-    ports = [int(m.group(1)) for m in re.finditer(r":(\d+)\s+\(LISTEN\)", proc.stdout)]
-    merged = sorted({p for p in ports if p > 0} | set(_cli_log_ports_for_pid(pid)), reverse=True)
-    if not merged:
+    return sorted(
+        {int(m.group(1)) for m in re.finditer(r":(\d+)\s+\(LISTEN\)", proc.stdout) if int(m.group(1)) > 0}
+    )
+
+
+def resolve_api_ports(process_info: dict[str, Any]) -> dict[str, int | None]:
+    pid = process_info["pid"]
+    port_map = _cli_log_port_map(pid)
+    lsof_ports = _lsof_listen_ports(pid)
+    https_port = port_map.get("https")
+    http_port = port_map.get("http") or process_info.get("extension_port")
+
+    if len(lsof_ports) >= 2:
+        lower, upper = lsof_ports[0], lsof_ports[-1]
+        https_port = https_port or lower
+        http_port = http_port or upper
+    elif len(lsof_ports) == 1:
+        only = lsof_ports[0]
+        https_port = https_port or only
+        http_port = http_port or only
+
+    if not https_port and not http_port:
         raise RuntimeError(
             f"Antigravity pid {pid} has no local quota API listeners. "
             "agy --print exits too quickly; use a persistent agy --continue or interactive session."
         )
-    return merged
+    return {"https": https_port, "http": http_port}
+
+
+def get_listening_ports(pid: int) -> list[int]:
+    ports = resolve_api_ports({"pid": pid, "extension_port": None})
+    return sorted({p for p in (ports["https"], ports["http"]) if p}, reverse=True)
 
 
 def _default_request_body() -> dict[str, Any]:
@@ -156,26 +183,6 @@ def _default_request_body() -> dict[str, Any]:
             "extensionName": "n0b-quota",
             "ideVersion": "unknown",
             "locale": "en",
-        }
-    }
-
-
-def _unleash_request_body() -> dict[str, Any]:
-    import platform
-
-    return {
-        "context": {
-            "properties": {
-                "devMode": "false",
-                "extensionVersion": "0.1.0",
-                "hasAnthropicModelAccess": "true",
-                "ide": "antigravity",
-                "ideVersion": "unknown",
-                "installationId": "n0b-quota",
-                "language": "UNSPECIFIED",
-                "os": platform.system().lower(),
-                "requestedModelId": "MODEL_UNSPECIFIED",
-            }
         }
     }
 
@@ -218,7 +225,7 @@ def _post_local(
 
 
 def _make_request(
-    https_port: int,
+    https_port: int | None,
     http_port: int | None,
     csrf_token: str,
     path: str,
@@ -226,46 +233,31 @@ def _make_request(
     *,
     timeout: float = REQUEST_TIMEOUT_S,
 ) -> str:
-    try:
-        return _post_local(https_port, csrf_token, path, body, use_ssl=True, timeout=timeout)
-    except RuntimeError:
-        if http_port and http_port != https_port:
+    last_error: RuntimeError | None = None
+    if https_port:
+        try:
+            return _post_local(https_port, csrf_token, path, body, use_ssl=True, timeout=timeout)
+        except RuntimeError as exc:
+            last_error = exc
+    if http_port and http_port != https_port:
+        try:
             return _post_local(http_port, csrf_token, path, body, use_ssl=False, timeout=timeout)
-        raise
-
-
-def find_working_port(ports: list[int], csrf_token: str, http_port: int | None = None) -> int:
-    if csrf_token:
-        for port in ports:
-            try:
-                _make_request(port, http_port, csrf_token, LIVE_ENDPOINTS["unleash"], _unleash_request_body(), timeout=PROBE_TIMEOUT_S)
-                return port
-            except RuntimeError:
-                continue
-    else:
-        for port in ports:
-            try:
-                _post_local(port, "", LIVE_ENDPOINTS["unleash"], _unleash_request_body(), use_ssl=False, timeout=PROBE_TIMEOUT_S)
-                return port
-            except RuntimeError:
-                try:
-                    _post_local(port, "", LIVE_ENDPOINTS["unleash"], _unleash_request_body(), use_ssl=True, timeout=PROBE_TIMEOUT_S)
-                    return port
-                except RuntimeError:
-                    continue
-    raise RuntimeError("Could not find Antigravity's local quota API port.")
+        except RuntimeError as exc:
+            last_error = exc
+    if last_error:
+        raise last_error
+    raise RuntimeError("No Antigravity API port available.")
 
 
 def fetch_raw_agy_quota() -> dict[str, Any]:
     process_info = detect_antigravity_process()
-    ports = get_listening_ports(process_info["pid"])
-    api_port = find_working_port(ports, process_info["csrf_token"], process_info["extension_port"])
-    extension_port = process_info["extension_port"]
+    api_ports = resolve_api_ports(process_info)
+    api_port = api_ports["https"] or api_ports["http"]
 
     try:
         raw = _make_request(
-            api_port,
-            extension_port,
+            api_ports["https"],
+            api_ports["http"],
             process_info["csrf_token"],
             LIVE_ENDPOINTS["userQuotaSummary"],
             _default_request_body(),
@@ -279,8 +271,8 @@ def fetch_raw_agy_quota() -> dict[str, Any]:
 
     try:
         raw = _make_request(
-            api_port,
-            extension_port,
+            api_ports["https"],
+            api_ports["http"],
             process_info["csrf_token"],
             LIVE_ENDPOINTS["userStatus"],
             _default_request_body(),
@@ -288,8 +280,8 @@ def fetch_raw_agy_quota() -> dict[str, Any]:
         return {"json": json.loads(raw), "shape": "userStatus", "api_port": api_port}
     except (RuntimeError, json.JSONDecodeError):
         raw = _make_request(
-            api_port,
-            extension_port,
+            api_ports["https"],
+            api_ports["http"],
             process_info["csrf_token"],
             LIVE_ENDPOINTS["commandModelConfigs"],
             _default_request_body(),

--- a/apps/n0b/commands/quota_cmd.py
+++ b/apps/n0b/commands/quota_cmd.py
@@ -1,0 +1,669 @@
+"""AI tool quota checks — starting with Antigravity (agy)."""
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import ssl
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+LIVE_ENDPOINTS = {
+    "userStatus": "/exa.language_server_pb.LanguageServerService/GetUserStatus",
+    "commandModelConfigs": "/exa.language_server_pb.LanguageServerService/GetCommandModelConfigs",
+    "userQuotaSummary": "/exa.language_server_pb.LanguageServerService/GetUserQuotaSummary",
+    "unleash": "/exa.language_server_pb.LanguageServerService/GetUnleashData",
+}
+
+REQUEST_TIMEOUT_S = 8
+PROBE_TIMEOUT_S = 1.5
+
+_SSL_CTX = ssl.create_default_context()
+_SSL_CTX.check_hostname = False
+_SSL_CTX.verify_mode = ssl.CERT_NONE
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _extract_flag(command: str, flag: str) -> str | None:
+    escaped = re.escape(flag)
+    match = re.search(rf"{escaped}(?:=|\s+)([^\s]+)", command, re.IGNORECASE)
+    return match.group(1) if match else None
+
+
+def _parse_number(value: str | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except ValueError:
+        return None
+    return parsed if parsed >= 0 else None
+
+
+def detect_antigravity_process() -> dict[str, Any]:
+    proc = subprocess.run(
+        ["ps", "-ax", "-o", "pid=,command="],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError("Could not list processes (ps failed).")
+
+    candidates: list[tuple[int, dict[str, Any]]] = []
+    for line in proc.stdout.splitlines():
+        match = re.match(r"^(\d+)\s+(.+)$", line.strip())
+        if not match:
+            continue
+        pid = int(match.group(1))
+        command = match.group(2)
+        lower = command.lower()
+        is_language_server = (
+            "language_server" in lower
+            or "agentapi" in lower
+            or lower == "agy"
+            or lower.endswith("/agy")
+            or " /agy" in lower
+        )
+        is_antigravity = (
+            "antigravity" in lower
+            or "agy" in lower
+            or ".gemini/antigravity-cli" in lower
+        )
+        if not is_language_server or not is_antigravity:
+            continue
+
+        score = 0
+        if "language_server" in lower:
+            score += 100
+        if _extract_flag(command, "--csrf_token"):
+            score += 50
+        if "--continue" in lower:
+            score += 10
+        if "--print" in lower or "--prompt" in lower:
+            score -= 25
+        candidates.append(
+            (
+                score,
+                {
+                    "pid": pid,
+                    "command": command,
+                    "csrf_token": _extract_flag(command, "--csrf_token") or "",
+                    "extension_port": _parse_number(_extract_flag(command, "--extension_server_port")),
+                },
+            )
+        )
+
+    if not candidates:
+        raise RuntimeError(
+            "Antigravity language server is not running. "
+            "Start Antigravity IDE, an interactive agy session, or agy --continue."
+        )
+
+    candidates.sort(key=lambda item: item[0], reverse=True)
+    return candidates[0][1]
+
+
+def _cli_log_ports_for_pid(pid: int) -> list[int]:
+    log_dir = Path.home() / ".gemini" / "antigravity-cli" / "log"
+    if not log_dir.is_dir():
+        return []
+
+    ports: list[int] = []
+    for log_path in sorted(log_dir.glob("cli-*.log"), key=lambda p: p.stat().st_mtime, reverse=True)[:5]:
+        text = log_path.read_text(encoding="utf-8", errors="replace")
+        if f"language server process with pid {pid}" not in text:
+            continue
+        ports.extend(int(m.group(1)) for m in re.finditer(r"listening on random port at (\d+)", text))
+        if ports:
+            break
+    return sorted({p for p in ports if p > 0}, reverse=True)
+
+
+def get_listening_ports(pid: int) -> list[int]:
+    lsof = next((p for p in ("/usr/bin/lsof", "/usr/sbin/lsof") if shutil.which(p)), None)
+    if not lsof:
+        raise RuntimeError("lsof is required to discover Antigravity's local API port.")
+
+    proc = subprocess.run(
+        [lsof, "-nP", "-a", "-p", str(pid), "-iTCP", "-sTCP:LISTEN"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    ports = [int(m.group(1)) for m in re.finditer(r":(\d+)\s+\(LISTEN\)", proc.stdout)]
+    merged = sorted({p for p in ports if p > 0} | set(_cli_log_ports_for_pid(pid)), reverse=True)
+    if not merged:
+        raise RuntimeError(
+            f"Antigravity pid {pid} has no local quota API listeners. "
+            "agy --print exits too quickly; use a persistent agy --continue or interactive session."
+        )
+    return merged
+
+
+def _default_request_body() -> dict[str, Any]:
+    return {
+        "metadata": {
+            "ideName": "antigravity",
+            "extensionName": "n0b-quota",
+            "ideVersion": "unknown",
+            "locale": "en",
+        }
+    }
+
+
+def _unleash_request_body() -> dict[str, Any]:
+    import platform
+
+    return {
+        "context": {
+            "properties": {
+                "devMode": "false",
+                "extensionVersion": "0.1.0",
+                "hasAnthropicModelAccess": "true",
+                "ide": "antigravity",
+                "ideVersion": "unknown",
+                "installationId": "n0b-quota",
+                "language": "UNSPECIFIED",
+                "os": platform.system().lower(),
+                "requestedModelId": "MODEL_UNSPECIFIED",
+            }
+        }
+    }
+
+
+def _post_local(
+    port: int,
+    csrf_token: str,
+    path: str,
+    body: dict[str, Any],
+    *,
+    use_ssl: bool,
+    timeout: float = REQUEST_TIMEOUT_S,
+) -> str:
+    body_text = json.dumps(body).encode("utf-8")
+    url = f"{'https' if use_ssl else 'http'}://127.0.0.1:{port}{path}"
+    request = urllib.request.Request(
+        url,
+        data=body_text,
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "Content-Length": str(len(body_text)),
+            "Connect-Protocol-Version": "1",
+            "X-Codeium-Csrf-Token": csrf_token,
+        },
+    )
+    try:
+        with urllib.request.urlopen(
+            request,
+            timeout=timeout,
+            context=_SSL_CTX if use_ssl else None,
+        ) as response:
+            data = response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"Antigravity API returned HTTP {exc.code}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"Antigravity API request failed: {exc.reason}") from exc
+
+    return data
+
+
+def _make_request(
+    https_port: int,
+    http_port: int | None,
+    csrf_token: str,
+    path: str,
+    body: dict[str, Any],
+    *,
+    timeout: float = REQUEST_TIMEOUT_S,
+) -> str:
+    try:
+        return _post_local(https_port, csrf_token, path, body, use_ssl=True, timeout=timeout)
+    except RuntimeError:
+        if http_port and http_port != https_port:
+            return _post_local(http_port, csrf_token, path, body, use_ssl=False, timeout=timeout)
+        raise
+
+
+def find_working_port(ports: list[int], csrf_token: str, http_port: int | None = None) -> int:
+    if csrf_token:
+        for port in ports:
+            try:
+                _make_request(port, http_port, csrf_token, LIVE_ENDPOINTS["unleash"], _unleash_request_body(), timeout=PROBE_TIMEOUT_S)
+                return port
+            except RuntimeError:
+                continue
+    else:
+        for port in ports:
+            try:
+                _post_local(port, "", LIVE_ENDPOINTS["unleash"], _unleash_request_body(), use_ssl=False, timeout=PROBE_TIMEOUT_S)
+                return port
+            except RuntimeError:
+                try:
+                    _post_local(port, "", LIVE_ENDPOINTS["unleash"], _unleash_request_body(), use_ssl=True, timeout=PROBE_TIMEOUT_S)
+                    return port
+                except RuntimeError:
+                    continue
+    raise RuntimeError("Could not find Antigravity's local quota API port.")
+
+
+def fetch_raw_agy_quota() -> dict[str, Any]:
+    process_info = detect_antigravity_process()
+    ports = get_listening_ports(process_info["pid"])
+    api_port = find_working_port(ports, process_info["csrf_token"], process_info["extension_port"])
+    extension_port = process_info["extension_port"]
+
+    try:
+        raw = _make_request(
+            api_port,
+            extension_port,
+            process_info["csrf_token"],
+            LIVE_ENDPOINTS["userQuotaSummary"],
+            _default_request_body(),
+        )
+        payload = json.loads(raw)
+        parsed = parse_quota_response(payload, "quotaSummary")
+        if parsed["models"]:
+            return {"json": payload, "shape": "quotaSummary", "api_port": api_port}
+    except (RuntimeError, json.JSONDecodeError):
+        pass
+
+    try:
+        raw = _make_request(
+            api_port,
+            extension_port,
+            process_info["csrf_token"],
+            LIVE_ENDPOINTS["userStatus"],
+            _default_request_body(),
+        )
+        return {"json": json.loads(raw), "shape": "userStatus", "api_port": api_port}
+    except (RuntimeError, json.JSONDecodeError):
+        raw = _make_request(
+            api_port,
+            extension_port,
+            process_info["csrf_token"],
+            LIVE_ENDPOINTS["commandModelConfigs"],
+            _default_request_body(),
+        )
+        return {"json": json.loads(raw), "shape": "commandModelConfigs", "api_port": api_port}
+
+
+def fetch_agy_quota(*, include_raw: bool = False) -> dict[str, Any]:
+    raw = fetch_raw_agy_quota()
+    parsed = parse_quota_response(raw["json"], raw["shape"])
+    result = {
+        "tool": "agy",
+        "generated_at": _utc_now().isoformat(),
+        "source": raw["shape"],
+        "api_port": raw["api_port"],
+        **parsed,
+    }
+    if include_raw:
+        result["raw"] = raw["json"]
+    return result
+
+
+def _is_ok_code(code: Any) -> bool:
+    if code is None:
+        return True
+    if isinstance(code, int):
+        return code == 0
+    if isinstance(code, str):
+        return code.lower() in {"ok", "success", "0"}
+    if isinstance(code, dict):
+        return code.get("isOK") is True
+    return False
+
+
+def _read_number(value: Any) -> float | None:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed == parsed else None
+
+
+def _read_first(node: dict[str, Any], names: list[str]) -> Any:
+    for name in names:
+        if name in node:
+            return node[name]
+    return None
+
+
+def _parse_reset_time(value: Any) -> datetime | None:
+    if not value:
+        return None
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, (int, float)):
+        return datetime.fromtimestamp(value, tz=timezone.utc)
+    text = str(value)
+    try:
+        if text.isdigit():
+            return datetime.fromtimestamp(int(text), tz=timezone.utc)
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed
+    except ValueError:
+        return None
+
+
+def _title_case(value: str) -> str:
+    spaced = re.sub(r"([a-z])([A-Z])", r"\1 \2", value)
+    spaced = re.sub(r"[_-]+", " ", spaced)
+    return " ".join(part.capitalize() for part in spaced.split())
+
+
+def _has_quota_shape(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+    if any(key in value for key in ("quotaInfo", "quotaSummary", "usageLimits", "commandQuota")):
+        return True
+    return any(re.search(r"quota|limit|remaining|reset|usage", key, re.I) for key in value)
+
+
+def _walk_object(value: Any, visitor: Callable[[Any, list[str]], None], path: list[str] | None = None, seen: set[int] | None = None) -> None:
+    if path is None:
+        path = []
+    if seen is None:
+        seen = set()
+    if not isinstance(value, (dict, list)) or id(value) in seen:
+        return
+    seen.add(id(value))
+    if isinstance(value, dict):
+        visitor(value, path)
+        for key, child in value.items():
+            _walk_object(child, visitor, path + [str(key)], seen)
+    else:
+        for index, child in enumerate(value):
+            _walk_object(child, visitor, path + [str(index)], seen)
+
+
+def _find_model_configs(value: dict[str, Any]) -> list[dict[str, Any]]:
+    direct = (
+        value.get("cascadeModelConfigData", {}).get("clientModelConfigs")
+        or value.get("clientModelConfigs")
+        or value.get("modelConfigs")
+        or value.get("models")
+    )
+    if isinstance(direct, list):
+        return [item for item in direct if isinstance(item, dict)]
+
+    arrays: list[list[dict[str, Any]]] = []
+
+    def visitor(node: Any, path_parts: list[str]) -> None:
+        if not isinstance(node, list):
+            return
+        serialized = ".".join(path_parts).lower()
+        if any(
+            isinstance(item, dict)
+            and (
+                "model" in serialized
+                or item.get("model")
+                or item.get("modelId")
+                or item.get("modelOrAlias")
+                or item.get("label")
+            )
+            and _has_quota_shape(item)
+            for item in node
+        ):
+            arrays.append([item for item in node if isinstance(item, dict)])
+
+    _walk_object(value, visitor)
+    if not arrays:
+        return []
+    return max(arrays, key=len)
+
+
+def _read_fraction(node: dict[str, Any]) -> float | None:
+    remaining = _read_number(
+        _read_first(node, ["remainingFraction", "remainingRatio", "remainingPercent", "remainingPercentage"])
+    )
+    if remaining is not None:
+        return remaining / 100 if remaining > 1 else remaining
+
+    used = _read_number(_read_first(node, ["used", "usedCount", "consumed", "consumedCount", "usage"]))
+    limit = _read_number(_read_first(node, ["limit", "max", "maximum", "total", "quota", "capacity"]))
+    if used is not None and limit and limit > 0:
+        return max(0.0, min(1.0, 1.0 - used / limit))
+    return None
+
+
+def _quota_bucket_label(path_parts: list[str], node: dict[str, Any]) -> str:
+    explicit = _read_first(node, ["label", "displayName", "name", "period", "bucket", "window"])
+    if explicit and not isinstance(explicit, (dict, list)):
+        return _title_case(str(explicit))
+
+    text = " ".join(path_parts).lower()
+    if re.search(r"hourly|perhour|per_hour|\bhour\b", text):
+        return "Hourly"
+    if re.search(r"weekly|perweek|per_week|\bweek\b", text):
+        return "Weekly"
+    if re.search(r"daily|perday|per_day|\bday\b", text):
+        return "Daily"
+    if re.search(r"monthly|permonth|per_month|\bmonth\b", text):
+        return "Monthly"
+
+    useful = [part for part in path_parts if not part.isdigit()]
+    return _title_case(useful[-1]) if useful else "Quota"
+
+
+def _extract_quota_buckets(quota: Any) -> list[dict[str, Any]]:
+    buckets: list[dict[str, Any]] = []
+
+    def visitor(node: Any, path_parts: list[str]) -> None:
+        if not isinstance(node, dict):
+            return
+        remaining_fraction = _read_fraction(node)
+        reset_time = _parse_reset_time(_read_first(node, ["resetTime", "resetAt", "resetsAt", "nextResetTime"]))
+        used = _read_number(_read_first(node, ["used", "usedCount", "consumed", "consumedCount", "usage"]))
+        limit = _read_number(_read_first(node, ["limit", "max", "maximum", "total", "quota", "capacity"]))
+        if remaining_fraction is None and reset_time is None and (used is None or limit is None):
+            return
+        buckets.append(
+            {
+                "label": _quota_bucket_label(path_parts, node),
+                "remaining_fraction": remaining_fraction,
+                "reset_time": reset_time.isoformat() if reset_time else None,
+                "used": used,
+                "limit": limit,
+            }
+        )
+
+    _walk_object(quota, visitor)
+
+    seen: set[str] = set()
+    deduped: list[dict[str, Any]] = []
+    for bucket in buckets:
+        key = "|".join(
+            str(bucket.get(field, ""))
+            for field in ("label", "remaining_fraction", "reset_time", "used", "limit")
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(bucket)
+    return deduped
+
+
+def _parse_model_quota(config: dict[str, Any]) -> dict[str, Any] | None:
+    quota = (
+        config.get("quotaInfo")
+        or config.get("quotaSummary")
+        or config.get("usageLimits")
+        or config.get("commandQuota")
+        or config
+    )
+    label = (
+        config.get("label")
+        or config.get("displayName")
+        or config.get("name")
+        or (config.get("modelOrAlias") or {}).get("model")
+        or config.get("model")
+        or "Unknown model"
+    )
+    buckets = _extract_quota_buckets(quota)
+    if not buckets:
+        return None
+
+    for bucket in buckets:
+        if bucket["label"] == "Quota":
+            bucket["label"] = "Hourly"
+
+    fractions = [b["remaining_fraction"] for b in buckets if isinstance(b["remaining_fraction"], (int, float))]
+    reset_times = sorted(
+        b["reset_time"] for b in buckets if b.get("reset_time")
+    )
+    return {
+        "label": label,
+        "model_id": (config.get("modelOrAlias") or {}).get("model") or config.get("model") or config.get("modelId"),
+        "buckets": buckets,
+        "remaining_fraction": min(fractions) if fractions else None,
+        "reset_time": reset_times[0] if reset_times else None,
+    }
+
+
+def parse_quota_response(response: dict[str, Any], shape: str) -> dict[str, Any]:
+    if not _is_ok_code(response.get("code")):
+        raise RuntimeError("Antigravity quota API returned a non-OK response.")
+
+    status = response.get("userStatus", response) if shape == "userStatus" else response
+    configs = _find_model_configs(status)
+    models = sorted(
+        (m for m in (_parse_model_quota(cfg) for cfg in configs) if m),
+        key=lambda item: item["label"].lower(),
+    )
+    plan_info = (status.get("planStatus") or {}).get("planInfo") or {}
+    return {
+        "error": None,
+        "account": {
+            "email": status.get("email"),
+            "plan": plan_info.get("planDisplayName")
+            or plan_info.get("displayName")
+            or plan_info.get("productName")
+            or plan_info.get("planName"),
+        },
+        "available_prompt_credits": (status.get("planStatus") or {}).get("availablePromptCredits"),
+        "models": models,
+    }
+
+
+def _format_duration_until(iso_time: str | None) -> str | None:
+    if not iso_time:
+        return None
+    try:
+        reset = datetime.fromisoformat(iso_time.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if reset.tzinfo is None:
+        reset = reset.replace(tzinfo=timezone.utc)
+    diff_mins = max(0, round((reset - _utc_now()).total_seconds() / 60))
+    hours, mins = divmod(diff_mins, 60)
+    if hours:
+        return f"{hours}h {mins}m"
+    return f"{mins}m"
+
+
+def _format_bucket(bucket: dict[str, Any]) -> str:
+    fraction = bucket.get("remaining_fraction")
+    if not isinstance(fraction, (int, float)):
+        return "unknown"
+    percent = round(fraction * 100)
+    reset = _format_duration_until(bucket.get("reset_time"))
+    if reset:
+        return f"{percent}% remaining · refreshes in {reset}"
+    return f"{percent}% remaining"
+
+
+def format_agy_quota_text(payload: dict[str, Any]) -> str:
+    lines = ["Antigravity (agy)"]
+    plan = (payload.get("account") or {}).get("plan")
+    if plan:
+        lines[0] += f" — {plan}"
+
+    if payload.get("error"):
+        lines.append(f"Error: {payload['error']}")
+        return "\n".join(lines)
+
+    models = payload.get("models") or []
+    if not models:
+        lines.append("No model quota data returned.")
+        return "\n".join(lines)
+
+    for model in models:
+        lines.append("")
+        lines.append(model["label"])
+        for bucket in model.get("buckets") or []:
+            label = bucket.get("label") or "Quota"
+            if label in {"Hourly", "Quota"}:
+                label = "5h limit"
+            lines.append(f"  {label}: {_format_bucket(bucket)}")
+
+    credits = payload.get("available_prompt_credits")
+    if credits is not None:
+        lines.extend(["", f"Prompt credits: {credits}"])
+    return "\n".join(lines)
+
+
+QUOTA_TOOLS: dict[str, dict[str, Any]] = {
+    "agy": {
+        "name": "Antigravity",
+        "installed": lambda: shutil.which("agy") is not None,
+        "fetch": fetch_agy_quota,
+        "format": format_agy_quota_text,
+    },
+}
+
+
+def available_tool_names() -> list[str]:
+    return sorted(name for name, meta in QUOTA_TOOLS.items() if meta["installed"]())
+
+
+def cmd_quota(tools: list[str] | None, *, as_json: bool = False, raw: bool = False) -> int:
+    selected = [t.lower() for t in tools] if tools else available_tool_names()
+    if not selected:
+        print("n0b quota: no supported AI tools found on PATH.", file=sys.stderr)
+        print("Supported tools: agy (Antigravity)", file=sys.stderr)
+        return 1
+
+    unknown = [t for t in selected if t not in QUOTA_TOOLS]
+    if unknown:
+        print(
+            f"n0b quota: unknown tool(s): {', '.join(unknown)}",
+            file=sys.stderr,
+        )
+        print(f"Supported: {', '.join(sorted(QUOTA_TOOLS))}", file=sys.stderr)
+        return 2
+
+    results: list[dict[str, Any]] = []
+    exit_code = 0
+    for tool in selected:
+        meta = QUOTA_TOOLS[tool]
+        if not meta["installed"]():
+            payload = {"tool": tool, "error": f"{meta['name']} is not installed"}
+            results.append(payload)
+            exit_code = 1
+            continue
+        try:
+            payload = meta["fetch"](include_raw=raw)
+        except RuntimeError as exc:
+            payload = {"tool": tool, "error": str(exc)}
+            exit_code = 1
+        results.append(payload)
+
+    if as_json:
+        print(json.dumps(results[0] if len(results) == 1 else results, indent=2))
+    else:
+        chunks = [meta["format"](payload) for meta, payload in zip((QUOTA_TOOLS[r["tool"]] for r in results), results)]
+        print("\n\n".join(chunks))
+    return exit_code

--- a/apps/n0b/commands/quota_cmd.py
+++ b/apps/n0b/commands/quota_cmd.py
@@ -7,7 +7,9 @@ import shutil
 import ssl
 import subprocess
 import sys
+import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
@@ -21,6 +23,22 @@ LIVE_ENDPOINTS = {
 }
 
 REQUEST_TIMEOUT_S = 8
+
+SNAPSHOT_PATH = Path.home() / ".config" / "n0b" / "quota-agy.json"
+
+OAUTH_CREDS_PATH = Path.home() / ".gemini" / "oauth_creds.json"
+OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token"
+# Refreshing the token that gemini-cli/agy login writes to disk requires
+# gemini-cli's installed-app OAuth client pair. The values ship in
+# gemini-cli's public source but trip secret scanners, so they resolve via
+# n0b secrets (env, ~/lib, Keychain) instead of living in this repo.
+OAUTH_CLIENT_ID_SECRET_NAME = "GEMINI_OAUTH_CLIENT_ID"
+OAUTH_CLIENT_SECRET_SECRET_NAME = "GEMINI_OAUTH_CLIENT_SECRET"
+CLOUD_HOSTS = (
+    "https://cloudcode-pa.googleapis.com",
+    "https://daily-cloudcode-pa.googleapis.com",
+)
+CLOUD_LOAD_CODE_ASSIST = "/v1internal:loadCodeAssist"
 
 _SSL_CTX = ssl.create_default_context()
 _SSL_CTX.check_hostname = False
@@ -328,12 +346,13 @@ def fetch_raw_agy_quota() -> dict[str, Any]:
         return {"json": json.loads(raw), "shape": "commandModelConfigs", "api_port": api_port}
 
 
-def fetch_agy_quota(*, include_raw: bool = False) -> dict[str, Any]:
+def _fetch_agy_live(*, include_raw: bool = False) -> dict[str, Any]:
     raw = fetch_raw_agy_quota()
     parsed = parse_quota_response(raw["json"], raw["shape"])
     result = {
         "tool": "agy",
         "generated_at": _utc_now().isoformat(),
+        "origin": "live",
         "source": raw["shape"],
         "api_port": raw["api_port"],
         **parsed,
@@ -341,6 +360,204 @@ def fetch_agy_quota(*, include_raw: bool = False) -> dict[str, Any]:
     if include_raw:
         result["raw"] = raw["json"]
     return result
+
+
+def save_snapshot(payload: dict[str, Any]) -> None:
+    data = {
+        "saved_at": _utc_now().isoformat(),
+        "payload": {k: v for k, v in payload.items() if k != "raw"},
+    }
+    SNAPSHOT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp = SNAPSHOT_PATH.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(data), encoding="utf-8")
+    tmp.replace(SNAPSHOT_PATH)
+
+
+def load_snapshot() -> dict[str, Any] | None:
+    try:
+        data = json.loads(SNAPSHOT_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict) or "saved_at" not in data or "payload" not in data:
+        return None
+    return data
+
+
+def snapshot_age_text(saved_at_iso: str) -> str:
+    saved = datetime.fromisoformat(saved_at_iso.replace("Z", "+00:00"))
+    if saved.tzinfo is None:
+        saved = saved.replace(tzinfo=timezone.utc)
+    mins = max(0, round((_utc_now() - saved).total_seconds() / 60))
+    days, rem = divmod(mins, 1440)
+    hours, mins = divmod(rem, 60)
+    if days:
+        return f"{days}d {hours}h"
+    if hours:
+        return f"{hours}h {mins}m"
+    return f"{mins}m"
+
+
+def _load_oauth_creds() -> dict[str, Any]:
+    if not OAUTH_CREDS_PATH.is_file():
+        raise RuntimeError(
+            "Not logged in to Antigravity/Gemini — "
+            f"no OAuth credentials at {OAUTH_CREDS_PATH} (try: agy, then /login)"
+        )
+    try:
+        creds = json.loads(OAUTH_CREDS_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"Could not read {OAUTH_CREDS_PATH}: {exc} (try: agy, then /login)") from exc
+    if not creds.get("refresh_token"):
+        raise RuntimeError(
+            f"{OAUTH_CREDS_PATH} has no refresh_token (try: agy, then /login)"
+        )
+    return creds
+
+
+def _oauth_client_pair() -> tuple[str, str]:
+    from commands.secrets_cmd import resolve
+
+    client_id = resolve(OAUTH_CLIENT_ID_SECRET_NAME)
+    client_secret = resolve(OAUTH_CLIENT_SECRET_SECRET_NAME)
+    if not client_id or not client_secret:
+        raise RuntimeError(
+            "OAuth client pair not configured — set gemini-cli's public client "
+            f"(try: n0b secrets set {OAUTH_CLIENT_ID_SECRET_NAME}, "
+            f"then n0b secrets set {OAUTH_CLIENT_SECRET_SECRET_NAME})"
+        )
+    return client_id, client_secret
+
+
+def _cloud_access_token() -> str:
+    creds = _load_oauth_creds()
+    expiry_ms = creds.get("expiry_date")
+    if creds.get("access_token") and isinstance(expiry_ms, (int, float)):
+        if expiry_ms / 1000 > time.time() + 60:
+            return creds["access_token"]
+    client_id, client_secret = _oauth_client_pair()
+    body = urllib.parse.urlencode(
+        {
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "refresh_token": creds["refresh_token"],
+            "grant_type": "refresh_token",
+        }
+    ).encode("utf-8")
+    request = urllib.request.Request(OAUTH_TOKEN_URL, data=body, method="POST")
+    try:
+        with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT_S) as response:
+            token = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(
+            f"OAuth token refresh rejected (HTTP {exc.code}) — re-login needed (try: agy, then /login)"
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"OAuth token refresh failed: {exc.reason}") from exc
+    access = token.get("access_token")
+    if not access:
+        raise RuntimeError("OAuth token refresh returned no access_token (try: agy, then /login)")
+    return access
+
+
+def parse_cloud_quota(response: dict[str, Any]) -> dict[str, Any]:
+    plan = None
+    for tier_key in ("paidTier", "currentTier"):
+        tier = response.get(tier_key)
+        if isinstance(tier, dict) and tier.get("name"):
+            plan = tier["name"]
+            break
+    configs = _find_model_configs(response)
+    models = sorted(
+        (m for m in (_parse_model_quota(cfg) for cfg in configs) if m),
+        key=lambda item: item["label"].lower(),
+    )
+    return {
+        "error": None,
+        "account": {"email": None, "plan": plan},
+        "available_prompt_credits": None,
+        "models": models,
+        "groups": group_model_quotas(models),
+    }
+
+
+def fetch_agy_quota_cloud(*, include_raw: bool = False) -> dict[str, Any]:
+    token = _cloud_access_token()
+    body = json.dumps(
+        {
+            "metadata": {
+                "ideType": "ANTIGRAVITY",
+                "platform": "PLATFORM_UNSPECIFIED",
+                "pluginType": "GEMINI",
+            }
+        }
+    ).encode("utf-8")
+    last_error: RuntimeError | None = None
+    payload = None
+    for host in CLOUD_HOSTS:
+        request = urllib.request.Request(
+            host + CLOUD_LOAD_CODE_ASSIST,
+            data=body,
+            method="POST",
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {token}",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT_S) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+            break
+        except urllib.error.HTTPError as exc:
+            last_error = RuntimeError(f"loadCodeAssist returned HTTP {exc.code} at {host}")
+        except (urllib.error.URLError, json.JSONDecodeError) as exc:
+            last_error = RuntimeError(f"loadCodeAssist failed at {host}: {exc}")
+    if payload is None:
+        raise last_error or RuntimeError("loadCodeAssist failed")
+    result = {
+        "tool": "agy",
+        "generated_at": _utc_now().isoformat(),
+        "origin": "cloud",
+        "source": "loadCodeAssist",
+        **parse_cloud_quota(payload),
+    }
+    if include_raw:
+        result["raw"] = payload
+    return result
+
+
+def fetch_agy_quota(*, include_raw: bool = False) -> dict[str, Any]:
+    errors: list[str] = []
+    try:
+        result = _fetch_agy_live(include_raw=include_raw)
+        save_snapshot(result)
+        return result
+    except RuntimeError as exc:
+        errors.append(f"live: {exc}")
+
+    cloud_result: dict[str, Any] | None = None
+    try:
+        cloud_result = fetch_agy_quota_cloud(include_raw=include_raw)
+        if cloud_result["models"]:
+            save_snapshot(cloud_result)
+            return cloud_result
+        errors.append("cloud: loadCodeAssist has no per-model quota for this account")
+    except RuntimeError as exc:
+        errors.append(f"cloud: {exc}")
+
+    snapshot = load_snapshot()
+    if snapshot:
+        payload = dict(snapshot["payload"])
+        payload["origin"] = "snapshot"
+        payload["as_of"] = snapshot["saved_at"]
+        payload["age"] = snapshot_age_text(snapshot["saved_at"])
+        return payload
+
+    if cloud_result is not None:
+        return cloud_result
+
+    raise RuntimeError(
+        "; ".join(errors) + " (try: open Antigravity IDE or run agy --continue)"
+    )
 
 
 def _is_ok_code(code: Any) -> bool:
@@ -690,6 +907,22 @@ def _format_bucket(bucket: dict[str, Any]) -> str:
     return f"{percent_text} remaining"
 
 
+def _format_source_line(payload: dict[str, Any]) -> str | None:
+    origin = payload.get("origin")
+    if origin == "live":
+        port = payload.get("api_port")
+        return f"  source: live language server{f' (port {port})' if port else ''}"
+    if origin == "cloud":
+        return "  source: cloud (loadCodeAssist)"
+    if origin == "snapshot":
+        age = payload.get("age") or "unknown age"
+        return (
+            f"  source: cached snapshot — as of {age} ago "
+            "(try: open Antigravity IDE or agy --continue for live data)"
+        )
+    return None
+
+
 def format_agy_quota_text(payload: dict[str, Any]) -> str:
     lines = ["Antigravity (agy)"]
     plan = (payload.get("account") or {}).get("plan")
@@ -697,18 +930,24 @@ def format_agy_quota_text(payload: dict[str, Any]) -> str:
         lines[0] += f" — {plan}"
 
     if payload.get("error"):
-        lines.append(f"Error: {payload['error']}")
+        lines.append(f"  ✗ {payload['error']}")
         return "\n".join(lines)
+
+    source_line = _format_source_line(payload)
+    if source_line:
+        lines.append(source_line)
 
     groups = payload.get("groups") or []
     if not groups:
-        lines.append("No model quota data returned.")
+        lines.append("  ✗ no model quota data returned")
         return "\n".join(lines)
 
     for group in groups:
         lines.extend(["", group["name"], f"({group['description']})"])
         for bucket in group.get("buckets") or []:
-            lines.append(f"  {bucket.get('label', 'Quota')}: {_format_bucket(bucket)}")
+            known = isinstance(bucket.get("remaining_fraction"), (int, float))
+            mark = "✓" if known else "✗"
+            lines.append(f"  {mark} {bucket.get('label', 'Quota')}: {_format_bucket(bucket)}")
 
     credits = payload.get("available_prompt_credits")
     if credits is not None:

--- a/apps/n0b/commands/quota_cmd.py
+++ b/apps/n0b/commands/quota_cmd.py
@@ -17,6 +17,7 @@ LIVE_ENDPOINTS = {
     "userStatus": "/exa.language_server_pb.LanguageServerService/GetUserStatus",
     "commandModelConfigs": "/exa.language_server_pb.LanguageServerService/GetCommandModelConfigs",
     "userQuotaSummary": "/exa.language_server_pb.LanguageServerService/GetUserQuotaSummary",
+    "cascadeModelConfig": "/exa.language_server_pb.LanguageServerService/GetCascadeModelConfigData",
 }
 
 REQUEST_TIMEOUT_S = 8
@@ -253,6 +254,44 @@ def fetch_raw_agy_quota() -> dict[str, Any]:
     process_info = detect_antigravity_process()
     api_ports = resolve_api_ports(process_info)
     api_port = api_ports["https"] or api_ports["http"]
+
+    try:
+        raw = _make_request(
+            api_ports["https"],
+            api_ports["http"],
+            process_info["csrf_token"],
+            LIVE_ENDPOINTS["userStatus"],
+            _default_request_body(),
+        )
+        payload = json.loads(raw)
+        parsed = parse_quota_response(payload, "userStatus")
+        if parsed["models"]:
+            return {"json": payload, "shape": "userStatus", "api_port": api_port}
+    except (RuntimeError, json.JSONDecodeError):
+        pass
+
+    try:
+        raw = _make_request(
+            api_ports["https"],
+            api_ports["http"],
+            process_info["csrf_token"],
+            LIVE_ENDPOINTS["cascadeModelConfig"],
+            _default_request_body(),
+        )
+        status_raw = _make_request(
+            api_ports["https"],
+            api_ports["http"],
+            process_info["csrf_token"],
+            LIVE_ENDPOINTS["userStatus"],
+            _default_request_body(),
+        )
+        payload = json.loads(raw)
+        payload["userStatus"] = json.loads(status_raw).get("userStatus", {})
+        parsed = parse_quota_response(payload, "cascadeModelConfig")
+        if parsed["models"]:
+            return {"json": payload, "shape": "cascadeModelConfig", "api_port": api_port}
+    except (RuntimeError, json.JSONDecodeError):
+        pass
 
     try:
         raw = _make_request(
@@ -525,28 +564,99 @@ def _parse_model_quota(config: dict[str, Any]) -> dict[str, Any] | None:
     }
 
 
+QUOTA_GROUPS = [
+    {
+        "name": "GEMINI MODELS",
+        "description": "Gemini Flash, Gemini Pro",
+        "match": lambda label: "gemini" in label.lower(),
+    },
+    {
+        "name": "CLAUDE AND GPT MODELS",
+        "description": "Claude Opus, Claude Sonnet, GPT-OSS",
+        "match": lambda label: "claude" in label.lower() or "gpt" in label.lower(),
+    },
+]
+
+
+def _quota_window_for_label(label: str) -> str:
+    lower = label.lower()
+    if "gemini" in lower:
+        return "weekly"
+    return "five_hour"
+
+
+def group_model_quotas(models: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    grouped: list[dict[str, Any]] = []
+    for grp in QUOTA_GROUPS:
+        matched = [model for model in models if grp["match"](model["label"])]
+        if not matched:
+            continue
+
+        buckets: list[dict[str, Any]] = []
+        for window, display in (("weekly", "Weekly Limit"), ("five_hour", "Five Hour Limit")):
+            candidates: list[dict[str, Any]] = []
+            for model in matched:
+                if _quota_window_for_label(model["label"]) != window:
+                    continue
+                for bucket in model.get("buckets") or []:
+                    candidates.append({**bucket, "label": display})
+            if not candidates:
+                buckets.append({"label": display, "remaining_fraction": None, "reset_time": None})
+                continue
+            best = min(
+                candidates,
+                key=lambda bucket: bucket["remaining_fraction"]
+                if isinstance(bucket.get("remaining_fraction"), (int, float))
+                else 1.0,
+            )
+            buckets.append(
+                {
+                    "label": display,
+                    "remaining_fraction": best.get("remaining_fraction"),
+                    "reset_time": best.get("reset_time"),
+                    "used": best.get("used"),
+                    "limit": best.get("limit"),
+                }
+            )
+
+        grouped.append(
+            {
+                "name": grp["name"],
+                "description": grp["description"],
+                "buckets": buckets,
+            }
+        )
+    return grouped
+
+
 def parse_quota_response(response: dict[str, Any], shape: str) -> dict[str, Any]:
     if not _is_ok_code(response.get("code")):
         raise RuntimeError("Antigravity quota API returned a non-OK response.")
 
-    status = response.get("userStatus", response) if shape == "userStatus" else response
+    if shape == "userStatus":
+        status = response.get("userStatus", response)
+    else:
+        status = response
     configs = _find_model_configs(status)
     models = sorted(
         (m for m in (_parse_model_quota(cfg) for cfg in configs) if m),
         key=lambda item: item["label"].lower(),
     )
-    plan_info = (status.get("planStatus") or {}).get("planInfo") or {}
+    account_root = response.get("userStatus", status)
+    plan_status = account_root.get("planStatus") or {}
+    plan_info = plan_status.get("planInfo") or {}
     return {
         "error": None,
         "account": {
-            "email": status.get("email"),
+            "email": account_root.get("email"),
             "plan": plan_info.get("planDisplayName")
             or plan_info.get("displayName")
             or plan_info.get("productName")
             or plan_info.get("planName"),
         },
-        "available_prompt_credits": (status.get("planStatus") or {}).get("availablePromptCredits"),
+        "available_prompt_credits": plan_status.get("availablePromptCredits"),
         "models": models,
+        "groups": group_model_quotas(models),
     }
 
 
@@ -570,11 +680,14 @@ def _format_bucket(bucket: dict[str, Any]) -> str:
     fraction = bucket.get("remaining_fraction")
     if not isinstance(fraction, (int, float)):
         return "unknown"
-    percent = round(fraction * 100)
+    if fraction >= 0.9999 and bucket.get("label") == "Five Hour Limit":
+        return "Quota available"
+    percent = fraction * 100
+    percent_text = f"{round(percent)}%" if abs(percent - round(percent)) < 0.05 else f"{percent:.2f}%"
     reset = _format_duration_until(bucket.get("reset_time"))
     if reset:
-        return f"{percent}% remaining · refreshes in {reset}"
-    return f"{percent}% remaining"
+        return f"{percent_text} remaining · refreshes in {reset}"
+    return f"{percent_text} remaining"
 
 
 def format_agy_quota_text(payload: dict[str, Any]) -> str:
@@ -587,19 +700,15 @@ def format_agy_quota_text(payload: dict[str, Any]) -> str:
         lines.append(f"Error: {payload['error']}")
         return "\n".join(lines)
 
-    models = payload.get("models") or []
-    if not models:
+    groups = payload.get("groups") or []
+    if not groups:
         lines.append("No model quota data returned.")
         return "\n".join(lines)
 
-    for model in models:
-        lines.append("")
-        lines.append(model["label"])
-        for bucket in model.get("buckets") or []:
-            label = bucket.get("label") or "Quota"
-            if label in {"Hourly", "Quota"}:
-                label = "5h limit"
-            lines.append(f"  {label}: {_format_bucket(bucket)}")
+    for group in groups:
+        lines.extend(["", group["name"], f"({group['description']})"])
+        for bucket in group.get("buckets") or []:
+            lines.append(f"  {bucket.get('label', 'Quota')}: {_format_bucket(bucket)}")
 
     credits = payload.get("available_prompt_credits")
     if credits is not None:

--- a/apps/n0b/docs/quota.md
+++ b/apps/n0b/docs/quota.md
@@ -19,22 +19,22 @@ n0b quota agy --raw    # JSON plus raw Antigravity API payload (debug)
 
 ## Antigravity (`agy`)
 
-Queries the **local language-server API** that Antigravity runs on your machine — the same approach as [antigravitycli-usage-stats](https://github.com/mdsameersakib/antigravitycli-usage-stats):
+Sources are tried in order; the first that yields quota data wins:
 
-1. Find a running Antigravity language-server process (`language_server_*`, or embedded in `agy`)
-2. Discover its localhost listen port(s) via `lsof` (and CLI logs as fallback)
-3. POST Connect-RPC endpoints such as `GetUserQuotaSummary` / `GetUserStatus`
-4. Parse per-model buckets (`remaining_fraction`, reset time)
+1. **Live** — the local language-server API (same approach as [antigravitycli-usage-stats](https://github.com/mdsameersakib/antigravitycli-usage-stats)): find a running `language_server_*` / `agy` process, discover its localhost port(s) via `lsof` (CLI logs as fallback), POST Connect-RPC endpoints such as `GetUserStatus`. Every successful live read persists a timestamped snapshot to `~/.config/n0b/quota-agy.json`.
+2. **Cloud** — when nothing is running locally, refresh the OAuth token from `~/.gemini/oauth_creds.json` and call `v1internal:loadCodeAssist` on `cloudcode-pa.googleapis.com`. Works with the app closed; returns plan/tier, plus per-model quota when the account exposes it there. The token refresh needs gemini-cli's public installed-app OAuth client pair, resolved via `n0b secrets` (they live in gemini-cli's open source but trip GitHub secret scanning, so they are not hardcoded here): one-time `n0b secrets set GEMINI_OAUTH_CLIENT_ID` and `n0b secrets set GEMINI_OAUTH_CLIENT_SECRET`.
+3. **Snapshot** — last persisted state, reported with an explicit age (`as of 43m ago`).
 
-No cloud calls. No credential file reads. Localhost only.
+If all three miss, the error says what to do (`try: open Antigravity IDE or run agy --continue`).
 
 ### When it works
 
-| Session | Quota available? |
-|---------|------------------|
-| Antigravity IDE open (language server running) | Yes |
-| Interactive `agy` / `agy --continue` (persistent session) | Yes — includes a8s headless agents using `--continue` |
-| Ephemeral `agy --print` / `agy -p` | **No** — language server starts and exits with the one-shot command |
+| Session | Quota source |
+|---------|--------------|
+| Antigravity IDE open (language server running) | Live |
+| Interactive `agy` / `agy --continue` (persistent session) | Live — includes a8s headless agents using `--continue` |
+| Nothing running, logged in (`~/.gemini/oauth_creds.json`) | Cloud, else snapshot with age |
+| Nothing running, never logged in, no snapshot | Actionable error |
 
 For programmatic model switching, keep a **persistent** `agy --continue` session alive (as a8s does), then poll pool limits (same grouping as `agy /usage`):
 
@@ -67,19 +67,20 @@ Prefer `groups` for automation; `models` remains for per-model debug.
 - `groups[].buckets[]` — `Weekly Limit`, `Five Hour Limit`
 - `groups[].buckets[].remaining_fraction` — 0.0–1.0 when known
 - `models[]` — raw per-model API data
+- `origin` — `live`, `cloud`, or `snapshot`; snapshots also carry `as_of` and `age`
 
 Exit code `0` when quota data is returned; `1` on error or unavailable server.
 
 ### Limits
 
-- Local API returns one `quotaInfo` per model; agy `/usage` also shows cloud-backed pool quotas (e.g. Gemini five-hour ~90%, Claude weekly ~98%) that appear as `unknown` here today.
-- Requires `lsof` on macOS/Linux.
+- Local API returns one `quotaInfo` per model; agy `/usage` also shows cloud-backed pool quotas (e.g. Gemini five-hour ~90%, Claude weekly ~98%) that appear as `unknown` here today. The `loadCodeAssist` fallback returns tier/plan but not those pool fractions for consumer accounts — filling them needs Antigravity's own session token (tracked in issue #141).
+- Requires `lsof` on macOS/Linux for the live path.
 
 ## Supported tools
 
 | Id | Tool | Requires |
 |----|------|----------|
-| `agy` | Antigravity (`agy` on PATH) | Running language server |
+| `agy` | Antigravity (`agy` on PATH) | Running language server, or a prior login / snapshot |
 
 More providers (Claude Code, Codex, Cursor, …) planned — see [issue #141](https://github.com/neilobremski/bin/issues/141).
 

--- a/apps/n0b/docs/quota.md
+++ b/apps/n0b/docs/quota.md
@@ -36,36 +36,44 @@ No cloud calls. No credential file reads. Localhost only.
 | Interactive `agy` / `agy --continue` (persistent session) | Yes — includes a8s headless agents using `--continue` |
 | Ephemeral `agy --print` / `agy -p` | **No** — language server starts and exits with the one-shot command |
 
-For programmatic model switching, keep a **persistent** `agy --continue` session alive (as a8s does), then poll:
+For programmatic model switching, keep a **persistent** `agy --continue` session alive (as a8s does), then poll pool limits (same grouping as `agy /usage`):
 
 ```bash
 n0b quota agy --json | jq -r '
-  .models[]
+  .groups[]
+  | .name as $g
+  | .buckets[]
   | select(.remaining_fraction != null)
-  | "\(.label)\t\(.remaining_fraction)"
+  | "\($g)\t\(.label)\t\(.remaining_fraction)"
 '
 ```
 
-Pick a model whose `remaining_fraction` is still above your threshold, or fall back to another provider when the lowest bucket hits zero.
+### Output shape
+
+Human output mirrors `agy /usage`: **GEMINI MODELS** and **CLAUDE AND GPT MODELS** pools, each with **Weekly Limit** and **Five Hour Limit**.
+
+The local API exposes one `quotaInfo` per model. We map it by pool the way agy presents it:
+
+- Gemini `quotaInfo` → **Weekly Limit** (matches agy’s ~4% weekly row)
+- Claude/GPT `quotaInfo` → **Five Hour Limit** (matches agy’s “Quota available” row)
+
+Cloud-backed pool values that agy shows but the local API omits (Gemini five-hour ~90%, Claude weekly ~98%) appear as `unknown`.
 
 ### JSON shape (scripting)
 
-Key fields:
+Prefer `groups` for automation; `models` remains for per-model debug.
 
-- `models[].label` — display name (e.g. `Gemini 3.5 Flash`)
-- `models[].model_id` — backend id when present
-- `models[].remaining_fraction` — 0.0–1.0 aggregate across buckets
-- `models[].buckets[]` — per-window limits (`Hourly` / 5h, `Weekly` when exposed)
-- `models[].buckets[].remaining_fraction` — fraction left in that window
-- `models[].buckets[].reset_time` — ISO timestamp for next reset
+- `groups[].name` — `GEMINI MODELS`, `CLAUDE AND GPT MODELS`
+- `groups[].buckets[]` — `Weekly Limit`, `Five Hour Limit`
+- `groups[].buckets[].remaining_fraction` — 0.0–1.0 when known
+- `models[]` — raw per-model API data
 
 Exit code `0` when quota data is returned; `1` on error or unavailable server.
 
 ### Limits
 
-- **Weekly quotas** are often not exposed by the local API (same limitation as the reference VS Code extension).
+- Local API returns one `quotaInfo` per model; agy `/usage` also shows cloud-backed pool quotas (e.g. Gemini five-hour ~90%, Claude weekly ~98%) that appear as `unknown` here today.
 - Requires `lsof` on macOS/Linux.
-- IDE sessions expose `--csrf_token` on the `language_server` command line; CLI-embedded servers use HTTP localhost without that flag.
 
 ## Supported tools
 

--- a/apps/n0b/docs/quota.md
+++ b/apps/n0b/docs/quota.md
@@ -1,0 +1,81 @@
+---
+name: "n0b-quota"
+description: "Check live AI tool rate-limit quotas via n0b quota. Antigravity (agy) supported today."
+allowed-tools: Bash(n0b quota *)
+---
+
+# n0b quota
+
+Check live model quota / rate limits for AI tools installed on the system.
+
+## Usage
+
+```bash
+n0b quota              # all installed tools with quota support
+n0b quota agy          # Antigravity only
+n0b quota agy --json   # machine-readable JSON for scripts
+n0b quota agy --raw    # JSON plus raw Antigravity API payload (debug)
+```
+
+## Antigravity (`agy`)
+
+Queries the **local language-server API** that Antigravity runs on your machine — the same approach as [antigravitycli-usage-stats](https://github.com/mdsameersakib/antigravitycli-usage-stats):
+
+1. Find a running Antigravity language-server process (`language_server_*`, or embedded in `agy`)
+2. Discover its localhost listen port(s) via `lsof` (and CLI logs as fallback)
+3. POST Connect-RPC endpoints such as `GetUserQuotaSummary` / `GetUserStatus`
+4. Parse per-model buckets (`remaining_fraction`, reset time)
+
+No cloud calls. No credential file reads. Localhost only.
+
+### When it works
+
+| Session | Quota available? |
+|---------|------------------|
+| Antigravity IDE open (language server running) | Yes |
+| Interactive `agy` / `agy --continue` (persistent session) | Yes — includes a8s headless agents using `--continue` |
+| Ephemeral `agy --print` / `agy -p` | **No** — language server starts and exits with the one-shot command |
+
+For programmatic model switching, keep a **persistent** `agy --continue` session alive (as a8s does), then poll:
+
+```bash
+n0b quota agy --json | jq -r '
+  .models[]
+  | select(.remaining_fraction != null)
+  | "\(.label)\t\(.remaining_fraction)"
+'
+```
+
+Pick a model whose `remaining_fraction` is still above your threshold, or fall back to another provider when the lowest bucket hits zero.
+
+### JSON shape (scripting)
+
+Key fields:
+
+- `models[].label` — display name (e.g. `Gemini 3.5 Flash`)
+- `models[].model_id` — backend id when present
+- `models[].remaining_fraction` — 0.0–1.0 aggregate across buckets
+- `models[].buckets[]` — per-window limits (`Hourly` / 5h, `Weekly` when exposed)
+- `models[].buckets[].remaining_fraction` — fraction left in that window
+- `models[].buckets[].reset_time` — ISO timestamp for next reset
+
+Exit code `0` when quota data is returned; `1` on error or unavailable server.
+
+### Limits
+
+- **Weekly quotas** are often not exposed by the local API (same limitation as the reference VS Code extension).
+- Requires `lsof` on macOS/Linux.
+- IDE sessions expose `--csrf_token` on the `language_server` command line; CLI-embedded servers use HTTP localhost without that flag.
+
+## Supported tools
+
+| Id | Tool | Requires |
+|----|------|----------|
+| `agy` | Antigravity (`agy` on PATH) | Running language server |
+
+More providers (Claude Code, Codex, Cursor, …) planned — see [issue #141](https://github.com/neilobremski/bin/issues/141).
+
+## Implementation
+
+- **CLI:** `n0b quota`
+- **Module:** `apps/n0b/commands/quota_cmd.py`

--- a/apps/n0b/tests/test_quota.py
+++ b/apps/n0b/tests/test_quota.py
@@ -11,14 +11,20 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+import commands.quota_cmd as quota_cmd  # noqa: E402
 from commands.quota_cmd import (  # noqa: E402
     QUOTA_TOOLS,
     cmd_quota,
     detect_antigravity_process,
+    fetch_agy_quota,
+    fetch_agy_quota_cloud,
     get_listening_ports,
     group_model_quotas,
+    load_snapshot,
     parse_quota_response,
     resolve_api_ports,
+    save_snapshot,
+    snapshot_age_text,
 )
 
 
@@ -174,3 +180,163 @@ def test_cmd_quota_unknown_tool(capsys):
     err = capsys.readouterr().err
     assert rc == 2
     assert "unknown tool" in err.lower()
+
+
+def _sample_payload():
+    return {
+        "tool": "agy",
+        "generated_at": "2026-01-01T00:00:00+00:00",
+        "origin": "live",
+        "source": "userStatus",
+        "api_port": 1234,
+        **parse_quota_response(SAMPLE_USER_STATUS, "userStatus"),
+    }
+
+
+def test_snapshot_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setattr(quota_cmd, "SNAPSHOT_PATH", tmp_path / "quota-agy.json")
+    payload = _sample_payload()
+    payload["raw"] = {"secret": "stripped"}
+    save_snapshot(payload)
+    snap = load_snapshot()
+    assert snap is not None
+    assert "raw" not in snap["payload"]
+    assert snap["payload"]["account"]["plan"] == "Pro"
+    assert snap["saved_at"]
+
+
+def test_snapshot_age_text():
+    with patch("commands.quota_cmd._utc_now") as now:
+        from datetime import datetime, timezone
+
+        now.return_value = datetime(2026, 1, 2, 3, 43, tzinfo=timezone.utc)
+        assert snapshot_age_text("2026-01-02T03:00:00+00:00") == "43m"
+        assert snapshot_age_text("2026-01-02T01:38:00+00:00") == "2h 5m"
+        assert snapshot_age_text("2025-12-30T01:00:00+00:00") == "3d 2h"
+
+
+def test_fetch_live_success_writes_snapshot(tmp_path, monkeypatch):
+    monkeypatch.setattr(quota_cmd, "SNAPSHOT_PATH", tmp_path / "quota-agy.json")
+    monkeypatch.setattr(quota_cmd, "_fetch_agy_live", lambda **_: _sample_payload())
+    result = fetch_agy_quota()
+    assert result["origin"] == "live"
+    assert load_snapshot() is not None
+
+
+def test_fetch_falls_back_to_cloud(tmp_path, monkeypatch):
+    monkeypatch.setattr(quota_cmd, "SNAPSHOT_PATH", tmp_path / "quota-agy.json")
+
+    def live_down(**_):
+        raise RuntimeError("not running")
+
+    cloud = {**_sample_payload(), "origin": "cloud", "source": "loadCodeAssist"}
+    monkeypatch.setattr(quota_cmd, "_fetch_agy_live", live_down)
+    monkeypatch.setattr(quota_cmd, "fetch_agy_quota_cloud", lambda **_: cloud)
+    result = fetch_agy_quota()
+    assert result["origin"] == "cloud"
+    assert load_snapshot() is not None
+
+
+def test_fetch_falls_back_to_snapshot(tmp_path, monkeypatch):
+    monkeypatch.setattr(quota_cmd, "SNAPSHOT_PATH", tmp_path / "quota-agy.json")
+    save_snapshot(_sample_payload())
+
+    def down(**_):
+        raise RuntimeError("down")
+
+    monkeypatch.setattr(quota_cmd, "_fetch_agy_live", down)
+    monkeypatch.setattr(quota_cmd, "fetch_agy_quota_cloud", down)
+    result = fetch_agy_quota()
+    assert result["origin"] == "snapshot"
+    assert result["as_of"]
+    assert result["age"]
+    assert result["account"]["plan"] == "Pro"
+
+
+def test_fetch_error_when_nothing_available(tmp_path, monkeypatch):
+    monkeypatch.setattr(quota_cmd, "SNAPSHOT_PATH", tmp_path / "quota-agy.json")
+
+    def down(**_):
+        raise RuntimeError("down")
+
+    monkeypatch.setattr(quota_cmd, "_fetch_agy_live", down)
+    monkeypatch.setattr(quota_cmd, "fetch_agy_quota_cloud", down)
+    with pytest.raises(RuntimeError, match=r"\(try:"):
+        fetch_agy_quota()
+
+
+def test_fetch_cloud_result_without_models_prefers_snapshot(tmp_path, monkeypatch):
+    monkeypatch.setattr(quota_cmd, "SNAPSHOT_PATH", tmp_path / "quota-agy.json")
+    save_snapshot(_sample_payload())
+
+    def live_down(**_):
+        raise RuntimeError("not running")
+
+    cloud = {
+        "tool": "agy",
+        "generated_at": "2026-01-01T00:00:00+00:00",
+        "origin": "cloud",
+        "source": "loadCodeAssist",
+        "error": None,
+        "account": {"email": None, "plan": "Pro"},
+        "available_prompt_credits": None,
+        "models": [],
+        "groups": [],
+    }
+    monkeypatch.setattr(quota_cmd, "_fetch_agy_live", live_down)
+    monkeypatch.setattr(quota_cmd, "fetch_agy_quota_cloud", lambda **_: cloud)
+    result = fetch_agy_quota()
+    assert result["origin"] == "snapshot"
+
+
+def test_cloud_auth_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(quota_cmd, "OAUTH_CREDS_PATH", tmp_path / "missing.json")
+    with pytest.raises(RuntimeError, match=r"Not logged in.*\(try: agy"):
+        fetch_agy_quota_cloud()
+
+
+def test_cloud_parses_load_code_assist(monkeypatch, tmp_path):
+    creds = tmp_path / "oauth_creds.json"
+    creds.write_text(json.dumps({"refresh_token": "r", "access_token": "a", "expiry_date": 4102444800000}))
+    monkeypatch.setattr(quota_cmd, "OAUTH_CREDS_PATH", creds)
+
+    class FakeResponse:
+        def __init__(self, body):
+            self._body = json.dumps(body).encode()
+
+        def read(self):
+            return self._body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    cloud_body = {
+        "currentTier": {"id": "standard-tier", "name": "Gemini Code Assist"},
+        "paidTier": {"id": "g1-pro-tier", "name": "Google One AI Pro"},
+    }
+    monkeypatch.setattr(
+        quota_cmd.urllib.request, "urlopen", lambda req, timeout=None: FakeResponse(cloud_body)
+    )
+    result = fetch_agy_quota_cloud()
+    assert result["origin"] == "cloud"
+    assert result["account"]["plan"] == "Google One AI Pro"
+    assert result["models"] == []
+
+
+def test_format_snapshot_source_line():
+    payload = {**_sample_payload(), "origin": "snapshot", "age": "43m"}
+    text = quota_cmd.format_agy_quota_text(payload)
+    assert "as of 43m ago" in text
+    assert "✓" in text
+
+
+def test_cloud_client_pair_unconfigured(tmp_path, monkeypatch):
+    creds = tmp_path / "oauth_creds.json"
+    creds.write_text(json.dumps({"refresh_token": "r", "access_token": "expired", "expiry_date": 1}))
+    monkeypatch.setattr(quota_cmd, "OAUTH_CREDS_PATH", creds)
+    monkeypatch.setattr("commands.secrets_cmd.resolve", lambda name: None)
+    with pytest.raises(RuntimeError, match=r"try: n0b secrets set GEMINI_OAUTH_CLIENT_ID"):
+        fetch_agy_quota_cloud()

--- a/apps/n0b/tests/test_quota.py
+++ b/apps/n0b/tests/test_quota.py
@@ -16,6 +16,7 @@ from commands.quota_cmd import (  # noqa: E402
     cmd_quota,
     detect_antigravity_process,
     get_listening_ports,
+    group_model_quotas,
     parse_quota_response,
     resolve_api_ports,
 )
@@ -39,7 +40,15 @@ SAMPLE_USER_STATUS = {
                         "resetTime": "2099-01-01T12:00:00Z",
                     }
                 },
-            }
+            },
+            {
+                "label": "Claude Sonnet 4.6 (Thinking)",
+                "model": "claude-sonnet",
+                "quotaInfo": {
+                    "remainingFraction": 1.0,
+                    "resetTime": "2099-01-01T15:00:00Z",
+                },
+            },
         ],
     },
 }
@@ -49,9 +58,9 @@ def test_parse_quota_response_user_status():
     parsed = parse_quota_response(SAMPLE_USER_STATUS, "userStatus")
     assert parsed["account"]["plan"] == "Pro"
     assert parsed["available_prompt_credits"] == 42
-    assert len(parsed["models"]) == 1
-    assert parsed["models"][0]["label"] == "Gemini Flash"
-    assert parsed["models"][0]["buckets"][0]["remaining_fraction"] == pytest.approx(0.56)
+    assert len(parsed["models"]) == 2
+    gemini = next(m for m in parsed["models"] if "Gemini" in m["label"])
+    assert gemini["buckets"][0]["remaining_fraction"] == pytest.approx(0.56)
 
 
 def test_detect_antigravity_process_from_ps():
@@ -116,6 +125,17 @@ def test_detect_antigravity_process_missing():
             detect_antigravity_process()
 
 
+def test_group_model_quotas_matches_agy_pools():
+    parsed = parse_quota_response(SAMPLE_USER_STATUS, "userStatus")
+    assert len(parsed["groups"]) == 2
+    gemini = parsed["groups"][0]
+    assert gemini["name"] == "GEMINI MODELS"
+    weekly = next(b for b in gemini["buckets"] if b["label"] == "Weekly Limit")
+    five_hour = next(b for b in gemini["buckets"] if b["label"] == "Five Hour Limit")
+    assert weekly["remaining_fraction"] == pytest.approx(0.56)
+    assert five_hour["remaining_fraction"] is None
+
+
 def test_cmd_quota_agy_success(capsys):
     sample = {
         "tool": "agy",
@@ -129,7 +149,8 @@ def test_cmd_quota_agy_success(capsys):
     assert rc == 0
     out = capsys.readouterr().out
     assert "Antigravity (agy)" in out
-    assert "Gemini Flash" in out
+    assert "GEMINI MODELS" in out
+    assert "Weekly Limit" in out
 
 
 def test_cmd_quota_json(capsys):
@@ -145,7 +166,7 @@ def test_cmd_quota_json(capsys):
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["tool"] == "agy"
-    assert payload["models"][0]["label"] == "Gemini Flash"
+    assert payload["groups"][0]["name"] == "GEMINI MODELS"
 
 
 def test_cmd_quota_unknown_tool(capsys):

--- a/apps/n0b/tests/test_quota.py
+++ b/apps/n0b/tests/test_quota.py
@@ -17,6 +17,7 @@ from commands.quota_cmd import (  # noqa: E402
     detect_antigravity_process,
     get_listening_ports,
     parse_quota_response,
+    resolve_api_ports,
 )
 
 
@@ -86,19 +87,25 @@ def test_get_listening_ports_uses_lsof_and_flag(monkeypatch):
         "commands.quota_cmd.shutil.which",
         lambda path: path if path.endswith("lsof") else None,
     )
-    monkeypatch.setattr("commands.quota_cmd._cli_log_ports_for_pid", lambda pid: [])
+    monkeypatch.setattr(
+        "commands.quota_cmd._cli_log_port_map",
+        lambda pid: {"https": 62154, "http": 62155},
+    )
 
     def fake_run(argv, **kwargs):
         assert "-a" in argv
         return subprocess.CompletedProcess(
             argv,
             0,
-            stdout="agy 12345 neilo  12u  IPv4 0x0  0t0  TCP 127.0.0.1:61030 (LISTEN)\n",
+            stdout="agy 12345 neilo  12u  IPv4 0x0  0t0  TCP 127.0.0.1:62154 (LISTEN)\n"
+            "agy 12345 neilo  13u  IPv4 0x0  0t0  TCP 127.0.0.1:62155 (LISTEN)\n",
             stderr="",
         )
 
     monkeypatch.setattr("commands.quota_cmd.subprocess.run", fake_run)
-    assert get_listening_ports(12345) == [61030]
+    ports = resolve_api_ports({"pid": 12345, "extension_port": None})
+    assert ports == {"https": 62154, "http": 62155}
+    assert get_listening_ports(12345) == [62155, 62154]
 
 
 def test_detect_antigravity_process_missing():

--- a/apps/n0b/tests/test_quota.py
+++ b/apps/n0b/tests/test_quota.py
@@ -1,0 +1,148 @@
+"""n0b quota command tests."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from commands.quota_cmd import (  # noqa: E402
+    QUOTA_TOOLS,
+    cmd_quota,
+    detect_antigravity_process,
+    get_listening_ports,
+    parse_quota_response,
+)
+
+
+SAMPLE_USER_STATUS = {
+    "code": 0,
+    "userStatus": {
+        "email": "user@example.com",
+        "planStatus": {
+            "planInfo": {"planDisplayName": "Pro"},
+            "availablePromptCredits": 42,
+        },
+        "clientModelConfigs": [
+            {
+                "label": "Gemini Flash",
+                "model": "gemini-flash",
+                "quotaInfo": {
+                    "hourlyQuota": {
+                        "remainingFraction": 0.56,
+                        "resetTime": "2099-01-01T12:00:00Z",
+                    }
+                },
+            }
+        ],
+    },
+}
+
+
+def test_parse_quota_response_user_status():
+    parsed = parse_quota_response(SAMPLE_USER_STATUS, "userStatus")
+    assert parsed["account"]["plan"] == "Pro"
+    assert parsed["available_prompt_credits"] == 42
+    assert len(parsed["models"]) == 1
+    assert parsed["models"][0]["label"] == "Gemini Flash"
+    assert parsed["models"][0]["buckets"][0]["remaining_fraction"] == pytest.approx(0.56)
+
+
+def test_detect_antigravity_process_from_ps():
+    ps_output = (
+        "12345 /Users/me/.gemini/antigravity-cli/bin/language_server "
+        "--csrf_token=abc123 --extension_server_port=9999\n"
+    )
+    with patch("commands.quota_cmd.subprocess.run") as run:
+        run.return_value.returncode = 0
+        run.return_value.stdout = ps_output
+        info = detect_antigravity_process()
+    assert info["pid"] == 12345
+    assert info["csrf_token"] == "abc123"
+    assert info["extension_port"] == 9999
+
+
+def test_detect_antigravity_prefers_language_server_with_csrf():
+    ps_output = (
+        "100 /Users/me/.local/bin/agy --continue\n"
+        "200 /Applications/Antigravity IDE.app/.../language_server_macos_arm "
+        "--csrf_token=abc123 --extension_server_port=9999\n"
+    )
+    with patch("commands.quota_cmd.subprocess.run") as run:
+        run.return_value.returncode = 0
+        run.return_value.stdout = ps_output
+        info = detect_antigravity_process()
+    assert info["pid"] == 200
+    assert info["csrf_token"] == "abc123"
+
+
+def test_get_listening_ports_uses_lsof_and_flag(monkeypatch):
+    monkeypatch.setattr(
+        "commands.quota_cmd.shutil.which",
+        lambda path: path if path.endswith("lsof") else None,
+    )
+    monkeypatch.setattr("commands.quota_cmd._cli_log_ports_for_pid", lambda pid: [])
+
+    def fake_run(argv, **kwargs):
+        assert "-a" in argv
+        return subprocess.CompletedProcess(
+            argv,
+            0,
+            stdout="agy 12345 neilo  12u  IPv4 0x0  0t0  TCP 127.0.0.1:61030 (LISTEN)\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr("commands.quota_cmd.subprocess.run", fake_run)
+    assert get_listening_ports(12345) == [61030]
+
+
+def test_detect_antigravity_process_missing():
+    with patch("commands.quota_cmd.subprocess.run") as run:
+        run.return_value.returncode = 0
+        run.return_value.stdout = "99999 /usr/bin/sleep 1\n"
+        with pytest.raises(RuntimeError, match="not running"):
+            detect_antigravity_process()
+
+
+def test_cmd_quota_agy_success(capsys):
+    sample = {
+        "tool": "agy",
+        "generated_at": "2026-01-01T00:00:00+00:00",
+        "source": "userStatus",
+        "api_port": 1234,
+        **parse_quota_response(SAMPLE_USER_STATUS, "userStatus"),
+    }
+    with patch.dict(QUOTA_TOOLS["agy"], {"fetch": lambda **_: sample}):
+        rc = cmd_quota(["agy"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Antigravity (agy)" in out
+    assert "Gemini Flash" in out
+
+
+def test_cmd_quota_json(capsys):
+    sample = {
+        "tool": "agy",
+        "generated_at": "2026-01-01T00:00:00+00:00",
+        "source": "userStatus",
+        "api_port": 1234,
+        **parse_quota_response(SAMPLE_USER_STATUS, "userStatus"),
+    }
+    with patch.dict(QUOTA_TOOLS["agy"], {"fetch": lambda **_: sample}):
+        rc = cmd_quota(["agy"], as_json=True)
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["tool"] == "agy"
+    assert payload["models"][0]["label"] == "Gemini Flash"
+
+
+def test_cmd_quota_unknown_tool(capsys):
+    rc = cmd_quota(["bogus"])
+    err = capsys.readouterr().err
+    assert rc == 2
+    assert "unknown tool" in err.lower()


### PR DESCRIPTION
## Summary

- Add `n0b quota [agy] [--json] [--raw]` to query Antigravity model rate limits from the local language-server API
- Group output like `agy /usage` (GEMINI vs CLAUDE/GPT pools, Weekly + Five Hour rows)
- Fix macOS port discovery (`lsof -a`) and HTTPS/HTTP port selection for CLI `agy`
- Map local `quotaInfo` by pool: Gemini → weekly, Claude/GPT → five hour

Closes #141 (initial slice; cloud quota gaps tracked in issue)

## vs `agy /usage`

| Pool | Limit | Local API today | Cloud-only in `/usage` |
|------|-------|-----------------|------------------------|
| GEMINI | Weekly | yes (~4%) | — |
| GEMINI | Five Hour | **no** | ~90% |
| CLAUDE/GPT | Five Hour | yes (100%) | — |
| CLAUDE/GPT | Weekly | **no** | ~98% |

Follow-up: wire cloud quota (`loadCodeAssist` / quota_manager) for the missing rows. The reference VS Code extension does not solve this — it is local-API-only and excludes real weekly limits per its README.

## VS Code extension reference

[antigravitycli-usage-stats](https://github.com/mdsameersakib/antigravitycli-usage-stats) uses the same local endpoints. It labels hourly buckets as Five Hour Limit and shows weekly as Unknown when absent. It does not fetch Gemini five-hour headroom or Claude weekly usage from cloud.

## Test plan

- [x] `python3 -m pytest apps/n0b/tests/test_quota.py` (9 tests)
- [x] Interactive `agy` session: `n0b quota agy` shows grouped pools
- [x] Gemini weekly ~4% aligns with `agy /usage`; Gemini five-hour shows `unknown`
- [x] Claude/GPT five-hour shows `Quota available`; weekly shows `unknown`
- [ ] IDE language server: verify `GetUserQuotaSummary` when available
- [ ] Cloud quota integration (future PR)