### PR TITLE
feat(k7e): retrieval overhaul + explicit LLM commands (#145)

### DIFF
--- a/apps/k7e/README.md
+++ b/apps/k7e/README.md
@@ -1,194 +1,114 @@
-# k7e — Knowledge
+# k7e — Knowledge accumulation engine
 
-Standalone knowledge accumulation engine. Flat markdown files + hybrid search.
+A durable, local memory for knowledge that compounds. Flat markdown files +
+hybrid search, zero-dependency core.
 
-## Quick Start
+## Mission
 
-Try this in a terminal (uses a temp store so nothing is polluted):
+k7e exists so that an agent — or the human working alongside it — **never has to
+re-learn the same thing twice**. Hard-won facts, corrections, procedures, and
+decisions are captured once, kept as plain markdown you can read and edit by
+hand, and surfaced again at the moment they're relevant.
+
+Three commitments shape every design decision:
+
+- **Files are truth.** Knowledge lives as flat markdown on your disk. The search
+  index (SQLite FTS5 + optional embeddings) is a cache you can delete and
+  rebuild anytime. No database lock-in, no opaque blobs, no cloud.
+- **The core is dependency-free.** Storage and keyword retrieval need nothing
+  but Python's standard library. ollama (embeddings + LLM) is *optional*
+  enhancement — k7e degrades gracefully to FTS5 + pattern extraction.
+- **Relevance is earned, not assumed.** Knowledge you keep using stays fresh;
+  knowledge you never touch fades in *ranking* — never in storage. The store
+  accumulates; retrieval forgets.
+
+k7e is deliberately **personal, single-user, and local** — the inverse of
+multi-tenant cloud memory layers. It optimizes for one person's (and their
+agents') accumulated expertise, portable as a folder of text files.
+
+## Cheat sheet
 
 ```bash
-export K7E_HOME=/tmp/k7e-demo
-
-# Store some knowledge
-k7e store "SSH Local Forwarding" --tags ssh,networking \
-  --content "ssh -L 8080:target:80 bastion — forwards local:8080 to target:80 via bastion"
-
-k7e store "SSH Remote Forwarding" --tags ssh,networking \
-  --content "ssh -R 9090:localhost:3000 server — exposes local:3000 as server:9090"
-
-k7e store "Docker Port Mapping" --tags docker,networking \
-  --content "docker run -p 8080:80 nginx — maps host:8080 to container:80"
-
-# Search by keyword
-k7e search "forwarding"
-
-# Search by concept
-k7e search "expose local service remotely"
-
-# Read a full entry
-k7e get K7E-000-00002
-
-# Append new information to an existing entry
-k7e append K7E-000-00001 --section "Edge Cases" \
-  --content "Requires SSH key or password auth. Fails silently if port is in use."
-
-# See what you've built
+# Read
+k7e search "expose local service remotely"   # hybrid search (BM25+semantic+meta)
+k7e search "port forwarding" --rerank --ids  # LLM rerank, IDs only
+k7e get K7E-000-00001                         # full entry (counts as a "use")
+k7e recall "SSH bastion access"               # RAG answer over the store
+echo "we were discussing tunnels" | k7e recall
+k7e list --tag ssh --ids
 k7e stats
-k7e list
-k7e check
 
-# Distill knowledge from a raw file
-echo "TIL: Use ssh -J for ProxyJump, cleaner than -L for bastion hopping" > /tmp/notes.md
-k7e distill /tmp/notes.md
+# Write
+k7e store "SSH Local Forwarding" --tags ssh,net --content "ssh -L 8080:host:80 ..."
+echo "..." | k7e store "Title" --tags x,y      # content via stdin
+k7e append K7E-000-00001 --section "Edge Cases" --content "Fails if port in use."
+k7e supersede K7E-000-00001 K7E-000-00009      # retire old, keep audit trail
+k7e asset screenshot.png                       # store binary (deduped)
+k7e distill notes.md [--dry-run]               # extract knowledge from raw files
+k7e consolidate [--dry-run]                    # merge duplicates
+k7e compile networking [--dry-run]             # synthesize a tag into a page
 
-# Search for the distilled knowledge
-k7e search "ProxyJump bastion"
-
-# Recall: ask a question or pass conversation context (requires LLM)
-k7e recall "SSH bastion access"
-echo "We were discussing port forwarding tunnels" | k7e recall
-
-# Consolidate duplicate nodes (dedup by title similarity)
-k7e consolidate --dry-run
-k7e consolidate
-
-# Compile a topic into a reference page (requires LLM)
-k7e compile networking
-
-# Clean up
-rm -rf /tmp/k7e-demo /tmp/notes.md
+# Maintain / inspect
+k7e reindex [--embeddings]                      # rebuild index from markdown
+k7e check [--fix]                               # audit integrity
+k7e status                                      # capabilities + resolved models
+k7e config llm_model qwen3:8b                   # pin ollama model (unset=auto)
 ```
 
-## Usage
+Full flags and every command: **[docs/cli.md](docs/cli.md)**.
+
+## Install
 
 ```bash
-k7e store "title" --tags x,y [--content "..." | stdin]
-k7e search "query" [--limit N] [--json] [--ids] [--rerank] [--include-superseded]
-k7e get K7E-000-00001
-k7e supersede K7E-000-00001 K7E-000-00002
-k7e append K7E-000-00001 --section "name" [--content "..." | stdin]
-k7e asset screenshot.png
-k7e recall "topic or conversation" [--limit N]
-k7e distill file.md [--dry-run]
-k7e consolidate [--dry-run]
-k7e compile <tag> [--dry-run]
-k7e reindex [--embeddings]
-k7e embed-pending
-k7e rebuild-mocs
-k7e stats [--json]
-k7e check [--fix]
-k7e list [--tag x] [--status active] [--ids]
-k7e status
-k7e config <key> [value]
+# From ~/bin, k7e is already on PATH via install.sh. Standalone:
+python3 apps/k7e/k7e.py status
 ```
 
-## Storage
+Required: Python 3.10+ (sqlite3 bundled). Optional: **ollama** for semantic
+search + LLM features (`curl -fsSL https://ollama.com/install.sh | sh`, then
+`ollama pull nomic-embed-text`).
 
-`K7E_HOME` env var (default: `~/.k7e`):
-```
-$K7E_HOME/
-├── nodes/BBB/   # Bucketed atomic markdown entries (source of truth)
-├── mocs/        # Maps of Content (mutable topic indexes)
-├── assets/XX/   # Bucketed content-addressed binaries (SHA256 deduped)
-└── .index.db    # SQLite FTS5 + embeddings (derived, rebuildable)
-```
+## How it works (30 seconds)
 
-Files are truth. Index is cache. `k7e reindex` rebuilds from scratch.
+- Every fact is a markdown file under `$K7E_HOME/nodes/` (default `~/.k7e`).
+  `.index.db` is a derived cache — delete it and `k7e reindex` rebuilds.
+- **Search** fuses BM25 + metadata + embeddings (RRF), then weights by
+  confidence, recency decay, and use-count, with an optional LLM reranker.
+- **Recall** is RAG: retrieve + synthesize an answer (reranker on by default).
+- **Distill** extracts knowledge from raw files (pattern + LLM), dedupes, and
+  stores only genuine deltas.
+- The LLM backend is **ollama, called directly** — never a stateful CLI.
 
-## Entry format
+## Documentation
 
-```markdown
----
-id: K7E-000-00001
-title: SSH Local Forwarding
-aliases: [ssh-tunnel, port-forward]
-status: active
-confidence: 0.5
-verification_count: 0
-last_updated: 2026-05-20
-tags: [ssh, networking]
----
-
-## Verified Protocol
-ssh -L 8080:target:80 bastion — forwards local:8080 to target:80 via bastion
-
-## Edge Cases
-## False Paths
-## History
-* 2026-05-20: Initial entry.
-```
-
-## Configuration
-
-```bash
-k7e status                  # show what's active, incl. the resolved LLM model
-k7e config llm_model qwen3:8b   # pin the ollama model (unset = auto-detect)
-k7e config llm none         # disable the LLM entirely (pattern-only distill)
-k7e config embed_model nomic-embed-text
-k7e config ollama_url http://localhost:11434
-k7e config rerank true      # LLM rerank search results (off by default)
-k7e config decay_scale_days 365   # recency half-life past the flat zone
-```
-
-Config stored in `$K7E_HOME/config.json`. Env vars override: `K7E_LLM`,
-`K7E_LLM_MODEL`, `EMBED_MODEL`, `OLLAMA_URL`, `K7E_RERANK`, `K7E_DECAY_OFFSET`,
-`K7E_DECAY_SCALE`, `K7E_USE_WEIGHT`.
-
-### LLM backend
-
-k7e calls **ollama's HTTP API directly** for generation (distill, recall,
-rerank, compile) — never a CLI like `l9m`/`claude`/`codex`. Those carry their
-own rolling context or agent preamble, which would leak into k7e's prompts;
-talking to ollama keeps every call stateless. When `llm_model` is unset, k7e
-auto-detects the best installed model (qwen family preferred, largest wins) and
-falls back to `qwen3:0.6b`. To see exactly which model is in use:
-
-```bash
-k7e status          # → "LLM: ollama (qwen3:8b, auto-detected) ✓"
-k7e config llm_model  # → resolved model name when unset
-```
-
-### Ranking
-
-Search fuses BM25, metadata, and embeddings via RRF, then multiplies each
-score by confidence, a recency decay (gauss; flat for `decay_offset_days`,
-half at `decay_scale_days` past that), and a use-count boost. Entries earn
-freshness when returned by `recall` or read by `get` (index-only signal, reset
-on `reindex`). `--rerank` adds an LLM cross-encoder pass over the candidate
-pool; it is on by default inside `recall`.
-
-## Capabilities
-
-| Feature | Backend | Required? |
-|---------|---------|-----------|
-| Keyword search (BM25) | SQLite FTS5 | Always available |
-| Semantic search | ollama embeddings | Optional — `ollama pull nomic-embed-text` |
-| Distillation (LLM) | ollama | Optional — pattern extraction without |
-| Recall (RAG synthesis) | ollama | Optional — falls back to raw search results |
-| Consolidation (dedup) | title similarity | Always available |
-
-`k7e status` tells you exactly what's active and what to install for full capability.
+| Doc | What's in it |
+|-----|--------------|
+| [docs/architecture.md](docs/architecture.md) | Storage model, entry format, schema, lifecycle |
+| [docs/retrieval.md](docs/retrieval.md) | Search/recall pipeline, ranking, reranker, eval harness |
+| [docs/distillation.md](docs/distillation.md) | Extracting knowledge from raw experience |
+| [docs/configuration.md](docs/configuration.md) | Config keys, env, LLM/embedding backends |
+| [docs/cli.md](docs/cli.md) | Full command + flag reference |
 
 ## Tests
 
 ```bash
 cd ~/bin/apps/k7e
-tests/run           # 69 tests, ~20s
-tests/run -v        # verbose
-tests/run -k dedup  # filter
-tests/run -m "not slow"  # skip slow tests
+tests/run                 # deterministic suite (~15s)
+tests/run -m "not llm"    # skip live-LLM tests
+tests/run -k eval         # the Recall@K harness
 ```
 
-## Dependencies
-
-Required: Python 3.10+, sqlite3 (bundled).
-
-Optional:
-- **ollama** — local embeddings + LLM for distill/recall/rerank/compile (`curl -fsSL https://ollama.com/install.sh | sh`)
-
-Without ollama, k7e runs FTS5-only with pattern-based distillation — still effective for keyword recall.
+The `@llm` tests need a running ollama; everything else is deterministic.
 
 ## Integration
 
-Any agent or harness can call `k7e search` (read) and `k7e store` (write).
-Separation of concerns: the agent reads, the harness/surgeon writes.
+Any agent or harness can call `k7e search`/`k7e recall` (read) and
+`k7e store`/`k7e distill` (write). Separation of concerns: the agent reads, the
+harness/curator writes.
+
+## Status
+
+Pre-v1. The on-disk format (markdown + frontmatter) is the stable contract; the
+derived index schema may change (just `reindex`). See
+[issue #145](https://github.com/neilobremski/bin/issues/145) for the retrieval
+roadmap.

--- a/apps/k7e/README.md
+++ b/apps/k7e/README.md
@@ -15,9 +15,10 @@ Three commitments shape every design decision:
 - **Files are truth.** Knowledge lives as flat markdown on your disk. The search
   index (SQLite FTS5 + optional embeddings) is a cache you can delete and
   rebuild anytime. No database lock-in, no opaque blobs, no cloud.
-- **The core is dependency-free.** Storage and keyword retrieval need nothing
-  but Python's standard library. ollama (embeddings + LLM) is *optional*
-  enhancement — k7e degrades gracefully to FTS5 + pattern extraction.
+- **The core is dependency-free.** Storage and keyword search (FTS5) need
+  nothing but Python's standard library and work fully offline. ollama powers
+  the *enhancements*: semantic search, and knowledge *capture*
+  (distill/recall/compile), which require an LLM and fail fast without one.
 - **Relevance is earned, not assumed.** Knowledge you keep using stays fresh;
   knowledge you never touch fades in *ranking* — never in storage. The store
   accumulates; retrieval forgets.
@@ -75,8 +76,8 @@ search + LLM features (`curl -fsSL https://ollama.com/install.sh | sh`, then
 - **Search** fuses BM25 + metadata + embeddings (RRF), then weights by
   confidence, recency decay, and use-count, with an optional LLM reranker.
 - **Recall** is RAG: retrieve + synthesize an answer (reranker on by default).
-- **Distill** extracts knowledge from raw files (pattern + LLM), dedupes, and
-  stores only genuine deltas.
+- **Distill** extracts knowledge from raw files (LLM), dedupes, and stores only
+  genuine deltas. Requires ollama (fails fast without it).
 - The LLM backend is **ollama, called directly** — never a stateful CLI.
 
 ## Documentation

--- a/apps/k7e/README.md
+++ b/apps/k7e/README.md
@@ -16,9 +16,9 @@ Three commitments shape every design decision:
   index (SQLite FTS5 + optional embeddings) is a cache you can delete and
   rebuild anytime. No database lock-in, no opaque blobs, no cloud.
 - **The core is dependency-free.** Storage and keyword search (FTS5) need
-  nothing but Python's standard library and work fully offline. ollama powers
-  the *enhancements*: semantic search, and knowledge *capture*
-  (distill/recall/compile), which require an LLM and fail fast without one.
+  nothing but Python's standard library and work fully offline. Semantic search
+  uses ollama embeddings; knowledge *capture* (distill/recall/compile) uses
+  **explicit stdin→stdout CLI commands** you configure — no auto-detection.
 - **Relevance is earned, not assumed.** Knowledge you keep using stays fresh;
   knowledge you never touch fades in *ranking* — never in storage. The store
   accumulates; retrieval forgets.
@@ -52,8 +52,9 @@ k7e compile networking [--dry-run]             # synthesize a tag into a page
 # Maintain / inspect
 k7e reindex [--embeddings]                      # rebuild index from markdown
 k7e check [--fix]                               # audit integrity
-k7e status                                      # capabilities + resolved models
-k7e config llm_model qwen3:8b                   # pin ollama model (unset=auto)
+k7e status                                      # capabilities + LLM commands
+k7e config llm_command 'your-stdin-stdout-cli'  # required for distill/recall/compile
+k7e config summarize_command '...'              # optional recall override
 ```
 
 Full flags and every command: **[docs/cli.md](docs/cli.md)**.
@@ -65,9 +66,8 @@ Full flags and every command: **[docs/cli.md](docs/cli.md)**.
 python3 apps/k7e/k7e.py status
 ```
 
-Required: Python 3.10+ (sqlite3 bundled). Optional: **ollama** for semantic
-search + LLM features (`curl -fsSL https://ollama.com/install.sh | sh`, then
-`ollama pull nomic-embed-text`).
+Required: Python 3.10+ (sqlite3 bundled). Optional: **ollama** for semantic search
+embeddings; an **LLM CLI** you configure via `llm_command` for distill/recall/compile.
 
 ## How it works (30 seconds)
 
@@ -77,8 +77,9 @@ search + LLM features (`curl -fsSL https://ollama.com/install.sh | sh`, then
   confidence, recency decay, and use-count, with an optional LLM reranker.
 - **Recall** is RAG: retrieve + synthesize an answer (reranker on by default).
 - **Distill** extracts knowledge from raw files (LLM), dedupes, and stores only
-  genuine deltas. Requires ollama (fails fast without it).
-- The LLM backend is **ollama, called directly** — never a stateful CLI.
+  genuine deltas. Requires `distill_command` or `llm_command`.
+- **LLM backend** is whatever you configure — stdin in, stdout out. No
+  auto-detection, no bundled ollama generation path.
 
 ## Documentation
 

--- a/apps/k7e/README.md
+++ b/apps/k7e/README.md
@@ -63,8 +63,9 @@ rm -rf /tmp/k7e-demo /tmp/notes.md
 
 ```bash
 k7e store "title" --tags x,y [--content "..." | stdin]
-k7e search "query" [--limit N] [--json] [--ids]
+k7e search "query" [--limit N] [--json] [--ids] [--rerank] [--include-superseded]
 k7e get K7E-000-00001
+k7e supersede K7E-000-00001 K7E-000-00002
 k7e append K7E-000-00001 --section "name" [--content "..." | stdin]
 k7e asset screenshot.png
 k7e recall "topic or conversation" [--limit N]
@@ -120,13 +121,41 @@ ssh -L 8080:target:80 bastion — forwards local:8080 to target:80 via bastion
 ## Configuration
 
 ```bash
-k7e status                  # show what's available + recommendations
-k7e config llm gemini       # set distillation LLM (gemini|claude|codex|ollama|auto)
+k7e status                  # show what's active, incl. the resolved LLM model
+k7e config llm_model qwen3:8b   # pin the ollama model (unset = auto-detect)
+k7e config llm none         # disable the LLM entirely (pattern-only distill)
 k7e config embed_model nomic-embed-text
 k7e config ollama_url http://localhost:11434
+k7e config rerank true      # LLM rerank search results (off by default)
+k7e config decay_scale_days 365   # recency half-life past the flat zone
 ```
 
-Config stored in `$K7E_HOME/config.json`. Env vars override: `K7E_LLM`, `EMBED_MODEL`, `OLLAMA_URL`.
+Config stored in `$K7E_HOME/config.json`. Env vars override: `K7E_LLM`,
+`K7E_LLM_MODEL`, `EMBED_MODEL`, `OLLAMA_URL`, `K7E_RERANK`, `K7E_DECAY_OFFSET`,
+`K7E_DECAY_SCALE`, `K7E_USE_WEIGHT`.
+
+### LLM backend
+
+k7e calls **ollama's HTTP API directly** for generation (distill, recall,
+rerank, compile) — never a CLI like `l9m`/`claude`/`codex`. Those carry their
+own rolling context or agent preamble, which would leak into k7e's prompts;
+talking to ollama keeps every call stateless. When `llm_model` is unset, k7e
+auto-detects the best installed model (qwen family preferred, largest wins) and
+falls back to `qwen3:0.6b`. To see exactly which model is in use:
+
+```bash
+k7e status          # → "LLM: ollama (qwen3:8b, auto-detected) ✓"
+k7e config llm_model  # → resolved model name when unset
+```
+
+### Ranking
+
+Search fuses BM25, metadata, and embeddings via RRF, then multiplies each
+score by confidence, a recency decay (gauss; flat for `decay_offset_days`,
+half at `decay_scale_days` past that), and a use-count boost. Entries earn
+freshness when returned by `recall` or read by `get` (index-only signal, reset
+on `reindex`). `--rerank` adds an LLM cross-encoder pass over the candidate
+pool; it is on by default inside `recall`.
 
 ## Capabilities
 
@@ -134,8 +163,8 @@ Config stored in `$K7E_HOME/config.json`. Env vars override: `K7E_LLM`, `EMBED_M
 |---------|---------|-----------|
 | Keyword search (BM25) | SQLite FTS5 | Always available |
 | Semantic search | ollama embeddings | Optional — `ollama pull nomic-embed-text` |
-| Distillation (LLM) | gemini/claude/codex/ollama | Optional — pattern extraction without |
-| Recall (RAG synthesis) | any LLM | Optional — falls back to raw search results |
+| Distillation (LLM) | ollama | Optional — pattern extraction without |
+| Recall (RAG synthesis) | ollama | Optional — falls back to raw search results |
 | Consolidation (dedup) | title similarity | Always available |
 
 `k7e status` tells you exactly what's active and what to install for full capability.
@@ -155,10 +184,9 @@ tests/run -m "not slow"  # skip slow tests
 Required: Python 3.10+, sqlite3 (bundled).
 
 Optional:
-- **ollama** — local embeddings + fallback LLM (`curl -fsSL https://ollama.com/install.sh | sh`)
-- **LLM CLI** — one of: gemini, claude, codex (for distillation + compilation)
+- **ollama** — local embeddings + LLM for distill/recall/rerank/compile (`curl -fsSL https://ollama.com/install.sh | sh`)
 
-On slim machines without GPU: use a cloud LLM CLI for distillation and skip local embeddings (FTS5-only mode is still effective).
+Without ollama, k7e runs FTS5-only with pattern-based distillation — still effective for keyword recall.
 
 ## Integration
 

--- a/apps/k7e/cli.py
+++ b/apps/k7e/cli.py
@@ -48,6 +48,11 @@ COMMANDS: list[tuple[str, str, str]] = [
     ("config",      "<key> [value]",                   "Get or set configuration (llm, embeddings, etc)."),
 ]
 
+_LLM_REQUIRED = (
+    "k7e {cmd} requires an LLM. Start ollama and pull a chat model, then retry "
+    "(see `k7e status`). To run offline without it, that command is unavailable."
+)
+
 
 def main(argv=None):
     parser = argparse.ArgumentParser(
@@ -217,20 +222,24 @@ def main(argv=None):
                 print("Usage: k7e recall <text>  or  echo '...' | k7e recall", file=sys.stderr)
                 return 1
             text = sys.stdin.read()
+        if not config.llm_available():
+            print(_LLM_REQUIRED.format(cmd="recall"), file=sys.stderr)
+            return 1
         answer, sources = recall(text, limit=args.limit)
-        if answer:
-            print(answer)
-            if sources:
-                ids = ", ".join(e["id"] for e in sources)
-                print(f"\n---\nSources: {ids}")
-        elif sources:
-            print("No LLM available — raw search results:", file=sys.stderr)
-            for e in sources:
-                print(f"  {e['id']}  {e['title']}")
-        else:
+        if not sources:
             print("No relevant knowledge found.")
+        elif answer:
+            print(answer)
+            ids = ", ".join(e["id"] for e in sources)
+            print(f"\n---\nSources: {ids}")
+        else:
+            print("LLM synthesis failed.", file=sys.stderr)
+            return 1
 
     elif args.command == "distill":
+        if not config.llm_available():
+            print(_LLM_REQUIRED.format(cmd="distill"), file=sys.stderr)
+            return 1
         results = distill(args.paths, dry_run=args.dry_run)
         for r in results:
             action = r["action"]
@@ -255,6 +264,9 @@ def main(argv=None):
             print(f"\nConsolidated: {total_superseded} nodes superseded across {len(results)} groups.")
 
     elif args.command == "compile":
+        if not config.llm_available():
+            print(_LLM_REQUIRED.format(cmd="compile"), file=sys.stderr)
+            return 1
         node_id = compile_tag(args.tag, dry_run=args.dry_run)
         if node_id:
             print(f"Compiled {node_id}: {args.tag} — Compiled Reference")

--- a/apps/k7e/cli.py
+++ b/apps/k7e/cli.py
@@ -21,6 +21,7 @@ from engine import (
     append_entry,
     compile_tag,
     process_pending_embeddings,
+    supersede,
 )
 from distill import distill, consolidate
 from hygiene import run_audit
@@ -29,6 +30,7 @@ from hygiene import run_audit
 COMMANDS: list[tuple[str, str, str]] = [
     ("search",      "<query> [--limit N] [--json] [--ids]", "Hybrid search (BM25 + semantic + metadata)."),
     ("get",         "<id>",                            "Read a full knowledge entry."),
+    ("supersede",   "<old_id> <new_id>",               "Mark an entry as superseded by a newer one."),
     ("store",       "<title> [--tags] [--aliases]",    "Create a new entry (content from stdin or --content)."),
     ("append",        "<id> --section <name>",           "Append to an existing entry's section."),
     ("asset",       "<file>",                          "Store binary (content-addressed, deduped). Prints path."),
@@ -62,10 +64,17 @@ def main(argv=None):
     p.add_argument("--limit", type=int, default=5)
     p.add_argument("--json", action="store_true")
     p.add_argument("--ids", action="store_true", help="Output IDs only, one per line")
+    p.add_argument("--rerank", action="store_true", help="Rerank results with the LLM")
+    p.add_argument("--include-superseded", action="store_true", help="Include superseded entries")
 
     # get
     p = sub.add_parser("get", help="Read entry")
     p.add_argument("id", help="Entry ID (e.g., KG-00001)")
+
+    # supersede
+    p = sub.add_parser("supersede", help="Mark an entry as superseded by a newer one")
+    p.add_argument("old_id", help="Entry being retired")
+    p.add_argument("new_id", help="Entry that replaces it")
 
     # store
     p = sub.add_parser("store", help="Create new entry")
@@ -145,7 +154,12 @@ def main(argv=None):
     init()
 
     if args.command == "search":
-        results = search(args.query, limit=args.limit)
+        results = search(
+            args.query,
+            limit=args.limit,
+            include_superseded=args.include_superseded,
+            rerank=True if args.rerank else None,
+        )
         if args.ids:
             for r in results:
                 print(r['id'])
@@ -159,9 +173,21 @@ def main(argv=None):
 
     elif args.command == "get":
         try:
-            print(get(args.id))
+            print(get(args.id, track_usage=True))
         except FileNotFoundError as e:
             print(str(e), file=sys.stderr)
+            return 1
+
+    elif args.command == "supersede":
+        try:
+            get(args.new_id)
+        except FileNotFoundError:
+            print(f"Node {args.new_id} not found", file=sys.stderr)
+            return 1
+        if supersede(args.old_id, args.new_id):
+            print(f"{args.old_id} superseded by {args.new_id}")
+        else:
+            print(f"Node {args.old_id} not found", file=sys.stderr)
             return 1
 
     elif args.command == "store":
@@ -283,6 +309,10 @@ def main(argv=None):
             val = config.get(args.key)
             if val is not None:
                 print(val)
+            elif args.key == "llm_model":
+                print(f"{config.resolve_llm_model()} (auto-detected)")
+            elif args.key == "llm":
+                print("ollama (default)")
             else:
                 print(f"{args.key}: not set")
         else:

--- a/apps/k7e/cli.py
+++ b/apps/k7e/cli.py
@@ -49,8 +49,8 @@ COMMANDS: list[tuple[str, str, str]] = [
 ]
 
 _LLM_REQUIRED = (
-    "k7e {cmd} requires an LLM. Start ollama and pull a chat model, then retry "
-    "(see `k7e status`). To run offline without it, that command is unavailable."
+    "k7e {cmd} requires an LLM command. Set llm_command (or a purpose-specific "
+    "override) — stdin in, stdout out — then retry (see `k7e status`)."
 )
 
 
@@ -147,7 +147,7 @@ def main(argv=None):
 
     # config
     p = sub.add_parser("config", help="Get or set configuration")
-    p.add_argument("key", help="Config key (llm, embeddings, embed_model, ollama_url)")
+    p.add_argument("key", help="Config key (llm_command, summarize_command, embeddings, ...)")
     p.add_argument("value", nargs="?", default=None, help="Value to set (omit to read)")
 
     args = parser.parse_args(argv)
@@ -222,7 +222,7 @@ def main(argv=None):
                 print("Usage: k7e recall <text>  or  echo '...' | k7e recall", file=sys.stderr)
                 return 1
             text = sys.stdin.read()
-        if not config.llm_available():
+        if not config.llm_configured("summarize"):
             print(_LLM_REQUIRED.format(cmd="recall"), file=sys.stderr)
             return 1
         answer, sources = recall(text, limit=args.limit)
@@ -237,7 +237,7 @@ def main(argv=None):
             return 1
 
     elif args.command == "distill":
-        if not config.llm_available():
+        if not config.llm_configured("distill"):
             print(_LLM_REQUIRED.format(cmd="distill"), file=sys.stderr)
             return 1
         results = distill(args.paths, dry_run=args.dry_run)
@@ -264,7 +264,7 @@ def main(argv=None):
             print(f"\nConsolidated: {total_superseded} nodes superseded across {len(results)} groups.")
 
     elif args.command == "compile":
-        if not config.llm_available():
+        if not config.llm_configured("compile"):
             print(_LLM_REQUIRED.format(cmd="compile"), file=sys.stderr)
             return 1
         node_id = compile_tag(args.tag, dry_run=args.dry_run)
@@ -321,10 +321,15 @@ def main(argv=None):
             val = config.get(args.key)
             if val is not None:
                 print(val)
-            elif args.key == "llm_model":
-                print(f"{config.resolve_llm_model()} (auto-detected)")
-            elif args.key == "llm":
-                print("ollama (default)")
+            elif args.key in {v[0] for v in config.LLM_PURPOSES.values()}:
+                purpose = next(
+                    p for p, (k, _) in config.LLM_PURPOSES.items() if k == args.key
+                )
+                cmd, source = config.command_source(purpose)
+                if cmd and source == config.LLM_FALLBACK_KEY:
+                    print(f"{cmd} (via llm_command)")
+                else:
+                    print(f"{args.key}: not set")
             else:
                 print(f"{args.key}: not set")
         else:

--- a/apps/k7e/config.py
+++ b/apps/k7e/config.py
@@ -1,12 +1,17 @@
-"""k7e configuration — LLM providers, embedding backends, status reporting.
+"""k7e configuration — LLM model, embedding backend, status reporting.
 
 Config file: $K7E_HOME/config.json (created by `k7e init` or `k7e config`)
 Falls back to env vars, then sensible defaults.
 
+k7e talks to ollama's HTTP API directly for both generation and embeddings.
+It deliberately does NOT shell out to LLM CLIs (l9m, claude, codex, …): those
+carry their own rolling context / agent preamble, which would contaminate
+k7e's distill, recall, and rerank prompts. Every k7e LLM call is stateless.
+
 Config format:
 {
-  "llm": "gemini",                    # CLI for distillation: gemini|claude|ollama|codex
-  "llm_model": null,                  # model override (for ollama)
+  "llm": "ollama",                    # "ollama" (default) or "none" to disable
+  "llm_model": null,                  # pin a model; null = auto-detect installed
   "embeddings": "ollama",             # embedding backend: ollama|none
   "embed_model": "nomic-embed-text",  # model for embeddings
   "ollama_url": "http://localhost:11434"
@@ -15,11 +20,12 @@ Config format:
 
 import json
 import os
-import shutil
-import subprocess
+import re
 import urllib.error
 import urllib.request
 from pathlib import Path
+
+DEFAULT_LLM_MODEL = "qwen3:0.6b"
 
 
 def _k7e_home():
@@ -55,6 +61,10 @@ def get(key, default=None):
         "embeddings": "K7E_EMBEDDINGS",
         "embed_model": "EMBED_MODEL",
         "ollama_url": "OLLAMA_URL",
+        "decay_offset_days": "K7E_DECAY_OFFSET",
+        "decay_scale_days": "K7E_DECAY_SCALE",
+        "use_count_weight": "K7E_USE_WEIGHT",
+        "rerank": "K7E_RERANK",
     }
     env_key = env_map.get(key)
     if env_key and os.environ.get(env_key):
@@ -65,46 +75,83 @@ def get(key, default=None):
 
 # --- Provider detection ---
 
-KNOWN_LLMS = {
-    "l9m": {"bin": "l9m", "invoke": ["l9m", "-s", "-p", "{prompt}"]},
-    "agy": {"bin": "agy", "invoke": ["agy", "-p", "{prompt}"]},
-    "claude": {"bin": "claude", "invoke": ["claude", "-p", "{prompt}"]},
-    "codex": {"bin": "codex", "invoke": ["codex", "--full-auto", "{prompt}"]},
-    "ollama": {"bin": "ollama", "invoke": None},  # uses HTTP API
-}
-
-
-def detect_providers():
-    """Check what's available on this system."""
-    results = {}
-
-    # LLM CLIs
-    for name, info in KNOWN_LLMS.items():
-        binary = shutil.which(info["bin"])
-        results[f"llm:{name}"] = {"available": binary is not None, "path": binary}
-
-    # Ollama embeddings
+def _list_ollama_models():
+    """Return the list of model names installed in ollama, or [] if unreachable."""
     ollama_url = get("ollama_url", "http://localhost:11434")
     try:
         req = urllib.request.Request(f"{ollama_url}/api/tags", method="GET")
         with urllib.request.urlopen(req, timeout=3) as resp:
             data = json.loads(resp.read())
-            models = [m["name"] for m in data.get("models", [])]
-            embed_model = get("embed_model", "nomic-embed-text")
-            has_embed = any(embed_model in m for m in models)
-            results["embeddings:ollama"] = {
-                "available": True,
-                "models": models,
-                "has_embed_model": has_embed,
-                "embed_model": embed_model,
-            }
-    except (urllib.error.URLError, OSError):
-        results["embeddings:ollama"] = {"available": False}
+            return [m["name"] for m in data.get("models", [])]
+    except (urllib.error.URLError, OSError, json.JSONDecodeError, KeyError):
+        return []
+
+
+def _model_size(name):
+    """Best-effort parameter count parsed from a model tag (e.g. '8b' -> 8.0)."""
+    m = re.search(r"(\d+(?:\.\d+)?)\s*b\b", name.lower())
+    return float(m.group(1)) if m else 0.0
+
+
+def resolve_llm_model(models=None):
+    """Resolve the ollama model k7e should use for generation.
+
+    Precedence: pinned `llm_model`/`K7E_LLM_MODEL` > best installed model
+    (qwen family preferred, largest wins) > DEFAULT_LLM_MODEL. Pass `models`
+    to reuse an already-fetched `/api/tags` listing."""
+    pinned = get("llm_model")
+    if pinned:
+        return pinned
+    if models is None:
+        models = _list_ollama_models()
+    candidates = [m for m in models if "embed" not in m.lower()]
+    if not candidates:
+        return DEFAULT_LLM_MODEL
+    qwen = [m for m in candidates if m.lower().startswith("qwen")]
+    pool = qwen or candidates
+    pool.sort(key=_model_size, reverse=True)
+    return pool[0]
+
+
+def detect_providers():
+    """Check what's available on this system (single ollama probe)."""
+    results = {}
+
+    models = _list_ollama_models()
+    ollama_up = bool(models) or _ollama_reachable()
+
+    embed_model = get("embed_model", "nomic-embed-text")
+    has_embed = any(embed_model in m for m in models)
+    results["embeddings:ollama"] = {
+        "available": ollama_up,
+        "models": models,
+        "has_embed_model": has_embed,
+        "embed_model": embed_model,
+    }
+
+    llm_enabled = get("llm", "ollama") != "none"
+    results["llm:ollama"] = {
+        "available": ollama_up and llm_enabled,
+        "model": resolve_llm_model(models),
+        "pinned": bool(get("llm_model")),
+        "enabled": llm_enabled,
+    }
 
     # FTS5 (always available with Python's sqlite3)
     results["search:fts5"] = {"available": True}
 
     return results
+
+
+def _ollama_reachable():
+    """True if ollama answers on /api/tags even with zero models installed."""
+    ollama_url = get("ollama_url", "http://localhost:11434")
+    try:
+        req = urllib.request.Request(f"{ollama_url}/api/tags", method="GET")
+        with urllib.request.urlopen(req, timeout=3):
+            return True
+    except (urllib.error.URLError, OSError):
+        return False
 
 
 def status():
@@ -119,16 +166,17 @@ def status():
         lines.append("    → Not initialized. Run any k7e command to create.")
     lines.append("")
 
-    # Configured LLM
-    llm = get("llm", "auto")
-    lines.append(f"  Distillation LLM: {llm}")
-    if llm == "auto":
-        for name in KNOWN_LLMS:
-            if providers.get(f"llm:{name}", {}).get("available"):
-                lines.append(f"    → auto-detected: {name}")
-                break
+    # LLM (ollama, direct HTTP — no CLI shell-out)
+    llm_info = providers.get("llm:ollama", {})
+    if not llm_info.get("enabled", True):
+        lines.append("  LLM: disabled (llm=none) — distill uses pattern-only extraction")
+    else:
+        model = llm_info.get("model", DEFAULT_LLM_MODEL)
+        source = "configured" if llm_info.get("pinned") else "auto-detected"
+        if llm_info.get("available"):
+            lines.append(f"  LLM: ollama ({model}, {source}) ✓")
         else:
-            lines.append("    → NONE detected (distill will use pattern-only extraction)")
+            lines.append(f"  LLM: ollama ({model}, {source}) ✗ — ollama not running")
 
     # Embeddings
     embed_cfg = get("embeddings", "ollama")
@@ -155,8 +203,8 @@ def status():
     # Recommendations
     lines.append("")
     missing = []
-    if not any(providers.get(f"llm:{n}", {}).get("available") for n in KNOWN_LLMS):
-        missing.append("Install an LLM CLI (gemini, claude, or ollama) for distillation")
+    if llm_info.get("enabled", True) and not llm_info.get("available"):
+        missing.append("Start ollama (and `ollama pull` a model) for LLM distillation/recall")
     if not embed_status.get("has_embed_model"):
         missing.append(f"Run `ollama pull {get('embed_model', 'nomic-embed-text')}` for semantic search")
     if missing:
@@ -167,25 +215,3 @@ def status():
         lines.append("  All capabilities active.")
 
     return "\n".join(lines)
-
-
-def resolve_llm_command(prompt):
-    """Return the command list to run for LLM distillation, or None."""
-    llm = get("llm", "auto")
-
-    if llm == "auto":
-        for name in ["l9m", "agy", "claude", "codex", "ollama"]:
-            if shutil.which(KNOWN_LLMS[name]["bin"]):
-                llm = name
-                break
-        else:
-            return None
-
-    if llm == "ollama":
-        return None  # handled via HTTP API in distill.py
-
-    info = KNOWN_LLMS.get(llm)
-    if not info or not shutil.which(info["bin"]):
-        return None
-
-    return [arg.replace("{prompt}", prompt) for arg in info["invoke"]]

--- a/apps/k7e/config.py
+++ b/apps/k7e/config.py
@@ -113,6 +113,15 @@ def resolve_llm_model(models=None):
     return pool[0]
 
 
+def llm_available():
+    """True when k7e can make an LLM call: not explicitly disabled and ollama
+    is reachable. Used by the LLM-requiring commands (distill/recall/compile)
+    to fail fast with an actionable message instead of degrading silently."""
+    if get("llm", "ollama") == "none":
+        return False
+    return _ollama_reachable()
+
+
 def detect_providers():
     """Check what's available on this system (single ollama probe)."""
     results = {}

--- a/apps/k7e/config.py
+++ b/apps/k7e/config.py
@@ -1,31 +1,46 @@
-"""k7e configuration — LLM model, embedding backend, status reporting.
+"""k7e configuration — LLM commands, embedding backend, status reporting.
 
 Config file: $K7E_HOME/config.json (created by `k7e init` or `k7e config`)
 Falls back to env vars, then sensible defaults.
 
-k7e talks to ollama's HTTP API directly for both generation and embeddings.
-It deliberately does NOT shell out to LLM CLIs (l9m, claude, codex, …): those
-carry their own rolling context / agent preamble, which would contaminate
-k7e's distill, recall, and rerank prompts. Every k7e LLM call is stateless.
+LLM integration is explicit and CLI-based. Each command is a shell string
+invoked with the prompt on stdin; the model response is read from stdout.
+No auto-detection. Embeddings use ollama's HTTP API separately.
 
 Config format:
 {
-  "llm": "ollama",                    # "ollama" (default) or "none" to disable
-  "llm_model": null,                  # pin a model; null = auto-detect installed
-  "embeddings": "ollama",             # embedding backend: ollama|none
-  "embed_model": "nomic-embed-text",  # model for embeddings
-  "ollama_url": "http://localhost:11434"
+  "llm_command": "l9m -s",              # fallback for all LLM purposes
+  "summarize_command": null,            # recall synthesis
+  "decompose_command": null,            # long-text query extraction
+  "distill_command": null,              # knowledge extraction
+  "compile_command": null,              # tag synthesis
+  "rerank_command": null,               # search/recall reranking
+  "embeddings": "ollama",
+  "embed_model": "nomic-embed-text",
+  "ollama_url": "http://localhost:11434",
+  "rerank": false,
+  "decay_offset_days": 30,
+  "decay_scale_days": 365,
+  "use_count_weight": 0.2
 }
 """
 
 import json
 import os
-import re
 import urllib.error
 import urllib.request
 from pathlib import Path
 
-DEFAULT_LLM_MODEL = "qwen3:0.6b"
+LLM_FALLBACK_KEY = "llm_command"
+LLM_FALLBACK_ENV = "K7E_LLM_COMMAND"
+
+LLM_PURPOSES = {
+    "summarize": ("summarize_command", "K7E_SUMMARIZE_COMMAND"),
+    "decompose": ("decompose_command", "K7E_DECOMPOSE_COMMAND"),
+    "distill": ("distill_command", "K7E_DISTILL_COMMAND"),
+    "compile": ("compile_command", "K7E_COMPILE_COMMAND"),
+    "rerank": ("rerank_command", "K7E_RERANK_COMMAND"),
+}
 
 
 def _k7e_home():
@@ -53,11 +68,21 @@ def save_config(cfg):
     path.write_text(json.dumps(cfg, indent=2) + "\n", encoding="utf-8")
 
 
+def _get_raw(key, env_key=None):
+    if env_key and os.environ.get(env_key):
+        return os.environ[env_key]
+    return load_config().get(key)
+
+
 def get(key, default=None):
     """Read config value with env var override."""
     env_map = {
-        "llm": "K7E_LLM",
-        "llm_model": "K7E_LLM_MODEL",
+        LLM_FALLBACK_KEY: LLM_FALLBACK_ENV,
+        "summarize_command": "K7E_SUMMARIZE_COMMAND",
+        "decompose_command": "K7E_DECOMPOSE_COMMAND",
+        "distill_command": "K7E_DISTILL_COMMAND",
+        "compile_command": "K7E_COMPILE_COMMAND",
+        "rerank_command": "K7E_RERANK_COMMAND",
         "embeddings": "K7E_EMBEDDINGS",
         "embed_model": "EMBED_MODEL",
         "ollama_url": "OLLAMA_URL",
@@ -67,106 +92,71 @@ def get(key, default=None):
         "rerank": "K7E_RERANK",
     }
     env_key = env_map.get(key)
-    if env_key and os.environ.get(env_key):
-        return os.environ[env_key]
-    cfg = load_config()
-    return cfg.get(key, default)
+    val = _get_raw(key, env_key)
+    return val if val is not None else default
 
 
-# --- Provider detection ---
+def resolve_command(purpose):
+    """Return the shell command string for an LLM purpose, or None."""
+    cfg_key, env_key = LLM_PURPOSES[purpose]
+    cmd = _get_raw(cfg_key, env_key)
+    if cmd and str(cmd).strip():
+        return str(cmd).strip()
+    fallback = _get_raw(LLM_FALLBACK_KEY, LLM_FALLBACK_ENV)
+    return str(fallback).strip() if fallback else None
 
-def _list_ollama_models():
-    """Return the list of model names installed in ollama, or [] if unreachable."""
+
+def command_source(purpose):
+    """Return (command, source_label) for status/config display."""
+    cfg_key, env_key = LLM_PURPOSES[purpose]
+    cmd = _get_raw(cfg_key, env_key)
+    if cmd and str(cmd).strip():
+        return str(cmd).strip(), cfg_key
+    fallback = _get_raw(LLM_FALLBACK_KEY, LLM_FALLBACK_ENV)
+    if fallback and str(fallback).strip():
+        return str(fallback).strip(), LLM_FALLBACK_KEY
+    return None, "not configured"
+
+
+def llm_configured(purpose):
+    """True when a command is configured for the given LLM purpose."""
+    return resolve_command(purpose) is not None
+
+
+# Back-compat alias used by CLI fail-fast guards.
+llm_available = llm_configured
+
+
+# --- Provider detection (embeddings only) ---
+
+def detect_providers():
+    """Check what's available on this system."""
+    results = {}
+
     ollama_url = get("ollama_url", "http://localhost:11434")
     try:
         req = urllib.request.Request(f"{ollama_url}/api/tags", method="GET")
         with urllib.request.urlopen(req, timeout=3) as resp:
             data = json.loads(resp.read())
-            return [m["name"] for m in data.get("models", [])]
-    except (urllib.error.URLError, OSError, json.JSONDecodeError, KeyError):
-        return []
-
-
-def _model_size(name):
-    """Best-effort parameter count parsed from a model tag (e.g. '8b' -> 8.0)."""
-    m = re.search(r"(\d+(?:\.\d+)?)\s*b\b", name.lower())
-    return float(m.group(1)) if m else 0.0
-
-
-def resolve_llm_model(models=None):
-    """Resolve the ollama model k7e should use for generation.
-
-    Precedence: pinned `llm_model`/`K7E_LLM_MODEL` > best installed model
-    (qwen family preferred, largest wins) > DEFAULT_LLM_MODEL. Pass `models`
-    to reuse an already-fetched `/api/tags` listing."""
-    pinned = get("llm_model")
-    if pinned:
-        return pinned
-    if models is None:
-        models = _list_ollama_models()
-    candidates = [m for m in models if "embed" not in m.lower()]
-    if not candidates:
-        return DEFAULT_LLM_MODEL
-    qwen = [m for m in candidates if m.lower().startswith("qwen")]
-    pool = qwen or candidates
-    pool.sort(key=_model_size, reverse=True)
-    return pool[0]
-
-
-def llm_available():
-    """True when k7e can make an LLM call: not explicitly disabled and ollama
-    is reachable. Used by the LLM-requiring commands (distill/recall/compile)
-    to fail fast with an actionable message instead of degrading silently."""
-    if get("llm", "ollama") == "none":
-        return False
-    return _ollama_reachable()
-
-
-def detect_providers():
-    """Check what's available on this system (single ollama probe)."""
-    results = {}
-
-    models = _list_ollama_models()
-    ollama_up = bool(models) or _ollama_reachable()
-
-    embed_model = get("embed_model", "nomic-embed-text")
-    has_embed = any(embed_model in m for m in models)
-    results["embeddings:ollama"] = {
-        "available": ollama_up,
-        "models": models,
-        "has_embed_model": has_embed,
-        "embed_model": embed_model,
-    }
-
-    llm_enabled = get("llm", "ollama") != "none"
-    results["llm:ollama"] = {
-        "available": ollama_up and llm_enabled,
-        "model": resolve_llm_model(models),
-        "pinned": bool(get("llm_model")),
-        "enabled": llm_enabled,
-    }
-
-    # FTS5 (always available with Python's sqlite3)
-    results["search:fts5"] = {"available": True}
-
-    return results
-
-
-def _ollama_reachable():
-    """True if ollama answers on /api/tags even with zero models installed."""
-    ollama_url = get("ollama_url", "http://localhost:11434")
-    try:
-        req = urllib.request.Request(f"{ollama_url}/api/tags", method="GET")
-        with urllib.request.urlopen(req, timeout=3):
-            return True
+            models = [m["name"] for m in data.get("models", [])]
+            embed_model = get("embed_model", "nomic-embed-text")
+            has_embed = any(embed_model in m for m in models)
+            results["embeddings:ollama"] = {
+                "available": True,
+                "models": models,
+                "has_embed_model": has_embed,
+                "embed_model": embed_model,
+            }
     except (urllib.error.URLError, OSError):
-        return False
+        results["embeddings:ollama"] = {"available": False}
+
+    results["search:fts5"] = {"available": True}
+    return results
 
 
 def status():
     """Human-readable status report."""
     providers = detect_providers()
-    cfg = load_config()
     home = _k7e_home()
     lines = ["k7e status:", ""]
 
@@ -175,20 +165,22 @@ def status():
         lines.append("    → Not initialized. Run any k7e command to create.")
     lines.append("")
 
-    # LLM (ollama, direct HTTP — no CLI shell-out)
-    llm_info = providers.get("llm:ollama", {})
-    if not llm_info.get("enabled", True):
-        lines.append("  LLM: disabled (llm=none) — distill uses pattern-only extraction")
+    fallback = _get_raw(LLM_FALLBACK_KEY, LLM_FALLBACK_ENV)
+    if fallback and str(fallback).strip():
+        lines.append(f"  LLM fallback: {fallback.strip()} ✓")
     else:
-        model = llm_info.get("model", DEFAULT_LLM_MODEL)
-        source = "configured" if llm_info.get("pinned") else "auto-detected"
-        if llm_info.get("available"):
-            lines.append(f"  LLM: ollama ({model}, {source}) ✓")
-        else:
-            lines.append(f"  LLM: ollama ({model}, {source}) ✗ — ollama not running")
+        lines.append("  LLM fallback: not configured")
+        lines.append("    → Set: k7e config llm_command 'your-stdin-stdout-cli'")
 
-    # Embeddings
-    embed_cfg = get("embeddings", "ollama")
+    for purpose, (cfg_key, _) in LLM_PURPOSES.items():
+        cmd, source = command_source(purpose)
+        if source == cfg_key:
+            lines.append(f"  LLM {purpose}: {cmd} ({source})")
+        elif cmd:
+            lines.append(f"  LLM {purpose}: {cmd} (via llm_command)")
+        else:
+            lines.append(f"  LLM {purpose}: unavailable")
+
     embed_status = providers.get("embeddings:ollama", {})
     if embed_status.get("available"):
         if embed_status.get("has_embed_model"):
@@ -202,18 +194,16 @@ def status():
         lines.append("    → Install: curl -fsSL https://ollama.com/install.sh | sh")
         lines.append(f"    → Then: ollama pull {get('embed_model', 'nomic-embed-text')}")
 
-    # Search
     lines.append("  Search: FTS5 (keyword) ✓")
     if embed_status.get("available") and embed_status.get("has_embed_model"):
         lines.append("  Search: Semantic (embeddings) ✓")
     else:
         lines.append("  Search: Semantic (embeddings) ✗ — FTS5-only mode")
 
-    # Recommendations
     lines.append("")
     missing = []
-    if llm_info.get("enabled", True) and not llm_info.get("available"):
-        missing.append("Start ollama (and `ollama pull` a model) for LLM distillation/recall")
+    if not (fallback and str(fallback).strip()):
+        missing.append("Set llm_command (stdin→stdout CLI) for distill/recall/compile")
     if not embed_status.get("has_embed_model"):
         missing.append(f"Run `ollama pull {get('embed_model', 'nomic-embed-text')}` for semantic search")
     if missing:

--- a/apps/k7e/distill.py
+++ b/apps/k7e/distill.py
@@ -3,11 +3,11 @@
 Scans raw files (journals, transcripts, command output, images, audio, video).
 Extracts knowledge candidates. Diffs against existing store. Stores genuine deltas.
 
-Text files: LLM extraction (ollama).
-Media files: ollama vision (image description) + asset storage.
+Text files: LLM extraction via distill_command (stdin→stdout).
+Media files: multimodal via distill_command (prompt includes file path).
 
-Distillation requires an LLM. The CLI fails fast when ollama is unavailable;
-set llm=none to explicitly opt out (extraction returns nothing).
+Distillation requires a configured LLM command. The CLI fails fast when
+distill_command (or llm_command) is unset.
 """
 
 import json
@@ -141,40 +141,35 @@ def extract_from_file(path):
 
 
 def _multimodal_extract(path):
-    """Extract knowledge from media via ollama's multimodal API.
-
-    Images are sent to a vision-capable ollama model as base64. ollama can't
-    transcribe audio/video, so those are skipped — transcribe them with a
-    dedicated tool first, then distill the resulting text."""
-    import base64
+    """Extract knowledge from media via distill_command (prompt on stdin)."""
     import config
 
-    if config.get("llm", "ollama") == "none":
+    if not config.resolve_command("distill"):
+        print(f"  [distill] distill_command not configured — cannot process {path}", file=sys.stderr)
         return []
 
     kind = _media_type(path)
     abs_path = str(Path(path).resolve())
 
-    if kind != "image":
-        print(f"  [distill] ollama can't transcribe {kind} — skipping {path}", file=sys.stderr)
+    if kind == "image":
+        instruction = "Describe this image in detail."
+    elif kind == "audio":
+        instruction = "Transcribe this audio file completely. Include speaker identification if multiple speakers."
+    elif kind == "video":
+        instruction = "Transcribe the audio and describe key visual content of this video."
+    else:
         return []
 
     prompt = (
-        "Describe this image in detail.\n\n"
+        f"{instruction} File: {abs_path}\n\n"
         "Return a JSON object with:\n"
         '- "title": short descriptive title for this content\n'
-        '- "content": the full description\n'
+        '- "content": the full transcription or description\n'
         '- "tags": list of topic keywords\n'
         "Return ONLY the JSON object, no markdown fencing."
     )
 
-    try:
-        b64 = base64.b64encode(Path(path).read_bytes()).decode()
-    except OSError as e:
-        print(f"  [distill] could not read {path}: {e}", file=sys.stderr)
-        return []
-
-    response = engine._call_llm(prompt, timeout=180, images=[b64])
+    response = engine._call_llm(prompt, purpose="distill", timeout=180)
     if not response:
         return []
     parsed = _parse_multimodal_response(response, path)
@@ -427,9 +422,7 @@ def _llm_extract(text):
 
     import config
 
-    # Explicit opt-out (tests, deliberately-offline use). The CLI fails fast
-    # before reaching here when the LLM is simply unavailable.
-    if config.get("llm", "ollama") == "none":
+    if not config.resolve_command("distill"):
         return []
 
     # Chunk the input and extract from each chunk independently
@@ -463,7 +456,7 @@ def _llm_extract(text):
 
 def _run_llm_prompt(prompt):
     """Run a single LLM prompt and return parsed candidates."""
-    response = engine._call_llm(prompt, timeout=180)
+    response = engine._call_llm(prompt, purpose="distill", timeout=180)
     if response:
         return _parse_llm_response(response)
     return []

--- a/apps/k7e/distill.py
+++ b/apps/k7e/distill.py
@@ -3,18 +3,17 @@
 Scans raw files (journals, transcripts, command output, images, audio, video).
 Extracts knowledge candidates. Diffs against existing store. Stores genuine deltas.
 
-Text files: pattern extraction + LLM extraction.
+Text files: LLM extraction (ollama).
 Media files: ollama vision (image description) + asset storage.
 
-Uses ollama directly for LLM extraction. Falls back to pattern-based
-extraction when ollama is unavailable.
+Distillation requires an LLM. The CLI fails fast when ollama is unavailable;
+set llm=none to explicitly opt out (extraction returns nothing).
 """
 
 import json
 import os
 import re
 import sys
-import urllib.request
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
@@ -138,11 +137,7 @@ def extract_from_file(path):
     if _media_type(path):
         return _multimodal_extract(path)
     text = Path(path).read_text(encoding="utf-8")
-    candidates = _pattern_extract(text)
-    llm_candidates = _llm_extract(text)
-    if llm_candidates:
-        candidates.extend(llm_candidates)
-    return candidates
+    return _llm_extract(text)
 
 
 def _multimodal_extract(path):
@@ -426,46 +421,15 @@ def _dedup_candidates(candidates):
     return deduped
 
 
-def _pattern_extract(text):
-    candidates = []
-
-    # Pattern: "TIL:" or "Today I learned:" lines
-    for match in re.finditer(r"(?:TIL|Today I learned)[:\s]+(.+?)(?:\n\n|\n###|\Z)", text, re.DOTALL):
-        content = match.group(1).strip()
-        if len(content) > 20:
-            title = content[:60].split("\n")[0].rstrip(".")
-            candidates.append({"title": title, "content": content, "tags": ["learned"]})
-
-    # Pattern: "The fix is:" or "Solution:" followed by content
-    for match in re.finditer(r"(?:The fix is|Solution|Fix)[:\s]+(.+?)(?:\n\n|\n###|\Z)", text, re.DOTALL):
-        content = match.group(1).strip()
-        if len(content) > 15:
-            title = f"Fix: {content[:50].split(chr(10))[0].rstrip('.')}"
-            candidates.append({"title": title, "content": content, "tags": ["fix"]})
-
-    # Pattern: Code blocks preceded by instructional context
-    for match in re.finditer(r"(?:use|run|execute|command)[:\s]*\n```[^\n]*\n(.+?)```", text, re.DOTALL | re.IGNORECASE):
-        content = match.group(1).strip()
-        if len(content) > 10:
-            title = f"Command: {content.split(chr(10))[0][:50]}"
-            candidates.append({"title": title, "content": content, "tags": ["command"]})
-
-    return candidates
-
-
 def _llm_extract(text):
     if len(text) < 100:
         return []
 
     import config
 
+    # Explicit opt-out (tests, deliberately-offline use). The CLI fails fast
+    # before reaching here when the LLM is simply unavailable.
     if config.get("llm", "ollama") == "none":
-        return []
-    ollama_url = config.get("ollama_url", "http://localhost:11434")
-    try:
-        urllib.request.urlopen(f"{ollama_url}/api/tags", timeout=2)
-    except Exception:
-        print("  [distill] ollama not available — pattern extraction only", file=sys.stderr)
         return []
 
     # Chunk the input and extract from each chunk independently

--- a/apps/k7e/distill.py
+++ b/apps/k7e/distill.py
@@ -4,17 +4,15 @@ Scans raw files (journals, transcripts, command output, images, audio, video).
 Extracts knowledge candidates. Diffs against existing store. Stores genuine deltas.
 
 Text files: pattern extraction + LLM extraction.
-Media files: multimodal LLM (describe/transcribe) + asset storage.
+Media files: ollama vision (image description) + asset storage.
 
-Uses agy/claude/codex CLI or ollama for LLM extraction. Falls back to
-pattern-based extraction if neither is available.
+Uses ollama directly for LLM extraction. Falls back to pattern-based
+extraction when ollama is unavailable.
 """
 
 import json
 import os
 import re
-import shutil
-import subprocess
 import sys
 import urllib.request
 from pathlib import Path
@@ -148,57 +146,47 @@ def extract_from_file(path):
 
 
 def _multimodal_extract(path):
-    """Extract knowledge from media files via multimodal LLM."""
+    """Extract knowledge from media via ollama's multimodal API.
+
+    Images are sent to a vision-capable ollama model as base64. ollama can't
+    transcribe audio/video, so those are skipped — transcribe them with a
+    dedicated tool first, then distill the resulting text."""
+    import base64
     import config
 
-    cmd = config.resolve_llm_command("test")
-    if not cmd:
-        print(f"  [distill] no LLM available — cannot process media file {path}", file=sys.stderr)
+    if config.get("llm", "ollama") == "none":
         return []
 
     kind = _media_type(path)
     abs_path = str(Path(path).resolve())
 
-    if kind == "image":
-        instruction = "Describe this image in detail."
-    elif kind == "audio":
-        instruction = "Transcribe this audio file completely. Include speaker identification if multiple speakers."
-    elif kind == "video":
-        instruction = "Transcribe the audio and describe key visual content of this video."
-    else:
+    if kind != "image":
+        print(f"  [distill] ollama can't transcribe {kind} — skipping {path}", file=sys.stderr)
         return []
 
     prompt = (
-        f"{instruction} File: {abs_path}\n\n"
+        "Describe this image in detail.\n\n"
         "Return a JSON object with:\n"
         '- "title": short descriptive title for this content\n'
-        '- "content": the full transcription or description\n'
+        '- "content": the full description\n'
         '- "tags": list of topic keywords\n'
         "Return ONLY the JSON object, no markdown fencing."
     )
 
-    real_cmd = config.resolve_llm_command(prompt)
-    if not real_cmd:
+    try:
+        b64 = base64.b64encode(Path(path).read_bytes()).decode()
+    except OSError as e:
+        print(f"  [distill] could not read {path}: {e}", file=sys.stderr)
         return []
 
-    try:
-        result = subprocess.run(
-            real_cmd, capture_output=True, text=True, timeout=180,
-            cwd=str(config._k7e_home()),
-        )
-        if result.returncode != 0:
-            print(f"  [llm] non-zero exit ({result.returncode}) for {path}", file=sys.stderr)
-            return []
-        parsed = _parse_multimodal_response(result.stdout, path)
-        if parsed:
-            parsed["_asset_path"] = abs_path
-            parsed["_media_type"] = kind
-            return [parsed]
-    except subprocess.TimeoutExpired:
-        print(f"  [llm] timed out (180s) for {path}", file=sys.stderr)
-    except OSError as e:
-        print(f"  [llm] launch failed: {e}", file=sys.stderr)
-
+    response = engine._call_llm(prompt, timeout=180, images=[b64])
+    if not response:
+        return []
+    parsed = _parse_multimodal_response(response, path)
+    if parsed:
+        parsed["_asset_path"] = abs_path
+        parsed["_media_type"] = kind
+        return [parsed]
     return []
 
 
@@ -471,13 +459,14 @@ def _llm_extract(text):
 
     import config
 
-    if not config.resolve_llm_command("test"):
-        ollama_url = config.get("ollama_url", "http://localhost:11434")
-        try:
-            urllib.request.urlopen(f"{ollama_url}/api/tags", timeout=2)
-        except Exception:
-            print("  [distill] no LLM available — pattern extraction only", file=sys.stderr)
-            return []
+    if config.get("llm", "ollama") == "none":
+        return []
+    ollama_url = config.get("ollama_url", "http://localhost:11434")
+    try:
+        urllib.request.urlopen(f"{ollama_url}/api/tags", timeout=2)
+    except Exception:
+        print("  [distill] ollama not available — pattern extraction only", file=sys.stderr)
+        return []
 
     # Chunk the input and extract from each chunk independently
     chunks = _chunk_text(text, size=3000, overlap=200)

--- a/apps/k7e/docs/architecture.md
+++ b/apps/k7e/docs/architecture.md
@@ -1,0 +1,95 @@
+# Architecture
+
+> Files are truth. The index is a rebuildable cache.
+
+k7e stores knowledge as flat markdown files on disk and derives a SQLite search
+index from them. If the index is ever lost, corrupted, or schema-changed, delete
+it and run `k7e reindex` — nothing is lost, because the markdown *is* the
+database.
+
+## Storage layout
+
+`K7E_HOME` (default `~/.k7e`):
+
+```
+$K7E_HOME/
+├── nodes/BBB/        # atomic knowledge entries (source of truth)
+│   └── K7E-000-00001.md
+├── mocs/             # Maps of Content — mutable per-tag index pages
+│   └── networking.md
+├── assets/XX/        # content-addressed binaries (SHA256, deduped)
+├── config.json       # configuration (see configuration.md)
+└── .index.db         # SQLite FTS5 + embeddings (DERIVED, rebuildable)
+```
+
+- **nodes/** — the canonical store. One markdown file per fact, bucketed into
+  `BBB/` subdirectories to keep directory sizes sane.
+- **mocs/** — Maps of Content. Auto-generated topic index pages, one per tag.
+  Mutable and rebuildable (`k7e rebuild-mocs`).
+- **assets/** — binaries (images, audio, etc.) stored by content hash so the
+  same file is never stored twice. `k7e asset <file>` returns the stored path.
+- **.index.db** — the only non-authoritative artifact. Holds the FTS5 keyword
+  index, embedding vectors, and the ranking-signal columns. Safe to delete.
+
+## Entry format
+
+Each node is YAML frontmatter + markdown sections:
+
+```markdown
+---
+id: K7E-000-00001
+title: SSH Local Forwarding
+aliases: [ssh-tunnel, port-forward]
+status: active
+confidence: 0.5
+verification_count: 0
+last_updated: 2026-05-20
+tags: [ssh, networking]
+---
+
+## Verified Protocol
+ssh -L 8080:target:80 bastion — forwards local:8080 to target:80 via bastion
+
+## Edge Cases
+## False Paths
+## History
+* 2026-05-20: Initial entry.
+```
+
+- `id` — `K7E-BBB-NNNNN`, stable for the life of the entry.
+- `status` — `active` (default), `superseded`, or `compiled`. Only `active`
+  entries appear in default search (see [retrieval.md](retrieval.md)).
+- `confidence` — 0..1, a static prior folded into ranking.
+- `aliases` — alternate names matched by metadata search.
+- Sections (`Verified Protocol`, `Edge Cases`, `False Paths`, `History`) are
+  conventional; `k7e append` adds to a named section.
+
+## Derived index schema
+
+The `nodes` table in `.index.db` mirrors the frontmatter plus two
+**index-only** ranking columns that are *not* written back to markdown:
+
+- `last_used_at` — last time the entry was returned by `recall()` or read by
+  `get()`.
+- `use_count` — how many times it has been used.
+
+These reset on `reindex` by design: ranking is *re-earned from usage*, not
+frozen forever. See [retrieval.md](retrieval.md) for how they feed scoring.
+
+## Lifecycle
+
+- **Create** — `k7e store` (manual) or `k7e distill` (extracted from raw files).
+- **Grow** — `k7e append` adds detail to a section.
+- **Retire** — `k7e supersede <old> <new>` flips `old` to `status: superseded`
+  and records `superseded_by`. The audit trail is preserved (queryable with
+  `--include-superseded`) but hidden from default search.
+- **Synthesize** — `k7e compile <tag>` writes a `compiled` reference page from
+  the active entries for a tag.
+- **Rebuild** — `k7e reindex` regenerates `.index.db` from the markdown.
+
+## Why this shape
+
+k7e is the inverse of a multi-tenant cloud memory service. It optimizes for a
+single person (and their agents): portable as a folder of text files,
+greppable, diffable, git-friendly, and never hostage to a running database or a
+remote endpoint. The index exists only to make retrieval fast.

--- a/apps/k7e/docs/cli.md
+++ b/apps/k7e/docs/cli.md
@@ -1,0 +1,82 @@
+# CLI reference
+
+`k7e <command> [args]`. Run `k7e` with no args for the command list.
+
+## Read
+
+### `search <query>`
+Hybrid search (BM25 + metadata + semantic), fused and ranked.
+
+```
+--limit N              max results (default 5)
+--json                 JSON output
+--ids                  IDs only, one per line
+--rerank               LLM rerank the candidate pool
+--include-superseded   include retired entries
+```
+
+### `get <id>`
+Print a full entry. Counts as a "use" (bumps ranking signals).
+
+### `recall <text> [--limit N]`
+RAG: retrieve relevant entries for a topic or pasted conversation and synthesize
+an answer (LLM, reranker on by default). Accepts text as an arg or via stdin.
+
+### `list [--tag X] [--status active] [--ids]`
+List entries with optional filters.
+
+### `stats [--json]`
+Store statistics (entry counts, tags, confidence).
+
+## Write
+
+### `store <title>`
+Create a new entry. Content from `--content` or stdin.
+
+```
+--tags a,b,c       comma-separated tags
+--aliases x,y      comma-separated aliases
+--content "..."    inline content (else read stdin)
+```
+
+### `append <id> --section <name>`
+Append content (arg or stdin) to a named section of an existing entry.
+
+### `supersede <old_id> <new_id>`
+Mark `old_id` as superseded by `new_id`. Preserves the audit trail; hides the
+old entry from default search.
+
+### `asset <file>`
+Store a binary content-addressed (SHA256, deduped). Prints the stored path.
+
+### `distill <file|dir> [--dry-run]`
+Extract knowledge from raw files. See [distillation.md](distillation.md).
+
+### `consolidate [--dry-run]`
+Find and merge duplicate nodes by title similarity.
+
+### `compile <tag> [--dry-run]`
+Synthesize active entries for a tag into a `compiled` reference page (LLM).
+
+## Maintenance
+
+### `reindex [--embeddings]`
+Rebuild `.index.db` from the markdown files. `--embeddings` recomputes vectors.
+Resets the `use_count`/`last_used_at` ranking signals (by design).
+
+### `embed-pending`
+Process queued embeddings.
+
+### `rebuild-mocs`
+Regenerate all Maps of Content from entry tags.
+
+### `check [--fix]`
+Audit structural integrity; `--fix` repairs what it safely can.
+
+## System
+
+### `status`
+Show capabilities, the resolved LLM/embedding models, and recommendations.
+
+### `config <key> [value]`
+Get/set configuration. See [configuration.md](configuration.md).

--- a/apps/k7e/docs/configuration.md
+++ b/apps/k7e/docs/configuration.md
@@ -4,7 +4,7 @@ Config lives in `$K7E_HOME/config.json`. Every key has an environment-variable
 override (env wins over file). Inspect effective state with `k7e status`.
 
 ```bash
-k7e config <key>          # read (shows the resolved value for llm/llm_model)
+k7e config <key>          # read (purpose commands show llm_command fallback)
 k7e config <key> <value>  # write to config.json
 k7e status                # what's active + recommendations
 ```
@@ -13,11 +13,15 @@ k7e status                # what's active + recommendations
 
 | Key | Env override | Default | Meaning |
 |-----|--------------|---------|---------|
-| `llm` | `K7E_LLM` | `ollama` | `ollama` or `none` (disable LLM features) |
-| `llm_model` | `K7E_LLM_MODEL` | *(auto-detect)* | pin the ollama generation model |
+| `llm_command` | `K7E_LLM_COMMAND` | *(unset)* | fallback stdin→stdout CLI for all LLM uses |
+| `summarize_command` | `K7E_SUMMARIZE_COMMAND` | *(fallback)* | recall synthesis |
+| `decompose_command` | `K7E_DECOMPOSE_COMMAND` | *(fallback)* | long-text query extraction |
+| `distill_command` | `K7E_DISTILL_COMMAND` | *(fallback)* | knowledge extraction |
+| `compile_command` | `K7E_COMPILE_COMMAND` | *(fallback)* | tag synthesis |
+| `rerank_command` | `K7E_RERANK_COMMAND` | *(fallback)* | search/recall reranking |
 | `embeddings` | `K7E_EMBEDDINGS` | `ollama` | `ollama` or `none` |
 | `embed_model` | `EMBED_MODEL` | `nomic-embed-text` | embedding model |
-| `ollama_url` | `OLLAMA_URL` | `http://localhost:11434` | ollama endpoint |
+| `ollama_url` | `OLLAMA_URL` | `http://localhost:11434` | ollama endpoint (embeddings) |
 | `rerank` | `K7E_RERANK` | off | LLM rerank in `search` by default |
 | `decay_offset_days` | `K7E_DECAY_OFFSET` | 30 | flat (no-decay) window |
 | `decay_scale_days` | `K7E_DECAY_SCALE` | 365 | decay half-life; `<=0` disables decay |
@@ -25,67 +29,41 @@ k7e status                # what's active + recommendations
 
 See [retrieval.md](retrieval.md#tuning) for what the ranking knobs do.
 
-## LLM backend
+## LLM commands (stdin → stdout)
 
-k7e calls **ollama's HTTP API directly** for all generation (distill, recall,
-rerank, compile). It does **not** shell out to LLM CLIs like `l9m`, `claude`, or
-`codex`: those carry their own rolling context or agent preamble, which would
-leak into k7e's prompts. Every k7e LLM call is stateless (`think: false`,
-no history).
-
-### Model resolution
-
-When `llm_model` is unset, k7e auto-detects from installed ollama models:
-qwen family preferred, largest parameter count wins, falling back to
-`qwen3:0.6b`. Pin a specific model to override:
+k7e does **not** auto-detect LLMs and does **not** call ollama for generation.
+You define explicit shell commands; k7e writes the prompt to **stdin** and reads
+the response from **stdout**.
 
 ```bash
-k7e config llm_model qwen3.6:27b   # or any installed model
+k7e config llm_command 'l9m -s'              # fallback for all purposes
+k7e config summarize_command 'my-sum-cli'    # optional recall override
+k7e config rerank_command 'my-rank-cli'      # optional rerank override
 ```
 
-### Seeing which model is in use
+Purpose-specific commands fall back to `llm_command` when unset. `k7e status`
+lists each purpose and which command it resolves to.
 
-This is the fast answer to "what LLM is k7e actually using?":
-
-```bash
-k7e status
-#   LLM: ollama (qwen3.6:27b, auto-detected) ✓
-
-k7e config llm_model
-#   qwen3.6:27b (auto-detected)      # resolved value, even when unset
-
-k7e config llm
-#   ollama (default)
-```
-
-### Disabling the LLM
-
-```bash
-k7e config llm none      # explicit opt-out: distill/recall/compile become unavailable
-```
+Pick commands you control — a stateless ollama wrapper, a cloud CLI, whatever
+fits your setup. k7e stays agnostic as long as the interface is stdin/stdout.
 
 ## Embeddings
 
-Semantic search needs an embedding model pulled into ollama:
+Semantic search uses ollama's `/api/embed` separately from LLM commands:
 
 ```bash
 ollama pull nomic-embed-text
 ```
 
 Without it (or with `embeddings none`), k7e runs FTS5-only — still effective for
-keyword recall. Embeddings are computed via ollama's `/api/embed`, separate from
-the generation model above.
+keyword recall.
 
 ## What needs what
 
-k7e's store and keyword search (FTS5) are always available offline. The
-LLM-powered commands **fail fast** with an actionable message rather than
-degrading silently:
-
 | Missing | Still works | Unavailable (fails fast) |
 |---------|-------------|--------------------------|
-| ollama entirely | store, FTS5 search, get, list, stats | semantic search; `distill`, `recall`, `compile` |
-| embed model only | everything except semantic search | vector recall |
-| `llm=none` | store, FTS5 search, get, list, stats | `distill`, `recall`, `compile` |
+| `llm_command` (and no purpose overrides) | store, FTS5 search, get, list, stats | `distill`, `recall`, `compile` |
+| ollama / embed model | everything except semantic search | vector recall |
+| purpose override only | other purposes via `llm_command` | that specific purpose if fallback also unset |
 
-`k7e status` always reports exactly what's active and what to install.
+`k7e status` always reports exactly what's configured.

--- a/apps/k7e/docs/configuration.md
+++ b/apps/k7e/docs/configuration.md
@@ -61,7 +61,7 @@ k7e config llm
 ### Disabling the LLM
 
 ```bash
-k7e config llm none      # distill falls back to pattern-only; recall to raw search
+k7e config llm none      # explicit opt-out: distill/recall/compile become unavailable
 ```
 
 ## Embeddings
@@ -76,12 +76,16 @@ Without it (or with `embeddings none`), k7e runs FTS5-only — still effective f
 keyword recall. Embeddings are computed via ollama's `/api/embed`, separate from
 the generation model above.
 
-## Graceful degradation
+## What needs what
 
-| Missing | k7e still does | Loses |
-|---------|----------------|-------|
-| ollama entirely | store, FTS5 search, pattern distill | semantic search, LLM distill/recall/rerank |
+k7e's store and keyword search (FTS5) are always available offline. The
+LLM-powered commands **fail fast** with an actionable message rather than
+degrading silently:
+
+| Missing | Still works | Unavailable (fails fast) |
+|---------|-------------|--------------------------|
+| ollama entirely | store, FTS5 search, get, list, stats | semantic search; `distill`, `recall`, `compile` |
 | embed model only | everything except semantic search | vector recall |
-| `llm=none` | store, search, pattern distill | LLM distill/recall/rerank/compile |
+| `llm=none` | store, FTS5 search, get, list, stats | `distill`, `recall`, `compile` |
 
 `k7e status` always reports exactly what's active and what to install.

--- a/apps/k7e/docs/configuration.md
+++ b/apps/k7e/docs/configuration.md
@@ -1,0 +1,87 @@
+# Configuration
+
+Config lives in `$K7E_HOME/config.json`. Every key has an environment-variable
+override (env wins over file). Inspect effective state with `k7e status`.
+
+```bash
+k7e config <key>          # read (shows the resolved value for llm/llm_model)
+k7e config <key> <value>  # write to config.json
+k7e status                # what's active + recommendations
+```
+
+## Keys
+
+| Key | Env override | Default | Meaning |
+|-----|--------------|---------|---------|
+| `llm` | `K7E_LLM` | `ollama` | `ollama` or `none` (disable LLM features) |
+| `llm_model` | `K7E_LLM_MODEL` | *(auto-detect)* | pin the ollama generation model |
+| `embeddings` | `K7E_EMBEDDINGS` | `ollama` | `ollama` or `none` |
+| `embed_model` | `EMBED_MODEL` | `nomic-embed-text` | embedding model |
+| `ollama_url` | `OLLAMA_URL` | `http://localhost:11434` | ollama endpoint |
+| `rerank` | `K7E_RERANK` | off | LLM rerank in `search` by default |
+| `decay_offset_days` | `K7E_DECAY_OFFSET` | 30 | flat (no-decay) window |
+| `decay_scale_days` | `K7E_DECAY_SCALE` | 365 | decay half-life; `<=0` disables decay |
+| `use_count_weight` | `K7E_USE_WEIGHT` | 0.2 | strength of use-count boost |
+
+See [retrieval.md](retrieval.md#tuning) for what the ranking knobs do.
+
+## LLM backend
+
+k7e calls **ollama's HTTP API directly** for all generation (distill, recall,
+rerank, compile). It does **not** shell out to LLM CLIs like `l9m`, `claude`, or
+`codex`: those carry their own rolling context or agent preamble, which would
+leak into k7e's prompts. Every k7e LLM call is stateless (`think: false`,
+no history).
+
+### Model resolution
+
+When `llm_model` is unset, k7e auto-detects from installed ollama models:
+qwen family preferred, largest parameter count wins, falling back to
+`qwen3:0.6b`. Pin a specific model to override:
+
+```bash
+k7e config llm_model qwen3.6:27b   # or any installed model
+```
+
+### Seeing which model is in use
+
+This is the fast answer to "what LLM is k7e actually using?":
+
+```bash
+k7e status
+#   LLM: ollama (qwen3.6:27b, auto-detected) ✓
+
+k7e config llm_model
+#   qwen3.6:27b (auto-detected)      # resolved value, even when unset
+
+k7e config llm
+#   ollama (default)
+```
+
+### Disabling the LLM
+
+```bash
+k7e config llm none      # distill falls back to pattern-only; recall to raw search
+```
+
+## Embeddings
+
+Semantic search needs an embedding model pulled into ollama:
+
+```bash
+ollama pull nomic-embed-text
+```
+
+Without it (or with `embeddings none`), k7e runs FTS5-only — still effective for
+keyword recall. Embeddings are computed via ollama's `/api/embed`, separate from
+the generation model above.
+
+## Graceful degradation
+
+| Missing | k7e still does | Loses |
+|---------|----------------|-------|
+| ollama entirely | store, FTS5 search, pattern distill | semantic search, LLM distill/recall/rerank |
+| embed model only | everything except semantic search | vector recall |
+| `llm=none` | store, search, pattern distill | LLM distill/recall/rerank/compile |
+
+`k7e status` always reports exactly what's active and what to install.

--- a/apps/k7e/docs/distillation.md
+++ b/apps/k7e/docs/distillation.md
@@ -9,13 +9,16 @@ k7e distill ./transcripts/      # a whole directory
 k7e distill notes.md --dry-run  # show candidates, store nothing
 ```
 
+**Distillation requires an LLM (ollama).** The CLI fails fast with an
+actionable message when ollama is unavailable — there is no offline
+pattern-matching fallback. Set `llm=none` to explicitly opt out (extraction
+returns nothing).
+
 ## Pipeline
 
 ```
-raw file ─┬─ text  ─┬─ pattern extraction (regex, always on)
-          │         └─ LLM extraction  (ollama, optional)
+raw file ─┬─ text  ─ LLM extraction (ollama, chunked)
           │              │
-          │              ▼
           │         dedup across chunks
           │              │
           └─ media ─ ollama vision (images only)
@@ -26,15 +29,11 @@ raw file ─┬─ text  ─┬─ pattern extraction (regex, always on)
 
 ### Text extraction
 
-1. **Pattern extraction** — regex heuristics pull obvious knowledge: fixes,
-   commands, "use X to Y" instructions. Zero dependencies, always runs.
-2. **LLM extraction** — if ollama is reachable, the text is chunked
-   (~3000 chars, 200 overlap) and each chunk is sent to the model with a strict
-   "extract only genuinely novel knowledge" prompt (max 3 items/chunk). Output
-   is parsed as a JSON array of `{title, content, tags}`.
-3. **Dedup** — candidates are deduplicated across chunks before storage.
-
-Without ollama, distillation runs pattern-only and prints a notice.
+1. **LLM extraction** — the text is chunked (~3000 chars, 200 overlap) and each
+   chunk is sent to the model with a strict "extract only genuinely novel
+   knowledge" prompt (max 3 items/chunk). Output is parsed as a JSON array of
+   `{title, content, tags}`.
+2. **Dedup** — candidates are deduplicated across chunks before storage.
 
 ### Media extraction
 

--- a/apps/k7e/docs/distillation.md
+++ b/apps/k7e/docs/distillation.md
@@ -1,0 +1,61 @@
+# Distillation
+
+Turning raw experience (notes, transcripts, command output, images) into
+durable, deduplicated knowledge entries.
+
+```bash
+k7e distill notes.md
+k7e distill ./transcripts/      # a whole directory
+k7e distill notes.md --dry-run  # show candidates, store nothing
+```
+
+## Pipeline
+
+```
+raw file ─┬─ text  ─┬─ pattern extraction (regex, always on)
+          │         └─ LLM extraction  (ollama, optional)
+          │              │
+          │              ▼
+          │         dedup across chunks
+          │              │
+          └─ media ─ ollama vision (images only)
+                         │
+                         ▼
+                  diff vs existing store ─► store genuine deltas
+```
+
+### Text extraction
+
+1. **Pattern extraction** — regex heuristics pull obvious knowledge: fixes,
+   commands, "use X to Y" instructions. Zero dependencies, always runs.
+2. **LLM extraction** — if ollama is reachable, the text is chunked
+   (~3000 chars, 200 overlap) and each chunk is sent to the model with a strict
+   "extract only genuinely novel knowledge" prompt (max 3 items/chunk). Output
+   is parsed as a JSON array of `{title, content, tags}`.
+3. **Dedup** — candidates are deduplicated across chunks before storage.
+
+Without ollama, distillation runs pattern-only and prints a notice.
+
+### Media extraction
+
+- **Images** — base64-encoded and sent to a vision-capable ollama model for
+  description; the binary is stored as a content-addressed asset.
+- **Audio / video** — *not supported via ollama.* Transcribe with a dedicated
+  tool first, then distill the resulting text. (This capability previously
+  relied on cloud LLM CLIs, which were removed — see
+  [configuration.md](configuration.md#llm-backend).)
+
+## Delta detection
+
+Before storing, candidates are diffed against the existing store so distillation
+is idempotent-ish: re-running over the same input doesn't pile up duplicates.
+Genuinely new or changed knowledge becomes new entries.
+
+## Related write operations
+
+- `k7e consolidate [--dry-run]` — find and merge duplicate nodes by title
+  similarity (uses `supersede` under the hood).
+- `k7e compile <tag> [--dry-run]` — synthesize the active entries for a tag into
+  a single `compiled` reference page (LLM).
+
+See [cli.md](cli.md) for full command/flag reference.

--- a/apps/k7e/docs/distillation.md
+++ b/apps/k7e/docs/distillation.md
@@ -9,19 +9,17 @@ k7e distill ./transcripts/      # a whole directory
 k7e distill notes.md --dry-run  # show candidates, store nothing
 ```
 
-**Distillation requires an LLM (ollama).** The CLI fails fast with an
-actionable message when ollama is unavailable — there is no offline
-pattern-matching fallback. Set `llm=none` to explicitly opt out (extraction
-returns nothing).
+**Distillation requires `distill_command` (or `llm_command`).** The CLI fails
+fast when neither is configured. There is no offline pattern-matching fallback.
 
 ## Pipeline
 
 ```
-raw file ─┬─ text  ─ LLM extraction (ollama, chunked)
+raw file ─┬─ text  ─ LLM via distill_command (chunked, stdin→stdout)
           │              │
           │         dedup across chunks
           │              │
-          └─ media ─ ollama vision (images only)
+          └─ media ─ distill_command (prompt includes file path)
                          │
                          ▼
                   diff vs existing store ─► store genuine deltas
@@ -37,12 +35,10 @@ raw file ─┬─ text  ─ LLM extraction (ollama, chunked)
 
 ### Media extraction
 
-- **Images** — base64-encoded and sent to a vision-capable ollama model for
-  description; the binary is stored as a content-addressed asset.
-- **Audio / video** — *not supported via ollama.* Transcribe with a dedicated
-  tool first, then distill the resulting text. (This capability previously
-  relied on cloud LLM CLIs, which were removed — see
-  [configuration.md](configuration.md#llm-backend).)
+Media goes through the same `distill_command`. The prompt includes the absolute
+file path — your CLI must know how to handle images, audio, or video (e.g. a
+multimodal wrapper). The binary is stored as a content-addressed asset when
+extraction succeeds.
 
 ## Delta detection
 

--- a/apps/k7e/docs/retrieval.md
+++ b/apps/k7e/docs/retrieval.md
@@ -69,7 +69,7 @@ or the response can't be parsed.
 |---|---|---|
 | Returns | ranked entries | LLM-synthesized answer over retrieved entries (RAG) |
 | Reranker | opt-in (`--rerank`) | on by default |
-| Needs LLM | no | yes (falls back to raw results) |
+| Needs LLM | no | yes (fails fast without it) |
 | Use when | you want the source entries | you want a synthesized answer for a topic/conversation |
 
 ## Tuning

--- a/apps/k7e/docs/retrieval.md
+++ b/apps/k7e/docs/retrieval.md
@@ -1,0 +1,102 @@
+# Retrieval & ranking
+
+How `k7e search` and `k7e recall` turn a query into the right entries.
+
+## Pipeline
+
+```
+query
+  │
+  ├─ BM25 (SQLite FTS5)        ┐
+  ├─ metadata (title/alias/tag)├─ Reciprocal Rank Fusion (RRF)
+  └─ embeddings (ollama)       ┘            │
+                                            ▼
+                         score × confidence × recency-decay × use-boost
+                                            │
+                                            ▼
+                              (optional) LLM reranker
+                                            │
+                                            ▼
+                                        top-K results
+```
+
+### 1. Candidate retrieval (three signals)
+
+- **BM25** — keyword relevance via FTS5. Always available (stdlib sqlite3).
+- **Metadata** — exact-ish matches against title, aliases, and tags.
+- **Embeddings** — semantic similarity via ollama vectors. Optional; linear
+  scan, automatically skipped past ~10k nodes (k7e is single-user scale, not a
+  vector-DB).
+
+All three filter to `status='active'` unless `include_superseded` is set.
+
+### 2. Fusion (RRF)
+
+The three ranked lists are merged with Reciprocal Rank Fusion — robust to the
+fact that BM25 scores and cosine similarities aren't on the same scale. Search
+over-fetches (`limit × 3`) so later stages have a real pool to work with.
+
+### 3. Score multipliers
+
+Each fused score is multiplied by:
+
+- **Confidence** — `0.7 + 0.3 × confidence` (static prior, 0.85..1.0).
+- **Recency decay** — a Gaussian on age: flat for `decay_offset_days`, then
+  `exp(-(age − offset)² / 2s²)` with `s` chosen so the multiplier hits 0.5 at
+  `decay_scale_days` past the flat zone. Basis date is `last_used_at` if set,
+  else `last_updated`. **This is relevance decay, not truth decay** — fading
+  only affects ranking, never deletes anything. Disabled when `scale <= 0`.
+- **Use-count boost** — `1 + log10(1 + use_count) × use_count_weight`
+  (~1.2× at 10 uses, ~1.4× at 100). Facts you keep retrieving stay near the top.
+
+Entries earn freshness when returned by `recall()` or read by `get()`. Because
+`last_used_at`/`use_count` are index-only, this signal resets on `reindex`.
+
+### 4. LLM reranker (optional)
+
+A cross-encoder-style pass: the top ~15 candidates (id, title, snippet) and the
+query go to the LLM, which returns a ranked ID list used to reorder the pool.
+Attacks "sibling collisions" (several true facts on one topic) that fusion alone
+can't separate. Degrades gracefully to the fused order when no LLM is available
+or the response can't be parsed.
+
+- `k7e search` — off by default; enable with `--rerank`.
+- `k7e recall` — on by default (recall is already LLM-heavy).
+
+## search vs recall
+
+| | `k7e search` | `k7e recall` |
+|---|---|---|
+| Returns | ranked entries | LLM-synthesized answer over retrieved entries (RAG) |
+| Reranker | opt-in (`--rerank`) | on by default |
+| Needs LLM | no | yes (falls back to raw results) |
+| Use when | you want the source entries | you want a synthesized answer for a topic/conversation |
+
+## Tuning
+
+All tunable via `k7e config` or env (see [configuration.md](configuration.md)):
+
+| Knob | Default | Effect |
+|------|---------|--------|
+| `decay_offset_days` | 30 | flat (no decay) window |
+| `decay_scale_days` | 365 | half-life past the flat window; `<=0` disables decay |
+| `use_count_weight` | 0.2 | strength of the use-count boost |
+| `rerank` | off | LLM rerank by default in `search` |
+
+## Measuring quality: the eval harness
+
+Tuning ranking blind is guesswork, so retrieval quality is measured with a
+checked-in **Recall@K** harness (`apps/k7e/tests/`):
+
+- `tests/eval/corpus.json` — hand-curated dev-knowledge facts, including
+  deliberate sibling-collision clusters.
+- `tests/eval/questions.json` — paraphrased questions mapped to the expected
+  entry.
+- `tests/test_eval_recall.py`:
+  - **Tier A** (deterministic, no ollama) — FTS + metadata + RRF + decay;
+    asserts baseline R@1/R@3/R@5/R@10. Runs in the always-on CI job.
+  - **Tier B** (`@llm`, needs ollama) — full hybrid + reranker; higher
+    thresholds; prints an R@K summary. Runs in the `llm` CI job.
+
+Recall@K = fraction of questions whose expected entry appears in the top K.
+Raise the floors as ranking improves; never let them regress.

--- a/apps/k7e/engine.py
+++ b/apps/k7e/engine.py
@@ -536,36 +536,33 @@ def stats():
 
 # --- LLM ---
 
-def _call_llm(prompt, timeout=120, images=None):
-    """Call the configured ollama model directly. Returns response text or None.
-
-    k7e talks to ollama's HTTP API rather than shelling out to an LLM CLI so
-    every call is stateless: no rolling context or agent preamble leaks into
-    distill/recall/rerank prompts. `think: false` keeps thinking-model output
-    clean. Pass base64-encoded `images` for multimodal (vision) extraction."""
+def _call_llm(prompt, purpose="summarize", timeout=120):
+    """Invoke the configured stdin→stdout CLI for an LLM purpose."""
     import config
+    import shlex
+    import subprocess
 
-    if config.get("llm", "ollama") == "none":
+    cmd_str = config.resolve_command(purpose)
+    if not cmd_str:
         return None
 
-    ollama_url = config.get("ollama_url", "http://localhost:11434")
-    model = config.resolve_llm_model()
-    payload = {"model": model, "prompt": prompt, "stream": False, "think": False}
-    if images:
-        payload["images"] = images
     try:
-        data = json.dumps(payload).encode()
-        req = urllib.request.Request(
-            f"{ollama_url}/api/generate",
-            data=data, headers={"Content-Type": "application/json"}
+        cmd = shlex.split(cmd_str)
+        result = subprocess.run(
+            cmd, input=prompt, capture_output=True, text=True, timeout=timeout,
+            cwd=str(config._k7e_home()),
         )
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            response = json.loads(resp.read())
-            text = response.get("response", "").strip()
-            return text if text else None
-    except Exception as e:
-        print(f"  [llm] ollama failed: {e}", file=sys.stderr)
-        return None
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+        if result.returncode != 0:
+            print(f"  [llm:{purpose}] exit {result.returncode}", file=sys.stderr)
+            if result.stderr.strip():
+                print(f"  [llm:{purpose}] {result.stderr.strip()}", file=sys.stderr)
+    except subprocess.TimeoutExpired:
+        print(f"  [llm:{purpose}] timed out ({timeout}s)", file=sys.stderr)
+    except OSError as e:
+        print(f"  [llm:{purpose}] launch failed: {e}", file=sys.stderr)
+    return None
 
 
 # --- Reranking ---
@@ -601,7 +598,7 @@ def _rerank(query, results, limit):
         f"Query: {query[:500]}\n\nEntries:\n{listing}"
     )
 
-    response = _call_llm(prompt, timeout=30)
+    response = _call_llm(prompt, purpose="rerank", timeout=30)
     if not response:
         return results[:limit]
 
@@ -706,7 +703,7 @@ def recall(text, limit=8, include_superseded=False):
         f"Knowledge entries:\n{context_text}"
     )
 
-    answer = _call_llm(prompt)
+    answer = _call_llm(prompt, purpose="summarize")
     return answer, entries
 
 
@@ -718,7 +715,7 @@ def _decompose_queries(text):
         "key topics in this text. Return one query per line, nothing else.\n\n"
         f"Text: {text[:2000]}"
     )
-    response = _call_llm(prompt, timeout=30)
+    response = _call_llm(prompt, purpose="decompose", timeout=30)
     if not response:
         return []
     lines = [l.strip().strip("-•*").strip() for l in response.splitlines() if l.strip()]
@@ -772,9 +769,9 @@ def compile_tag(tag, dry_run=False):
             print(f"  {e['id']}  {e['title']}")
         return None
 
-    compiled_content = _call_llm(prompt)
+    compiled_content = _call_llm(prompt, purpose="compile")
     if not compiled_content:
-        print("Error: LLM call failed while compiling entries.", file=sys.stderr)
+        print("Error: compile_command (or llm_command) not configured or call failed.", file=sys.stderr)
         return None
 
     # Store as a new compiled node

--- a/apps/k7e/engine.py
+++ b/apps/k7e/engine.py
@@ -50,6 +50,87 @@ def _load_config_val(key, default):
 
 RRF_K = 60
 
+# Recency decay + use-count ranking (see issue #145, workstream 1).
+# Defaults tuned for dev-knowledge churn (tighter than the article's 5yr).
+DECAY_OFFSET_DAYS = 30.0   # flat zone: facts younger than this don't decay
+DECAY_SCALE_DAYS = 365.0   # days past the flat zone at which the multiplier hits 0.5
+USE_COUNT_WEIGHT = 0.2     # log10 use-count boost weight
+
+
+def _num_config(key, default):
+    val = _load_config_val(key, default)
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return default
+
+
+def _decay_config():
+    return (
+        _num_config("decay_offset_days", DECAY_OFFSET_DAYS),
+        _num_config("decay_scale_days", DECAY_SCALE_DAYS),
+        _num_config("use_count_weight", USE_COUNT_WEIGHT),
+    )
+
+
+def _rerank_enabled():
+    val = _load_config_val("rerank", None)
+    if val is None:
+        return False
+    if isinstance(val, bool):
+        return val
+    return str(val).strip().lower() in ("1", "true", "yes", "on")
+
+
+def _days_since(date_str):
+    if not date_str:
+        return None
+    try:
+        t = time.strptime(str(date_str)[:10], "%Y-%m-%d")
+    except (ValueError, TypeError):
+        return None
+    return max(0.0, (time.time() - time.mktime(t)) / 86400.0)
+
+
+def _recency_factor(last_used_at, last_updated, offset, scale):
+    """Gauss-shaped relevance decay. 1.0 inside the flat zone, 0.5 at `scale`
+    days past it. Basis date is last_used_at (recall-time freshness) if present,
+    else the persisted last_updated."""
+    if scale <= 0:
+        return 1.0
+    age = _days_since(last_used_at) if last_used_at else None
+    if age is None:
+        age = _days_since(last_updated)
+    if age is None:
+        return 1.0
+    effective = age - offset
+    if effective <= 0:
+        return 1.0
+    s = scale / math.sqrt(2 * math.log(2))
+    return math.exp(-(effective * effective) / (2 * s * s))
+
+
+def _use_boost(use_count, weight):
+    if not use_count or weight <= 0:
+        return 1.0
+    return 1.0 + math.log10(1 + use_count) * weight
+
+
+def _bump_usage(node_ids):
+    """Increment use_count and refresh last_used_at for the given nodes.
+    Index-only signal; reset on reindex (re-earns ranking from usage)."""
+    if not node_ids:
+        return
+    now = time.strftime("%Y-%m-%d")
+    conn = _connect()
+    for nid in node_ids:
+        conn.execute(
+            "UPDATE nodes SET use_count = COALESCE(use_count, 0) + 1, last_used_at = ? WHERE id = ?",
+            (now, nid),
+        )
+    conn.commit()
+    conn.close()
+
 
 def reset(home=None):
     """Reset store paths. For testing or multi-store usage."""
@@ -241,10 +322,10 @@ def append_entry(node_id, section, content):
 
 
 def supersede(old_id, new_id):
-    """Mark old_id as superseded by new_id."""
+    """Mark old_id as superseded by new_id. Returns True if old_id existed."""
     node_path = _node_path(old_id)
     if not node_path.exists():
-        return
+        return False
     text = node_path.read_text(encoding="utf-8")
     text = re.sub(r"status: active", "status: superseded", text)
     text = re.sub(r"(tags: \[.*?\])", r"\1\nsuperseded_by: " + new_id, text)
@@ -254,17 +335,24 @@ def supersede(old_id, new_id):
     conn.execute("UPDATE nodes SET status = 'superseded', superseded_by = ? WHERE id = ?", (new_id, old_id))
     conn.commit()
     conn.close()
+    return True
 
 
-def search(query, limit=5, json_output=False):
+def search(query, limit=5, json_output=False, include_superseded=False, rerank=None):
     init()
+    if rerank is None:
+        rerank = _rerank_enabled()
+
+    # Over-fetch a wider candidate pool when reranking so the reranker has
+    # something to reorder; otherwise keep the historical limit-sized pool.
+    pool = max(limit, 15) if rerank else limit
+
     conn = _connect()
+    bm25_results = _search_bm25(conn, query, pool * 3, include_superseded)
+    meta_results = _search_metadata(conn, query, pool * 3, include_superseded)
+    embed_results = _search_embeddings(conn, query, pool * 3, include_superseded)
 
-    bm25_results = _search_bm25(conn, query, limit * 3)
-    meta_results = _search_metadata(conn, query, limit * 3)
-    embed_results = _search_embeddings(conn, query, limit * 3)
-
-    fused = _rrf_fuse([bm25_results, meta_results, embed_results], limit)
+    fused = _rrf_fuse([bm25_results, meta_results, embed_results], pool)
     conn.close()
 
     # Filter out noise: require minimum RRF score.
@@ -274,26 +362,39 @@ def search(query, limit=5, json_output=False):
     min_score = 1.0 / (RRF_K + 1) - 0.001  # ~0.0154
     fused = [r for r in fused if r["score"] >= min_score]
 
-    # Apply confidence as a tiebreaker boost
+    # Apply confidence, recency decay, and use-count boost as score multipliers.
     if fused:
+        offset, scale, weight = _decay_config()
         conn2 = _connect()
         for r in fused:
-            conf_row = conn2.execute("SELECT confidence FROM nodes WHERE id = ?", (r["id"],)).fetchone()
-            if conf_row and conf_row[0]:
-                r["score"] = round(r["score"] * (0.7 + 0.3 * conf_row[0]), 4)
+            row = conn2.execute(
+                "SELECT confidence, last_used_at, use_count, last_updated FROM nodes WHERE id = ?",
+                (r["id"],),
+            ).fetchone()
+            if row:
+                conf_factor = 0.7 + 0.3 * (row[0] if row[0] else 0.5)
+                recency = _recency_factor(row[1], row[3], offset, scale)
+                use_boost = _use_boost(row[2], weight)
+                r["score"] = round(r["score"] * conf_factor * recency * use_boost, 4)
         conn2.close()
         fused.sort(key=lambda x: -x["score"])
 
-    if json_output:
-        return fused
+    if rerank and fused:
+        fused = _rerank(query, fused, limit)
+    else:
+        fused = fused[:limit]
+
     return fused
 
 
-def get(node_id):
+def get(node_id, track_usage=False):
     node_path = _node_path(node_id)
     if not node_path.exists():
         raise FileNotFoundError(f"Node {node_id} not found")
-    return node_path.read_text(encoding="utf-8")
+    text = node_path.read_text(encoding="utf-8")
+    if track_usage:
+        _bump_usage([node_id])
+    return text
 
 
 def reindex(embeddings=False):
@@ -435,33 +536,25 @@ def stats():
 
 # --- LLM ---
 
-def _call_llm(prompt, timeout=120):
-    """Call configured LLM with prompt. Returns response text or None."""
-    import config
-    import subprocess
+def _call_llm(prompt, timeout=120, images=None):
+    """Call the configured ollama model directly. Returns response text or None.
 
-    cmd = config.resolve_llm_command(prompt)
-    if cmd:
-        try:
-            result = subprocess.run(
-                cmd, capture_output=True, text=True, timeout=timeout,
-                cwd=str(config._k7e_home()),
-            )
-            if result.returncode == 0 and result.stdout.strip():
-                return result.stdout.strip()
-            if result.returncode != 0:
-                print(f"  [llm] non-zero exit ({result.returncode})", file=sys.stderr)
-        except subprocess.TimeoutExpired:
-            print(f"  [llm] timed out ({timeout}s)", file=sys.stderr)
-        except OSError as e:
-            print(f"  [llm] launch failed: {e}", file=sys.stderr)
+    k7e talks to ollama's HTTP API rather than shelling out to an LLM CLI so
+    every call is stateless: no rolling context or agent preamble leaks into
+    distill/recall/rerank prompts. `think: false` keeps thinking-model output
+    clean. Pass base64-encoded `images` for multimodal (vision) extraction."""
+    import config
+
+    if config.get("llm", "ollama") == "none":
         return None
 
-    # Fallback: ollama HTTP API
     ollama_url = config.get("ollama_url", "http://localhost:11434")
-    model = config.get("llm_model", "qwen3.5:latest")
+    model = config.resolve_llm_model()
+    payload = {"model": model, "prompt": prompt, "stream": False, "think": False}
+    if images:
+        payload["images"] = images
     try:
-        data = json.dumps({"model": model, "prompt": prompt, "stream": False}).encode()
+        data = json.dumps(payload).encode()
         req = urllib.request.Request(
             f"{ollama_url}/api/generate",
             data=data, headers={"Content-Type": "application/json"}
@@ -475,9 +568,71 @@ def _call_llm(prompt, timeout=120):
         return None
 
 
+# --- Reranking ---
+
+_ID_RE = re.compile(r"K7E-\d{3}-\d{5}")
+
+
+def _snippet(node_id, length=200):
+    try:
+        body = _extract_body(get(node_id))
+    except FileNotFoundError:
+        return ""
+    return " ".join(body.split())[:length]
+
+
+def _rerank(query, results, limit):
+    """Reorder candidates using the LLM as a cross-encoder-style relevance
+    scorer (issue #145, workstream 2). Over-fetch wide, rerank a small pool.
+    Degrades gracefully to the input order when no LLM is available or the
+    response can't be parsed, so callers can always rely on it."""
+    if len(results) <= 1:
+        return results[:limit]
+
+    candidates = results[:15]
+    by_id = {r["id"]: r for r in candidates}
+    listing = "\n".join(
+        f"[{r['id']}] {r['title']}: {_snippet(r['id'])}" for r in candidates
+    )
+    prompt = (
+        "Rank these knowledge entries by how well they answer the query. "
+        "Return ONLY the entry IDs in descending relevance order, one per line, "
+        "with no other text.\n\n"
+        f"Query: {query[:500]}\n\nEntries:\n{listing}"
+    )
+
+    response = _call_llm(prompt, timeout=30)
+    if not response:
+        return results[:limit]
+
+    ordered = []
+    seen = set()
+    for line in response.splitlines():
+        m = _ID_RE.search(line)
+        if m and m.group(0) in by_id and m.group(0) not in seen:
+            ordered.append(by_id[m.group(0)])
+            seen.add(m.group(0))
+
+    if not ordered:
+        return results[:limit]
+
+    # Append candidates the LLM dropped (preserve original order), then any
+    # results beyond the rerank window.
+    for r in candidates:
+        if r["id"] not in seen:
+            ordered.append(r)
+            seen.add(r["id"])
+    for r in results[15:]:
+        if r["id"] not in seen:
+            ordered.append(r)
+            seen.add(r["id"])
+
+    return ordered[:limit]
+
+
 # --- Recall (RAG) ---
 
-def recall(text, limit=8):
+def recall(text, limit=8, include_superseded=False):
     """RAG recall: given arbitrary text, find relevant knowledge and synthesize.
 
     Returns (answer_text, source_entries) where answer_text may be None if
@@ -496,11 +651,12 @@ def recall(text, limit=8):
         if not queries:
             queries = [text[:100]]
 
-    # Search across all queries, merge by node ID (keep max score)
+    # Search across all queries, merge by node ID (keep max score). Subquery
+    # searches don't rerank (one LLM rerank over the merged pool below is enough).
     hit_counts = {}
     hit_info = {}
     for q in queries:
-        results = search(q, limit=limit)
+        results = search(q, limit=limit, include_superseded=include_superseded, rerank=False)
         for r in results:
             hit_counts[r["id"]] = hit_counts.get(r["id"], 0) + 1
             if r["id"] not in hit_info or r.get("score", 0) > hit_info[r["id"]].get("score", 0):
@@ -509,12 +665,17 @@ def recall(text, limit=8):
     if not hit_counts:
         return None, []
 
-    # Rank by frequency across queries, then by score
+    # Rank by frequency across queries, then by score, into a wide pool
+    pool_size = max(limit, 15)
     ranked_ids = sorted(
         hit_counts.keys(),
         key=lambda nid: (hit_counts[nid], hit_info[nid].get("score", 0)),
         reverse=True,
-    )[:limit]
+    )[:pool_size]
+
+    # Rerank the merged pool with the LLM (no-op/fallback when no LLM), then trim.
+    candidates = [{"id": nid, "title": hit_info[nid]["title"]} for nid in ranked_ids]
+    ranked_ids = [r["id"] for r in _rerank(text, candidates, limit)]
 
     # Retrieve full content
     entries = []
@@ -528,6 +689,8 @@ def recall(text, limit=8):
 
     if not entries:
         return None, []
+
+    _bump_usage([e["id"] for e in entries])
 
     # Synthesize
     context_text = "\n\n---\n\n".join(
@@ -732,7 +895,9 @@ CREATE TABLE IF NOT EXISTS nodes (
     created_at TEXT,
     updated_at TEXT,
     content_hash TEXT DEFAULT '',
-    superseded_by TEXT DEFAULT ''
+    superseded_by TEXT DEFAULT '',
+    last_used_at TEXT,
+    use_count INTEGER DEFAULT 0
 );
 
 CREATE VIRTUAL TABLE IF NOT EXISTS nodes_fts USING fts5(
@@ -770,6 +935,10 @@ def _migrate(conn):
         conn.execute("ALTER TABLE nodes ADD COLUMN content_hash TEXT DEFAULT ''")
     if "superseded_by" not in cols:
         conn.execute("ALTER TABLE nodes ADD COLUMN superseded_by TEXT DEFAULT ''")
+    if "last_used_at" not in cols:
+        conn.execute("ALTER TABLE nodes ADD COLUMN last_used_at TEXT")
+    if "use_count" not in cols:
+        conn.execute("ALTER TABLE nodes ADD COLUMN use_count INTEGER DEFAULT 0")
     conn.commit()
 
 
@@ -870,7 +1039,7 @@ _STOPWORDS = {"a", "an", "the", "is", "are", "was", "were", "be", "been", "being
               "or", "so", "if", "then", "than", "too", "very", "just"}
 
 
-def _search_bm25(conn, query, limit):
+def _search_bm25(conn, query, limit, include_superseded=False):
     expanded = query.replace("-", " ").replace("_", " ")
     queries_to_try = [query, expanded]
 
@@ -879,12 +1048,13 @@ def _search_bm25(conn, query, limit):
     if meaningful:
         queries_to_try.append(" OR ".join(meaningful))
 
+    status_clause = "" if include_superseded else "AND nodes.status = 'active'"
     for q in queries_to_try:
         try:
             rows = conn.execute(
                 "SELECT nodes.id, nodes.title, bm25(nodes_fts) as score "
                 "FROM nodes_fts JOIN nodes ON nodes_fts.rowid = nodes.rowid "
-                "WHERE nodes_fts MATCH ? AND nodes.status = 'active' ORDER BY score LIMIT ?",
+                f"WHERE nodes_fts MATCH ? {status_clause} ORDER BY score LIMIT ?",
                 (q, limit)
             ).fetchall()
             if rows:
@@ -894,12 +1064,13 @@ def _search_bm25(conn, query, limit):
     return []
 
 
-def _search_metadata(conn, query, limit):
+def _search_metadata(conn, query, limit, include_superseded=False):
     terms = [t for t in query.lower().split() if len(t) > 2]
     if not terms:
         return []
+    status_clause = "" if include_superseded else "WHERE status = 'active'"
     rows = conn.execute(
-        "SELECT id, title, tags, aliases FROM nodes WHERE status = 'active'"
+        f"SELECT id, title, tags, aliases FROM nodes {status_clause}"
     ).fetchall()
     scored = []
     for r in rows:
@@ -912,22 +1083,24 @@ def _search_metadata(conn, query, limit):
     return scored[:limit]
 
 
-def _search_embeddings(conn, query, limit):
+def _search_embeddings(conn, query, limit, include_superseded=False):
     query_vec = embed_text(query)
     if not query_vec:
         return []
     count = conn.execute("SELECT COUNT(*) FROM embeddings").fetchone()[0]
     if count > _EMBED_SCAN_LIMIT:
         return []
-    rows = conn.execute("SELECT node_id, vector FROM embeddings").fetchall()
+    status_clause = "" if include_superseded else "WHERE n.status = 'active'"
+    rows = conn.execute(
+        "SELECT e.node_id, e.vector, n.title FROM embeddings e "
+        f"JOIN nodes n ON e.node_id = n.id {status_clause}"
+    ).fetchall()
     scored = []
-    for node_id, vec_blob in rows:
+    for node_id, vec_blob, title in rows:
         node_vec = _unpack_vector(vec_blob)
         sim = cosine_similarity(query_vec, node_vec)
         if sim > 0.3:
-            title_row = conn.execute("SELECT title FROM nodes WHERE id = ?", (node_id,)).fetchone()
-            title = title_row[0] if title_row else ""
-            scored.append((node_id, title, sim))
+            scored.append((node_id, title or "", sim))
     scored.sort(key=lambda x: -x[2])
     return scored[:limit]
 

--- a/apps/k7e/engine.py
+++ b/apps/k7e/engine.py
@@ -635,8 +635,9 @@ def _rerank(query, results, limit):
 def recall(text, limit=8, include_superseded=False):
     """RAG recall: given arbitrary text, find relevant knowledge and synthesize.
 
-    Returns (answer_text, source_entries) where answer_text may be None if
-    no LLM is available (sources still returned for fallback display).
+    Returns (answer_text, source_entries). The CLI gates this behind an LLM
+    availability check (fail fast); answer_text is None only when nothing was
+    found or the LLM call failed at runtime.
     """
     init()
     text = text.strip()
@@ -710,24 +711,19 @@ def recall(text, limit=8, include_superseded=False):
 
 
 def _decompose_queries(text):
-    """Use LLM to extract search queries from long text. Falls back to splitting."""
+    """Use the LLM to extract search queries from long text. Returns [] if the
+    LLM is unavailable or returns nothing; recall() then searches the raw text."""
     prompt = (
         "Extract 3-5 short search queries (2-4 words each) that capture the "
         "key topics in this text. Return one query per line, nothing else.\n\n"
         f"Text: {text[:2000]}"
     )
     response = _call_llm(prompt, timeout=30)
-    if response:
-        lines = [l.strip().strip("-•*").strip() for l in response.splitlines() if l.strip()]
-        queries = [l for l in lines if 2 <= len(l.split()) <= 8 and len(l) < 80]
-        if queries:
-            return queries[:5]
-
-    # Fallback: split into meaningful chunks by sentence boundaries
-    words = [w for w in text.split() if len(w) > 3]
-    if len(words) > 6:
-        return [" ".join(words[:5]), " ".join(words[-5:])]
-    return [" ".join(words)] if words else []
+    if not response:
+        return []
+    lines = [l.strip().strip("-•*").strip() for l in response.splitlines() if l.strip()]
+    queries = [l for l in lines if 2 <= len(l.split()) <= 8 and len(l) < 80]
+    return queries[:5]
 
 
 # --- Compile (knowledge compounding) ---
@@ -778,7 +774,7 @@ def compile_tag(tag, dry_run=False):
 
     compiled_content = _call_llm(prompt)
     if not compiled_content:
-        print("Error: No LLM available to compile entries. Configure with: k7e config llm <provider>", file=sys.stderr)
+        print("Error: LLM call failed while compiling entries.", file=sys.stderr)
         return None
 
     # Store as a new compiled node

--- a/apps/k7e/tests/conftest.py
+++ b/apps/k7e/tests/conftest.py
@@ -5,20 +5,20 @@ from pathlib import Path
 
 import pytest
 
-# Add k7e source to path
 K7E_DIR = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(K7E_DIR))
+
+import config
 
 
 @pytest.fixture
 def store(tmp_path, monkeypatch):
     """Isolated K7E store in tmp_path."""
     monkeypatch.setenv("K7E_HOME", str(tmp_path))
-    # Disable ollama for deterministic tests
     monkeypatch.setenv("OLLAMA_URL", "http://localhost:99999")
-    # Disable LLM CLI resolution so search/recall never shell out to a real
-    # provider (e.g. l9m on PATH) and block. @llm tests use their own fixtures.
-    monkeypatch.setenv("K7E_LLM", "none")
+    monkeypatch.delenv("K7E_LLM_COMMAND", raising=False)
+    for _, env_key in config.LLM_PURPOSES.values():
+        monkeypatch.delenv(env_key, raising=False)
 
     import engine
     engine.reset(tmp_path)

--- a/apps/k7e/tests/conftest.py
+++ b/apps/k7e/tests/conftest.py
@@ -16,6 +16,9 @@ def store(tmp_path, monkeypatch):
     monkeypatch.setenv("K7E_HOME", str(tmp_path))
     # Disable ollama for deterministic tests
     monkeypatch.setenv("OLLAMA_URL", "http://localhost:99999")
+    # Disable LLM CLI resolution so search/recall never shell out to a real
+    # provider (e.g. l9m on PATH) and block. @llm tests use their own fixtures.
+    monkeypatch.setenv("K7E_LLM", "none")
 
     import engine
     engine.reset(tmp_path)

--- a/apps/k7e/tests/eval/corpus.json
+++ b/apps/k7e/tests/eval/corpus.json
@@ -1,0 +1,44 @@
+[
+  {"key": "ssh-local-fwd", "title": "SSH Local Port Forwarding", "content": "ssh -L 8080:target:80 bastion forwards your local port 8080 to target:80 through the bastion host. Use it to reach a remote service from your machine.", "tags": ["ssh", "networking"]},
+  {"key": "ssh-remote-fwd", "title": "SSH Remote Port Forwarding", "content": "ssh -R 9090:localhost:3000 server exposes your local port 3000 as port 9090 on the remote server. Use it to publish a local service outward.", "tags": ["ssh", "networking"]},
+  {"key": "ssh-proxyjump", "title": "SSH ProxyJump Bastion Hopping", "content": "ssh -J bastion target connects through a jump host in one step. ProxyJump is cleaner than nested ssh -W for bastion access.", "tags": ["ssh", "networking"]},
+  {"key": "ssh-key-auth", "title": "SSH Key Authentication", "content": "Generate a keypair with ssh-keygen -t ed25519 and copy the public key with ssh-copy-id. Passwordless login uses the private key in ~/.ssh.", "tags": ["ssh", "security"]},
+
+  {"key": "docker-port", "title": "Docker Port Mapping", "content": "docker run -p 8080:80 nginx maps host port 8080 to container port 80. The host port is on the left of the colon.", "tags": ["docker", "networking"]},
+  {"key": "docker-bridge", "title": "Docker Bridge Networking", "content": "The default bridge network isolates containers; use a user-defined bridge so containers resolve each other by name via embedded DNS.", "tags": ["docker", "networking"]},
+  {"key": "docker-layers", "title": "Docker Layer Caching", "content": "Order Dockerfile instructions from least to most frequently changing. Put dependency installs before copying source so the cache survives code edits.", "tags": ["docker", "performance"]},
+  {"key": "docker-volumes", "title": "Docker Named Volumes", "content": "docker run -v mydata:/var/lib/data persists data in a named volume that outlives the container. Bind mounts map a host directory instead.", "tags": ["docker", "storage"]},
+
+  {"key": "git-rebase", "title": "Git Rebase Workflow", "content": "Rebase a feature branch onto main with git rebase main to keep history linear before merging. Resolve conflicts per commit, then continue.", "tags": ["git"]},
+  {"key": "git-cherry-pick", "title": "Git Cherry Pick", "content": "git cherry-pick <sha> applies a single commit from another branch onto the current one. Useful for backporting one fix without merging everything.", "tags": ["git"]},
+  {"key": "git-bisect", "title": "Git Bisect Regression Hunt", "content": "git bisect start, mark a good and a bad commit, and git binary-searches to find the commit that introduced a regression.", "tags": ["git", "debugging"]},
+  {"key": "git-reflog", "title": "Git Reflog Recovery", "content": "git reflog lists every HEAD movement so you can recover commits lost after a bad reset or rebase by checking out the dangling sha.", "tags": ["git", "recovery"]},
+
+  {"key": "pg-vacuum", "title": "PostgreSQL VACUUM", "content": "VACUUM reclaims dead tuples left by updates and deletes. VACUUM ANALYZE also refreshes planner statistics for better query plans.", "tags": ["postgres", "database"]},
+  {"key": "pg-index", "title": "PostgreSQL Index Types", "content": "B-tree indexes serve equality and range queries; GIN indexes accelerate full-text and jsonb containment lookups. Create with CREATE INDEX.", "tags": ["postgres", "database"]},
+  {"key": "pg-explain", "title": "PostgreSQL EXPLAIN ANALYZE", "content": "EXPLAIN ANALYZE runs the query and shows actual row counts and timing per node, exposing sequential scans that should use an index.", "tags": ["postgres", "performance"]},
+  {"key": "pg-pool", "title": "PostgreSQL Connection Pooling", "content": "Use PgBouncer in transaction mode to multiplex many client connections onto a small pool, avoiding the per-connection memory cost of Postgres backends.", "tags": ["postgres", "performance"]},
+
+  {"key": "py-gil", "title": "Python GIL", "content": "The Global Interpreter Lock lets only one thread execute Python bytecode at a time, so CPU-bound threads do not run in parallel. Use multiprocessing for parallelism.", "tags": ["python", "concurrency"]},
+  {"key": "py-asyncio", "title": "Python Asyncio Event Loop", "content": "asyncio runs coroutines cooperatively on a single-threaded event loop. await yields control so I/O-bound tasks overlap without threads.", "tags": ["python", "concurrency"]},
+  {"key": "py-venv", "title": "Python Virtual Environments", "content": "python -m venv .venv creates an isolated environment; activate it and pip install dependencies without polluting the system interpreter.", "tags": ["python", "tooling"]},
+  {"key": "py-comprehension", "title": "Python List Comprehensions", "content": "A list comprehension like [x*x for x in items if x > 0] builds a list in one expression, faster and clearer than an append loop.", "tags": ["python"]},
+
+  {"key": "tmux-prefix", "title": "Tmux Prefix Key", "content": "The default tmux prefix is Ctrl-b. Many remap it to Ctrl-a in tmux.conf for easier reach before pane and window commands.", "tags": ["tmux", "terminal"]},
+  {"key": "vim-macros", "title": "Vim Macros", "content": "Record a macro with qa, perform edits, stop with q, then replay with @a. Prefix a count like 10@a to repeat it ten times.", "tags": ["vim", "terminal"]},
+
+  {"key": "net-tcp-udp", "title": "TCP vs UDP", "content": "TCP is connection-oriented with ordered, reliable delivery and retransmission. UDP is connectionless and unreliable but lower latency, good for streaming.", "tags": ["networking"]},
+  {"key": "net-dns-ttl", "title": "DNS TTL and Caching", "content": "A DNS record's TTL tells resolvers how long to cache it. Lower the TTL before a migration so clients pick up the new IP quickly.", "tags": ["networking", "dns"]},
+
+  {"key": "http-status", "title": "HTTP Status Codes", "content": "2xx means success, 3xx redirection, 4xx client error like 404 not found, and 5xx server error like 502 bad gateway.", "tags": ["http", "web"]},
+  {"key": "http-cors", "title": "HTTP CORS Preflight", "content": "Browsers send an OPTIONS preflight for cross-origin requests; the server must return Access-Control-Allow-Origin and allowed methods or the call is blocked.", "tags": ["http", "web", "security"]},
+
+  {"key": "redis-persist", "title": "Redis Persistence RDB AOF", "content": "Redis can persist with RDB snapshots or an append-only file. AOF replays writes on restart for better durability; RDB is faster to load.", "tags": ["redis", "database"]},
+  {"key": "redis-expire", "title": "Redis Key Expiration", "content": "Set a TTL on a key with EXPIRE key seconds or SET key val EX seconds. Expired keys are removed lazily and by a background sampler.", "tags": ["redis", "database"]},
+
+  {"key": "k8s-probe", "title": "Kubernetes Liveness and Readiness Probes", "content": "A liveness probe restarts an unhealthy container; a readiness probe gates traffic until the pod is ready. Configure httpGet path and period.", "tags": ["kubernetes"]},
+  {"key": "k8s-resources", "title": "Kubernetes Resource Requests and Limits", "content": "Requests reserve CPU and memory for scheduling; limits cap usage. Exceeding a memory limit triggers an OOMKill of the container.", "tags": ["kubernetes", "performance"]},
+
+  {"key": "make-phony", "title": "Makefile PHONY Targets", "content": "Declare .PHONY: clean test so make runs the recipe even when a file named clean exists, since the target is not a real file.", "tags": ["make", "tooling"]},
+  {"key": "bash-set-euo", "title": "Bash Strict Mode", "content": "set -euo pipefail makes a bash script exit on error, error on unset variables, and fail a pipeline if any stage fails.", "tags": ["bash", "tooling"]}
+]

--- a/apps/k7e/tests/eval/questions.json
+++ b/apps/k7e/tests/eval/questions.json
@@ -1,0 +1,44 @@
+[
+  {"q": "tunnel so my laptop can open an internal web app that sits behind a gateway box", "expect": "ssh-local-fwd"},
+  {"q": "make a service running on my machine reachable from a box out on the internet", "expect": "ssh-remote-fwd"},
+  {"q": "hop through an intermediate gateway in one command to reach a private host", "expect": "ssh-proxyjump"},
+  {"q": "stop typing a password every time by using a generated keypair to log in", "expect": "ssh-key-auth"},
+
+  {"q": "make a service inside a container reachable from the host browser", "expect": "docker-port"},
+  {"q": "my containers cannot find each other by hostname on the same network", "expect": "docker-bridge"},
+  {"q": "stop my image rebuild from reinstalling everything when I only edit code", "expect": "docker-layers"},
+  {"q": "keep data around after I delete and recreate a container", "expect": "docker-volumes"},
+
+  {"q": "tidy up my branch into a straight line before opening a pull request", "expect": "git-rebase"},
+  {"q": "grab a single fix from another branch without merging all of it", "expect": "git-cherry-pick"},
+  {"q": "automatically narrow down which change introduced a bug", "expect": "git-bisect"},
+  {"q": "I wiped commits with a bad reset, how do I get them back", "expect": "git-reflog"},
+
+  {"q": "my table bloated after lots of deletes and the planner picks bad plans", "expect": "pg-vacuum"},
+  {"q": "speed up containment lookups on a jsonb column", "expect": "pg-index"},
+  {"q": "find out why one query is slow with real timings per step", "expect": "pg-explain"},
+  {"q": "too many app connections are exhausting database memory", "expect": "pg-pool"},
+
+  {"q": "my multithreaded number crunching is not getting faster on many cores", "expect": "py-gil"},
+  {"q": "handle thousands of network calls on one thread without blocking", "expect": "py-asyncio"},
+  {"q": "keep one project's packages from clashing with another", "expect": "py-venv"},
+  {"q": "transform and filter a sequence into a new collection in a single line", "expect": "py-comprehension"},
+
+  {"q": "remap the leader keystroke for my terminal multiplexer", "expect": "tmux-prefix"},
+  {"q": "capture a sequence of edits and run them again many times in my editor", "expect": "vim-macros"},
+
+  {"q": "pick a protocol with guaranteed in order delivery versus one tuned for speed", "expect": "net-tcp-udp"},
+  {"q": "make clients pick up a new server address fast during a cutover", "expect": "net-dns-ttl"},
+
+  {"q": "what category is a 404 or a 502 response", "expect": "http-status"},
+  {"q": "my javascript call to another domain is blocked before it even sends", "expect": "http-cors"},
+
+  {"q": "choose between snapshotting and a write log for surviving a redis restart", "expect": "redis-persist"},
+  {"q": "have a cached entry disappear on its own after some seconds", "expect": "redis-expire"},
+
+  {"q": "automatically reboot a stuck pod and hold traffic until it can serve", "expect": "k8s-probe"},
+  {"q": "my container keeps getting killed for using too much memory on the cluster", "expect": "k8s-resources"},
+
+  {"q": "force a build recipe to run even though a same named file is present", "expect": "make-phony"},
+  {"q": "make my shell script stop immediately when any command fails", "expect": "bash-set-euo"}
+]

--- a/apps/k7e/tests/test_config_commands.py
+++ b/apps/k7e/tests/test_config_commands.py
@@ -1,0 +1,26 @@
+"""Tests for explicit LLM command configuration."""
+import config
+
+
+class TestResolveCommand:
+    def test_fallback_used_when_purpose_unset(self, store, monkeypatch):
+        monkeypatch.setenv("K7E_LLM_COMMAND", "my-llm")
+        monkeypatch.delenv("K7E_SUMMARIZE_COMMAND", raising=False)
+        assert config.resolve_command("summarize") == "my-llm"
+
+    def test_purpose_override_wins(self, store, monkeypatch):
+        monkeypatch.setenv("K7E_LLM_COMMAND", "my-llm")
+        monkeypatch.setenv("K7E_RERANK_COMMAND", "my-reranker")
+        assert config.resolve_command("rerank") == "my-reranker"
+        assert config.resolve_command("distill") == "my-llm"
+
+    def test_none_when_unconfigured(self, store, monkeypatch):
+        monkeypatch.delenv("K7E_LLM_COMMAND", raising=False)
+        monkeypatch.delenv("K7E_DISTILL_COMMAND", raising=False)
+        assert config.resolve_command("distill") is None
+
+    def test_command_source_labels_override(self, store, monkeypatch):
+        monkeypatch.setenv("K7E_COMPILE_COMMAND", "compile-cli")
+        cmd, source = config.command_source("compile")
+        assert cmd == "compile-cli"
+        assert source == "compile_command"

--- a/apps/k7e/tests/test_dedup.py
+++ b/apps/k7e/tests/test_dedup.py
@@ -32,25 +32,29 @@ class TestDedupStress:
 
 
 class TestDistillDedup:
-    """Test that the distill path actually deduplicates."""
+    """Test that the distill diff path deduplicates candidates against the store.
 
-    def test_distill_skips_known_content(self, store, tmp_path):
+    Exercised at the candidate level (diff_against_store) so it stays
+    deterministic without an LLM; end-to-end extraction is covered in
+    test_llm_distill.py (@llm)."""
+
+    def test_diff_skips_known_content(self, store):
         import distill
-        engine.store_entry("Known Fact", "The sky is blue on clear days", tags=["nature"])
-        journal = tmp_path / "j.md"
-        journal.write_text("TIL: The sky is blue on clear days")
-        results = distill.distill([str(journal)])
-        stored = [r for r in results if r["action"] == "stored"]
-        assert len(stored) == 0, f"Re-stored known fact: {stored}"
+        engine.store_entry("Sky color", "The sky is blue on clear days", tags=["nature"])
+        candidates = [
+            {"title": "Sky is blue", "content": "The sky is blue on clear days", "tags": ["nature"]},
+        ]
+        new = distill.diff_against_store(candidates)
+        assert new == [], f"Known content should be deduped, got: {new}"
 
-    def test_distill_stores_new_content(self, store, tmp_path):
+    def test_diff_keeps_new_content(self, store):
         import distill
         engine.store_entry("Old Fact", "Something unrelated", tags=["misc"])
-        journal = tmp_path / "j.md"
-        journal.write_text("TIL: Quantum entanglement allows instant correlation across any distance")
-        results = distill.distill([str(journal)])
-        stored = [r for r in results if r["action"] in ("stored", "would_store")]
-        assert len(stored) >= 1
+        candidates = [
+            {"title": "Quantum entanglement correlation", "content": "Quantum entanglement allows instant correlation across any distance", "tags": ["physics"]},
+        ]
+        new = distill.diff_against_store(candidates)
+        assert len(new) >= 1
 
 
 class TestTitleDedup:

--- a/apps/k7e/tests/test_distill.py
+++ b/apps/k7e/tests/test_distill.py
@@ -1,55 +1,24 @@
-"""Distill extraction tests — accuracy and noise rejection."""
-import engine
+"""Distill offline contract.
+
+Text distillation requires an LLM — there is no offline pattern-matching
+fallback. With llm=none (the conftest default) extraction yields nothing.
+Real extraction behavior is covered in test_llm_distill.py (@llm)."""
 import distill
 
 
-class TestPatternExtraction:
-    def test_til_pattern(self, store, tmp_path):
+class TestDistillRequiresLLM:
+    def test_offline_extracts_nothing(self, store, tmp_path):
         journal = tmp_path / "j.md"
-        journal.write_text("TIL: kubectl port-forward requires the pod to be Running. CrashLoopBackOff gives a cryptic error.")
+        journal.write_text(
+            "TIL: kubectl port-forward requires the pod to be Running.\n\n"
+            "The fix is: add --vfs-cache-max-size 10G to cap cache growth.\n\n"
+            "Use this command:\n```\nssh -L 8080:localhost:3000 user@host\n```\n"
+        )
         results = distill.distill([str(journal)])
-        stored = [r for r in results if r["action"] in ("stored", "would_store")]
-        assert len(stored) >= 1
+        assert results == [], f"Offline distill should extract nothing, got: {results}"
 
-    def test_fix_pattern(self, store, tmp_path):
+    def test_offline_short_text_noop(self, store, tmp_path):
         journal = tmp_path / "j.md"
-        journal.write_text("The fix is: add --vfs-cache-max-size 10G to prevent unbounded cache growth.")
+        journal.write_text("short note")
         results = distill.distill([str(journal)])
-        stored = [r for r in results if r["action"] in ("stored", "would_store")]
-        assert len(stored) >= 1
-
-    def test_code_block_pattern(self, store, tmp_path):
-        journal = tmp_path / "j.md"
-        journal.write_text("Use this command:\n```\nssh -L 8080:localhost:3000 user@host\n```\n")
-        results = distill.distill([str(journal)])
-        stored = [r for r in results if r["action"] in ("stored", "would_store")]
-        assert len(stored) >= 1
-
-    def test_noise_rejected(self, store, tmp_path):
-        journal = tmp_path / "j.md"
-        journal.write_text("Hey team, let's sync tomorrow morning. I think we should look into this next week.")
-        results = distill.distill([str(journal)])
-        assert len(results) == 0, f"Extracted noise: {results}"
-
-    def test_multiple_facts_in_one_file(self, store, tmp_path):
-        journal = tmp_path / "j.md"
-        journal.write_text("""
-TIL: Redis expires keys lazily — only checked on access.
-
-Also: The fix is: use SCAN instead of KEYS in production to avoid blocking.
-
-TIL: PostgreSQL VACUUM doesn't reclaim disk space, only marks pages reusable.
-""")
-        results = distill.distill([str(journal)])
-        stored = [r for r in results if r["action"] in ("stored", "would_store")]
-        assert len(stored) >= 2, f"Only extracted {len(stored)} from 3 facts"
-
-
-class TestDistillDedup:
-    def test_skips_already_known(self, store, tmp_path):
-        engine.store_entry("Redis SCAN not KEYS production", "Use SCAN instead of KEYS in production to avoid blocking Redis", tags=["redis"])
-        journal = tmp_path / "j.md"
-        journal.write_text("TIL: Use SCAN instead of KEYS in production to avoid blocking Redis")
-        results = distill.distill([str(journal)])
-        stored = [r for r in results if r["action"] == "stored"]
-        assert len(stored) == 0
+        assert results == []

--- a/apps/k7e/tests/test_distill.py
+++ b/apps/k7e/tests/test_distill.py
@@ -1,8 +1,8 @@
 """Distill offline contract.
 
 Text distillation requires an LLM — there is no offline pattern-matching
-fallback. With llm=none (the conftest default) extraction yields nothing.
-Real extraction behavior is covered in test_llm_distill.py (@llm)."""
+fallback. With no llm_command configured (the conftest default) extraction
+yields nothing. Real extraction behavior is covered in test_llm_distill.py (@llm)."""
 import distill
 
 

--- a/apps/k7e/tests/test_eval_recall.py
+++ b/apps/k7e/tests/test_eval_recall.py
@@ -1,0 +1,134 @@
+"""Recall@K evaluation harness (issue #145, workstream 4).
+
+Deterministic, checked-in fixtures (eval/corpus.json + eval/questions.json)
+measure whether the right entry surfaces in the top-K results.
+
+- Tier A (this default-fixture class): FTS + metadata + RRF + decay, no ollama.
+  Runs in the always-on `k7e` CI job. The ruler that proves ranking changes
+  help (or at least do not regress).
+- Tier B (@llm class): full hybrid + LLM reranker against a real ollama.
+  Runs in the `llm` CI job; skipped when ollama is unavailable.
+"""
+import json
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+import engine
+
+EVAL_DIR = Path(__file__).resolve().parent / "eval"
+
+
+def _load(name):
+    return json.loads((EVAL_DIR / name).read_text(encoding="utf-8"))
+
+
+def _seed():
+    """Store the corpus; return {fixture_key: node_id}."""
+    key_to_id = {}
+    for fact in _load("corpus.json"):
+        nid = engine.store_entry(fact["title"], fact["content"], tags=fact.get("tags", []))
+        key_to_id[fact["key"]] = nid
+    return key_to_id
+
+
+def _recall_at_k(key_to_id, questions, k, rerank=False):
+    hits = 0
+    misses = []
+    for item in questions:
+        results = engine.search(item["q"], limit=k, rerank=rerank)
+        ids = [r["id"] for r in results[:k]]
+        if key_to_id.get(item["expect"]) in ids:
+            hits += 1
+        else:
+            misses.append(item["expect"])
+    return hits / len(questions), misses
+
+
+class TestEvalRecallDeterministic:
+    """Tier A: FTS + metadata + RRF + decay. No LLM, no ollama."""
+
+    def test_corpus_and_questions_consistent(self, store):
+        corpus_keys = {f["key"] for f in _load("corpus.json")}
+        for item in _load("questions.json"):
+            assert item["expect"] in corpus_keys, f"question targets unknown key {item['expect']}"
+
+    def test_recall_thresholds(self, store, capsys):
+        # Deterministic FTS + metadata + RRF + decay baseline (no ollama):
+        # measured R@1=0.66 R@3=0.81 R@5=R@10=0.84. Thresholds sit just under
+        # that so fixture tweaks have a little slack; embeddings + rerank
+        # (Tier B) are expected to push these higher.
+        key_to_id = _seed()
+        questions = _load("questions.json")
+        scores = {k: _recall_at_k(key_to_id, questions, k)[0] for k in (1, 3, 5, 10)}
+        with capsys.disabled():
+            print("\n[eval] FTS-only " + " ".join(f"R@{k}={v:.2f}" for k, v in scores.items()))
+        floors = {1: 0.60, 3: 0.75, 5: 0.80, 10: 0.80}
+        for k, floor in floors.items():
+            assert scores[k] >= floor, f"R@{k}={scores[k]:.2f} below floor {floor}"
+
+    def test_decay_does_not_regress_recent_corpus(self, store, monkeypatch):
+        """A freshly stored corpus is inside the flat zone, so an aggressive
+        decay scale must not change which docs surface in the top-K."""
+        key_to_id = _seed()
+        questions = _load("questions.json")
+        baseline, _ = _recall_at_k(key_to_id, questions, 10)
+        monkeypatch.setenv("K7E_DECAY_SCALE", "30")
+        monkeypatch.setenv("K7E_DECAY_OFFSET", "1")
+        decayed, _ = _recall_at_k(key_to_id, questions, 10)
+        assert decayed == baseline
+
+
+def _ollama_available(url):
+    try:
+        urllib.request.urlopen(f"{url}/api/tags", timeout=2)
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.llm
+class TestEvalRecallHybrid:
+    """Tier B: full hybrid retrieval + LLM reranker against a real ollama.
+
+    Embeddings only contribute if the embed model is pulled; otherwise this
+    still exercises the LLM rerank path end-to-end. Asserts no regression
+    against the Tier A floor and prints the measured numbers.
+    """
+
+    @pytest.fixture
+    def hybrid_store(self, tmp_path, monkeypatch):
+        url = "http://localhost:11434"
+        if not _ollama_available(url):
+            pytest.skip("ollama not running")
+        monkeypatch.setenv("K7E_HOME", str(tmp_path))
+        monkeypatch.setenv("OLLAMA_URL", url)
+        engine.reset(tmp_path)
+        engine.init()
+        return tmp_path
+
+    def test_hybrid_recall_with_rerank(self, hybrid_store, capsys):
+        key_to_id = _seed()
+        engine.process_pending_embeddings()
+        questions = _load("questions.json")
+        # One reranked search per question; derive R@5 and R@10 from it to keep
+        # the LLM call count (and CI time) down.
+        hits5 = hits10 = 0
+        miss10 = []
+        for item in questions:
+            ranked = [r["id"] for r in engine.search(item["q"], limit=10, rerank=True)]
+            target = key_to_id.get(item["expect"])
+            if target in ranked[:5]:
+                hits5 += 1
+            if target in ranked[:10]:
+                hits10 += 1
+            else:
+                miss10.append(item["expect"])
+        r5, r10 = hits5 / len(questions), hits10 / len(questions)
+        with capsys.disabled():
+            print(f"\n[eval] hybrid+rerank R@5={r5:.2f} R@10={r10:.2f}")
+        # Conservative floor: proves the LLM rerank path runs end-to-end against
+        # a real (tiny) model without catastrophic regression. The printed
+        # numbers carry the quality signal; small rerankers have known variance.
+        assert r10 >= 0.75, f"R@10={r10:.2f} misses={miss10}"

--- a/apps/k7e/tests/test_llm_distill.py
+++ b/apps/k7e/tests/test_llm_distill.py
@@ -1,14 +1,12 @@
 """LLM-dependent distill tests — require a running ollama instance.
 
-Run with: pytest -m llm
-Skipped by default in CI unless ollama is available.
+Uses a stateless ollama HTTP wrapper as llm_command (stdin→stdout).
 """
 import json
 import urllib.request
 
 import pytest
 
-import config
 import distill
 import engine
 
@@ -33,22 +31,36 @@ def _skip_if_no_ollama():
 
 @pytest.fixture
 def store(tmp_path, monkeypatch):
-    """Isolated K7E store with ollama enabled (overrides conftest's store)."""
+    """Isolated K7E store with a stateless ollama stdin→stdout llm_command."""
     monkeypatch.setenv("K7E_HOME", str(tmp_path))
     monkeypatch.setenv("OLLAMA_URL", OLLAMA_URL)
 
     engine.reset(tmp_path)
     engine.init()
 
+    wrapper = tmp_path / "ollama-stdin.py"
+    wrapper.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, os, sys, urllib.request\n"
+        'url = os.environ.get("OLLAMA_URL", "http://localhost:11434")\n'
+        'model = os.environ.get("K7E_TEST_LLM_MODEL", "qwen3:0.6b")\n'
+        "prompt = sys.stdin.read()\n"
+        'data = json.dumps({"model": model, "prompt": prompt, "stream": False, "think": False}).encode()\n'
+        'req = urllib.request.Request(f"{url}/api/generate", data=data, headers={"Content-Type": "application/json"})\n'
+        "with urllib.request.urlopen(req, timeout=180) as resp:\n"
+        '    print(json.loads(resp.read()).get("response", "").strip())\n'
+    )
+    wrapper.chmod(0o755)
+    monkeypatch.setenv("K7E_LLM_COMMAND", str(wrapper))
+
     cfg_path = tmp_path / "config.json"
-    cfg_path.write_text(json.dumps({"llm": "ollama", "llm_model": "qwen3:0.6b"}))
+    cfg_path.write_text(json.dumps({"llm_command": str(wrapper)}))
 
     return tmp_path
 
 
 class TestLLMDistill:
     def test_extracts_knowledge_from_plain_text(self, store):
-        """LLM should extract structured knowledge from prose with no patterns."""
         text = (
             "Kubernetes uses etcd as its backing store for all cluster data. "
             "etcd is a consistent, distributed key-value store. "
@@ -62,7 +74,6 @@ class TestLLMDistill:
         assert len(stored) >= 1, f"LLM should extract at least 1 fact, got: {results}"
 
     def test_extracts_from_conversation(self, store):
-        """LLM should extract knowledge from a conversation-like transcript."""
         text = (
             "I discovered that Python's asyncio.run() creates a new event loop "
             "each time. If you call it from within an already-running loop, "
@@ -76,7 +87,6 @@ class TestLLMDistill:
         assert len(stored) >= 1
 
     def test_dedup_on_second_run(self, store):
-        """Running distill twice should not cause unbounded growth."""
         text = (
             "Git's reflog stores every position of HEAD for the last 90 days. "
             "Even after a hard reset, you can recover commits via "
@@ -90,15 +100,9 @@ class TestLLMDistill:
 
         results2 = distill.distill([str(path)])
         new_stored = [r for r in results2 if r["action"] == "stored"]
-        # Small LLMs are non-deterministic — may extract a different facet.
-        # Key property: second run doesn't produce MORE than first + 1
-        # (allows one novel extraction from non-determinism, blocks unbounded growth)
-        assert len(new_stored) <= len(stored1) + 1, (
-            f"Second run grew too much: first={len(stored1)}, second={len(new_stored)}"
-        )
+        assert len(new_stored) <= len(stored1) + 1
 
     def test_returns_empty_for_noise(self, store):
-        """LLM should return nothing for trivial/noise content."""
         text = "Hey, sounds good! Let's sync tomorrow morning."
         path = store / "noise.txt"
         path.write_text(text)

--- a/apps/k7e/tests/test_recall.py
+++ b/apps/k7e/tests/test_recall.py
@@ -42,8 +42,9 @@ class TestRecallNoLLM:
         _, sources = engine.recall("knowledge topic", limit=3)
         assert len(sources) <= 3
 
-    def test_long_input_uses_decomposition_fallback(self, store):
-        """Long input without LLM falls back to word-based splitting."""
+    def test_long_input_searches_raw_text(self, store):
+        """Long input without LLM: decompose returns nothing, so recall searches
+        the raw text directly. Key assertion: no crash, sources is a list."""
         engine.store_entry("SSH Tunneling", "Use ssh -L for local port forwarding", tags=["ssh"])
         long_text = (
             "We were discussing SSH tunneling and port forwarding techniques "
@@ -51,9 +52,6 @@ class TestRecallNoLLM:
             "covered both local and remote forwarding patterns."
         )
         _, sources = engine.recall(long_text)
-        # Should still find SSH-related content via fallback decomposition
-        # (may or may not match depending on FTS5 tokenization)
-        # The key assertion: no crash on long input without LLM
         assert isinstance(sources, list)
 
 
@@ -74,19 +72,12 @@ class TestCallLlm:
 
 
 class TestDecomposeQueries:
-    """Test _decompose_queries fallback (no LLM)."""
+    """Without an LLM, _decompose_queries returns [] (no word-split fallback);
+    recall() then searches the raw text."""
 
-    def test_short_text_returns_word_chunks(self, store):
+    def test_returns_empty_without_llm(self, store):
         queries = engine._decompose_queries("short text only four words here extra padding needed")
-        assert isinstance(queries, list)
-        assert len(queries) >= 1
-        for q in queries:
-            assert len(q) > 0
-
-    def test_very_short_text_returns_single_query(self, store):
-        queries = engine._decompose_queries("hello world")
-        # Only 2 words, both ≤ 3 chars after filtering — may be empty
-        assert isinstance(queries, list)
+        assert queries == []
 
     def test_empty_returns_empty(self, store):
         queries = engine._decompose_queries("")
@@ -94,20 +85,21 @@ class TestDecomposeQueries:
 
 
 class TestRecallCLI:
-    """Test CLI recall dispatch."""
+    """CLI recall fails fast when no LLM is available (conftest sets llm=none)."""
 
-    def test_recall_no_args_no_tty(self, store, monkeypatch):
+    def test_recall_fails_fast_without_llm(self, store, monkeypatch, capsys):
         import io
         import cli
 
         monkeypatch.setattr("sys.stdin", io.StringIO("redis port forwarding"))
         monkeypatch.setattr("sys.stdin.isatty", lambda: False)
-        # Should not crash — either finds results or prints "No relevant..."
         exit_code = cli.main(["recall"])
-        assert exit_code in (0, None)
+        assert exit_code == 1
+        assert "requires an LLM" in capsys.readouterr().err
 
-    def test_recall_with_text_arg(self, store):
+    def test_recall_with_text_arg_fails_fast(self, store, capsys):
         import cli
         engine.store_entry("Test Node", "Some test content for recall", tags=["test"])
         exit_code = cli.main(["recall", "test content"])
-        assert exit_code in (0, None)
+        assert exit_code == 1
+        assert "requires an LLM" in capsys.readouterr().err

--- a/apps/k7e/tests/test_recall.py
+++ b/apps/k7e/tests/test_recall.py
@@ -58,16 +58,18 @@ class TestRecallNoLLM:
 class TestCallLlm:
     """Test _call_llm graceful failures."""
 
-    def test_returns_none_when_no_provider(self, store, monkeypatch):
-        monkeypatch.setenv("K7E_LLM", "nonexistent_binary_xyz")
-        monkeypatch.setenv("OLLAMA_URL", "http://localhost:99999")
-        result = engine._call_llm("test prompt")
+    def test_returns_none_when_no_command(self, store, monkeypatch):
+        monkeypatch.delenv("K7E_LLM_COMMAND", raising=False)
+        monkeypatch.delenv("K7E_SUMMARIZE_COMMAND", raising=False)
+        result = engine._call_llm("test prompt", purpose="summarize")
         assert result is None
 
-    def test_returns_none_on_timeout(self, store, monkeypatch):
-        monkeypatch.setenv("K7E_LLM", "nonexistent_binary_xyz")
-        monkeypatch.setenv("OLLAMA_URL", "http://localhost:99999")
-        result = engine._call_llm("test", timeout=1)
+    def test_returns_none_on_timeout(self, store, monkeypatch, tmp_path):
+        script = tmp_path / "slow.sh"
+        script.write_text("#!/usr/bin/env bash\nsleep 5\n")
+        script.chmod(0o755)
+        monkeypatch.setenv("K7E_LLM_COMMAND", str(script))
+        result = engine._call_llm("test", purpose="summarize", timeout=1)
         assert result is None
 
 
@@ -85,7 +87,7 @@ class TestDecomposeQueries:
 
 
 class TestRecallCLI:
-    """CLI recall fails fast when no LLM is available (conftest sets llm=none)."""
+    """CLI recall fails fast when no LLM command is configured."""
 
     def test_recall_fails_fast_without_llm(self, store, monkeypatch, capsys):
         import io


### PR DESCRIPTION
## Summary

Implements the k7e retrieval-quality overhaul from #145, plus a docs pass and a
redesigned LLM integration model: **explicit stdin→stdout CLI commands** you
configure, with no auto-detection and no bundled generation provider.

Closes #145.

### Retrieval overhaul (#145)

- **Time-decay + use-count** — index-only `last_used_at`/`use_count` columns
  (re-earned on `reindex`). `search()` folds a Gaussian relevance decay and a
  log10 use-count boost into scoring; `recall()`/`get()` bump usage. Tunable via
  config + env; decay disabled when `scale<=0` to keep tests deterministic.
- **LLM reranker** — over-fetch wide, rerank the top pool via the LLM as a joint
  scorer. On by default in `recall()`, opt-in `--rerank` for `search`. Graceful
  fallback to fused order when the rerank command fails or output is unparseable.
- **Supersession** — fixed the `_search_embeddings` status leak, threaded
  `include_superseded` through `search()`/`recall()`, exposed `k7e supersede`.
- **Recall@K eval harness** — checked-in `corpus.json`/`questions.json` fixtures
  and a two-tier test (deterministic Tier A; `@llm` hybrid+rerank Tier B).

### LLM commands (stdin → stdout)

k7e does **not** auto-detect LLMs and does **not** call ollama for generation.
You define shell commands; k7e writes the prompt to **stdin** and reads the
response from **stdout**.

| Purpose | Config key | Env var |
|---------|------------|---------|
| fallback (all uses) | `llm_command` | `K7E_LLM_COMMAND` |
| recall synthesis | `summarize_command` | `K7E_SUMMARIZE_COMMAND` |
| long-text decompose | `decompose_command` | `K7E_DECOMPOSE_COMMAND` |
| distill | `distill_command` | `K7E_DISTILL_COMMAND` |
| compile | `compile_command` | `K7E_COMPILE_COMMAND` |
| rerank | `rerank_command` | `K7E_RERANK_COMMAND` |

Purpose-specific commands fall back to `llm_command`. `k7e status` shows the
resolved command for each purpose.

**Multimedia distillation:** stdin is always prompt text (instruction + absolute
file path). k7e never passes binary to the LLM command. The configured
`distill_command` must handle the path; k7e stores the original file in
`assets/` and appends a markdown `![name](assets/...)` marker to the entry.

**Embeddings** remain on ollama HTTP (`/api/embed`) separately from LLM commands.

### Fail-fast

`distill`, `recall`, and `compile` exit with an actionable error when their
required command is not configured — no silent pattern-extraction or raw-search
fallbacks for LLM-shaped features. FTS5 keyword search stays fully offline.

### Docs

- README cheat-sheet with mission statement
- Cross-linked references under `apps/k7e/docs/`: architecture, retrieval,
  distillation, configuration, cli

## Test plan

- [x] `tests/run -m "not llm"` — 103 passed (deterministic, incl. Tier A eval)
- [x] `test_config_commands.py` — command resolution + purpose overrides
- [ ] CI `llm` job — Tier B eval + `@llm` distill (stateless ollama HTTP wrapper as `llm_command`)