### PR TITLE
feat(n0b): ai transcribe — local Whisper speech-to-text

### DIFF
--- a/apps/n0b/README.md
+++ b/apps/n0b/README.md
@@ -24,6 +24,7 @@ Detailed docs live in [`docs/`](docs/):
 | [ltx-video.md](docs/ltx-video.md) | `n0b ai video` | LTX-Video generation, models, setup guide |
 | [research.md](docs/research.md) | `n0b ai research` | OpenAI o4-mini-deep-research |
 | [secrets.md](docs/secrets.md) | `n0b secrets` | Get/set secrets — env, `~/lib`, Keychain, dotenv |
+| [transcribe.md](docs/transcribe.md) | `n0b ai transcribe` | Local Whisper speech-to-text, hints file |
 
 ### Quick reference (no separate doc yet)
 
@@ -33,7 +34,7 @@ Detailed docs live in [`docs/`](docs/):
 | `ports` | `free`, `listen <port>` | Ephemeral free port; list process on a port (`lsof` / `netstat`) |
 | `gpu` | `cuda`, `mps`, `mlx`, `mb-free` | GPU / MLX checks; free MiB |
 | `mqtt` | `pub`, `sub` | `mosquitto_*` with `MQTT_HOST`, `MQTT_PORT`, `MQTT_USER`, `MQTT_PASS` |
-| `ai` | `image`, `video`, `audio`, `research` | See [ltx-video.md](docs/ltx-video.md) for video; [research.md](docs/research.md) for deep research |
+| `ai` | `image`, `video`, `audio`, `research`, `transcribe` | See [ltx-video.md](docs/ltx-video.md) for video; [research.md](docs/research.md) for deep research; [transcribe.md](docs/transcribe.md) for speech-to-text |
 | `video` | `last-frame` | Extract last frame with `ffmpeg` |
 
 ### AI model defaults
@@ -43,6 +44,7 @@ Detailed docs live in [`docs/`](docs/):
 | `n0b ai image` | Z-Image (`z-image.sh`) | `--model z-image` |
 | `n0b ai video` | LTX-Video 1, LTX-2 (PyTorch), MLX-Video (Apple Silicon) | `--model ltx-2`, `--model ltx-1`, or `-2`/`-1` flags |
 | `n0b ai audio` | AudioLDM (`audioldm.sh`) | `--model bark` for Suno Bark |
+| `n0b ai transcribe` | Whisper `turbo` (local, no API key) | `--model tiny|base|small|medium|large` |
 
 ## Layout
 

--- a/apps/n0b/README.md
+++ b/apps/n0b/README.md
@@ -24,7 +24,7 @@ Detailed docs live in [`docs/`](docs/):
 | [ltx-video.md](docs/ltx-video.md) | `n0b ai video` | LTX-Video generation, models, setup guide |
 | [research.md](docs/research.md) | `n0b ai research` | OpenAI o4-mini-deep-research |
 | [secrets.md](docs/secrets.md) | `n0b secrets` | Get/set secrets — env, `~/lib`, Keychain, dotenv |
-| [transcribe.md](docs/transcribe.md) | `n0b ai transcribe` | Local Whisper speech-to-text, hints file |
+| [transcribe.md](docs/transcribe.md) | `n0b ai transcribe` | Local Whisper speech-to-text, hints + replacement files |
 
 ### Quick reference (no separate doc yet)
 

--- a/apps/n0b/cli.py
+++ b/apps/n0b/cli.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import argparse
 import sys
 
-from commands.ai_cmd import cmd_ai, cmd_research
+from commands.ai_cmd import cmd_ai, cmd_research, cmd_transcribe
 from commands.az_cmd import cmd_tail
 from commands.gpu_cmd import cmd_cuda, cmd_mb_free, cmd_mlx, cmd_mps
 from commands.json_cmd import cmd_json
@@ -80,6 +80,27 @@ def build_parser() -> argparse.ArgumentParser:
     ai_sub = ai_p.add_subparsers(dest="ai_kind", required=True)
     ai_research = ai_sub.add_parser("research", help="Deep research via o4-mini-deep-research")
     ai_research.add_argument("prompt", nargs=argparse.REMAINDER)
+    ai_transcribe = ai_sub.add_parser(
+        "transcribe", help="Transcribe an audio file locally with Whisper"
+    )
+    ai_transcribe.add_argument("audio", help="Audio file (anything ffmpeg reads)")
+    ai_transcribe.add_argument(
+        "--hint",
+        "--hints",
+        action="append",
+        default=[],
+        dest="hints",
+        help=(
+            "Vocabulary hint, repeatable; merged with "
+            "~/.config/n0b/transcribe-hints.txt"
+        ),
+    )
+    ai_transcribe.add_argument(
+        "--language", help="Spoken language (e.g. en); default auto-detect"
+    )
+    ai_transcribe.add_argument(
+        "--model", default="turbo", help="Whisper model (default: turbo)"
+    )
     for kind, help_text in (
         ("image", "Generate images (default model: z-image)"),
         ("video", "Generate videos — LTX-Video 1/2, MLX on Apple Silicon (default: auto)"),
@@ -150,6 +171,8 @@ def dispatch(args: argparse.Namespace) -> int:
     if group == "ai":
         if args.ai_kind == "research":
             return cmd_research(args.prompt)
+        if args.ai_kind == "transcribe":
+            return cmd_transcribe(args.audio, args.hints, args.language, args.model)
         rest = args.args
         if rest[:1] == ["--"]:
             rest = rest[1:]

--- a/apps/n0b/cli.py
+++ b/apps/n0b/cli.py
@@ -83,7 +83,9 @@ def build_parser() -> argparse.ArgumentParser:
     ai_transcribe = ai_sub.add_parser(
         "transcribe", help="Transcribe an audio file locally with Whisper"
     )
-    ai_transcribe.add_argument("audio", help="Audio file (anything ffmpeg reads)")
+    ai_transcribe.add_argument(
+        "audio", nargs="?", help="Audio file (anything ffmpeg reads)"
+    )
     ai_transcribe.add_argument(
         "--hint",
         "--hints",
@@ -100,6 +102,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     ai_transcribe.add_argument(
         "--model", default="turbo", help="Whisper model (default: turbo)"
+    )
+    ai_transcribe.add_argument(
+        "--save",
+        action="store_true",
+        help="Append the given --hint values to the global hints file",
     )
     for kind, help_text in (
         ("image", "Generate images (default model: z-image)"),
@@ -172,7 +179,9 @@ def dispatch(args: argparse.Namespace) -> int:
         if args.ai_kind == "research":
             return cmd_research(args.prompt)
         if args.ai_kind == "transcribe":
-            return cmd_transcribe(args.audio, args.hints, args.language, args.model)
+            return cmd_transcribe(
+                args.audio, args.hints, args.language, args.model, save=args.save
+            )
         rest = args.args
         if rest[:1] == ["--"]:
             rest = rest[1:]

--- a/apps/n0b/cli.py
+++ b/apps/n0b/cli.py
@@ -104,9 +104,20 @@ def build_parser() -> argparse.ArgumentParser:
         "--model", default="turbo", help="Whisper model (default: turbo)"
     )
     ai_transcribe.add_argument(
+        "--replace",
+        action="append",
+        default=[],
+        dest="replaces",
+        metavar="'WRONG => RIGHT'",
+        help=(
+            "Regex + correction; matches get annotated after transcription. "
+            "Merged with ~/.config/n0b/transcribe-replacements.txt"
+        ),
+    )
+    ai_transcribe.add_argument(
         "--save",
         action="store_true",
-        help="Append the given --hint values to the global hints file",
+        help="Append the given --hint/--replace values to their global files",
     )
     for kind, help_text in (
         ("image", "Generate images (default model: z-image)"),
@@ -180,7 +191,12 @@ def dispatch(args: argparse.Namespace) -> int:
             return cmd_research(args.prompt)
         if args.ai_kind == "transcribe":
             return cmd_transcribe(
-                args.audio, args.hints, args.language, args.model, save=args.save
+                args.audio,
+                args.hints,
+                args.language,
+                args.model,
+                save=args.save,
+                replaces=args.replaces,
             )
         rest = args.args
         if rest[:1] == ["--"]:

--- a/apps/n0b/commands/ai_cmd.py
+++ b/apps/n0b/commands/ai_cmd.py
@@ -59,26 +59,66 @@ import sys
 import whisper
 
 audio, model_name, language, prompt = sys.argv[1:5]
+print(f"loading model {model_name}...", file=sys.stderr)
 model = whisper.load_model(model_name)
+print(f"transcribing (language: {language or 'auto-detect'})...", file=sys.stderr)
 result = model.transcribe(
     audio,
     language=language or None,
     initial_prompt=prompt or None,
     fp16=False,
+    verbose=False,
 )
 print(result["text"].strip())
 """
 
 
-def merged_hints(cli_hints: list[str], hints_file: Path) -> str:
+def read_hints(hints_file: Path) -> list[str]:
+    if not hints_file.is_file():
+        return []
     hints: list[str] = []
-    if hints_file.is_file():
-        for line in hints_file.read_text().splitlines():
-            line = line.strip()
-            if line and not line.startswith("#"):
-                hints.append(line)
-    hints.extend(h.strip() for h in cli_hints if h.strip())
-    return ", ".join(hints)
+    for line in hints_file.read_text().splitlines():
+        line = line.strip()
+        if line and not line.startswith("#"):
+            hints.append(line)
+    return hints
+
+
+def split_cli_hints(cli_hints: list[str]) -> list[str]:
+    return [p.strip() for h in cli_hints for p in h.split(",") if p.strip()]
+
+
+def merged_hints(cli_hints: list[str], hints_file: Path) -> str:
+    return ", ".join(read_hints(hints_file) + split_cli_hints(cli_hints))
+
+
+def save_hints(cli_hints: list[str], hints_file: Path) -> int:
+    new = split_cli_hints(cli_hints)
+    if not new:
+        print("n0b ai transcribe: --save needs at least one --hint", file=sys.stderr)
+        return 2
+    existing = read_hints(hints_file)
+    known = {h.lower() for h in existing}
+    added = []
+    for hint in new:
+        if hint.lower() not in known:
+            known.add(hint.lower())
+            added.append(hint)
+    if added:
+        hints_file.parent.mkdir(parents=True, exist_ok=True)
+        lead = ""
+        if hints_file.is_file():
+            text = hints_file.read_text()
+            if text and not text.endswith("\n"):
+                lead = "\n"
+        with hints_file.open("a") as f:
+            f.write(lead + "".join(f"{h}\n" for h in added))
+    print(
+        f"saved {len(added)} hint(s) to {hints_file}"
+        + (f" ({len(new) - len(added)} already there)" if len(added) < len(new) else ""),
+        file=sys.stderr,
+    )
+    return 0
 
 
 def _whisper_python() -> Path:
@@ -103,8 +143,19 @@ def _whisper_python() -> Path:
 
 
 def cmd_transcribe(
-    audio: str, hints: list[str], language: str | None, model: str
+    audio: str | None,
+    hints: list[str],
+    language: str | None,
+    model: str,
+    save: bool = False,
 ) -> int:
+    if save:
+        rc = save_hints(hints, HINTS_FILE)
+        if rc != 0 or audio is None:
+            return rc
+    if audio is None:
+        print("n0b ai transcribe: audio file required (or --save)", file=sys.stderr)
+        return 2
     path = Path(audio).expanduser()
     if not path.is_file():
         print(f"n0b ai transcribe: no such file: {audio}", file=sys.stderr)
@@ -115,16 +166,27 @@ def cmd_transcribe(
             file=sys.stderr,
         )
         return 1
+    file_hints = read_hints(HINTS_FILE)
+    cli_hints = split_cli_hints(hints)
+    prompt = ", ".join(file_hints + cli_hints)
+    if prompt:
+        print(
+            f"hints: {prompt}\n"
+            f"  ({len(file_hints)} from {HINTS_FILE}, {len(cli_hints)} from --hint)",
+            file=sys.stderr,
+        )
+    else:
+        print(
+            f"hints: none (create {HINTS_FILE}, or pass --hint, add --save to keep)",
+            file=sys.stderr,
+        )
     try:
         python = _whisper_python()
     except subprocess.CalledProcessError as exc:
         print(f"n0b ai transcribe: Whisper setup failed: {exc}", file=sys.stderr)
         return 1
     proc = subprocess.run(
-        [
-            str(python), "-c", _WHISPER_SNIPPET,
-            str(path), model, language or "", merged_hints(hints, HINTS_FILE),
-        ]
+        [str(python), "-c", _WHISPER_SNIPPET, str(path), model, language or "", prompt]
     )
     return proc.returncode
 

--- a/apps/n0b/commands/ai_cmd.py
+++ b/apps/n0b/commands/ai_cmd.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -53,6 +54,7 @@ def cmd_research(args: list[str]) -> int:
 
 WHISPER_VENV = Path.home() / ".cache" / "n0b" / "whisper-venv"
 HINTS_FILE = Path.home() / ".config" / "n0b" / "transcribe-hints.txt"
+REPLACEMENTS_FILE = Path.home() / ".config" / "n0b" / "transcribe-replacements.txt"
 
 _WHISPER_SNIPPET = """\
 import sys
@@ -92,10 +94,98 @@ def merged_hints(cli_hints: list[str], hints_file: Path) -> str:
     return ", ".join(read_hints(hints_file) + split_cli_hints(cli_hints))
 
 
+def parse_replacement(line: str) -> tuple[str, str] | None:
+    if "=>" not in line:
+        return None
+    pattern, correction = line.split("=>", 1)
+    pattern, correction = pattern.strip(), correction.strip()
+    if not pattern or not correction:
+        return None
+    return pattern, correction
+
+
+def read_replacements(replacements_file: Path) -> list[tuple[str, str]]:
+    pairs: list[tuple[str, str]] = []
+    if not replacements_file.is_file():
+        return pairs
+    for line in replacements_file.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        pair = parse_replacement(line)
+        if pair is None:
+            print(
+                f"n0b ai transcribe: skipping bad replacement line "
+                f"(want 'wrong => right'): {line!r}",
+                file=sys.stderr,
+            )
+            continue
+        pairs.append(pair)
+    return pairs
+
+
+def parse_cli_replacements(cli_replaces: list[str]) -> list[tuple[str, str]]:
+    pairs: list[tuple[str, str]] = []
+    for raw in cli_replaces:
+        pair = parse_replacement(raw)
+        if pair is None:
+            print(
+                f"n0b ai transcribe: bad --replace value "
+                f"(want 'wrong => right'): {raw!r}",
+                file=sys.stderr,
+            )
+            continue
+        pairs.append(pair)
+    return pairs
+
+
+def apply_replacements(
+    text: str, pairs: list[tuple[str, str]]
+) -> tuple[str, list[str]]:
+    applied: list[str] = []
+    for pattern, correction in pairs:
+        def annotate(m: re.Match[str]) -> str:
+            return f"{m.group(0)} (possible transcribe error, might be '{correction}')"
+
+        try:
+            text, count = re.subn(pattern, annotate, text)
+        except re.error as exc:
+            print(
+                f"n0b ai transcribe: bad replacement regex {pattern!r}: {exc}",
+                file=sys.stderr,
+            )
+            continue
+        if count:
+            applied.append(f"{pattern} => {correction} (x{count})")
+    return text, applied
+
+
+def save_replacements(cli_replaces: list[str], replacements_file: Path) -> int:
+    new = parse_cli_replacements(cli_replaces)
+    if not new:
+        return 2
+    known = {pattern for pattern, _ in read_replacements(replacements_file)}
+    added = [(p, c) for p, c in new if p not in known]
+    if added:
+        replacements_file.parent.mkdir(parents=True, exist_ok=True)
+        lead = ""
+        if replacements_file.is_file():
+            text = replacements_file.read_text()
+            if text and not text.endswith("\n"):
+                lead = "\n"
+        with replacements_file.open("a") as f:
+            f.write(lead + "".join(f"{p} => {c}\n" for p, c in added))
+    print(
+        f"saved {len(added)} replacement(s) to {replacements_file}"
+        + (f" ({len(new) - len(added)} already there)" if len(added) < len(new) else ""),
+        file=sys.stderr,
+    )
+    return 0
+
+
 def save_hints(cli_hints: list[str], hints_file: Path) -> int:
     new = split_cli_hints(cli_hints)
     if not new:
-        print("n0b ai transcribe: --save needs at least one --hint", file=sys.stderr)
         return 2
     existing = read_hints(hints_file)
     known = {h.lower() for h in existing}
@@ -148,11 +238,25 @@ def cmd_transcribe(
     language: str | None,
     model: str,
     save: bool = False,
+    replaces: list[str] | None = None,
 ) -> int:
+    replaces = replaces or []
     if save:
-        rc = save_hints(hints, HINTS_FILE)
-        if rc != 0 or audio is None:
-            return rc
+        saved = False
+        if split_cli_hints(hints):
+            save_hints(hints, HINTS_FILE)
+            saved = True
+        if parse_cli_replacements(replaces):
+            save_replacements(replaces, REPLACEMENTS_FILE)
+            saved = True
+        if not saved:
+            print(
+                "n0b ai transcribe: --save needs at least one --hint or --replace",
+                file=sys.stderr,
+            )
+            return 2
+        if audio is None:
+            return 0
     if audio is None:
         print("n0b ai transcribe: audio file required (or --save)", file=sys.stderr)
         return 2
@@ -180,15 +284,27 @@ def cmd_transcribe(
             f"hints: none (create {HINTS_FILE}, or pass --hint, add --save to keep)",
             file=sys.stderr,
         )
+    pairs = read_replacements(REPLACEMENTS_FILE) + parse_cli_replacements(replaces)
+    if pairs:
+        print(f"replacements: {len(pairs)} pattern(s) loaded", file=sys.stderr)
     try:
         python = _whisper_python()
     except subprocess.CalledProcessError as exc:
         print(f"n0b ai transcribe: Whisper setup failed: {exc}", file=sys.stderr)
         return 1
     proc = subprocess.run(
-        [str(python), "-c", _WHISPER_SNIPPET, str(path), model, language or "", prompt]
+        [str(python), "-c", _WHISPER_SNIPPET, str(path), model, language or "", prompt],
+        stdout=subprocess.PIPE,
+        text=True,
     )
-    return proc.returncode
+    if proc.returncode != 0:
+        return proc.returncode
+    text, applied = apply_replacements(proc.stdout.strip(), pairs)
+    if pairs:
+        note = "; ".join(applied) if applied else "none matched"
+        print(f"replacements applied: {note}", file=sys.stderr)
+    print(text)
+    return 0
 
 
 def cmd_ai(kind: str, model: str | None, args: list[str]) -> int:

--- a/apps/n0b/commands/ai_cmd.py
+++ b/apps/n0b/commands/ai_cmd.py
@@ -1,7 +1,8 @@
-"""AI generation wrappers (image, video, audio) and deep research."""
+"""AI generation wrappers (image, video, audio), transcription, and deep research."""
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -48,6 +49,84 @@ def cmd_research(args: list[str]) -> int:
         print("Usage: n0b ai research <prompt...>", file=sys.stderr)
         return 2
     return run_research(args)
+
+
+WHISPER_VENV = Path.home() / ".cache" / "n0b" / "whisper-venv"
+HINTS_FILE = Path.home() / ".config" / "n0b" / "transcribe-hints.txt"
+
+_WHISPER_SNIPPET = """\
+import sys
+import whisper
+
+audio, model_name, language, prompt = sys.argv[1:5]
+model = whisper.load_model(model_name)
+result = model.transcribe(
+    audio,
+    language=language or None,
+    initial_prompt=prompt or None,
+    fp16=False,
+)
+print(result["text"].strip())
+"""
+
+
+def merged_hints(cli_hints: list[str], hints_file: Path) -> str:
+    hints: list[str] = []
+    if hints_file.is_file():
+        for line in hints_file.read_text().splitlines():
+            line = line.strip()
+            if line and not line.startswith("#"):
+                hints.append(line)
+    hints.extend(h.strip() for h in cli_hints if h.strip())
+    return ", ".join(hints)
+
+
+def _whisper_python() -> Path:
+    python = WHISPER_VENV / "bin" / "python3"
+    if python.is_file():
+        return python
+    print(f"Setting up Whisper venv at {WHISPER_VENV} (one-time)...", file=sys.stderr)
+    WHISPER_VENV.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        [sys.executable, "-m", "venv", str(WHISPER_VENV)],
+        check=True, stdout=sys.stderr,
+    )
+    subprocess.run(
+        [str(python), "-m", "pip", "install", "--upgrade", "pip"],
+        check=True, stdout=sys.stderr,
+    )
+    subprocess.run(
+        [str(python), "-m", "pip", "install", "openai-whisper"],
+        check=True, stdout=sys.stderr,
+    )
+    return python
+
+
+def cmd_transcribe(
+    audio: str, hints: list[str], language: str | None, model: str
+) -> int:
+    path = Path(audio).expanduser()
+    if not path.is_file():
+        print(f"n0b ai transcribe: no such file: {audio}", file=sys.stderr)
+        return 1
+    if shutil.which("ffmpeg") is None:
+        print(
+            "n0b ai transcribe: ffmpeg not found (try: brew install ffmpeg)",
+            file=sys.stderr,
+        )
+        return 1
+    try:
+        python = _whisper_python()
+    except subprocess.CalledProcessError as exc:
+        print(f"n0b ai transcribe: Whisper setup failed: {exc}", file=sys.stderr)
+        return 1
+    proc = subprocess.run(
+        [
+            str(python), "-c", _WHISPER_SNIPPET,
+            str(path), model, language or "", merged_hints(hints, HINTS_FILE),
+        ]
+    )
+    return proc.returncode
 
 
 def cmd_ai(kind: str, model: str | None, args: list[str]) -> int:

--- a/apps/n0b/docs/transcribe.md
+++ b/apps/n0b/docs/transcribe.md
@@ -19,7 +19,14 @@ n0b ai transcribe memo.m4a > memo.txt
 n0b ai transcribe memo.m4a --hint "Pay-i" --hint "a8s, r4t"   # bias proper nouns
 n0b ai transcribe memo.m4a --language en                       # skip auto-detect
 n0b ai transcribe memo.m4a --model base                        # smaller/faster model
+
+n0b ai transcribe --hint "Pay-i, k7e" --save                   # add to the global hints file
+n0b ai transcribe memo.m4a --hint "Pay-i" --save               # save, then transcribe
 ```
+
+stderr reports the hints in effect (and where each came from), model
+loading, and a progress bar over the audio, so a long silence is never
+ambiguous.
 
 Any format ffmpeg can read works: m4a, mp3, wav, aiff, ogg, mp4, ...
 
@@ -33,6 +40,10 @@ to bias decoding. Two sources, merged (file first, then flags):
   `--hint` on every call.
 - `--hint` / `--hints` — repeatable; each value may hold several
   comma-separated terms.
+
+`--save` appends the given `--hint` values to the global file (deduped,
+case-insensitive) instead of you editing it by hand; with no audio argument
+it saves and exits.
 
 ## Models
 

--- a/apps/n0b/docs/transcribe.md
+++ b/apps/n0b/docs/transcribe.md
@@ -1,0 +1,48 @@
+---
+name: "n0b-transcribe"
+description: "Transcribe an audio file to text with a local Whisper model. Use when the user provides audio (voice memo, recording) and wants its text."
+allowed-tools: Bash(n0b ai transcribe *)
+---
+
+# n0b ai transcribe
+
+Local speech-to-text via [openai-whisper](https://github.com/openai/whisper).
+No API key; the model runs on this machine. Transcription goes to stdout,
+everything else (setup, progress) to stderr, so output is pipe-safe.
+
+## Usage
+
+```bash
+n0b ai transcribe memo.m4a
+n0b ai transcribe memo.m4a > memo.txt
+
+n0b ai transcribe memo.m4a --hint "Pay-i" --hint "a8s, r4t"   # bias proper nouns
+n0b ai transcribe memo.m4a --language en                       # skip auto-detect
+n0b ai transcribe memo.m4a --model base                        # smaller/faster model
+```
+
+Any format ffmpeg can read works: m4a, mp3, wav, aiff, ogg, mp4, ...
+
+## Hints
+
+Whisper mishears names and jargon; hints are fed in as its `initial_prompt`
+to bias decoding. Two sources, merged (file first, then flags):
+
+- `~/.config/n0b/transcribe-hints.txt` — one hint per line, `#` comments
+  allowed. Put your recurring vocabulary here once instead of repeating
+  `--hint` on every call.
+- `--hint` / `--hints` — repeatable; each value may hold several
+  comma-separated terms.
+
+## Models
+
+`--model` takes any Whisper model name: `tiny`, `base`, `small`, `medium`,
+`large`, `turbo` (default). `turbo` is near-large accuracy at ~8x speed;
+use `base` when speed matters more than proper nouns.
+
+## First run
+
+Bootstraps a dedicated venv at `~/.cache/n0b/whisper-venv` (torch is heavy —
+this keeps it out of the repo venv) and downloads the model to
+`~/.cache/whisper/`. One-time cost of a few GB; subsequent runs are offline.
+Requires `ffmpeg` on PATH.

--- a/apps/n0b/docs/transcribe.md
+++ b/apps/n0b/docs/transcribe.md
@@ -22,6 +22,9 @@ n0b ai transcribe memo.m4a --model base                        # smaller/faster 
 
 n0b ai transcribe --hint "Pay-i, k7e" --save                   # add to the global hints file
 n0b ai transcribe memo.m4a --hint "Pay-i" --save               # save, then transcribe
+
+n0b ai transcribe memo.m4a --replace 'Jerry => Gerry'          # annotate known mis-hearings
+n0b ai transcribe --replace 'Jerry => Gerry' --save            # add to the global replacements file
 ```
 
 stderr reports the hints in effect (and where each came from), model
@@ -44,6 +47,24 @@ to bias decoding. Two sources, merged (file first, then flags):
 `--save` appends the given `--hint` values to the global file (deduped,
 case-insensitive) instead of you editing it by hand; with no audio argument
 it saves and exits.
+
+## Replacements
+
+Hints only bias decoding; some words lose anyway ("Gerry" always comes out
+"Jerry"). Replacements run **after** transcription: each is a regex plus the
+likely correction, and every match gets annotated in place —
+
+> Jerry (possible transcribe error, might be 'Gerry') said blah
+
+— verbose by design, so downstream agents aren't misled by a confident wrong
+word. Two sources, merged:
+
+- `~/.config/n0b/transcribe-replacements.txt` — one `wrong => right` per
+  line, `#` comments allowed; the left side is a Python regex.
+- `--replace 'wrong => right'` — repeatable; `--save` appends these to the
+  global file (deduped by pattern).
+
+stderr reports how many patterns loaded and which ones matched.
 
 ## Models
 

--- a/apps/n0b/tests/test_cli.py
+++ b/apps/n0b/tests/test_cli.py
@@ -12,7 +12,12 @@ import pytest
 N0B_PY = Path(__file__).resolve().parents[1] / "n0b.py"
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from commands.ai_cmd import cmd_ai, cmd_transcribe, merged_hints  # noqa: E402
+from commands.ai_cmd import (  # noqa: E402
+    cmd_ai,
+    cmd_transcribe,
+    merged_hints,
+    save_hints,
+)
 from commands.secrets_cmd import cmd_set, resolve  # noqa: E402
 
 
@@ -162,6 +167,38 @@ def test_merged_hints_no_file(tmp_path):
 def test_transcribe_missing_file():
     rc = cmd_transcribe("/nonexistent/audio.m4a", [], None, "turbo")
     assert rc == 1
+
+
+def test_transcribe_no_audio_no_save():
+    rc = cmd_transcribe(None, [], None, "turbo")
+    assert rc == 2
+
+
+def test_save_hints_appends_and_dedupes(tmp_path):
+    hints_file = tmp_path / "cfg" / "transcribe-hints.txt"
+    assert save_hints(["Pay-i", "a8s, r4t"], hints_file) == 0
+    assert hints_file.read_text() == "Pay-i\na8s\nr4t\n"
+    assert save_hints(["pay-i", "k7e"], hints_file) == 0
+    assert hints_file.read_text() == "Pay-i\na8s\nr4t\nk7e\n"
+
+
+def test_save_hints_requires_hints(tmp_path):
+    assert save_hints([], tmp_path / "hints.txt") == 2
+
+
+def test_save_hints_no_trailing_newline(tmp_path):
+    hints_file = tmp_path / "hints.txt"
+    hints_file.write_text("a8s")
+    assert save_hints(["k7e"], hints_file) == 0
+    assert hints_file.read_text() == "a8s\nk7e\n"
+
+
+def test_transcribe_save_only(tmp_path):
+    hints_file = tmp_path / "hints.txt"
+    with patch("commands.ai_cmd.HINTS_FILE", hints_file):
+        rc = cmd_transcribe(None, ["Pay-i"], None, "turbo", save=True)
+    assert rc == 0
+    assert hints_file.read_text() == "Pay-i\n"
 
 
 def test_transcribe_invokes_whisper_venv(tmp_path):

--- a/apps/n0b/tests/test_cli.py
+++ b/apps/n0b/tests/test_cli.py
@@ -12,7 +12,7 @@ import pytest
 N0B_PY = Path(__file__).resolve().parents[1] / "n0b.py"
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from commands.ai_cmd import cmd_ai  # noqa: E402
+from commands.ai_cmd import cmd_ai, cmd_transcribe, merged_hints  # noqa: E402
 from commands.secrets_cmd import cmd_set, resolve  # noqa: E402
 
 
@@ -146,3 +146,44 @@ def test_ai_video_ltx2_passes_flag():
         assert argv[0] == "bash"
         assert argv[2] == "--ltx2"
         assert argv[3] == "hello"
+
+
+def test_merged_hints_file_then_flags(tmp_path):
+    hints_file = tmp_path / "transcribe-hints.txt"
+    hints_file.write_text("# my glossary\nPay-i\n\nNeil Obremski\n")
+    assert merged_hints(["a8s", " r4t "], hints_file) == "Pay-i, Neil Obremski, a8s, r4t"
+
+
+def test_merged_hints_no_file(tmp_path):
+    assert merged_hints(["only-flag"], tmp_path / "missing.txt") == "only-flag"
+    assert merged_hints([], tmp_path / "missing.txt") == ""
+
+
+def test_transcribe_missing_file():
+    rc = cmd_transcribe("/nonexistent/audio.m4a", [], None, "turbo")
+    assert rc == 1
+
+
+def test_transcribe_invokes_whisper_venv(tmp_path):
+    audio = tmp_path / "memo.wav"
+    audio.write_bytes(b"RIFF")
+    fake_python = tmp_path / "venv" / "bin" / "python3"
+    with (
+        patch("commands.ai_cmd._whisper_python", return_value=fake_python),
+        patch("commands.ai_cmd.HINTS_FILE", tmp_path / "missing.txt"),
+        patch("commands.ai_cmd.subprocess.run") as run,
+    ):
+        run.return_value.returncode = 0
+        rc = cmd_transcribe(str(audio), ["Pay-i"], "en", "base")
+        assert rc == 0
+        argv = run.call_args[0][0]
+        assert argv[0] == str(fake_python)
+        assert argv[1] == "-c"
+        assert argv[3:] == [str(audio), "base", "en", "Pay-i"]
+
+
+def test_transcribe_help():
+    proc = run_n0b("ai", "transcribe", "--help")
+    assert proc.returncode == 0
+    assert "--hint" in proc.stdout
+    assert "--language" in proc.stdout

--- a/apps/n0b/tests/test_cli.py
+++ b/apps/n0b/tests/test_cli.py
@@ -13,10 +13,13 @@ N0B_PY = Path(__file__).resolve().parents[1] / "n0b.py"
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from commands.ai_cmd import (  # noqa: E402
+    apply_replacements,
     cmd_ai,
     cmd_transcribe,
     merged_hints,
+    read_replacements,
     save_hints,
+    save_replacements,
 )
 from commands.secrets_cmd import cmd_set, resolve  # noqa: E402
 
@@ -201,6 +204,68 @@ def test_transcribe_save_only(tmp_path):
     assert hints_file.read_text() == "Pay-i\n"
 
 
+def test_read_replacements_skips_bad_lines(tmp_path, capsys):
+    f = tmp_path / "transcribe-replacements.txt"
+    f.write_text("# comment\nJerry => Gerry\nnodelimiter\n\\bAmber up\\b => AmperUp\n")
+    pairs = read_replacements(f)
+    assert pairs == [("Jerry", "Gerry"), ("\\bAmber up\\b", "AmperUp")]
+    assert "nodelimiter" in capsys.readouterr().err
+
+
+def test_apply_replacements_annotates_every_match():
+    text, applied = apply_replacements(
+        "Jerry said hi. Then Jerry left.", [("Jerry", "Gerry")]
+    )
+    assert text == (
+        "Jerry (possible transcribe error, might be 'Gerry') said hi. "
+        "Then Jerry (possible transcribe error, might be 'Gerry') left."
+    )
+    assert applied == ["Jerry => Gerry (x2)"]
+
+
+def test_apply_replacements_regex_and_no_match():
+    text, applied = apply_replacements(
+        "amber up is live", [("[Aa]mber ?up", "AmperUp"), ("Jerry", "Gerry")]
+    )
+    assert "might be 'AmperUp'" in text
+    assert applied == ["[Aa]mber ?up => AmperUp (x1)"]
+
+
+def test_apply_replacements_bad_regex_skipped(capsys):
+    text, applied = apply_replacements("hello", [("(unclosed", "x")])
+    assert text == "hello"
+    assert applied == []
+    assert "bad replacement regex" in capsys.readouterr().err
+
+
+def test_save_replacements_dedupes_by_pattern(tmp_path):
+    f = tmp_path / "transcribe-replacements.txt"
+    assert save_replacements(["Jerry => Gerry"], f) == 0
+    assert save_replacements(["Jerry => Larry", "2020 => 2026"], f) == 0
+    assert f.read_text() == "Jerry => Gerry\n2020 => 2026\n"
+
+
+def test_transcribe_applies_replacements(tmp_path, capsys):
+    audio = tmp_path / "memo.wav"
+    audio.write_bytes(b"RIFF")
+    fake_python = tmp_path / "venv" / "bin" / "python3"
+    repl = tmp_path / "transcribe-replacements.txt"
+    repl.write_text("Jerry => Gerry\n")
+    with (
+        patch("commands.ai_cmd._whisper_python", return_value=fake_python),
+        patch("commands.ai_cmd.HINTS_FILE", tmp_path / "missing.txt"),
+        patch("commands.ai_cmd.REPLACEMENTS_FILE", repl),
+        patch("commands.ai_cmd.subprocess.run") as run,
+    ):
+        run.return_value.returncode = 0
+        run.return_value.stdout = "Jerry said hi.\n"
+        rc = cmd_transcribe(str(audio), [], "en", "base")
+    assert rc == 0
+    out, err = capsys.readouterr()
+    assert out == "Jerry (possible transcribe error, might be 'Gerry') said hi.\n"
+    assert "Jerry => Gerry (x1)" in err
+
+
 def test_transcribe_invokes_whisper_venv(tmp_path):
     audio = tmp_path / "memo.wav"
     audio.write_bytes(b"RIFF")
@@ -208,9 +273,11 @@ def test_transcribe_invokes_whisper_venv(tmp_path):
     with (
         patch("commands.ai_cmd._whisper_python", return_value=fake_python),
         patch("commands.ai_cmd.HINTS_FILE", tmp_path / "missing.txt"),
+        patch("commands.ai_cmd.REPLACEMENTS_FILE", tmp_path / "missing2.txt"),
         patch("commands.ai_cmd.subprocess.run") as run,
     ):
         run.return_value.returncode = 0
+        run.return_value.stdout = "hello\n"
         rc = cmd_transcribe(str(audio), ["Pay-i"], "en", "base")
         assert rc == 0
         argv = run.call_args[0][0]


### PR DESCRIPTION
Adds `n0b ai transcribe <audio>`: local speech-to-text via openai-whisper, no API key.

## Core
- `--hint`/`--hints` (repeatable) + `--language` + `--model` (default `turbo`)
- Hints merge from `~/.config/n0b/transcribe-hints.txt` (one per line, `#` comments) and feed Whisper's `initial_prompt` to bias proper nouns
- Dedicated venv at `~/.cache/n0b/whisper-venv`, bootstrapped on first use — keeps torch out of the repo venv, matching the per-backend-venv pattern of the other `ai` subcommands
- Transcript is the only stdout; everything else goes to stderr, so `> memo.txt` is safe even on first run

## From live use
- stderr status: merged hints with per-source counts, model loading, language, and a progress bar over the audio — long pauses are never ambiguous
- `--save` appends the given `--hint`/`--replace` values to their global config files (deduped) so growing the glossary doesn't mean editing files by hand; with no audio it saves and exits

## Replacements (post-transcription)
Hints only bias decoding; some words lose anyway ("Gerry" reliably transcribes as "Jerry"). `--replace 'Jerry => Gerry'` and `~/.config/n0b/transcribe-replacements.txt` hold regex `wrong => right` pairs applied **after** transcription — every match is annotated in place as `Jerry (possible transcribe error, might be 'Gerry')`. Deliberately verbose: these transcripts feed agents, and a confident wrong word misleads where an ugly annotation doesn't. stderr reports patterns loaded and which matched.

## Verified
- 33 tests pass (11 new)
- Live: venv bootstrap, tiny + turbo models, hints-file pickup, `--save` dedupe, replacement annotation on real audio

🤖 Generated with [Claude Code](https://claude.com/claude-code)