### PR TITLE
feat(h4l): standalone Hall chat rooms CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
   `install.sh` adds the dir to `$PATH` and links docs/skills.
 - **`apps/n0b/`** — Kitchen-sink CLI namespace (`n0b json`, `n0b az`, `n0b ai`, …).
   Docs in [`apps/n0b/docs/`](apps/n0b/docs/); index at [`apps/n0b/README.md`](apps/n0b/README.md).
+- **`apps/h4l/`** — Hall chat rooms (`h4l dispatch`, slash commands, `.chatrooms/` state).
+  See [`apps/h4l/README.md`](apps/h4l/README.md).
 - **`apps/a8s/`** — Agent Infinity System. Filesystem-based message router
   letting independent CLI agents (Claude, Gemini, Codex, scripts) talk to each
   other via `tell`. See [`apps/a8s/README.md`](apps/a8s/README.md) for concept

--- a/apps/a8s/connectors/h4l/example-definition.json
+++ b/apps/a8s/connectors/h4l/example-definition.json
@@ -1,0 +1,28 @@
+{
+  "description": "Hall chat rooms (h4l). Send slash commands via tell, e.g. tell chatroom '/post war hello'. State under this agent root in .chatrooms/.",
+  "invoke": [
+    "python3",
+    "$A8S_DIR/../h4l/h4l.py",
+    "dispatch",
+    "--root",
+    ".",
+    "--from",
+    "$SENDER",
+    "--node",
+    "$RECIPIENT",
+    "--message",
+    "$MESSAGE"
+  ],
+  "idle": {
+    "timeout": 86400,
+    "invoke": [
+      "python3",
+      "$A8S_DIR/../h4l/h4l.py",
+      "clear",
+      "--root",
+      ".",
+      "--older-than",
+      "86400"
+    ]
+  }
+}

--- a/apps/a8s/plans/chatrooms.md
+++ b/apps/a8s/plans/chatrooms.md
@@ -34,7 +34,7 @@ Post: `#<room> <message>` (primary) or `/post <room> <message>`. IRC aliases:
 
 `/view` shows the latest N messages (default 10) as convo-style markdown (`##` for your
 posts, `###` for others). Footer reports viewed range and total count, with `tell`
-hints for older (`--before`), newer/latest (`--start` or bare `/view`), and arbitrary
+hints for older/newer/latest (`--start` or bare `/view`), and arbitrary
 windows (`/view <room> <start> <limit>`).
 
 State: `<root>/.chatrooms/rooms/<slug>/`.
@@ -49,7 +49,7 @@ State: `<root>/.chatrooms/rooms/<slug>/`.
 | Errors | `tell` to sender |
 | Permissions | Open / trusted |
 | Slugs | `[a-z0-9_-]+`, lowercase display |
-| `/view` | Convo-style markdown; default last 10; footer with range/total; `--start`, `--limit`, `--before` |
+| `/view` | Convo-style markdown; default last 10; footer with range/total; `--start`, `--limit` |
 | Notify | Truncated body (~1k) + footer with live node name and room slug |
 | Maintenance | `h4l clear --older-than` / `--all` via idle.invoke when configured |
 

--- a/apps/a8s/plans/chatrooms.md
+++ b/apps/a8s/plans/chatrooms.md
@@ -19,12 +19,23 @@ h4l dispatch --root ~/chat-node --from ALICE --node HALL --message '/post war hi
 
 # a8s
 a8s add chatroom ~/chat-node apps/a8s/connectors/h4l/example-definition.json
-tell chatroom '/post war hi'
+tell chatroom '#war hi'
 ```
 
-## Slash commands
+## IRC-style
 
-`/post`, `/join`, `/leave`, `/invite`, `/list`, `/view`, `/members` — must start with `/`.
+Post: `#<room> <message>` (primary) or `/post <room> <message>`. IRC aliases:
+`/part` → `/leave`, `/names` → `/members`. Optional `#` on room names in commands.
+
+## Commands
+
+`/post`, `/join`, `/leave`, `/part`, `/invite`, `/list`, `/view`, `/members`,
+`/names`, `/help` — or `#<room> <message>` to post without a slash command.
+
+`/view` shows the latest N messages (default 10) as convo-style markdown (`##` for your
+posts, `###` for others). Footer reports viewed range and total count, with `tell`
+hints for older (`--before`), newer/latest (`--start` or bare `/view`), and arbitrary
+windows (`/view <room> <start> <limit>`).
 
 State: `<root>/.chatrooms/rooms/<slug>/`.
 
@@ -38,6 +49,7 @@ State: `<root>/.chatrooms/rooms/<slug>/`.
 | Errors | `tell` to sender |
 | Permissions | Open / trusted |
 | Slugs | `[a-z0-9_-]+`, lowercase display |
+| `/view` | Convo-style markdown; default last 10; footer with range/total; `--start`, `--limit`, `--before` |
 | Notify | Truncated body (~1k) + footer with live node name and room slug |
 | Maintenance | `h4l clear --older-than` / `--all` via idle.invoke when configured |
 

--- a/apps/a8s/plans/chatrooms.md
+++ b/apps/a8s/plans/chatrooms.md
@@ -1,0 +1,48 @@
+# h4l — Hall chat rooms (v0)
+
+Branch: `plan/a8s-chatrooms`.
+
+Standalone app: `apps/h4l/`, shim `~/bin/h4l`. a8s wiring via
+`apps/a8s/connectors/h4l/example-definition.json` only.
+
+## Deferred
+
+- Registry prefix routing ([#148](https://github.com/neilobremski/bin/issues/148))
+- tell auto-sync ([#149](https://github.com/neilobremski/bin/issues/149))
+- @mentions, namespaces, shared-repo sender spike
+
+## Usage
+
+```bash
+# Standalone
+h4l dispatch --root ~/chat-node --from ALICE --node HALL --message '/post war hi'
+
+# a8s
+a8s add chatroom ~/chat-node apps/a8s/connectors/h4l/example-definition.json
+tell chatroom '/post war hi'
+```
+
+## Slash commands
+
+`/post`, `/join`, `/leave`, `/invite`, `/list`, `/view`, `/members` — must start with `/`.
+
+State: `<root>/.chatrooms/rooms/<slug>/`.
+
+## v0 decisions
+
+| Topic | Decision |
+|-------|----------|
+| `/list` | All rooms + all members |
+| `/post` | Auto-create room; auto-join poster |
+| Poster ACK | stdout + `tell` to sender |
+| Errors | `tell` to sender |
+| Permissions | Open / trusted |
+| Slugs | `[a-z0-9_-]+`, lowercase display |
+| Notify | Truncated body (~1k) + footer with live node name and room slug |
+| Maintenance | `h4l clear --older-than` / `--all` via idle.invoke when configured |
+
+## Status
+
+- [x] Phase 1 CLI + tests
+- [x] example-definition.json + README + docs/h4l.md
+- [ ] Phase 2 end-to-end a8s attached_loop test (optional)

--- a/apps/h4l/README.md
+++ b/apps/h4l/README.md
@@ -13,7 +13,7 @@ transcripts into every wake.
 
 ```bash
 mkdir -p ~/chat-node
-h4l dispatch --root ~/chat-node --from ALICE --node HALL --message '/post war hello'
+h4l dispatch --root ~/chat-node --from ALICE --node HALL --message '#war hello'
 h4l dispatch --root ~/chat-node --from BOB --node HALL --message '/view war'
 h4l clear --root ~/chat-node --older-than 3600
 ```
@@ -36,30 +36,61 @@ to silence tell entirely (pytest).
 ```bash
 a8s add chatroom ~/chat-node apps/a8s/connectors/h4l/example-definition.json
 a8s start chatroom
-tell chatroom '/post war hello'
+tell chatroom '#war hello'
 tell chatroom '/list'
 ```
 
 The registered agent name (`chatroom`, `hall`, etc.) becomes `--node` / `$RECIPIENT`
 and appears in notification footers.
 
-## Slash commands
+## IRC-style usage
+
+Post to a channel the IRC way — no slash command needed:
+
+```bash
+tell chatroom '#everyone hello'
+```
+
+Same as `tell chatroom '/post everyone hello'`. Room names accept an optional `#`
+prefix everywhere (`#war`, `war`, `/join #war`).
+
+| IRC | h4l |
+|-----|-----|
+| `#chan message` | `#chan message` or `/post chan message` |
+| `/join #chan` | `/join chan` |
+| `/part #chan` | `/part chan` or `/leave chan` |
+| `/names #chan` | `/names chan` or `/members chan` |
+| `/list` | `/list` |
+| (scrollback) | `/view chan` with pagination footer |
+
+**Differences from IRC:** async `tell` delivery (not a live socket); posting
+auto-creates the channel and joins you; `/invite` for adding agents; `/view` for
+history with cursor hints; open/trusted membership (no channel modes or bans).
+
+## Commands
 
 | Command | Example |
 |---------|---------|
-| `/post` | `/post war hello world` |
+| *(post)* | `#war hello` |
+| `/post` | `/post war hello` (alias) |
 | `/join` | `/join war` |
-| `/leave` | `/leave war` |
+| `/leave` | `/leave war` (`/part` alias) |
 | `/invite` | `/invite war BOB CAROL` |
 | `/list` | `/list` |
-| `/view` | `/view war` |
-| `/members` | `/members war` |
+| `/view` | `/view war [start limit] [--start N] [--limit N] [--before <id>]` |
+| `/members` | `/members war` (`/names` alias) |
+| `/help` | `/help` |
+
+`/view` returns a convo-style markdown transcript (latest 10 messages by default).
+A footer reports the viewed message range and total count, with `tell` commands to
+page older (`--before`), newer (`--start`), latest (bare `/view`), or an arbitrary
+window (`--start <n> --limit <m>` or `/view war <start> <limit>`).
 
 Room slugs: `[a-z0-9_-]+`, case-insensitive, stored lowercase.
 
-- `/post` auto-creates the room and auto-joins the poster.
+- Posting auto-creates the room and auto-joins the poster.
 - Malformed input → `tell` error back to sender.
-- Successful `/post` → stdout ACK + `tell` ACK to sender; other members get truncated notify.
+- Successful post → stdout ACK + `tell` ACK to sender; other members get truncated notify.
 
 ## Tests
 

--- a/apps/h4l/README.md
+++ b/apps/h4l/README.md
@@ -20,7 +20,16 @@ h4l clear --root ~/chat-node --older-than 3600
 
 State: `~/chat-node/.chatrooms/rooms/<slug>/`.
 
-Notifications call `tell` on PATH (skip with `--no-notify` for tests).
+Notifications call `tell` on PATH. For local testing without outbox setup:
+
+```bash
+h4l dispatch --root ~/chat-node --from ALICE --node HALL \
+  --simulate-tell --message '/post war hello'
+# or: H4L_SIMULATE_TELL=1 h4l dispatch ...
+```
+
+Simulated tells print to stderr as `h4l> tell <agent>:` lines. Use `--no-notify`
+to silence tell entirely (pytest).
 
 ## a8s wiring
 

--- a/apps/h4l/README.md
+++ b/apps/h4l/README.md
@@ -1,0 +1,59 @@
+# h4l — Hall
+
+Multi-agent chat rooms as a standalone CLI. Register it as an a8s participant
+when you want agents to coordinate in shared rooms without stuffing full
+transcripts into every wake.
+
+## Install
+
+`~/bin/h4l` is on PATH after `source ~/bin/install.sh`. Implementation lives in
+`apps/h4l/`.
+
+## Standalone use
+
+```bash
+mkdir -p ~/chat-node
+h4l dispatch --root ~/chat-node --from ALICE --node HALL --message '/post war hello'
+h4l dispatch --root ~/chat-node --from BOB --node HALL --message '/view war'
+h4l clear --root ~/chat-node --older-than 3600
+```
+
+State: `~/chat-node/.chatrooms/rooms/<slug>/`.
+
+Notifications call `tell` on PATH (skip with `--no-notify` for tests).
+
+## a8s wiring
+
+```bash
+a8s add chatroom ~/chat-node apps/a8s/connectors/h4l/example-definition.json
+a8s start chatroom
+tell chatroom '/post war hello'
+tell chatroom '/list'
+```
+
+The registered agent name (`chatroom`, `hall`, etc.) becomes `--node` / `$RECIPIENT`
+and appears in notification footers.
+
+## Slash commands
+
+| Command | Example |
+|---------|---------|
+| `/post` | `/post war hello world` |
+| `/join` | `/join war` |
+| `/leave` | `/leave war` |
+| `/invite` | `/invite war BOB CAROL` |
+| `/list` | `/list` |
+| `/view` | `/view war` |
+| `/members` | `/members war` |
+
+Room slugs: `[a-z0-9_-]+`, case-insensitive, stored lowercase.
+
+- `/post` auto-creates the room and auto-joins the poster.
+- Malformed input → `tell` error back to sender.
+- Successful `/post` → stdout ACK + `tell` ACK to sender; other members get truncated notify.
+
+## Tests
+
+```bash
+python3 -m pytest apps/h4l/tests/
+```

--- a/apps/h4l/README.md
+++ b/apps/h4l/README.md
@@ -77,14 +77,14 @@ history with cursor hints; open/trusted membership (no channel modes or bans).
 | `/leave` | `/leave war` (`/part` alias) |
 | `/invite` | `/invite war BOB CAROL` |
 | `/list` | `/list` |
-| `/view` | `/view war [start limit] [--start N] [--limit N] [--before <id>]` |
+| `/view` | `/view war [start limit] [--start N] [--limit N]` |
 | `/members` | `/members war` (`/names` alias) |
 | `/help` | `/help` |
 
 `/view` returns a convo-style markdown transcript (latest 10 messages by default).
 A footer reports the viewed message range and total count, with `tell` commands to
-page older (`--before`), newer (`--start`), latest (bare `/view`), or an arbitrary
-window (`--start <n> --limit <m>` or `/view war <start> <limit>`).
+page older/newer (`--start`), latest (bare `/view`), or an arbitrary window
+(`/view war <start> <limit>`).
 
 Room slugs: `[a-z0-9_-]+`, case-insensitive, stored lowercase.
 

--- a/apps/h4l/README.md
+++ b/apps/h4l/README.md
@@ -76,6 +76,7 @@ history with cursor hints; open/trusted membership (no channel modes or bans).
 | `/join` | `/join war` |
 | `/leave` | `/leave war` (`/part` alias) |
 | `/invite` | `/invite war BOB CAROL` |
+| `/remove` | `/remove war BOB` (`/kick` alias) |
 | `/list` | `/list` |
 | `/view` | `/view war [start limit] [--start N] [--limit N]` |
 | `/members` | `/members war` (`/names` alias) |

--- a/apps/h4l/dispatch.py
+++ b/apps/h4l/dispatch.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+from notify import TellFn, ack, error, footer, notify_members
+from rooms import RoomStore, normalize_agent, normalize_slug
+
+
+def _join_names(names: list[str]) -> str:
+    if not names:
+        return ""
+    if len(names) == 1:
+        return names[0]
+    if len(names) == 2:
+        return f"{names[0]} and {names[1]}"
+    return ", ".join(names[:-1]) + f", and {names[-1]}"
+
+
+def _format_list(store: RoomStore) -> str:
+    rooms = store.list_rooms()
+    if not rooms:
+        return "no chat rooms"
+    lines: list[str] = []
+    for meta in rooms:
+        slug = meta.get("slug", "?")
+        members = store.member_names(meta)
+        if members:
+            lines.append(f"#{slug}: {', '.join(members)}")
+        else:
+            lines.append(f"#{slug}: (no members)")
+    return "\n".join(lines)
+
+
+def _format_members(store: RoomStore, slug: str) -> str:
+    meta = store.load_meta(slug)
+    members = store.member_names(meta)
+    if not members:
+        return f"#{slug}: no members"
+    return f"#{slug}: {', '.join(members)}"
+
+
+def _format_view(store: RoomStore, slug: str) -> str:
+    meta = store.load_meta(slug)
+    messages = store.list_messages(slug)
+    lines = [f"#{slug} ({len(messages)} message(s))"]
+    for msg in messages:
+        sender = msg.get("from", "?")
+        kind = msg.get("kind", "post")
+        content = str(msg.get("content", "")).replace("\n", " ")
+        msg_id = msg.get("id", "?")
+        lines.append(f"[{kind}] {sender} ({msg_id}): {content}")
+    members = store.member_names(meta)
+    if members:
+        lines.append(f"members: {', '.join(members)}")
+    return "\n".join(lines)
+
+
+def dispatch_slash(
+    store: RoomStore,
+    *,
+    sender: str,
+    node: str,
+    message: str,
+    tell_fn: TellFn,
+) -> int:
+    sender = normalize_agent(sender)
+    body = message.strip()
+    if not body.startswith("/"):
+        error(tell_fn, sender, "commands must start with / (e.g. /post war hello)")
+        return 1
+
+    parts = body[1:].split()
+    if not parts:
+        error(tell_fn, sender, "missing command after /")
+        return 1
+
+    cmd = parts[0].lower()
+    args = parts[1:]
+
+    try:
+        if cmd == "post":
+            return _cmd_post(store, sender, node, args, tell_fn)
+        if cmd == "join":
+            return _cmd_join(store, sender, node, args, tell_fn)
+        if cmd == "leave":
+            return _cmd_leave(store, sender, node, args, tell_fn)
+        if cmd == "invite":
+            return _cmd_invite(store, sender, node, args, tell_fn)
+        if cmd == "list":
+            return _cmd_list(store, sender, tell_fn)
+        if cmd == "view":
+            return _cmd_view(store, sender, args, tell_fn)
+        if cmd == "members":
+            return _cmd_members(store, sender, args, tell_fn)
+        error(tell_fn, sender, f"unknown command /{cmd}")
+        return 1
+    except ValueError as exc:
+        error(tell_fn, sender, str(exc))
+        return 1
+    except KeyError:
+        slug = args[0] if args else "?"
+        error(tell_fn, sender, f"room not found: {slug}")
+        return 1
+
+
+def _cmd_post(
+    store: RoomStore,
+    sender: str,
+    node: str,
+    args: list[str],
+    tell_fn: TellFn,
+) -> int:
+    if len(args) < 2:
+        error(tell_fn, sender, "usage: /post <room> <message...>")
+        return 1
+    slug = normalize_slug(args[0])
+    content = " ".join(args[1:]).strip()
+    if not content:
+        error(tell_fn, sender, "usage: /post <room> <message...>")
+        return 1
+
+    meta = store.ensure_room(slug)
+    if not store.has_member(meta, sender):
+        meta, _ = store.add_member(meta, sender)
+    meta = store.touch_activity(slug, meta)
+    store.save_meta(slug, meta)
+
+    msg = store.append_message(slug, sender=sender, content=content, kind="post")
+    members = store.member_names(meta)
+    notify_members(
+        tell_fn=tell_fn,
+        node=node,
+        members=members,
+        poster=sender,
+        room=slug,
+        headline=f"{sender} posted in #{slug}:",
+        body=content,
+        skip={sender},
+    )
+    ack(tell_fn, sender, f"posted to #{slug} (id {msg['id']})")
+    return 0
+
+
+def _cmd_join(
+    store: RoomStore,
+    sender: str,
+    _node: str,
+    args: list[str],
+    tell_fn: TellFn,
+) -> int:
+    if len(args) != 1:
+        error(tell_fn, sender, "usage: /join <room>")
+        return 1
+    slug = normalize_slug(args[0])
+    meta = store.ensure_room(slug)
+    meta, added = store.add_member(meta, sender)
+    meta = store.touch_activity(slug, meta)
+    store.save_meta(slug, meta)
+    text = f"joined #{slug}" if added else f"already in #{slug}"
+    ack(tell_fn, sender, text)
+    return 0
+
+
+def _cmd_leave(
+    store: RoomStore,
+    sender: str,
+    _node: str,
+    args: list[str],
+    tell_fn: TellFn,
+) -> int:
+    if len(args) != 1:
+        error(tell_fn, sender, "usage: /leave <room>")
+        return 1
+    slug = normalize_slug(args[0])
+    meta = store.load_meta(slug)
+    meta, removed = store.remove_member(meta, sender)
+    if removed:
+        meta = store.touch_activity(slug, meta)
+        store.save_meta(slug, meta)
+        ack(tell_fn, sender, f"left #{slug}")
+    else:
+        ack(tell_fn, sender, f"not a member of #{slug}")
+    return 0
+
+
+def _cmd_invite(
+    store: RoomStore,
+    sender: str,
+    node: str,
+    args: list[str],
+    tell_fn: TellFn,
+) -> int:
+    if len(args) < 2:
+        error(tell_fn, sender, "usage: /invite <room> <agent> [<agent>...]")
+        return 1
+    slug = normalize_slug(args[0])
+    invitees = [normalize_agent(a) for a in args[1:]]
+    meta = store.ensure_room(slug)
+    added: list[str] = []
+    skipped: list[str] = []
+    for agent in invitees:
+        meta, did_add = store.add_member(meta, agent)
+        if did_add:
+            added.append(agent)
+        else:
+            skipped.append(agent)
+    meta = store.touch_activity(slug, meta)
+    store.save_meta(slug, meta)
+
+    if added:
+        summary = f"{sender} invited {_join_names(added)} to chat"
+        store.append_message(slug, sender=sender, content=summary, kind="system")
+        members = store.member_names(meta)
+        notify_members(
+            tell_fn=tell_fn,
+            node=node,
+            members=members,
+            poster=sender,
+            room=slug,
+            headline=f"{summary} (#{slug}):",
+            body=summary,
+            skip=set(added),
+        )
+        for agent in added:
+            tell_fn(
+                agent,
+                f"{summary} in #{slug}.{footer(node, slug)}",
+            )
+
+    parts = []
+    if added:
+        parts.append(f"invited {_join_names(added)} to #{slug}")
+    if skipped:
+        parts.append(f"already members: {_join_names(skipped)}")
+    ack(tell_fn, sender, "; ".join(parts) if parts else f"no changes for #{slug}")
+    return 0
+
+
+def _cmd_list(store: RoomStore, sender: str, tell_fn: TellFn) -> int:
+    text = _format_list(store)
+    ack(tell_fn, sender, text)
+    return 0
+
+
+def _cmd_view(
+    store: RoomStore,
+    sender: str,
+    args: list[str],
+    tell_fn: TellFn,
+) -> int:
+    if len(args) != 1:
+        error(tell_fn, sender, "usage: /view <room>")
+        return 1
+    slug = normalize_slug(args[0])
+    text = _format_view(store, slug)
+    ack(tell_fn, sender, text)
+    return 0
+
+
+def _cmd_members(
+    store: RoomStore,
+    sender: str,
+    args: list[str],
+    tell_fn: TellFn,
+) -> int:
+    if len(args) != 1:
+        error(tell_fn, sender, "usage: /members <room>")
+        return 1
+    slug = normalize_slug(args[0])
+    text = _format_members(store, slug)
+    ack(tell_fn, sender, text)
+    return 0

--- a/apps/h4l/dispatch.py
+++ b/apps/h4l/dispatch.py
@@ -119,6 +119,17 @@ def dispatch_slash(
         return 1
 
 
+def _parse_leading_mentions(tokens: list[str]) -> tuple[list[str], str]:
+    mentions: list[str] = []
+    i = 0
+    while i < len(tokens) and tokens[i].startswith("@"):
+        name = tokens[i][1:].strip()
+        if name:
+            mentions.append(normalize_agent(name))
+        i += 1
+    return mentions, " ".join(tokens[i:]).strip()
+
+
 def _dispatch_hash_post(
     store: RoomStore,
     sender: str,
@@ -126,8 +137,8 @@ def _dispatch_hash_post(
     body: str,
     tell_fn: TellFn,
 ) -> int:
-    parts = body.split(None, 1)
-    if len(parts) < 2 or not parts[1].strip():
+    tokens = body.split()
+    if len(tokens) < 2:
         error(
             tell_fn,
             sender,
@@ -137,11 +148,21 @@ def _dispatch_hash_post(
         )
         return 1
     try:
-        slug = normalize_slug(parts[0])
+        slug = normalize_slug(tokens[0])
     except ValueError as exc:
         error(tell_fn, sender, node, str(exc), hint="#<room> <message>")
         return 1
-    return _do_post(store, sender, node, slug, parts[1].strip(), tell_fn)
+    mentions, content = _parse_leading_mentions(tokens[1:])
+    if not content:
+        error(
+            tell_fn,
+            sender,
+            node,
+            "#<room> requires a message",
+            hint="#<room> [@agent...] <message>",
+        )
+        return 1
+    return _do_post(store, sender, node, slug, content, tell_fn, mentions=mentions)
 
 
 def _cmd_post(
@@ -161,17 +182,17 @@ def _cmd_post(
         )
         return 1
     slug = normalize_slug(args[0])
-    content = " ".join(args[1:]).strip()
+    mentions, content = _parse_leading_mentions(args[1:])
     if not content:
         error(
             tell_fn,
             sender,
             node,
             "/post requires <room> and <message>",
-            hint="#<room> <message>",
+            hint="#<room> [@agent...] <message>",
         )
         return 1
-    return _do_post(store, sender, node, slug, content, tell_fn)
+    return _do_post(store, sender, node, slug, content, tell_fn, mentions=mentions)
 
 
 def _do_post(
@@ -181,10 +202,16 @@ def _do_post(
     slug: str,
     content: str,
     tell_fn: TellFn,
+    *,
+    mentions: list[str] | None = None,
 ) -> int:
     meta = store.ensure_room(slug)
     if not store.has_member(meta, sender):
         meta, _ = store.add_member(meta, sender)
+    sender_key = sender.lower()
+    for agent in mentions or []:
+        if agent.lower() != sender_key:
+            meta, _ = store.add_member(meta, agent)
     meta = store.touch_activity(slug, meta)
     store.save_meta(slug, meta)
 

--- a/apps/h4l/dispatch.py
+++ b/apps/h4l/dispatch.py
@@ -64,12 +64,24 @@ def dispatch_slash(
     sender = normalize_agent(sender)
     body = message.strip()
     if not body.startswith("/"):
-        error(tell_fn, sender, "commands must start with / (e.g. /post war hello)")
+        error(
+            tell_fn,
+            sender,
+            node,
+            "commands must start with /",
+            show_commands=True,
+        )
         return 1
 
     parts = body[1:].split()
     if not parts:
-        error(tell_fn, sender, "missing command after /")
+        error(
+            tell_fn,
+            sender,
+            node,
+            "missing command after /",
+            show_commands=True,
+        )
         return 1
 
     cmd = parts[0].lower()
@@ -87,17 +99,29 @@ def dispatch_slash(
         if cmd == "list":
             return _cmd_list(store, sender, tell_fn)
         if cmd == "view":
-            return _cmd_view(store, sender, args, tell_fn)
+            return _cmd_view(store, sender, node, args, tell_fn)
         if cmd == "members":
-            return _cmd_members(store, sender, args, tell_fn)
-        error(tell_fn, sender, f"unknown command /{cmd}")
+            return _cmd_members(store, sender, node, args, tell_fn)
+        error(
+            tell_fn,
+            sender,
+            node,
+            f"unknown command /{cmd}",
+            show_commands=True,
+        )
         return 1
     except ValueError as exc:
-        error(tell_fn, sender, str(exc))
+        error(tell_fn, sender, node, str(exc), show_commands=True)
         return 1
     except KeyError:
         slug = args[0] if args else "?"
-        error(tell_fn, sender, f"room not found: {slug}")
+        error(
+            tell_fn,
+            sender,
+            node,
+            f"room not found: {slug}",
+            hint="/list",
+        )
         return 1
 
 
@@ -109,12 +133,24 @@ def _cmd_post(
     tell_fn: TellFn,
 ) -> int:
     if len(args) < 2:
-        error(tell_fn, sender, "usage: /post <room> <message...>")
+        error(
+            tell_fn,
+            sender,
+            node,
+            "/post requires <room> and <message>",
+            hint="/post <room> <message>",
+        )
         return 1
     slug = normalize_slug(args[0])
     content = " ".join(args[1:]).strip()
     if not content:
-        error(tell_fn, sender, "usage: /post <room> <message...>")
+        error(
+            tell_fn,
+            sender,
+            node,
+            "/post requires <room> and <message>",
+            hint="/post <room> <message>",
+        )
         return 1
 
     meta = store.ensure_room(slug)
@@ -142,12 +178,18 @@ def _cmd_post(
 def _cmd_join(
     store: RoomStore,
     sender: str,
-    _node: str,
+    node: str,
     args: list[str],
     tell_fn: TellFn,
 ) -> int:
     if len(args) != 1:
-        error(tell_fn, sender, "usage: /join <room>")
+        error(
+            tell_fn,
+            sender,
+            node,
+            "/join requires <room>",
+            hint="/join <room>",
+        )
         return 1
     slug = normalize_slug(args[0])
     meta = store.ensure_room(slug)
@@ -162,12 +204,18 @@ def _cmd_join(
 def _cmd_leave(
     store: RoomStore,
     sender: str,
-    _node: str,
+    node: str,
     args: list[str],
     tell_fn: TellFn,
 ) -> int:
     if len(args) != 1:
-        error(tell_fn, sender, "usage: /leave <room>")
+        error(
+            tell_fn,
+            sender,
+            node,
+            "/leave requires <room>",
+            hint="/leave <room>",
+        )
         return 1
     slug = normalize_slug(args[0])
     meta = store.load_meta(slug)
@@ -189,7 +237,13 @@ def _cmd_invite(
     tell_fn: TellFn,
 ) -> int:
     if len(args) < 2:
-        error(tell_fn, sender, "usage: /invite <room> <agent> [<agent>...]")
+        error(
+            tell_fn,
+            sender,
+            node,
+            "/invite requires <room> and at least one <agent>",
+            hint="/invite <room> <agent> [<agent>...]",
+        )
         return 1
     slug = normalize_slug(args[0])
     invitees = [normalize_agent(a) for a in args[1:]]
@@ -243,11 +297,18 @@ def _cmd_list(store: RoomStore, sender: str, tell_fn: TellFn) -> int:
 def _cmd_view(
     store: RoomStore,
     sender: str,
+    node: str,
     args: list[str],
     tell_fn: TellFn,
 ) -> int:
     if len(args) != 1:
-        error(tell_fn, sender, "usage: /view <room>")
+        error(
+            tell_fn,
+            sender,
+            node,
+            "/view requires <room>",
+            hint="/view <room>",
+        )
         return 1
     slug = normalize_slug(args[0])
     text = _format_view(store, slug)
@@ -258,11 +319,18 @@ def _cmd_view(
 def _cmd_members(
     store: RoomStore,
     sender: str,
+    node: str,
     args: list[str],
     tell_fn: TellFn,
 ) -> int:
     if len(args) != 1:
-        error(tell_fn, sender, "usage: /members <room>")
+        error(
+            tell_fn,
+            sender,
+            node,
+            "/members requires <room>",
+            hint="/members <room>",
+        )
         return 1
     slug = normalize_slug(args[0])
     text = _format_members(store, slug)

--- a/apps/h4l/dispatch.py
+++ b/apps/h4l/dispatch.py
@@ -6,6 +6,7 @@ from notify import TellFn, ack, error, notify_agent, notify_members, usage_help
 _CMD_ALIASES = {
     "part": "leave",
     "names": "members",
+    "kick": "remove",
 }
 from rooms import RoomStore, normalize_agent, normalize_slug
 
@@ -88,6 +89,8 @@ def dispatch_slash(
             return _cmd_leave(store, sender, node, args, tell_fn)
         if cmd == "invite":
             return _cmd_invite(store, sender, node, args, tell_fn)
+        if cmd == "remove":
+            return _cmd_remove(store, sender, node, args, tell_fn)
         if cmd == "list":
             return _cmd_list(store, sender, tell_fn)
         if cmd == "view":
@@ -347,6 +350,78 @@ def _cmd_invite(
         parts.append(f"invited {_join_names(added)} to #{slug}")
     if skipped:
         parts.append(f"already members: {_join_names(skipped)}")
+    ack(tell_fn, sender, "; ".join(parts) if parts else f"no changes for #{slug}")
+    return 0
+
+
+def _cmd_remove(
+    store: RoomStore,
+    sender: str,
+    node: str,
+    args: list[str],
+    tell_fn: TellFn,
+) -> int:
+    if len(args) < 2:
+        error(
+            tell_fn,
+            sender,
+            node,
+            "/remove requires <room> and at least one <agent>",
+            hint="/remove <room> <agent> [<agent>...]",
+        )
+        return 1
+    slug = normalize_slug(args[0])
+    targets = [normalize_agent(a) for a in args[1:]]
+    meta = store.load_meta(slug)
+    if not store.has_member(meta, sender):
+        error(
+            tell_fn,
+            sender,
+            node,
+            f"not a member of #{slug}",
+            hint="/join <room>",
+        )
+        return 1
+    removed: list[str] = []
+    skipped: list[str] = []
+    sender_key = sender.lower()
+    for agent in targets:
+        if agent.lower() == sender_key:
+            skipped.append(f"{agent} (use /leave)")
+            continue
+        meta, did_remove = store.remove_member(meta, agent)
+        if did_remove:
+            removed.append(agent)
+        else:
+            skipped.append(agent)
+    if removed:
+        meta = store.touch_activity(slug, meta)
+        store.save_meta(slug, meta)
+        summary = f"{sender} removed {_join_names(removed)} from #{slug}"
+        store.append_message(slug, sender=sender, content=summary, kind="system")
+        members = store.member_names(meta)
+        notify_members(
+            tell_fn=tell_fn,
+            store=store,
+            slug=slug,
+            node=node,
+            members=members,
+            poster=sender,
+            room=slug,
+            headline=f"{summary}:",
+            body=summary,
+            skip=set(removed),
+        )
+        for agent in removed:
+            tell_fn(agent, f"{sender} removed you from #{slug}.")
+    elif skipped:
+        store.save_meta(slug, meta)
+
+    parts = []
+    if removed:
+        parts.append(f"removed {_join_names(removed)} from #{slug}")
+    if skipped:
+        parts.append(f"no change: {_join_names(skipped)}")
     ack(tell_fn, sender, "; ".join(parts) if parts else f"no changes for #{slug}")
     return 0
 

--- a/apps/h4l/dispatch.py
+++ b/apps/h4l/dispatch.py
@@ -122,15 +122,15 @@ def dispatch_slash(
         return 1
 
 
-def _parse_leading_mentions(tokens: list[str]) -> tuple[list[str], str]:
+def _leading_mention_agents(tokens: list[str]) -> list[str]:
     mentions: list[str] = []
-    i = 0
-    while i < len(tokens) and tokens[i].startswith("@"):
-        name = tokens[i][1:].strip()
+    for token in tokens:
+        if not token.startswith("@"):
+            break
+        name = token[1:].strip()
         if name:
             mentions.append(normalize_agent(name))
-        i += 1
-    return mentions, " ".join(tokens[i:]).strip()
+    return mentions
 
 
 def _dispatch_hash_post(
@@ -155,7 +155,9 @@ def _dispatch_hash_post(
     except ValueError as exc:
         error(tell_fn, sender, node, str(exc), hint="#<room> <message>")
         return 1
-    mentions, content = _parse_leading_mentions(tokens[1:])
+    message_tokens = tokens[1:]
+    mentions = _leading_mention_agents(message_tokens)
+    content = " ".join(message_tokens).strip()
     if not content:
         error(
             tell_fn,
@@ -185,7 +187,9 @@ def _cmd_post(
         )
         return 1
     slug = normalize_slug(args[0])
-    mentions, content = _parse_leading_mentions(args[1:])
+    message_tokens = args[1:]
+    mentions = _leading_mention_agents(message_tokens)
+    content = " ".join(message_tokens).strip()
     if not content:
         error(
             tell_fn,

--- a/apps/h4l/dispatch.py
+++ b/apps/h4l/dispatch.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
-from notify import TellFn, ack, error, footer, notify_members
+from format import format_room_view, parse_view_args
+from notify import TellFn, ack, error, footer, notify_members, usage_help
+
+_CMD_ALIASES = {
+    "part": "leave",
+    "names": "members",
+}
 from rooms import RoomStore, normalize_agent, normalize_slug
 
 
@@ -37,22 +43,6 @@ def _format_members(store: RoomStore, slug: str) -> str:
     return f"#{slug}: {', '.join(members)}"
 
 
-def _format_view(store: RoomStore, slug: str) -> str:
-    meta = store.load_meta(slug)
-    messages = store.list_messages(slug)
-    lines = [f"#{slug} ({len(messages)} message(s))"]
-    for msg in messages:
-        sender = msg.get("from", "?")
-        kind = msg.get("kind", "post")
-        content = str(msg.get("content", "")).replace("\n", " ")
-        msg_id = msg.get("id", "?")
-        lines.append(f"[{kind}] {sender} ({msg_id}): {content}")
-    members = store.member_names(meta)
-    if members:
-        lines.append(f"members: {', '.join(members)}")
-    return "\n".join(lines)
-
-
 def dispatch_slash(
     store: RoomStore,
     *,
@@ -63,12 +53,14 @@ def dispatch_slash(
 ) -> int:
     sender = normalize_agent(sender)
     body = message.strip()
+    if body.startswith("#"):
+        return _dispatch_hash_post(store, sender, node, body, tell_fn)
     if not body.startswith("/"):
         error(
             tell_fn,
             sender,
             node,
-            "commands must start with /",
+            "send #<room> <message> or a /command",
             show_commands=True,
         )
         return 1
@@ -84,7 +76,7 @@ def dispatch_slash(
         )
         return 1
 
-    cmd = parts[0].lower()
+    cmd = _CMD_ALIASES.get(parts[0].lower(), parts[0].lower())
     args = parts[1:]
 
     try:
@@ -102,11 +94,13 @@ def dispatch_slash(
             return _cmd_view(store, sender, node, args, tell_fn)
         if cmd == "members":
             return _cmd_members(store, sender, node, args, tell_fn)
+        if cmd == "help":
+            return _cmd_help(sender, node, tell_fn)
         error(
             tell_fn,
             sender,
             node,
-            f"unknown command /{cmd}",
+            f"unknown command /{parts[0].lower()}",
             show_commands=True,
         )
         return 1
@@ -125,6 +119,31 @@ def dispatch_slash(
         return 1
 
 
+def _dispatch_hash_post(
+    store: RoomStore,
+    sender: str,
+    node: str,
+    body: str,
+    tell_fn: TellFn,
+) -> int:
+    parts = body.split(None, 1)
+    if len(parts) < 2 or not parts[1].strip():
+        error(
+            tell_fn,
+            sender,
+            node,
+            "#<room> requires a message",
+            hint="#<room> <message>",
+        )
+        return 1
+    try:
+        slug = normalize_slug(parts[0])
+    except ValueError as exc:
+        error(tell_fn, sender, node, str(exc), hint="#<room> <message>")
+        return 1
+    return _do_post(store, sender, node, slug, parts[1].strip(), tell_fn)
+
+
 def _cmd_post(
     store: RoomStore,
     sender: str,
@@ -138,7 +157,7 @@ def _cmd_post(
             sender,
             node,
             "/post requires <room> and <message>",
-            hint="/post <room> <message>",
+            hint="#<room> <message>",
         )
         return 1
     slug = normalize_slug(args[0])
@@ -149,10 +168,20 @@ def _cmd_post(
             sender,
             node,
             "/post requires <room> and <message>",
-            hint="/post <room> <message>",
+            hint="#<room> <message>",
         )
         return 1
+    return _do_post(store, sender, node, slug, content, tell_fn)
 
+
+def _do_post(
+    store: RoomStore,
+    sender: str,
+    node: str,
+    slug: str,
+    content: str,
+    tell_fn: TellFn,
+) -> int:
     meta = store.ensure_room(slug)
     if not store.has_member(meta, sender):
         meta, _ = store.add_member(meta, sender)
@@ -294,6 +323,11 @@ def _cmd_list(store: RoomStore, sender: str, tell_fn: TellFn) -> int:
     return 0
 
 
+def _cmd_help(sender: str, node: str, tell_fn: TellFn) -> int:
+    ack(tell_fn, sender, usage_help(node))
+    return 0
+
+
 def _cmd_view(
     store: RoomStore,
     sender: str,
@@ -301,17 +335,48 @@ def _cmd_view(
     args: list[str],
     tell_fn: TellFn,
 ) -> int:
-    if len(args) != 1:
+    try:
+        slug, limit, before_id, start_n = parse_view_args(args)
+    except ValueError as exc:
         error(
             tell_fn,
             sender,
             node,
-            "/view requires <room>",
-            hint="/view <room>",
+            str(exc),
+            hint="/view <room> [[start] limit] [--start N] [--limit N] [--before <id>]",
         )
         return 1
-    slug = normalize_slug(args[0])
-    text = _format_view(store, slug)
+    try:
+        store.load_meta(slug)
+    except KeyError:
+        error(
+            tell_fn,
+            sender,
+            node,
+            f"room not found: {slug}",
+            hint="/list",
+        )
+        return 1
+    messages = store.list_messages(slug)
+    try:
+        text = format_room_view(
+            slug,
+            messages,
+            sender,
+            limit=limit,
+            before_id=before_id,
+            start_n=start_n,
+            node=node,
+        )
+    except KeyError:
+        error(
+            tell_fn,
+            sender,
+            node,
+            f"message id not found in #{slug}",
+            hint="/view <room> [--limit N]",
+        )
+        return 1
     ack(tell_fn, sender, text)
     return 0
 

--- a/apps/h4l/dispatch.py
+++ b/apps/h4l/dispatch.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from format import format_room_view, parse_view_args
-from notify import TellFn, ack, error, footer, notify_members, usage_help
+from notify import TellFn, ack, error, notify_agent, notify_members, usage_help
 
 _CMD_ALIASES = {
     "part": "leave",
@@ -188,10 +188,12 @@ def _do_post(
     meta = store.touch_activity(slug, meta)
     store.save_meta(slug, meta)
 
-    msg = store.append_message(slug, sender=sender, content=content, kind="post")
+    store.append_message(slug, sender=sender, content=content, kind="post")
     members = store.member_names(meta)
     notify_members(
         tell_fn=tell_fn,
+        store=store,
+        slug=slug,
         node=node,
         members=members,
         poster=sender,
@@ -200,7 +202,6 @@ def _do_post(
         body=content,
         skip={sender},
     )
-    ack(tell_fn, sender, f"posted to #{slug} (id {msg['id']})")
     return 0
 
 
@@ -294,6 +295,8 @@ def _cmd_invite(
         members = store.member_names(meta)
         notify_members(
             tell_fn=tell_fn,
+            store=store,
+            slug=slug,
             node=node,
             members=members,
             poster=sender,
@@ -303,9 +306,13 @@ def _cmd_invite(
             skip=set(added),
         )
         for agent in added:
-            tell_fn(
-                agent,
-                f"{summary} in #{slug}.{footer(node, slug)}",
+            notify_agent(
+                store=store,
+                slug=slug,
+                tell_fn=tell_fn,
+                node=node,
+                agent=agent,
+                body=f"{summary} in #{slug}.",
             )
 
     parts = []
@@ -336,14 +343,14 @@ def _cmd_view(
     tell_fn: TellFn,
 ) -> int:
     try:
-        slug, limit, before_id, start_n = parse_view_args(args)
+        slug, limit, start_n = parse_view_args(args)
     except ValueError as exc:
         error(
             tell_fn,
             sender,
             node,
             str(exc),
-            hint="/view <room> [[start] limit] [--start N] [--limit N] [--before <id>]",
+            hint="/view <room> [[start] limit] [--start N] [--limit N]",
         )
         return 1
     try:
@@ -358,25 +365,14 @@ def _cmd_view(
         )
         return 1
     messages = store.list_messages(slug)
-    try:
-        text = format_room_view(
-            slug,
-            messages,
-            sender,
-            limit=limit,
-            before_id=before_id,
-            start_n=start_n,
-            node=node,
-        )
-    except KeyError:
-        error(
-            tell_fn,
-            sender,
-            node,
-            f"message id not found in #{slug}",
-            hint="/view <room> [--limit N]",
-        )
-        return 1
+    text = format_room_view(
+        slug,
+        messages,
+        sender,
+        limit=limit,
+        start_n=start_n,
+        node=node,
+    )
     ack(tell_fn, sender, text)
     return 0
 

--- a/apps/h4l/format.py
+++ b/apps/h4l/format.py
@@ -22,7 +22,6 @@ def select_messages(
     messages: list[dict],
     *,
     limit: int,
-    before_id: str | None = None,
     start_n: int | None = None,
 ) -> tuple[list[dict], int, int]:
     """Return a chronological window, total count, and 0-based start index."""
@@ -36,15 +35,6 @@ def select_messages(
         if idx >= total:
             return [], total, idx
         return messages[idx : idx + limit], total, idx
-    if before_id:
-        idx = next(
-            (i for i, m in enumerate(messages) if m.get("id") == before_id),
-            None,
-        )
-        if idx is None:
-            raise KeyError(before_id)
-        start = max(0, idx - limit)
-        return messages[start:idx], total, start
     if total <= limit:
         return list(messages), total, 0
     start = total - limit
@@ -59,15 +49,15 @@ def _format_view_footer(
     total: int,
     limit: int,
     node: str,
-    oldest_id: str | None,
 ) -> str:
     lines = [
         "---",
         f"#{room}: viewed messages {start_n}–{end_n} of {total} (limit {limit}).",
     ]
-    if start_n > 1 and oldest_id:
+    if start_n > 1:
+        older_start = max(1, start_n - limit)
         lines.append(
-            f'Older: tell {node} "/view {room} --before {oldest_id} --limit {limit}"'
+            f'Older: tell {node} "/view {room} --start {older_start} --limit {limit}"'
         )
     if end_n < total:
         newer_start = end_n + 1
@@ -88,7 +78,6 @@ def format_room_view(
     viewer: str,
     *,
     limit: int = DEFAULT_VIEW_LIMIT,
-    before_id: str | None = None,
     start_n: int | None = None,
     node: str | None = None,
 ) -> str:
@@ -96,13 +85,12 @@ def format_room_view(
     window, total, start_idx = select_messages(
         messages,
         limit=limit,
-        before_id=before_id,
         start_n=start_n,
     )
     if total == 0:
         header = f"#{room}: no messages"
         if node:
-            header += f'\n\ntell {node} "/post {room} <message>"'
+            header += f'\n\ntell {node} "#{room} <message>"'
         return header
 
     viewer_key = (viewer or "").strip().lower()
@@ -125,11 +113,9 @@ def format_room_view(
         if window:
             view_start = start_idx + 1
             view_end = start_idx + len(window)
-            oldest_id = window[0].get("id", "") or None
         else:
             view_start = min((start_n or 1), total + 1)
             view_end = view_start - 1
-            oldest_id = None
         parts.append(
             _format_view_footer(
                 room,
@@ -138,22 +124,20 @@ def format_room_view(
                 total=total,
                 limit=limit,
                 node=node,
-                oldest_id=oldest_id,
             )
         )
 
     return "\n\n".join(parts)
 
 
-def parse_view_args(args: list[str]) -> tuple[str, int, str | None, int | None]:
-    """Parse `/view <room> [[start] limit] [--start N] [--limit N] [--before ID]`."""
+def parse_view_args(args: list[str]) -> tuple[str, int, int | None]:
+    """Parse `/view <room> [[start] limit] [--start N] [--limit N]`."""
     if not args:
         raise ValueError("/view requires <room>")
     from rooms import normalize_slug
 
     slug = normalize_slug(args[0])
     limit = DEFAULT_VIEW_LIMIT
-    before_id: str | None = None
     start_n: int | None = None
     i = 1
     if i < len(args) and args[i].isdigit():
@@ -188,17 +172,7 @@ def parse_view_args(args: list[str]) -> tuple[str, int, str | None, int | None]:
                 raise ValueError("--start must be at least 1")
             i += 2
             continue
-        if token == "--before":
-            if i + 1 >= len(args):
-                raise ValueError("--before requires a message id")
-            before_id = args[i + 1].strip()
-            if not before_id:
-                raise ValueError("--before requires a message id")
-            i += 2
-            continue
         raise ValueError(f"unknown /view argument: {token}")
-    if before_id and start_n is not None:
-        raise ValueError("use either --before or --start, not both")
     if limit < 1:
         raise ValueError("--limit must be at least 1")
-    return slug, limit, before_id, start_n
+    return slug, limit, start_n

--- a/apps/h4l/format.py
+++ b/apps/h4l/format.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+DEFAULT_VIEW_LIMIT = 10
+
+HEADING_OUT = "## from {from} to {to} at {timestamp}"
+HEADING_IN = "### from {from} to {to} at {timestamp}"
+
+
+def _format_heading(template: str, entry: dict, room: str) -> str:
+    ts = (entry.get("date") or "").strip()
+    return template.format(
+        **{
+            "from": entry.get("from", ""),
+            "to": f"#{room}",
+            "timestamp": ts,
+            "date": ts,
+        }
+    )
+
+
+def select_messages(
+    messages: list[dict],
+    *,
+    limit: int,
+    before_id: str | None = None,
+    start_n: int | None = None,
+) -> tuple[list[dict], int, int]:
+    """Return a chronological window, total count, and 0-based start index."""
+    total = len(messages)
+    if limit < 1:
+        return [], total, 0
+    if start_n is not None:
+        if start_n < 1:
+            raise ValueError("--start must be at least 1")
+        idx = start_n - 1
+        if idx >= total:
+            return [], total, idx
+        return messages[idx : idx + limit], total, idx
+    if before_id:
+        idx = next(
+            (i for i, m in enumerate(messages) if m.get("id") == before_id),
+            None,
+        )
+        if idx is None:
+            raise KeyError(before_id)
+        start = max(0, idx - limit)
+        return messages[start:idx], total, start
+    if total <= limit:
+        return list(messages), total, 0
+    start = total - limit
+    return messages[-limit:], total, start
+
+
+def _format_view_footer(
+    room: str,
+    *,
+    start_n: int,
+    end_n: int,
+    total: int,
+    limit: int,
+    node: str,
+    oldest_id: str | None,
+) -> str:
+    lines = [
+        "---",
+        f"#{room}: viewed messages {start_n}–{end_n} of {total} (limit {limit}).",
+    ]
+    if start_n > 1 and oldest_id:
+        lines.append(
+            f'Older: tell {node} "/view {room} --before {oldest_id} --limit {limit}"'
+        )
+    if end_n < total:
+        newer_start = end_n + 1
+        lines.append(
+            f'Newer: tell {node} "/view {room} --start {newer_start} --limit {limit}"'
+        )
+        lines.append(f'Latest: tell {node} "/view {room}"')
+    lines.append(
+        f'Window: tell {node} "/view {room} --start <n> --limit <m>" '
+        f"(or tell {node} \"/view {room} <start> <limit>\")"
+    )
+    return "\n".join(lines)
+
+
+def format_room_view(
+    room: str,
+    messages: list[dict],
+    viewer: str,
+    *,
+    limit: int = DEFAULT_VIEW_LIMIT,
+    before_id: str | None = None,
+    start_n: int | None = None,
+    node: str | None = None,
+) -> str:
+    """Markdown transcript for a chat room, matching a8s convo heading style."""
+    window, total, start_idx = select_messages(
+        messages,
+        limit=limit,
+        before_id=before_id,
+        start_n=start_n,
+    )
+    if total == 0:
+        header = f"#{room}: no messages"
+        if node:
+            header += f'\n\ntell {node} "/post {room} <message>"'
+        return header
+
+    viewer_key = (viewer or "").strip().lower()
+    parts: list[str] = []
+
+    for entry in window:
+        sent = (entry.get("from") or "").strip().lower() == viewer_key
+        heading = _format_heading(
+            HEADING_OUT if sent else HEADING_IN,
+            entry,
+            room,
+        )
+        content = entry.get("content", "")
+        block = heading
+        if content:
+            block = f"{heading}\n\n{content}"
+        parts.append(block)
+
+    if node:
+        if window:
+            view_start = start_idx + 1
+            view_end = start_idx + len(window)
+            oldest_id = window[0].get("id", "") or None
+        else:
+            view_start = min((start_n or 1), total + 1)
+            view_end = view_start - 1
+            oldest_id = None
+        parts.append(
+            _format_view_footer(
+                room,
+                start_n=view_start,
+                end_n=view_end,
+                total=total,
+                limit=limit,
+                node=node,
+                oldest_id=oldest_id,
+            )
+        )
+
+    return "\n\n".join(parts)
+
+
+def parse_view_args(args: list[str]) -> tuple[str, int, str | None, int | None]:
+    """Parse `/view <room> [[start] limit] [--start N] [--limit N] [--before ID]`."""
+    if not args:
+        raise ValueError("/view requires <room>")
+    from rooms import normalize_slug
+
+    slug = normalize_slug(args[0])
+    limit = DEFAULT_VIEW_LIMIT
+    before_id: str | None = None
+    start_n: int | None = None
+    i = 1
+    if i < len(args) and args[i].isdigit():
+        if i + 1 < len(args) and args[i + 1].isdigit():
+            start_n = int(args[i])
+            limit = int(args[i + 1])
+            i += 2
+        else:
+            limit = int(args[i])
+            i += 1
+    while i < len(args):
+        token = args[i]
+        if token == "--limit":
+            if i + 1 >= len(args):
+                raise ValueError("--limit requires a number")
+            try:
+                limit = int(args[i + 1])
+            except ValueError as exc:
+                raise ValueError("--limit requires a number") from exc
+            if limit < 1:
+                raise ValueError("--limit must be at least 1")
+            i += 2
+            continue
+        if token == "--start":
+            if i + 1 >= len(args):
+                raise ValueError("--start requires a number")
+            try:
+                start_n = int(args[i + 1])
+            except ValueError as exc:
+                raise ValueError("--start requires a number") from exc
+            if start_n < 1:
+                raise ValueError("--start must be at least 1")
+            i += 2
+            continue
+        if token == "--before":
+            if i + 1 >= len(args):
+                raise ValueError("--before requires a message id")
+            before_id = args[i + 1].strip()
+            if not before_id:
+                raise ValueError("--before requires a message id")
+            i += 2
+            continue
+        raise ValueError(f"unknown /view argument: {token}")
+    if before_id and start_n is not None:
+        raise ValueError("use either --before or --start, not both")
+    if limit < 1:
+        raise ValueError("--limit must be at least 1")
+    return slug, limit, before_id, start_n

--- a/apps/h4l/h4l.py
+++ b/apps/h4l/h4l.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""h4l — Hall chat rooms for multi-agent coordination.
+
+Standalone CLI with optional a8s invoke wiring. State lives under
+<root>/.chatrooms/; notifications use `tell` on PATH.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from dispatch import dispatch_slash
+from notify import default_tell
+from rooms import RoomStore
+
+
+def _resolve_root(raw: str | None) -> Path:
+    if raw:
+        return Path(raw).expanduser().resolve()
+    return Path.cwd().resolve()
+
+
+def cmd_dispatch(args: argparse.Namespace) -> int:
+    if not args.from_agent:
+        print("dispatch: --from is required", file=sys.stderr)
+        return 2
+    if not args.node:
+        print("dispatch: --node is required", file=sys.stderr)
+        return 2
+    if args.message is None:
+        print("dispatch: --message is required", file=sys.stderr)
+        return 2
+    store = RoomStore(_resolve_root(args.root))
+    tell_fn = default_tell if args.notify else lambda _a, _b: None
+    return dispatch_slash(
+        store,
+        sender=args.from_agent,
+        node=args.node,
+        message=args.message,
+        tell_fn=tell_fn,
+    )
+
+
+def cmd_clear(args: argparse.Namespace) -> int:
+    store = RoomStore(_resolve_root(args.root))
+    if args.all:
+        count = store.clear_all()
+        print(f"cleared {count} room(s)")
+        return 0
+    if args.older_than is None:
+        print("clear: specify --older-than SECS or --all", file=sys.stderr)
+        return 2
+    if args.older_than <= 0:
+        print("clear: --older-than must be positive", file=sys.stderr)
+        return 2
+    removed = store.clear_older_than(args.older_than)
+    if removed:
+        print(f"cleared {len(removed)} room(s): {', '.join(removed)}")
+    else:
+        print("cleared 0 room(s)")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="h4l",
+        description="Hall chat rooms — slash-command CLI for multi-agent chat.",
+    )
+    sub = p.add_subparsers(dest="command", required=True)
+
+    dispatch_p = sub.add_parser(
+        "dispatch",
+        help="Handle one slash-command message (a8s invoke or direct use).",
+    )
+    dispatch_p.add_argument(
+        "--root",
+        help="Agent root containing .chatrooms/ (default: cwd).",
+    )
+    dispatch_p.add_argument("--from", dest="from_agent", required=True)
+    dispatch_p.add_argument(
+        "--node",
+        required=True,
+        help="This hall node's a8s name (embedded in notification footers).",
+    )
+    dispatch_p.add_argument("--message", required=True)
+    dispatch_p.add_argument(
+        "--no-notify",
+        dest="notify",
+        action="store_false",
+        default=True,
+        help="Skip tell fan-out (tests).",
+    )
+    dispatch_p.set_defaults(func=cmd_dispatch)
+
+    clear_p = sub.add_parser("clear", help="Delete stale or all chat rooms.")
+    clear_p.add_argument("--root", help="Agent root (default: cwd).")
+    clear_p.add_argument(
+        "--older-than",
+        type=float,
+        metavar="SECS",
+        help="Remove rooms idle longer than SECS.",
+    )
+    clear_p.add_argument("--all", action="store_true", help="Remove every room.")
+    clear_p.set_defaults(func=cmd_clear)
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/h4l/h4l.py
+++ b/apps/h4l/h4l.py
@@ -11,7 +11,7 @@ import sys
 from pathlib import Path
 
 from dispatch import dispatch_slash
-from notify import default_tell
+from notify import resolve_tell_fn, simulate_enabled
 from rooms import RoomStore
 
 
@@ -32,7 +32,10 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         print("dispatch: --message is required", file=sys.stderr)
         return 2
     store = RoomStore(_resolve_root(args.root))
-    tell_fn = default_tell if args.notify else lambda _a, _b: None
+    tell_fn = resolve_tell_fn(
+        notify=args.notify,
+        simulate=simulate_enabled(args.simulate_tell),
+    )
     return dispatch_slash(
         store,
         sender=args.from_agent,
@@ -85,11 +88,17 @@ def build_parser() -> argparse.ArgumentParser:
     )
     dispatch_p.add_argument("--message", required=True)
     dispatch_p.add_argument(
+        "--simulate-tell",
+        action="store_true",
+        help="Print would-be tell calls to stderr instead of invoking tell "
+        "(also H4L_SIMULATE_TELL=1).",
+    )
+    dispatch_p.add_argument(
         "--no-notify",
         dest="notify",
         action="store_false",
         default=True,
-        help="Skip tell fan-out (tests).",
+        help="Drop tell fan-out entirely (unit tests).",
     )
     dispatch_p.set_defaults(func=cmd_dispatch)
 

--- a/apps/h4l/notify.py
+++ b/apps/h4l/notify.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from collections.abc import Callable
+from typing import TypeAlias
+
+TellFn: TypeAlias = Callable[[str, str], None]
+
+MAX_NOTIFY_CHARS = 1000
+
+
+def default_tell(agent: str, body: str) -> None:
+    subprocess.run(
+        ["tell", agent, body],
+        check=False,
+    )
+
+
+def truncate(text: str, limit: int = MAX_NOTIFY_CHARS) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: limit - 3] + "..."
+
+
+def footer(node: str, room: str | None = None) -> str:
+    room_token = room or "<room>"
+    return (
+        f"\n---\n"
+        f"tell {node} /view {room_token}\n"
+        f"tell {node} /leave {room_token}\n"
+        f"tell {node} /list"
+    )
+
+
+def notify_members(
+    *,
+    tell_fn: TellFn,
+    node: str,
+    members: list[str],
+    poster: str,
+    room: str,
+    headline: str,
+    body: str,
+    skip: set[str] | None = None,
+) -> None:
+    omitted = {m.lower() for m in (skip or set())}
+    text = truncate(body)
+    message = f"{headline}\n\n{text}{footer(node, room)}"
+    for member in members:
+        if member.lower() in omitted:
+            continue
+        tell_fn(member, message)
+
+
+def ack(tell_fn: TellFn, sender: str, text: str) -> None:
+    print(text)
+    tell_fn(sender, text)
+
+
+def error(tell_fn: TellFn, sender: str, text: str) -> None:
+    print(text, file=sys.stderr)
+    tell_fn(sender, f"h4l error: {text}")

--- a/apps/h4l/notify.py
+++ b/apps/h4l/notify.py
@@ -4,7 +4,10 @@ import os
 import subprocess
 import sys
 from collections.abc import Callable
-from typing import TypeAlias
+from typing import TYPE_CHECKING, TypeAlias
+
+if TYPE_CHECKING:
+    from rooms import RoomStore
 
 TellFn: TypeAlias = Callable[[str, str], None]
 
@@ -61,7 +64,7 @@ def usage_help(node: str) -> str:
         f'tell {node} "/invite <room> <agent> [<agent>...]"',
         f'tell {node} "/list"',
         f'tell {node} "/names <room>"  (/members)',
-        f'tell {node} "/view <room> [[start] limit] [--start N] [--limit N] [--before <id>]"',
+        f'tell {node} "/view <room> [[start] limit] [--start N] [--limit N]"',
         f'tell {node} "/help"',
         "",
         "Also: /post, /leave, /members; # prefix optional on room names.",
@@ -73,18 +76,25 @@ def command_hint(node: str, slash_cmd: str) -> str:
     return f'tell {node} "{slash_cmd}"'
 
 
-def footer(node: str, room: str | None = None) -> str:
-    room_token = room or "<room>"
+def onboard_footer(node: str, room: str) -> str:
     return (
         f"\n---\n"
-        f"tell {node} /view {room_token}\n"
-        f"tell {node} /leave {room_token}\n"
-        f"tell {node} /list"
+        f"Post a message: tell {node} #{room} <message>\n"
+        f"More commands: tell {node} /help"
     )
+
+
+def _onboard_suffix(store: RoomStore, meta: dict, agent: str, node: str, room: str) -> tuple[str, dict, bool]:
+    if store.has_seen_help(meta, agent):
+        return "", meta, False
+    meta = store.mark_help_seen(meta, agent)
+    return onboard_footer(node, room), meta, True
 
 
 def notify_members(
     *,
+    store: RoomStore,
+    slug: str,
     tell_fn: TellFn,
     node: str,
     members: list[str],
@@ -96,11 +106,33 @@ def notify_members(
 ) -> None:
     omitted = {m.lower() for m in (skip or set())}
     text = truncate(body)
-    message = f"{headline}\n\n{text}{footer(node, room)}"
+    meta = store.load_meta(slug)
+    dirty = False
     for member in members:
         if member.lower() in omitted:
             continue
+        suffix, meta, changed = _onboard_suffix(store, meta, member, node, room)
+        dirty = dirty or changed
+        message = f"{headline}\n\n{text}{suffix}"
         tell_fn(member, message)
+    if dirty:
+        store.save_meta(slug, meta)
+
+
+def notify_agent(
+    *,
+    store: RoomStore,
+    slug: str,
+    tell_fn: TellFn,
+    node: str,
+    agent: str,
+    body: str,
+) -> None:
+    meta = store.load_meta(slug)
+    suffix, meta, dirty = _onboard_suffix(store, meta, agent, node, slug)
+    if dirty:
+        store.save_meta(slug, meta)
+    tell_fn(agent, f"{body}{suffix}")
 
 
 def ack(tell_fn: TellFn, sender: str, text: str) -> None:

--- a/apps/h4l/notify.py
+++ b/apps/h4l/notify.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from collections.abc import Callable
@@ -8,6 +9,7 @@ from typing import TypeAlias
 TellFn: TypeAlias = Callable[[str, str], None]
 
 MAX_NOTIFY_CHARS = 1000
+SIMULATE_ENV = "H4L_SIMULATE_TELL"
 
 
 def default_tell(agent: str, body: str) -> None:
@@ -15,6 +17,31 @@ def default_tell(agent: str, body: str) -> None:
         ["tell", agent, body],
         check=False,
     )
+
+
+def simulate_tell(agent: str, body: str) -> None:
+    print(f"h4l> tell {agent}:", file=sys.stderr)
+    for line in body.splitlines():
+        print(f"h4l>   {line}", file=sys.stderr)
+
+
+def noop_tell(_agent: str, _body: str) -> None:
+    return None
+
+
+def resolve_tell_fn(*, notify: bool, simulate: bool) -> TellFn:
+    if simulate:
+        return simulate_tell
+    if notify:
+        return default_tell
+    return noop_tell
+
+
+def simulate_enabled(flag: bool) -> bool:
+    if flag:
+        return True
+    raw = os.environ.get(SIMULATE_ENV, "").strip().lower()
+    return raw in ("1", "true", "yes", "on")
 
 
 def truncate(text: str, limit: int = MAX_NOTIFY_CHARS) -> str:

--- a/apps/h4l/notify.py
+++ b/apps/h4l/notify.py
@@ -50,6 +50,24 @@ def truncate(text: str, limit: int = MAX_NOTIFY_CHARS) -> str:
     return text[: limit - 3] + "..."
 
 
+def usage_help(node: str) -> str:
+    lines = [
+        "Commands (send via tell):",
+        f'tell {node} "/post <room> <message>"',
+        f'tell {node} "/join <room>"',
+        f'tell {node} "/leave <room>"',
+        f'tell {node} "/invite <room> <agent> [<agent>...]"',
+        f'tell {node} "/list"',
+        f'tell {node} "/view <room>"',
+        f'tell {node} "/members <room>"',
+    ]
+    return "\n".join(lines)
+
+
+def command_hint(node: str, slash_cmd: str) -> str:
+    return f'tell {node} "{slash_cmd}"'
+
+
 def footer(node: str, room: str | None = None) -> str:
     room_token = room or "<room>"
     return (
@@ -85,6 +103,21 @@ def ack(tell_fn: TellFn, sender: str, text: str) -> None:
     tell_fn(sender, text)
 
 
-def error(tell_fn: TellFn, sender: str, text: str) -> None:
+def error(
+    tell_fn: TellFn,
+    sender: str,
+    node: str,
+    detail: str,
+    *,
+    show_commands: bool = False,
+    hint: str | None = None,
+) -> None:
+    parts = [f"Error: {detail}"]
+    if hint:
+        parts.append(command_hint(node, hint))
+    if show_commands:
+        parts.append("")
+        parts.append(usage_help(node))
+    text = "\n".join(parts)
     print(text, file=sys.stderr)
-    tell_fn(sender, f"h4l error: {text}")
+    tell_fn(sender, text)

--- a/apps/h4l/notify.py
+++ b/apps/h4l/notify.py
@@ -52,14 +52,19 @@ def truncate(text: str, limit: int = MAX_NOTIFY_CHARS) -> str:
 
 def usage_help(node: str) -> str:
     lines = [
-        "Commands (send via tell):",
-        f'tell {node} "/post <room> <message>"',
+        "Post (IRC style):",
+        f'tell {node} "#<room> <message>"',
+        "",
+        "Commands:",
         f'tell {node} "/join <room>"',
-        f'tell {node} "/leave <room>"',
+        f'tell {node} "/part <room>"  (/leave)',
         f'tell {node} "/invite <room> <agent> [<agent>...]"',
         f'tell {node} "/list"',
-        f'tell {node} "/view <room>"',
-        f'tell {node} "/members <room>"',
+        f'tell {node} "/names <room>"  (/members)',
+        f'tell {node} "/view <room> [[start] limit] [--start N] [--limit N] [--before <id>]"',
+        f'tell {node} "/help"',
+        "",
+        "Also: /post, /leave, /members; # prefix optional on room names.",
     ]
     return "\n".join(lines)
 

--- a/apps/h4l/notify.py
+++ b/apps/h4l/notify.py
@@ -62,12 +62,13 @@ def usage_help(node: str) -> str:
         f'tell {node} "/join <room>"',
         f'tell {node} "/part <room>"  (/leave)',
         f'tell {node} "/invite <room> <agent> [<agent>...]"',
+        f'tell {node} "/remove <room> <agent> [<agent>...]"  (/kick)',
         f'tell {node} "/list"',
         f'tell {node} "/names <room>"  (/members)',
         f'tell {node} "/view <room> [[start] limit] [--start N] [--limit N]"',
         f'tell {node} "/help"',
         "",
-        "Also: /post, /leave, /members; # prefix optional on room names.",
+        "Also: /post, /leave, /members, /kick; # prefix optional on room names.",
     ]
     return "\n".join(lines)
 

--- a/apps/h4l/rooms.py
+++ b/apps/h4l/rooms.py
@@ -17,7 +17,7 @@ def utc_now() -> str:
 
 
 def normalize_slug(raw: str) -> str:
-    slug = raw.strip().lower()
+    slug = raw.strip().lower().lstrip("#")
     if not slug or not SLUG_RE.match(slug):
         raise ValueError(f"invalid room slug: {raw!r}")
     return slug

--- a/apps/h4l/rooms.py
+++ b/apps/h4l/rooms.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+from ulid import new as new_ulid
+
+SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+CHATROOMS_DIR = ".chatrooms"
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def normalize_slug(raw: str) -> str:
+    slug = raw.strip().lower()
+    if not slug or not SLUG_RE.match(slug):
+        raise ValueError(f"invalid room slug: {raw!r}")
+    return slug
+
+
+def normalize_agent(name: str) -> str:
+    value = name.strip()
+    if not value:
+        raise ValueError("agent name must not be empty")
+    return value
+
+
+class RoomStore:
+    def __init__(self, root: Path) -> None:
+        self.root = root.resolve()
+        self.base = self.root / CHATROOMS_DIR
+
+    def rooms_dir(self) -> Path:
+        return self.base / "rooms"
+
+    def room_dir(self, slug: str) -> Path:
+        return self.rooms_dir() / slug
+
+    def meta_path(self, slug: str) -> Path:
+        return self.room_dir(slug) / "meta.json"
+
+    def messages_dir(self, slug: str) -> Path:
+        return self.room_dir(slug) / "messages"
+
+    def ensure_room(self, slug: str) -> dict:
+        slug = normalize_slug(slug)
+        meta_p = self.meta_path(slug)
+        if meta_p.is_file():
+            return self._load_meta(slug)
+        now = utc_now()
+        meta = {
+            "slug": slug,
+            "created_at": now,
+            "last_activity": now,
+            "members": [],
+        }
+        self._write_meta(slug, meta)
+        return meta
+
+    def load_meta(self, slug: str) -> dict:
+        slug = normalize_slug(slug)
+        meta_p = self.meta_path(slug)
+        if not meta_p.is_file():
+            raise KeyError(slug)
+        return self._load_meta(slug)
+
+    def save_meta(self, slug: str, meta: dict) -> None:
+        slug = normalize_slug(slug)
+        self._write_meta(slug, meta)
+
+    def touch_activity(self, slug: str, meta: dict) -> dict:
+        meta["last_activity"] = utc_now()
+        self.save_meta(slug, meta)
+        return meta
+
+    def member_names(self, meta: dict) -> list[str]:
+        raw = meta.get("members")
+        if not isinstance(raw, list):
+            return []
+        return [normalize_agent(str(m)) for m in raw if str(m).strip()]
+
+    def has_member(self, meta: dict, agent: str) -> bool:
+        key = agent.lower()
+        return any(m.lower() == key for m in self.member_names(meta))
+
+    def add_member(self, meta: dict, agent: str) -> tuple[dict, bool]:
+        agent = normalize_agent(agent)
+        members = self.member_names(meta)
+        if any(m.lower() == agent.lower() for m in members):
+            return meta, False
+        members.append(agent)
+        meta["members"] = members
+        return meta, True
+
+    def remove_member(self, meta: dict, agent: str) -> tuple[dict, bool]:
+        agent = normalize_agent(agent)
+        members = self.member_names(meta)
+        kept = [m for m in members if m.lower() != agent.lower()]
+        if len(kept) == len(members):
+            return meta, False
+        meta["members"] = kept
+        return meta, True
+
+    def append_message(
+        self,
+        slug: str,
+        *,
+        sender: str,
+        content: str,
+        kind: str = "post",
+    ) -> dict:
+        slug = normalize_slug(slug)
+        msg_id = new_ulid()
+        now = utc_now()
+        payload = {
+            "id": msg_id,
+            "date": now,
+            "from": normalize_agent(sender),
+            "kind": kind,
+            "content": content,
+        }
+        msg_dir = self.messages_dir(slug)
+        msg_dir.mkdir(parents=True, exist_ok=True)
+        path = msg_dir / f"{msg_id}.json"
+        self._atomic_write(path, payload)
+        return payload
+
+    def list_messages(self, slug: str) -> list[dict]:
+        slug = normalize_slug(slug)
+        msg_dir = self.messages_dir(slug)
+        if not msg_dir.is_dir():
+            return []
+        out: list[dict] = []
+        for path in sorted(msg_dir.glob("*.json")):
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if isinstance(data, dict):
+                out.append(data)
+        out.sort(key=lambda m: m.get("date", ""))
+        return out
+
+    def list_rooms(self) -> list[dict]:
+        rooms_root = self.rooms_dir()
+        if not rooms_root.is_dir():
+            return []
+        out: list[dict] = []
+        for entry in sorted(rooms_root.iterdir()):
+            if not entry.is_dir():
+                continue
+            meta_p = entry / "meta.json"
+            if not meta_p.is_file():
+                continue
+            try:
+                meta = json.loads(meta_p.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if isinstance(meta, dict):
+                out.append(meta)
+        out.sort(key=lambda m: m.get("slug", ""))
+        return out
+
+    def clear_older_than(self, seconds: float) -> list[str]:
+        from time import time as _time
+
+        cutoff = _time() - seconds
+        removed: list[str] = []
+        for meta in self.list_rooms():
+            slug = meta.get("slug", "")
+            if not slug:
+                continue
+            raw = meta.get("last_activity", "")
+            try:
+                dt = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+                if dt.timestamp() >= cutoff:
+                    continue
+            except ValueError:
+                pass
+            self._delete_room(slug)
+            removed.append(slug)
+        return removed
+
+    def clear_all(self) -> int:
+        rooms = self.list_rooms()
+        for meta in rooms:
+            slug = meta.get("slug", "")
+            if slug:
+                self._delete_room(slug)
+        return len(rooms)
+
+    def _delete_room(self, slug: str) -> None:
+        import shutil
+
+        path = self.room_dir(slug)
+        if path.is_dir():
+            shutil.rmtree(path)
+
+    def _load_meta(self, slug: str) -> dict:
+        data = json.loads(self.meta_path(slug).read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            raise ValueError(f"corrupt meta for room {slug}")
+        data["slug"] = normalize_slug(str(data.get("slug", slug)))
+        data["members"] = self.member_names(data)
+        return data
+
+    def _write_meta(self, slug: str, meta: dict) -> None:
+        room = self.room_dir(slug)
+        room.mkdir(parents=True, exist_ok=True)
+        self.messages_dir(slug).mkdir(parents=True, exist_ok=True)
+        self._atomic_write(self.meta_path(slug), meta)
+
+    def _atomic_write(self, path: Path, payload: dict) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        os.replace(tmp, path)

--- a/apps/h4l/rooms.py
+++ b/apps/h4l/rooms.py
@@ -106,6 +106,25 @@ class RoomStore:
         meta["members"] = kept
         return meta, True
 
+    def mark_help_seen(self, meta: dict, agent: str) -> dict:
+        agent = normalize_agent(agent)
+        if self.has_seen_help(meta, agent):
+            return meta
+        seen = self.help_seen_names(meta)
+        seen.append(agent)
+        meta["help_seen"] = seen
+        return meta
+
+    def help_seen_names(self, meta: dict) -> list[str]:
+        raw = meta.get("help_seen")
+        if not isinstance(raw, list):
+            return []
+        return [normalize_agent(str(a)) for a in raw if str(a).strip()]
+
+    def has_seen_help(self, meta: dict, agent: str) -> bool:
+        key = agent.lower()
+        return any(a.lower() == key for a in self.help_seen_names(meta))
+
     def append_message(
         self,
         slug: str,

--- a/apps/h4l/tests/conftest.py
+++ b/apps/h4l/tests/conftest.py
@@ -1,0 +1,8 @@
+"""pytest scaffolding for h4l."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_PKG = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PKG))

--- a/apps/h4l/tests/test_format.py
+++ b/apps/h4l/tests/test_format.py
@@ -26,18 +26,11 @@ def _room_messages(n: int) -> list[dict]:
 class TestSelectMessages:
     def test_latest_window(self):
         messages = _room_messages(15)
-        window, total, start = select_messages(messages, limit=10, before_id=None)
+        window, total, start = select_messages(messages, limit=10)
         assert total == 15
         assert start == 5
         assert len(window) == 10
         assert window[0]["id"] == "MSG006"
-
-    def test_before_anchor(self):
-        messages = _room_messages(15)
-        window, total, start = select_messages(messages, limit=3, before_id="MSG006")
-        assert total == 15
-        assert start == 2
-        assert [m["id"] for m in window] == ["MSG003", "MSG004", "MSG005"]
 
     def test_start_window(self):
         messages = _room_messages(15)
@@ -45,10 +38,6 @@ class TestSelectMessages:
         assert total == 15
         assert start == 4
         assert [m["id"] for m in window] == ["MSG005", "MSG006", "MSG007", "MSG008"]
-
-    def test_before_missing_raises(self):
-        with pytest.raises(KeyError):
-            select_messages(_room_messages(3), limit=2, before_id="NOPE")
 
 
 class TestFormatRoomView:
@@ -65,6 +54,7 @@ class TestFormatRoomView:
         assert "viewed messages 1–2 of 2" in text
         assert "Older:" not in text
         assert "Newer:" not in text
+        assert "MSG" not in text
 
     def test_default_limit_is_ten(self):
         messages = _room_messages(12)
@@ -73,33 +63,15 @@ class TestFormatRoomView:
         assert "viewed messages 3–12 of 12" in text
         assert "message 12" in text
         assert "message 2" not in text
-        assert 'Older: tell HALL "/view war --before MSG003 --limit 10"' in text
+        assert 'Older: tell HALL "/view war --start 1 --limit 10"' in text
         assert "Newer:" not in text
 
     def test_older_and_window_hints_when_paged(self):
         messages = _room_messages(12)
         text = format_room_view("war", messages, "ALICE", limit=5, node="HALL")
         assert "viewed messages 8–12 of 12" in text
-        assert 'Older: tell HALL "/view war --before MSG008 --limit 5"' in text
+        assert 'Older: tell HALL "/view war --start 3 --limit 5"' in text
         assert 'Window: tell HALL "/view war --start <n> --limit <m>"' in text
-
-    def test_before_pagination_footer(self):
-        messages = _room_messages(12)
-        text = format_room_view(
-            "war",
-            messages,
-            "ALICE",
-            limit=3,
-            before_id="MSG008",
-            node="HALL",
-        )
-        assert "viewed messages 5–7 of 12" in text
-        assert "message 5" in text
-        assert "message 7" in text
-        assert "MSG008" not in text
-        assert 'Older: tell HALL "/view war --before MSG005 --limit 3"' in text
-        assert 'Newer: tell HALL "/view war --start 8 --limit 3"' in text
-        assert 'Latest: tell HALL "/view war"' in text
 
     def test_start_pagination_footer(self):
         messages = _room_messages(20)
@@ -112,42 +84,31 @@ class TestFormatRoomView:
             node="HALL",
         )
         assert "viewed messages 6–10 of 20" in text
-        assert 'Older: tell HALL "/view war --before MSG006 --limit 5"' in text
+        assert 'Older: tell HALL "/view war --start 1 --limit 5"' in text
         assert 'Newer: tell HALL "/view war --start 11 --limit 5"' in text
         assert 'Latest: tell HALL "/view war"' in text
 
     def test_empty_room(self):
         text = format_room_view("war", [], "ALICE", node="HALL")
-        assert text == '#war: no messages\n\ntell HALL "/post war <message>"'
+        assert text == '#war: no messages\n\ntell HALL "#war <message>"'
 
 
 class TestParseViewArgs:
     def test_room_only(self):
-        assert parse_view_args(["war"]) == ("war", DEFAULT_VIEW_LIMIT, None, None)
+        assert parse_view_args(["war"]) == ("war", DEFAULT_VIEW_LIMIT, None)
 
     def test_positional_limit(self):
-        assert parse_view_args(["war", "5"]) == ("war", 5, None, None)
+        assert parse_view_args(["war", "5"]) == ("war", 5, None)
 
     def test_positional_start_and_limit(self):
-        assert parse_view_args(["war", "5", "10"]) == ("war", 10, None, 5)
+        assert parse_view_args(["war", "5", "10"]) == ("war", 10, 5)
 
     def test_named_flags(self):
-        assert parse_view_args(["war", "--limit", "3", "--before", "MSG010"]) == (
-            "war",
-            3,
-            "MSG010",
-            None,
-        )
         assert parse_view_args(["war", "--start", "5", "--limit", "3"]) == (
             "war",
             3,
-            None,
             5,
         )
-
-    def test_rejects_before_and_start(self):
-        with pytest.raises(ValueError, match="not both"):
-            parse_view_args(["war", "--start", "5", "--before", "MSG010"])
 
     def test_requires_room(self):
         with pytest.raises(ValueError, match="requires <room>"):
@@ -156,3 +117,7 @@ class TestParseViewArgs:
     def test_unknown_token(self):
         with pytest.raises(ValueError, match="unknown"):
             parse_view_args(["war", "--nope", "1"])
+
+    def test_rejects_before_flag(self):
+        with pytest.raises(ValueError, match="unknown"):
+            parse_view_args(["war", "--before", "MSG010"])

--- a/apps/h4l/tests/test_format.py
+++ b/apps/h4l/tests/test_format.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import pytest
+
+from format import (
+    DEFAULT_VIEW_LIMIT,
+    format_room_view,
+    parse_view_args,
+    select_messages,
+)
+
+
+def _msg(i: int, *, sender: str = "ALICE", content: str | None = None) -> dict:
+    return {
+        "id": f"MSG{i:03d}",
+        "date": f"2026-01-0{i}T12:00:00.000000Z",
+        "from": sender,
+        "content": content or f"message {i}",
+    }
+
+
+def _room_messages(n: int) -> list[dict]:
+    return [_msg(i, sender="ALICE" if i % 2 else "BOB") for i in range(1, n + 1)]
+
+
+class TestSelectMessages:
+    def test_latest_window(self):
+        messages = _room_messages(15)
+        window, total, start = select_messages(messages, limit=10, before_id=None)
+        assert total == 15
+        assert start == 5
+        assert len(window) == 10
+        assert window[0]["id"] == "MSG006"
+
+    def test_before_anchor(self):
+        messages = _room_messages(15)
+        window, total, start = select_messages(messages, limit=3, before_id="MSG006")
+        assert total == 15
+        assert start == 2
+        assert [m["id"] for m in window] == ["MSG003", "MSG004", "MSG005"]
+
+    def test_start_window(self):
+        messages = _room_messages(15)
+        window, total, start = select_messages(messages, limit=4, start_n=5)
+        assert total == 15
+        assert start == 4
+        assert [m["id"] for m in window] == ["MSG005", "MSG006", "MSG007", "MSG008"]
+
+    def test_before_missing_raises(self):
+        with pytest.raises(KeyError):
+            select_messages(_room_messages(3), limit=2, before_id="NOPE")
+
+
+class TestFormatRoomView:
+    def test_convo_style_headings(self):
+        messages = [
+            _msg(1, sender="ALICE", content="hello"),
+            _msg(2, sender="BOB", content="hi back"),
+        ]
+        text = format_room_view("war", messages, "ALICE", node="HALL")
+        assert "## from ALICE to #war at" in text
+        assert "hello" in text
+        assert "### from BOB to #war at" in text
+        assert "hi back" in text
+        assert "viewed messages 1–2 of 2" in text
+        assert "Older:" not in text
+        assert "Newer:" not in text
+
+    def test_default_limit_is_ten(self):
+        messages = _room_messages(12)
+        text = format_room_view("war", messages, "ALICE", node="HALL")
+        assert f"(limit {DEFAULT_VIEW_LIMIT})" in text
+        assert "viewed messages 3–12 of 12" in text
+        assert "message 12" in text
+        assert "message 2" not in text
+        assert 'Older: tell HALL "/view war --before MSG003 --limit 10"' in text
+        assert "Newer:" not in text
+
+    def test_older_and_window_hints_when_paged(self):
+        messages = _room_messages(12)
+        text = format_room_view("war", messages, "ALICE", limit=5, node="HALL")
+        assert "viewed messages 8–12 of 12" in text
+        assert 'Older: tell HALL "/view war --before MSG008 --limit 5"' in text
+        assert 'Window: tell HALL "/view war --start <n> --limit <m>"' in text
+
+    def test_before_pagination_footer(self):
+        messages = _room_messages(12)
+        text = format_room_view(
+            "war",
+            messages,
+            "ALICE",
+            limit=3,
+            before_id="MSG008",
+            node="HALL",
+        )
+        assert "viewed messages 5–7 of 12" in text
+        assert "message 5" in text
+        assert "message 7" in text
+        assert "MSG008" not in text
+        assert 'Older: tell HALL "/view war --before MSG005 --limit 3"' in text
+        assert 'Newer: tell HALL "/view war --start 8 --limit 3"' in text
+        assert 'Latest: tell HALL "/view war"' in text
+
+    def test_start_pagination_footer(self):
+        messages = _room_messages(20)
+        text = format_room_view(
+            "war",
+            messages,
+            "ALICE",
+            limit=5,
+            start_n=6,
+            node="HALL",
+        )
+        assert "viewed messages 6–10 of 20" in text
+        assert 'Older: tell HALL "/view war --before MSG006 --limit 5"' in text
+        assert 'Newer: tell HALL "/view war --start 11 --limit 5"' in text
+        assert 'Latest: tell HALL "/view war"' in text
+
+    def test_empty_room(self):
+        text = format_room_view("war", [], "ALICE", node="HALL")
+        assert text == '#war: no messages\n\ntell HALL "/post war <message>"'
+
+
+class TestParseViewArgs:
+    def test_room_only(self):
+        assert parse_view_args(["war"]) == ("war", DEFAULT_VIEW_LIMIT, None, None)
+
+    def test_positional_limit(self):
+        assert parse_view_args(["war", "5"]) == ("war", 5, None, None)
+
+    def test_positional_start_and_limit(self):
+        assert parse_view_args(["war", "5", "10"]) == ("war", 10, None, 5)
+
+    def test_named_flags(self):
+        assert parse_view_args(["war", "--limit", "3", "--before", "MSG010"]) == (
+            "war",
+            3,
+            "MSG010",
+            None,
+        )
+        assert parse_view_args(["war", "--start", "5", "--limit", "3"]) == (
+            "war",
+            3,
+            None,
+            5,
+        )
+
+    def test_rejects_before_and_start(self):
+        with pytest.raises(ValueError, match="not both"):
+            parse_view_args(["war", "--start", "5", "--before", "MSG010"])
+
+    def test_requires_room(self):
+        with pytest.raises(ValueError, match="requires <room>"):
+            parse_view_args([])
+
+    def test_unknown_token(self):
+        with pytest.raises(ValueError, match="unknown"):
+            parse_view_args(["war", "--nope", "1"])

--- a/apps/h4l/tests/test_h4l.py
+++ b/apps/h4l/tests/test_h4l.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import pytest
+
+from dispatch import dispatch_slash
+from rooms import RoomStore, normalize_slug
+from h4l import main as h4l_main
+
+
+@pytest.fixture
+def store(tmp_path):
+    return RoomStore(tmp_path)
+
+
+@pytest.fixture
+def tells():
+    sent: list[tuple[str, str]] = []
+
+    def capture(agent: str, body: str) -> None:
+        sent.append((agent, body))
+
+    return sent, capture
+
+
+class TestSlug:
+    def test_normalizes_case(self):
+        assert normalize_slug("War") == "war"
+
+    def test_rejects_empty(self):
+        with pytest.raises(ValueError):
+            normalize_slug("")
+
+    def test_rejects_bad_chars(self):
+        with pytest.raises(ValueError):
+            normalize_slug("war room")
+
+
+class TestPost:
+    def test_auto_create_join_notify_and_ack(self, store, tells):
+        sent, tell_fn = tells
+        rc = dispatch_slash(
+            store,
+            sender="ALICE",
+            node="HALL",
+            message="/post war hello everyone",
+            tell_fn=tell_fn,
+        )
+        assert rc == 0
+        meta = store.load_meta("war")
+        assert "ALICE" in store.member_names(meta)
+        messages = store.list_messages("war")
+        assert len(messages) == 1
+        assert messages[0]["content"] == "hello everyone"
+        acks = [b for a, b in sent if a == "ALICE"]
+        assert any("posted to #war" in b for b in acks)
+        assert not any(a == "ALICE" and "hello everyone" in b and "posted in" in b for a, b in sent)
+
+    def test_notifies_other_members(self, store, tells):
+        sent, tell_fn = tells
+        meta = store.ensure_room("war")
+        meta["members"] = ["ALICE", "BOB"]
+        store.save_meta("war", meta)
+        dispatch_slash(
+            store,
+            sender="ALICE",
+            node="HALL",
+            message="/post war update",
+            tell_fn=tell_fn,
+        )
+        bob_msgs = [b for a, b in sent if a == "BOB"]
+        assert len(bob_msgs) == 1
+        assert "ALICE posted in #war" in bob_msgs[0]
+        assert "update" in bob_msgs[0]
+        assert "tell HALL /view war" in bob_msgs[0]
+
+
+class TestInvite:
+    def test_invite_adds_and_notifies(self, store, tells):
+        sent, tell_fn = tells
+        store.ensure_room("war")
+        dispatch_slash(
+            store,
+            sender="ALICE",
+            node="HALL",
+            message="/invite war BOB CAROL",
+            tell_fn=tell_fn,
+        )
+        meta = store.load_meta("war")
+        members = {m.upper() for m in store.member_names(meta)}
+        assert members == {"BOB", "CAROL"}
+        assert any(a == "BOB" and "invited" in b for a, b in sent)
+        system = [m for m in store.list_messages("war") if m["kind"] == "system"]
+        assert system
+        assert "BOB" in system[0]["content"] and "CAROL" in system[0]["content"]
+
+
+class TestList:
+    def test_lists_all_rooms_and_members(self, store, tells):
+        sent, tell_fn = tells
+        m1 = store.ensure_room("war")
+        m1["members"] = ["ALICE", "BOB"]
+        store.save_meta("war", m1)
+        m2 = store.ensure_room("peace")
+        m2["members"] = ["CAROL"]
+        store.save_meta("peace", m2)
+        dispatch_slash(
+            store,
+            sender="ALICE",
+            node="HALL",
+            message="/list",
+            tell_fn=tell_fn,
+        )
+        ack = [b for a, b in sent if a == "ALICE"][-1]
+        assert "#war: ALICE, BOB" in ack
+        assert "#peace: CAROL" in ack
+
+
+class TestErrors:
+    def test_missing_slash_tells_error(self, store, tells):
+        sent, tell_fn = tells
+        rc = dispatch_slash(
+            store,
+            sender="ALICE",
+            node="HALL",
+            message="post war hi",
+            tell_fn=tell_fn,
+        )
+        assert rc == 1
+        assert sent == [("ALICE", "h4l error: commands must start with / (e.g. /post war hello)")]
+
+
+class TestClear:
+    def test_clear_older_than(self, store, tmp_path):
+        store.ensure_room("old")
+        store.ensure_room("new")
+        import json
+        from datetime import datetime, timezone, timedelta
+
+        old_meta = store.load_meta("old")
+        old_meta["last_activity"] = (
+            datetime.now(timezone.utc) - timedelta(days=2)
+        ).isoformat().replace("+00:00", "Z")
+        store.save_meta("old", old_meta)
+        removed = store.clear_older_than(3600)
+        assert "old" in removed
+        assert "new" not in removed
+
+    def test_cli_clear_all(self, store, tmp_path, capsys):
+        store.ensure_room("a")
+        store.ensure_room("b")
+        rc = h4l_main(["clear", "--root", str(tmp_path), "--all"])
+        assert rc == 0
+        assert "cleared 2 room(s)" in capsys.readouterr().out
+        assert store.list_rooms() == []

--- a/apps/h4l/tests/test_h4l.py
+++ b/apps/h4l/tests/test_h4l.py
@@ -121,12 +121,32 @@ class TestErrors:
         rc = dispatch_slash(
             store,
             sender="ALICE",
-            node="HALL",
-            message="post war hi",
+            node="CHATROOM",
+            message="How do I use you?",
             tell_fn=tell_fn,
         )
         assert rc == 1
-        assert sent == [("ALICE", "h4l error: commands must start with / (e.g. /post war hello)")]
+        assert len(sent) == 1
+        agent, body = sent[0]
+        assert agent == "ALICE"
+        assert body.startswith("Error: commands must start with /")
+        assert "h4l" not in body.lower()
+        assert 'tell CHATROOM "/post <room> <message>"' in body
+        assert 'tell CHATROOM "/list"' in body
+
+    def test_unknown_command_includes_usage(self, store, tells):
+        sent, tell_fn = tells
+        rc = dispatch_slash(
+            store,
+            sender="ALICE",
+            node="HALL",
+            message="/frobnicate",
+            tell_fn=tell_fn,
+        )
+        assert rc == 1
+        body = sent[0][1]
+        assert "Error: unknown command /frobnicate" in body
+        assert 'tell HALL "/join <room>"' in body
 
 
 class TestSimulateTell:

--- a/apps/h4l/tests/test_h4l.py
+++ b/apps/h4l/tests/test_h4l.py
@@ -235,6 +235,77 @@ class TestInvite:
         assert "BOB" in system[0]["content"] and "CAROL" in system[0]["content"]
 
 
+class TestRemove:
+    def test_remove_drops_member(self, store, tells):
+        sent, tell_fn = tells
+        meta = store.ensure_room("war")
+        meta["members"] = ["ALICE", "BOB", "CAROL"]
+        store.save_meta("war", meta)
+        dispatch_slash(
+            store,
+            sender="ALICE",
+            node="HALL",
+            message="/remove war BOB",
+            tell_fn=tell_fn,
+        )
+        meta = store.load_meta("war")
+        members = {m.upper() for m in store.member_names(meta)}
+        assert members == {"ALICE", "CAROL"}
+        bob_msgs = [b for a, b in sent if a.upper() == "BOB"]
+        assert len(bob_msgs) == 1
+        assert "removed you from #war" in bob_msgs[0]
+        system = [m for m in store.list_messages("war") if m["kind"] == "system"]
+        assert system
+        assert "removed BOB" in system[0]["content"]
+
+    def test_remove_requires_membership(self, store, tells):
+        sent, tell_fn = tells
+        meta = store.ensure_room("war")
+        meta["members"] = ["BOB"]
+        store.save_meta("war", meta)
+        rc = dispatch_slash(
+            store,
+            sender="ALICE",
+            node="HALL",
+            message="/remove war BOB",
+            tell_fn=tell_fn,
+        )
+        assert rc == 1
+        assert "not a member" in sent[0][1]
+
+    def test_remove_self_hints_leave(self, store, tells):
+        sent, tell_fn = tells
+        meta = store.ensure_room("war")
+        meta["members"] = ["ALICE", "BOB"]
+        store.save_meta("war", meta)
+        dispatch_slash(
+            store,
+            sender="ALICE",
+            node="HALL",
+            message="/remove war ALICE",
+            tell_fn=tell_fn,
+        )
+        meta = store.load_meta("war")
+        assert "ALICE" in store.member_names(meta)
+        ack = [b for a, b in sent if a == "ALICE"][-1]
+        assert "use /leave" in ack
+
+    def test_kick_alias(self, store, tells):
+        sent, tell_fn = tells
+        meta = store.ensure_room("war")
+        meta["members"] = ["ALICE", "BOB"]
+        store.save_meta("war", meta)
+        dispatch_slash(
+            store,
+            sender="ALICE",
+            node="HALL",
+            message="/kick war BOB",
+            tell_fn=tell_fn,
+        )
+        meta = store.load_meta("war")
+        assert "BOB" not in {m.upper() for m in store.member_names(meta)}
+
+
 class TestView:
     def test_view_convo_markdown(self, store, tells):
         sent, tell_fn = tells

--- a/apps/h4l/tests/test_h4l.py
+++ b/apps/h4l/tests/test_h4l.py
@@ -173,11 +173,10 @@ class TestPost:
         assert "knobert" in {m.lower() for m in store.member_names(meta)}
         messages = store.list_messages("everyone")
         assert len(messages) == 1
-        assert messages[0]["content"] == "I'm testing out chat rooms."
-        assert "@knobert" not in messages[0]["content"]
+        assert messages[0]["content"] == "@knobert I'm testing out chat rooms."
         knobert_msgs = [b for a, b in sent if a.lower() == "knobert"]
         assert len(knobert_msgs) == 1
-        assert "I'm testing out chat rooms." in knobert_msgs[0]
+        assert "@knobert I'm testing out chat rooms." in knobert_msgs[0]
         assert "posted in #everyone" in knobert_msgs[0]
         assert "invited" not in knobert_msgs[0]
 
@@ -193,7 +192,7 @@ class TestPost:
         meta = store.load_meta("war")
         members = {m.upper() for m in store.member_names(meta)}
         assert members >= {"ALICE", "BOB", "CAROL"}
-        assert store.list_messages("war")[0]["content"] == "hello team"
+        assert store.list_messages("war")[0]["content"] == "@bob @carol hello team"
         assert len([b for a, b in sent if a.upper() == "BOB"]) == 1
         assert len([b for a, b in sent if a.upper() == "CAROL"]) == 1
 

--- a/apps/h4l/tests/test_h4l.py
+++ b/apps/h4l/tests/test_h4l.py
@@ -55,8 +55,8 @@ class TestPost:
         messages = store.list_messages("war")
         assert len(messages) == 1
         assert messages[0]["content"] == "hello everyone"
-        acks = [b for a, b in sent if a == "ALICE"]
-        assert any("posted to #war" in b for b in acks)
+        alice_msgs = [b for a, b in sent if a == "ALICE"]
+        assert not alice_msgs
         assert not any(a == "ALICE" and "hello everyone" in b and "posted in" in b for a, b in sent)
 
     def test_hash_prefix_room_same_as_plain(self, store, tells):
@@ -99,8 +99,7 @@ class TestPost:
         messages = store.list_messages("everyone")
         assert len(messages) == 1
         assert messages[0]["content"] == "hello"
-        acks = [b for a, b in sent if a == "ALICE"]
-        assert any("posted to #everyone" in b for b in acks)
+        assert not [b for a, b in sent if a == "ALICE"]
 
     def test_irc_style_matches_slash_post(self, store, tells):
         sent, tell_fn = tells
@@ -137,7 +136,29 @@ class TestPost:
         assert len(bob_msgs) == 1
         assert "ALICE posted in #war" in bob_msgs[0]
         assert "update" in bob_msgs[0]
-        assert "tell HALL /view war" in bob_msgs[0]
+        assert "Post a message: tell HALL #war" in bob_msgs[0]
+        assert "More commands: tell HALL /help" in bob_msgs[0]
+        assert "tell HALL /view" not in bob_msgs[0]
+
+    def test_onboard_footer_only_once(self, store, tells):
+        sent, tell_fn = tells
+        meta = store.ensure_room("war")
+        meta["members"] = ["ALICE", "BOB"]
+        store.save_meta("war", meta)
+        for msg in ("/post war one", "/post war two"):
+            dispatch_slash(
+                store,
+                sender="ALICE",
+                node="HALL",
+                message=msg,
+                tell_fn=tell_fn,
+            )
+        bob_msgs = [b for a, b in sent if a == "BOB"]
+        assert len(bob_msgs) == 2
+        assert "Post a message:" in bob_msgs[0]
+        assert "Post a message:" not in bob_msgs[1]
+        meta = store.load_meta("war")
+        assert store.has_seen_help(meta, "BOB")
 
 
 class TestInvite:
@@ -154,6 +175,9 @@ class TestInvite:
         meta = store.load_meta("war")
         members = {m.upper() for m in store.member_names(meta)}
         assert members == {"BOB", "CAROL"}
+        bob_invite = [b for a, b in sent if a == "BOB"][0]
+        assert "invited" in bob_invite
+        assert "Post a message: tell HALL #war" in bob_invite
         assert any(a == "BOB" and "invited" in b for a, b in sent)
         system = [m for m in store.list_messages("war") if m["kind"] == "system"]
         assert system
@@ -282,9 +306,8 @@ class TestSimulateTell:
         ])
         assert rc == 0
         captured = capsys.readouterr()
-        assert "posted to #war" in captured.out
-        assert "h4l> tell ALICE:" in captured.err
-        assert "posted to #war" in captured.err
+        assert captured.out == ""
+        assert "h4l> tell ALICE:" not in captured.err
 
     def test_simulate_env_enables_mode(self, tmp_path, capsys, monkeypatch):
         monkeypatch.setenv("H4L_SIMULATE_TELL", "1")

--- a/apps/h4l/tests/test_h4l.py
+++ b/apps/h4l/tests/test_h4l.py
@@ -129,6 +129,43 @@ class TestErrors:
         assert sent == [("ALICE", "h4l error: commands must start with / (e.g. /post war hello)")]
 
 
+class TestSimulateTell:
+    def test_simulate_prints_tell_to_stderr(self, tmp_path, capsys):
+        rc = h4l_main([
+            "dispatch",
+            "--root",
+            str(tmp_path),
+            "--from",
+            "ALICE",
+            "--node",
+            "HALL",
+            "--simulate-tell",
+            "--message",
+            "/post war hello",
+        ])
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "posted to #war" in captured.out
+        assert "h4l> tell ALICE:" in captured.err
+        assert "posted to #war" in captured.err
+
+    def test_simulate_env_enables_mode(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.setenv("H4L_SIMULATE_TELL", "1")
+        rc = h4l_main([
+            "dispatch",
+            "--root",
+            str(tmp_path),
+            "--from",
+            "ALICE",
+            "--node",
+            "HALL",
+            "--message",
+            "/list",
+        ])
+        assert rc == 0
+        assert "h4l> tell ALICE:" in capsys.readouterr().err
+
+
 class TestClear:
     def test_clear_older_than(self, store, tmp_path):
         store.ensure_room("old")

--- a/apps/h4l/tests/test_h4l.py
+++ b/apps/h4l/tests/test_h4l.py
@@ -26,6 +26,10 @@ class TestSlug:
     def test_normalizes_case(self):
         assert normalize_slug("War") == "war"
 
+    def test_strips_hash_prefix(self):
+        assert normalize_slug("#war") == "war"
+        assert normalize_slug("  #War  ") == "war"
+
     def test_rejects_empty(self):
         with pytest.raises(ValueError):
             normalize_slug("")
@@ -54,6 +58,68 @@ class TestPost:
         acks = [b for a, b in sent if a == "ALICE"]
         assert any("posted to #war" in b for b in acks)
         assert not any(a == "ALICE" and "hello everyone" in b and "posted in" in b for a, b in sent)
+
+    def test_hash_prefix_room_same_as_plain(self, store, tells):
+        sent, tell_fn = tells
+        assert (
+            dispatch_slash(
+                store,
+                sender="ALICE",
+                node="HALL",
+                message="/post war first",
+                tell_fn=tell_fn,
+            )
+            == 0
+        )
+        assert (
+            dispatch_slash(
+                store,
+                sender="BOB",
+                node="HALL",
+                message="/post #war second",
+                tell_fn=tell_fn,
+            )
+            == 0
+        )
+        messages = store.list_messages("war")
+        assert len(messages) == 2
+        assert messages[0]["content"] == "first"
+        assert messages[1]["content"] == "second"
+
+    def test_irc_style_hash_post(self, store, tells):
+        sent, tell_fn = tells
+        rc = dispatch_slash(
+            store,
+            sender="ALICE",
+            node="CHATROOM",
+            message="#everyone hello",
+            tell_fn=tell_fn,
+        )
+        assert rc == 0
+        messages = store.list_messages("everyone")
+        assert len(messages) == 1
+        assert messages[0]["content"] == "hello"
+        acks = [b for a, b in sent if a == "ALICE"]
+        assert any("posted to #everyone" in b for b in acks)
+
+    def test_irc_style_matches_slash_post(self, store, tells):
+        sent, tell_fn = tells
+        dispatch_slash(
+            store,
+            sender="ALICE",
+            node="HALL",
+            message="#war irc hello",
+            tell_fn=tell_fn,
+        )
+        dispatch_slash(
+            store,
+            sender="BOB",
+            node="HALL",
+            message="/post war slash hello",
+            tell_fn=tell_fn,
+        )
+        messages = store.list_messages("war")
+        assert [m["content"] for m in messages] == ["irc hello", "slash hello"]
 
     def test_notifies_other_members(self, store, tells):
         sent, tell_fn = tells
@@ -94,7 +160,27 @@ class TestInvite:
         assert "BOB" in system[0]["content"] and "CAROL" in system[0]["content"]
 
 
-class TestList:
+class TestView:
+    def test_view_convo_markdown(self, store, tells):
+        sent, tell_fn = tells
+        store.ensure_room("war")
+        store.append_message("war", sender="ALICE", content="hello")
+        store.append_message("war", sender="BOB", content="hi back")
+        dispatch_slash(
+            store,
+            sender="ALICE",
+            node="HALL",
+            message="/view war",
+            tell_fn=tell_fn,
+        )
+        ack = [b for a, b in sent if a == "ALICE"][-1]
+        assert "## from ALICE to #war at" in ack
+        assert "hello" in ack
+        assert "### from BOB to #war at" in ack
+        assert "hi back" in ack
+        assert "viewed messages 1–2 of 2" in ack
+
+
     def test_lists_all_rooms_and_members(self, store, tells):
         sent, tell_fn = tells
         m1 = store.ensure_room("war")
@@ -129,10 +215,26 @@ class TestErrors:
         assert len(sent) == 1
         agent, body = sent[0]
         assert agent == "ALICE"
-        assert body.startswith("Error: commands must start with /")
+        assert body.startswith("Error: send #<room> <message> or a /command")
         assert "h4l" not in body.lower()
-        assert 'tell CHATROOM "/post <room> <message>"' in body
+        assert 'tell CHATROOM "#<room> <message>"' in body
         assert 'tell CHATROOM "/list"' in body
+
+    def test_help_outputs_usage(self, store, tells):
+        sent, tell_fn = tells
+        rc = dispatch_slash(
+            store,
+            sender="ALICE",
+            node="CHATROOM",
+            message="/help",
+            tell_fn=tell_fn,
+        )
+        assert rc == 0
+        ack = [b for a, b in sent if a == "ALICE"][-1]
+        assert "Post (IRC style):" in ack
+        assert 'tell CHATROOM "#<room> <message>"' in ack
+        assert 'tell CHATROOM "/help"' in ack
+        assert "Error:" not in ack
 
     def test_unknown_command_includes_usage(self, store, tells):
         sent, tell_fn = tells
@@ -147,6 +249,21 @@ class TestErrors:
         body = sent[0][1]
         assert "Error: unknown command /frobnicate" in body
         assert 'tell HALL "/join <room>"' in body
+
+    def test_part_alias_for_leave(self, store, tells):
+        sent, tell_fn = tells
+        meta = store.ensure_room("war")
+        meta, _ = store.add_member(meta, "ALICE")
+        store.save_meta("war", meta)
+        rc = dispatch_slash(
+            store,
+            sender="ALICE",
+            node="HALL",
+            message="/part war",
+            tell_fn=tell_fn,
+        )
+        assert rc == 0
+        assert any("left #war" in b for a, b in sent if a == "ALICE")
 
 
 class TestSimulateTell:

--- a/apps/h4l/tests/test_h4l.py
+++ b/apps/h4l/tests/test_h4l.py
@@ -160,6 +160,57 @@ class TestPost:
         meta = store.load_meta("war")
         assert store.has_seen_help(meta, "BOB")
 
+    def test_at_mention_invites_and_posts_once(self, store, tells):
+        sent, tell_fn = tells
+        dispatch_slash(
+            store,
+            sender="ALICE",
+            node="CHATROOM",
+            message="#everyone @knobert I'm testing out chat rooms.",
+            tell_fn=tell_fn,
+        )
+        meta = store.load_meta("everyone")
+        assert "knobert" in {m.lower() for m in store.member_names(meta)}
+        messages = store.list_messages("everyone")
+        assert len(messages) == 1
+        assert messages[0]["content"] == "I'm testing out chat rooms."
+        assert "@knobert" not in messages[0]["content"]
+        knobert_msgs = [b for a, b in sent if a.lower() == "knobert"]
+        assert len(knobert_msgs) == 1
+        assert "I'm testing out chat rooms." in knobert_msgs[0]
+        assert "posted in #everyone" in knobert_msgs[0]
+        assert "invited" not in knobert_msgs[0]
+
+    def test_multiple_at_mentions(self, store, tells):
+        sent, tell_fn = tells
+        dispatch_slash(
+            store,
+            sender="ALICE",
+            node="HALL",
+            message="#war @bob @carol hello team",
+            tell_fn=tell_fn,
+        )
+        meta = store.load_meta("war")
+        members = {m.upper() for m in store.member_names(meta)}
+        assert members >= {"ALICE", "BOB", "CAROL"}
+        assert store.list_messages("war")[0]["content"] == "hello team"
+        assert len([b for a, b in sent if a.upper() == "BOB"]) == 1
+        assert len([b for a, b in sent if a.upper() == "CAROL"]) == 1
+
+    def test_at_mention_only_at_message_start(self, store, tells):
+        sent, tell_fn = tells
+        dispatch_slash(
+            store,
+            sender="ALICE",
+            node="HALL",
+            message="#war ping @bob later",
+            tell_fn=tell_fn,
+        )
+        meta = store.load_meta("war")
+        assert "BOB" not in {m.upper() for m in store.member_names(meta)}
+        assert store.list_messages("war")[0]["content"] == "ping @bob later"
+        assert not [b for a, b in sent if a == "BOB"]
+
 
 class TestInvite:
     def test_invite_adds_and_notifies(self, store, tells):

--- a/apps/h4l/ulid.py
+++ b/apps/h4l/ulid.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import secrets
+import time
+
+ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+LENGTH = 26
+_RND_BYTES = 10
+_TS_BITS = 48
+_RND_BITS = 80
+_TS_MASK = (1 << _TS_BITS) - 1
+_RND_MASK = (1 << _RND_BITS) - 1
+
+
+def new() -> str:
+    ts_ms = int(time.time() * 1000) & _TS_MASK
+    rnd = int.from_bytes(secrets.token_bytes(_RND_BYTES), "big")
+    n = (ts_ms << _RND_BITS) | rnd
+    chars = []
+    for _ in range(LENGTH):
+        chars.append(ALPHABET[n & 0x1f])
+        n >>= 5
+    return "".join(reversed(chars))

--- a/docs/h4l.md
+++ b/docs/h4l.md
@@ -11,15 +11,17 @@ h4l dispatch --simulate-tell ...   # stderr preview; no tell/outbox required
 h4l clear --root <dir> --older-than <seconds>
 
 # Via a8s (after a8s add + start)
-tell <hall-name> '/post <room> <text>'
+tell <hall-name> '#<room> <text>'
 tell <hall-name> '/list'
-tell <hall-name> '/view <room>'
+tell <hall-name> '/view <room> [start limit] [--start N] [--limit N] [--before <id>]'
 tell <hall-name> '/invite <room> AGENT [AGENT...]'
 tell <hall-name> '/join <room>'
 tell <hall-name> '/leave <room>'
+tell <hall-name> '/help'
 ```
 
-Slash commands must start with `/`. Room slugs are lowercase `[a-z0-9_-]+`.
+Post with `#<room> <message>` (IRC style) or `/post <room> <message>`. `#` on room
+names is optional in commands (`/join #war`). `/part` and `/names` are IRC aliases.
 
 ## a8s setup
 

--- a/docs/h4l.md
+++ b/docs/h4l.md
@@ -13,7 +13,7 @@ h4l clear --root <dir> --older-than <seconds>
 # Via a8s (after a8s add + start)
 tell <hall-name> '#<room> <text>'
 tell <hall-name> '/list'
-tell <hall-name> '/view <room> [start limit] [--start N] [--limit N] [--before <id>]'
+tell <hall-name> '/view <room> [start limit] [--start N] [--limit N]'
 tell <hall-name> '/invite <room> AGENT [AGENT...]'
 tell <hall-name> '/join <room>'
 tell <hall-name> '/leave <room>'

--- a/docs/h4l.md
+++ b/docs/h4l.md
@@ -7,6 +7,7 @@ Hall chat rooms for multi-agent coordination. Standalone CLI; optional a8s node.
 ```bash
 # Direct (no a8s handler)
 h4l dispatch --root <dir> --from <agent> --node <hall-name> --message '/post <room> <text>'
+h4l dispatch --simulate-tell ...   # stderr preview; no tell/outbox required
 h4l clear --root <dir> --older-than <seconds>
 
 # Via a8s (after a8s add + start)

--- a/docs/h4l.md
+++ b/docs/h4l.md
@@ -1,0 +1,30 @@
+# h4l
+
+Hall chat rooms for multi-agent coordination. Standalone CLI; optional a8s node.
+
+## Usage
+
+```bash
+# Direct (no a8s handler)
+h4l dispatch --root <dir> --from <agent> --node <hall-name> --message '/post <room> <text>'
+h4l clear --root <dir> --older-than <seconds>
+
+# Via a8s (after a8s add + start)
+tell <hall-name> '/post <room> <text>'
+tell <hall-name> '/list'
+tell <hall-name> '/view <room>'
+tell <hall-name> '/invite <room> AGENT [AGENT...]'
+tell <hall-name> '/join <room>'
+tell <hall-name> '/leave <room>'
+```
+
+Slash commands must start with `/`. Room slugs are lowercase `[a-z0-9_-]+`.
+
+## a8s setup
+
+```bash
+a8s add chatroom ~/chat-node apps/a8s/connectors/h4l/example-definition.json
+a8s start chatroom
+```
+
+State lives under the registered root at `.chatrooms/`. See `apps/h4l/README.md`.

--- a/h4l
+++ b/h4l
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+echo `# <#` >/dev/null
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$SCRIPT_DIR/apps/h4l/h4l.py" "$@"
+#> > $null
+
+$ScriptPath = $PSCommandPath
+if (-not $ScriptPath) { $ScriptPath = $MyInvocation.MyCommand.Path }
+if (-not $ScriptPath) { $ScriptPath = Join-Path (Get-Location) "h4l" }
+
+$ScriptDir = Split-Path -Parent $ScriptPath
+$H4lPath = Join-Path $ScriptDir "apps/h4l/h4l.py"
+
+$Python = Get-Command python3 -ErrorAction SilentlyContinue
+if ($Python) { & $Python.Source $H4lPath @args; exit $LASTEXITCODE }
+$Python = Get-Command python -ErrorAction SilentlyContinue
+if ($Python) { & $Python.Source $H4lPath @args; exit $LASTEXITCODE }
+$Python = Get-Command py -ErrorAction SilentlyContinue
+if ($Python) { & $Python.Source -3 $H4lPath @args; exit $LASTEXITCODE }
+
+Write-Error "Could not find python3, python, or py on PATH."
+exit 127


### PR DESCRIPTION
## Summary
- Adds **h4l** (Hall) as a standalone stdlib app under `apps/h4l/` with `~/bin/h4l` shim.
- Slash commands (`/post`, `/join`, `/leave`, `/invite`, `/list`, `/view`, `/members`) with state in `<root>/.chatrooms/`.
- Member notifications via `tell` (truncated body + dynamic footer); poster ACK and errors also `tell` back to sender.
- Example a8s definition at `apps/a8s/connectors/h4l/example-definition.json` for registering a chatroom node.

## Test plan
- [x] `python3 -m pytest apps/h4l/tests/`
- [ ] `h4l dispatch --root ~/chat-node --from ALICE --node HALL --message '/post war hello'`
- [ ] `a8s add chatroom ~/chat-node apps/a8s/connectors/h4l/example-definition.json && a8s start chatroom`
- [ ] `tell chatroom '/list'` and `tell chatroom '/view war'`


Made with [Cursor](https://cursor.com)