### PR TITLE
feat(r4t): seat + chat — the human as a roster member, in one window

### DIFF
--- a/apps/a8s/definitions/human.json
+++ b/apps/a8s/definitions/human.json
@@ -1,0 +1,4 @@
+{
+  "description": "Human seat: file-proxy delivery. Messages land as JSON files in <root>/.inbox instead of waking a CLI; read them with `r4t chat` or any file watcher.",
+  "proxy": "file"
+}

--- a/apps/r4t/README.md
+++ b/apps/r4t/README.md
@@ -119,12 +119,18 @@ prior art per layer: [docs/governance.md](docs/governance.md).
 | `active_ttl_rotations` | 3 | Idle passes an agent stays on the crash-recovery watch list | Unbounded watch lists |
 | `rebroadcast_senders` | `["chatroom"]` | Inbound from these is classed bulk; a bulk-triggered turn may post back to that room at most once per suppression window | Two agents looping through a re-broadcasting room |
 
-Class marking ties it together: every envelope r4t releases carries `auto`
-in its header, so a header **without** `auto` was written by a deliberate
-hand — and resets that task's turn budget (human attention licenses more
-work). Suppressed, cut, and excess messages are never silently dropped:
-each becomes one JSON record (reason, count, from, to, task, time) in
-`~/.config/r4t/teams/<node>/dead-letter/`.
+Class marking ties it together — *inside the garden*: every envelope r4t
+releases internally carries `auto` in its header, so an internal header
+**without** `auto` was written by a deliberate hand and resets that task's
+turn budget (human attention licenses more work). The header is
+garden-internal serialization and never crosses egress: external releases
+carry the bare body (class survives as `x_r4t_class` envelope metadata),
+because other a8s nodes must not need to know whether a name is one agent,
+a human, a device, or a whole roster. Symmetrically, headers on inbound
+external messages are untrusted content — a forged header can't join,
+charge, or reset a task. Suppressed, cut, and excess messages are never
+silently dropped: each becomes one JSON record (reason, count, from, to,
+task, time) in `~/.config/r4t/teams/<node>/dead-letter/`.
 
 ## Security model
 

--- a/apps/r4t/README.md
+++ b/apps/r4t/README.md
@@ -72,6 +72,25 @@ Watch it: `a8s logs acme-node -f` (traffic + every governance decision line),
 `r4t status --node acme` (locks, buckets, tasks, dead letters), and the
 dead-letter dir under `~/.config/r4t/teams/acme/`.
 
+## Chat: the human seat
+
+`r4t chat` (from the team repo, or `--node <team>`) is all of the above in
+one window: messages delivered to the roster's human member, turn starts and
+completions, governance events, and an input line that sends as that human.
+Typed lines go to the leader by default; `/to <member>` retargets, `/who`
+shows the roster with live turn locks, `/tasks` the task ledgers, `/quit`
+leaves. Training wheels, not a replacement for autonomy — the team runs
+through normal dispatch with all governance; chat is how you watch and steer
+a young team before letting it run unattended.
+
+Two requirements, both checked at startup with the fix printed: the human
+member's `Address:` must be a registered a8s agent whose definition is a
+file-proxy (`a8s define <agent> ~/bin/apps/a8s/definitions/human.json`), and
+the team namespace must be bound (`a8s namespace <team> <node-agent>`).
+Chat spawns a dedicated router for the human seat (taking over from a shared
+handler if needed — a shared one delays delivery behind long team turns) and
+one for the node if nothing handles it; both stop at `/quit`.
+
 ## Governance knobs
 
 All keys live in the out-of-repo rig config (`~/.config/r4t/rigs.json`).

--- a/apps/r4t/README.md
+++ b/apps/r4t/README.md
@@ -72,24 +72,29 @@ Watch it: `a8s logs acme-node -f` (traffic + every governance decision line),
 `r4t status --node acme` (locks, buckets, tasks, dead letters), and the
 dead-letter dir under `~/.config/r4t/teams/acme/`.
 
-## Chat: the human seat
+## The seat: being the human in the roster
 
-`r4t chat` (from the team repo, or `--node <team>`) is all of the above in
-one window: messages delivered to the roster's human member, turn starts and
-completions, governance events, and an input line that sends as that human.
-Typed lines go to the leader by default; `/to <member>` retargets, `/who`
-shows the roster with live turn locks, `/tasks` the task ledgers, `/quit`
-leaves. Training wheels, not a replacement for autonomy — the team runs
-through normal dispatch with all governance; chat is how you watch and steer
-a young team before letting it run unattended.
+A human roster member is a first-class team address: teammates just
+`tell neil`, outsiders (your phone, another cluster) `tell acme:neil`, and
+both park in the node's seat mailbox under `~/.config/r4t/teams/acme/seat/` —
+no handler, no router, nothing to disconnect. Two surfaces read and speak
+for it:
 
-Two requirements, both checked at startup with the fix printed: the human
-member's `Address:` must be a registered a8s agent whose definition is a
-file-proxy (`a8s define <agent> ~/bin/apps/a8s/definitions/human.json`), and
-the team namespace must be bound (`a8s namespace <team> <node-agent>`).
-Chat spawns a dedicated router for the human seat (taking over from a shared
-handler if needed — a shared one delays delivery behind long team turns) and
-one for the node if nothing handles it; both stop at `/quit`.
+```bash
+r4t seat                    # summary: unread count, attached, doorbell
+r4t seat inbox              # read parked messages (marks them read; --peek, --json)
+r4t seat send "message"     # speak as the human — to the leader
+r4t seat send --to phil "…" # or to a member (runs their turn synchronously)
+```
+
+`r4t seat` is the scriptable surface — an orchestrating agent impersonates
+the human with it directly. `r4t chat` is the human view over the same
+mailbox: one window interleaving seat messages, turn starts/completions,
+and governance events, with an input line (`/to`, `/who`, `/tasks`,
+`/quit`). While chat (or anything touching the presence file) is attached,
+dispatch skips the `Address:` doorbell; detach and the doorbell rings
+again. Training wheels, not a replacement for autonomy — everything still
+flows through normal dispatch and governance.
 
 ## Governance knobs
 

--- a/apps/r4t/chat.py
+++ b/apps/r4t/chat.py
@@ -1,0 +1,509 @@
+"""r4t chat — the human seat for a team, in one window.
+
+Interleaves three streams: messages delivered to the roster's human member,
+r4t turn/event lines from the team's daily log, and router activity from any
+`a8s run` child this process spawns. Typed lines go out as tells from the
+human seat; slash commands inspect the team.
+
+Deliberately transport-respecting: chat never imports a8s code. It reads the
+same on-disk surfaces a8s documents (`~/.a8s/a8s.json`, pid files, the human
+agent's file-proxy inbox), spawns `a8s run` for unhandled agents, and sends
+via the `tell` CLI with TELL_OUTBOX_DIR pointed at the human agent's outbox.
+The human agent must use a file-proxy definition (`"proxy": "file"`) so the
+router delivers messages as JSON files instead of waking a CLI — chat checks
+this at startup and prints the fix if not.
+"""
+from __future__ import annotations
+
+import json
+import os
+import queue
+import signal
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+import state
+from roster import Member, Roster, RosterError, load_roster
+
+POLL_SECONDS = 0.5
+RECENT_ON_START = 3
+
+
+def a8s_home() -> Path:
+    override = os.environ.get("A8S_HOME")
+    return Path(override) if override else Path.home() / ".a8s"
+
+
+def load_a8s_registry(home: Path) -> dict:
+    path = home / "a8s.json"
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {"agents": {}, "aliases": {}, "namespaces": {}}
+    except (OSError, json.JSONDecodeError) as e:
+        raise RuntimeError(f"cannot read a8s registry at {path}: {e}") from e
+
+
+def handler_pid(home: Path, agent: str) -> int | None:
+    pid_file = home / "agents" / agent / "pid"
+    try:
+        pid = int(pid_file.read_text().strip())
+    except (OSError, ValueError):
+        return None
+    if pid <= 0:
+        return None
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return None
+    except PermissionError:
+        pass
+    return pid
+
+
+@dataclass
+class Seat:
+    node: str
+    node_agent: str
+    human: Member
+    human_agent: str
+    human_root: Path
+    inbox_dir: Path
+    outbox_dir: Path
+
+
+def resolve_seat(
+    registry: dict, node: str, roster: Roster
+) -> tuple[Seat | None, list[str]]:
+    """Map roster + a8s registry onto a chat seat, or explain what's missing.
+
+    Returns (seat, problems); seat is None whenever problems is non-empty."""
+    problems: list[str] = []
+    agents = registry.get("agents", {})
+    namespaces = {k.lower(): v for k, v in registry.get("namespaces", {}).items()}
+
+    node_agent = namespaces.get(node.lower())
+    if node_agent is None:
+        problems.append(
+            f"namespace {node!r} is not bound to an a8s agent"
+            f" (try: a8s namespace {node} <agent>)"
+        )
+    elif node_agent not in agents:
+        problems.append(
+            f"namespace {node!r} points at unregistered agent {node_agent!r}"
+            f" (try: a8s add {node_agent} <dir>)"
+        )
+
+    human = next((m for m in roster.members if m.is_human and m.address), None)
+    if human is None:
+        problems.append(
+            "roster has no human member with an Address:"
+            " — add one to ROSTER.md (Status: Human, Address: <a8s-agent>)"
+        )
+        return None, problems
+
+    entry = None
+    human_agent = None
+    for name, e in agents.items():
+        if name.lower() == human.address.lower():
+            human_agent, entry = name, e
+            break
+    if entry is None:
+        problems.append(
+            f"human address {human.address!r} is not a registered a8s agent"
+            f" (try: a8s add {human.address} <dir>)"
+        )
+        return None, problems
+
+    definition_path = Path(entry.get("definition", ""))
+    inbox_spec = None
+    try:
+        definition = json.loads(definition_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        problems.append(f"cannot read {human_agent}'s definition: {e}")
+        definition = {}
+    if definition and definition.get("proxy") != "file":
+        problems.append(
+            f"{human_agent}'s definition is not a file-proxy, so the router"
+            f" would wake a CLI instead of delivering messages as files"
+            f" (try: a8s define {human_agent}"
+            f" $A8S_DIR/definitions/human.json)"
+        )
+    else:
+        inbox_spec = definition.get("inbox_dir")
+
+    if problems:
+        return None, problems
+
+    human_root = Path(entry["root"]).expanduser()
+    raw = (inbox_spec or ".inbox").strip() or ".inbox"
+    inbox = Path(raw).expanduser()
+    if not inbox.is_absolute():
+        inbox = human_root / inbox
+    return (
+        Seat(
+            node=node,
+            node_agent=node_agent,
+            human=human,
+            human_agent=human_agent,
+            human_root=human_root,
+            inbox_dir=inbox,
+            outbox_dir=human_root / ".outbox",
+        ),
+        [],
+    )
+
+
+def render_envelope(envelope: dict) -> str:
+    sender = envelope.get("from", "?")
+    content = (envelope.get("content") or "").strip()
+    files = [
+        e.get("filename")
+        for e in (envelope.get("files") or [])
+        if e.get("filename")
+    ]
+    lines = content.splitlines() or ["(empty)"]
+    out = [f"{sender}: {lines[0]}"]
+    out.extend(f"    {line}" for line in lines[1:])
+    if files:
+        out.append(f"    [files: {', '.join(files)}]")
+    return "\n".join(out)
+
+
+def filter_log_line(line: str) -> str | None:
+    """Compact one team-log line into an activity event, or None to skip.
+
+    The daily log interleaves single-line events with full multi-line turn
+    transcripts; chat shows the events and the turn boundaries, never the
+    transcript bodies."""
+    if line.startswith("r4t: "):
+        return line
+    if line.startswith("## ") and " dispatch " in line:
+        _, _, rest = line.partition(" dispatch ")
+        return f"turn: {rest}"
+    if line.startswith("### Output ("):
+        return f"done: {line[len('### Output ('):].rstrip(')')}"
+    return None
+
+
+def format_tasks(node: str) -> list[str]:
+    tasks_dir = state.team_dir(node) / "tasks"
+    rows: list[str] = []
+    for path in sorted(tasks_dir.glob("*.json")):
+        try:
+            t = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        rows.append(
+            f"{t.get('id', path.stem)}  {t.get('status', '?'):8}"
+            f"  turns={t.get('turns', 0)}"
+            f"  used={t.get('used', 0):.2f}/{t.get('budget', 0):.2f}"
+            f"  creator={t.get('creator', '?')}"
+        )
+    return rows or ["(no task ledgers)"]
+
+
+def format_who(node: str, roster: Roster, home: Path, seat: Seat) -> list[str]:
+    locks = {
+        lock.get("name", "").lower(): lock
+        for lock in state.live_locks(node, prune=False)
+    }
+    rows: list[str] = []
+    for m in roster.members:
+        if m.is_human:
+            handled = handler_pid(home, m.address or "") if m.address else None
+            via = f"address {m.address}" + (
+                f", routed by PID {handled}" if handled else ", no router"
+            )
+            rows.append(f"{m.name:12} human   {via}")
+            continue
+        lock = locks.get(m.name.lower())
+        status = f"ACTIVE (pid {lock.get('pid')})" if lock else "idle"
+        leader = " leader" if m.leader else ""
+        rows.append(f"{m.name:12} {m.rig or '?':7} {status}{leader}")
+    node_pid = handler_pid(home, seat.node_agent)
+    rows.append(
+        f"{'[' + seat.node_agent + ']':12} node    "
+        + (f"routed by PID {node_pid}" if node_pid else "NO ROUTER")
+    )
+    return rows
+
+
+HELP = """\
+/to <name|node>   set message target (bare node = leader)
+/who              roster, live turn locks, router pids
+/tasks            task ledgers for this team
+/help             this help
+/quit             leave (spawned routers are stopped)"""
+
+
+class ChatSession:
+    def __init__(self, seat: Seat, roster: Roster, *, home: Path | None = None):
+        self.seat = seat
+        self.roster = roster
+        self.home = home or a8s_home()
+        self.target = seat.node
+        self.events: queue.Queue[tuple[str, str]] = queue.Queue()
+        self.children: list[subprocess.Popen] = []
+        self.seen: set[str] = set()
+        self.log_path: Path | None = None
+        self.log_offset = 0
+        self.quitting = False
+        self.tty = sys.stdout.isatty()
+
+    # ---------- output ----------
+
+    _STYLE = {"in": "\x1b[36m", "you": "\x1b[32m", "sys": "\x1b[33m", "act": "\x1b[2m"}
+
+    def emit(self, kind: str, text: str) -> None:
+        stamp = datetime.now().strftime("%H:%M:%S")
+        for line in text.splitlines():
+            if self.tty:
+                print(f"\x1b[2m{stamp}\x1b[0m {self._STYLE[kind]}{line}\x1b[0m")
+            else:
+                print(f"{stamp} {line}")
+        sys.stdout.flush()
+
+    # ---------- plumbing ----------
+
+    def ensure_routers(self) -> None:
+        """Human seat always gets a dedicated router: a shared handler drains
+        no inboxes while any wake is in flight, so replies to the human can
+        sit undelivered behind a teammate's long turn. The node keeps an
+        existing handler if it has one — its wakes are the team's business."""
+        human, node = self.seat.human_agent, self.seat.node_agent
+        human_holder = handler_pid(self.home, human)
+        if human_holder:
+            self.emit(
+                "sys",
+                f"{human}: taking over from PID {human_holder} for dedicated"
+                f" delivery (restart that router after /quit if you still need it)",
+            )
+        self._spawn_router(human)
+        if human != node:
+            node_pid = handler_pid(self.home, node)
+            if node_pid:
+                self.emit("sys", f"{node}: already routed by PID {node_pid}")
+            else:
+                self._spawn_router(node)
+
+    def _spawn_router(self, agent: str) -> None:
+        child = subprocess.Popen(
+            ["a8s", "run", agent],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            stdin=subprocess.DEVNULL,
+            text=True,
+            start_new_session=True,
+        )
+        self.children.append(child)
+        threading.Thread(
+            target=self._pump_child, args=(agent, child), daemon=True
+        ).start()
+        self.emit("sys", f"{agent}: started router (PID {child.pid})")
+
+    def _pump_child(self, agent: str, child: subprocess.Popen) -> None:
+        assert child.stdout is not None
+        for line in child.stdout:
+            self.events.put(("act", line.rstrip()))
+        if not self.quitting:
+            self.events.put(("sys", f"{agent}: router exited ({child.returncode})"))
+
+    def stop_children(self) -> None:
+        self.quitting = True
+        for child in self.children:
+            if child.poll() is None:
+                child.send_signal(signal.SIGINT)
+        deadline = time.monotonic() + 5
+        for child in self.children:
+            remaining = max(0.1, deadline - time.monotonic())
+            try:
+                child.wait(timeout=remaining)
+            except subprocess.TimeoutExpired:
+                child.kill()
+
+    # ---------- polling ----------
+
+    def poll_inbox(self, *, announce: bool = True) -> None:
+        try:
+            files = sorted(
+                f for f in self.seat.inbox_dir.iterdir()
+                if f.is_file() and f.name.endswith(".json")
+            )
+        except OSError:
+            return
+        for f in files:
+            if f.name in self.seen:
+                continue
+            self.seen.add(f.name)
+            if not announce:
+                continue
+            try:
+                envelope = json.loads(f.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            self.events.put(("in", render_envelope(envelope)))
+
+    def seed_inbox(self) -> None:
+        """Mark pre-existing messages seen, replaying only the newest few."""
+        try:
+            files = sorted(
+                f for f in self.seat.inbox_dir.iterdir()
+                if f.is_file() and f.name.endswith(".json")
+            )
+        except OSError:
+            return
+        for f in files[:-RECENT_ON_START] if RECENT_ON_START else files:
+            self.seen.add(f.name)
+        if files[-RECENT_ON_START:]:
+            self.emit("sys", "recent messages:")
+        self.poll_inbox()
+
+    def poll_log(self) -> None:
+        path = state.team_dir(self.seat.node) / "log" / (
+            datetime.now().strftime("%Y-%m-%d") + ".md"
+        )
+        if path != self.log_path:
+            self.log_path = path
+            self.log_offset = path.stat().st_size if path.is_file() else 0
+            return
+        if not path.is_file():
+            return
+        size = path.stat().st_size
+        if size <= self.log_offset:
+            self.log_offset = min(self.log_offset, size)
+            return
+        with path.open("r", encoding="utf-8") as f:
+            f.seek(self.log_offset)
+            chunk = f.read()
+            self.log_offset = f.tell()
+        for line in chunk.splitlines():
+            event = filter_log_line(line)
+            if event:
+                self.events.put(("act", event))
+
+    # ---------- input ----------
+
+    def _read_stdin(self, lines: queue.Queue[str]) -> None:
+        for line in sys.stdin:
+            lines.put(line.rstrip("\n"))
+        lines.put("/quit")
+
+    def handle_line(self, line: str) -> bool:
+        """Returns False when the session should end."""
+        line = line.strip()
+        if not line:
+            return True
+        if line.startswith("/"):
+            cmd, _, arg = line.partition(" ")
+            cmd = cmd.lower()
+            if cmd == "/quit":
+                return False
+            if cmd == "/help":
+                self.emit("sys", HELP)
+            elif cmd == "/to":
+                arg = arg.strip().lower()
+                if not arg or arg == self.seat.node:
+                    self.target = self.seat.node
+                elif any(
+                    not m.is_human and m.name.lower() == arg
+                    for m in self.roster.members
+                ):
+                    self.target = f"{self.seat.node}:{arg}"
+                else:
+                    self.emit("sys", f"no AI member named {arg!r} in the roster")
+                    return True
+                self.emit("sys", f"target: {self.target}")
+            elif cmd == "/who":
+                self.emit(
+                    "sys",
+                    "\n".join(
+                        format_who(self.seat.node, self.roster, self.home, self.seat)
+                    ),
+                )
+            elif cmd == "/tasks":
+                self.emit("sys", "\n".join(format_tasks(self.seat.node)))
+            else:
+                self.emit("sys", f"unknown command {cmd!r} (/help)")
+            return True
+        self.send(line)
+        return True
+
+    def send(self, text: str) -> None:
+        env = dict(os.environ)
+        env["TELL_OUTBOX_DIR"] = str(self.seat.outbox_dir)
+        proc = subprocess.run(
+            ["tell", self.target, text],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        if proc.returncode != 0:
+            self.emit("sys", f"tell failed: {proc.stderr.strip() or proc.stdout.strip()}")
+            return
+        self.emit("you", f"you -> {self.target}: {text}")
+
+    # ---------- main loop ----------
+
+    def run(self) -> int:
+        self.emit(
+            "sys",
+            f"chat: {self.seat.node} — you are {self.seat.human.name}"
+            f" ({self.seat.human_agent}); messages go to {self.target}"
+            f" (leader). /help for commands.",
+        )
+        self.ensure_routers()
+        self.seed_inbox()
+        self.poll_log()
+
+        lines: queue.Queue[str] = queue.Queue()
+        threading.Thread(target=self._read_stdin, args=(lines,), daemon=True).start()
+        try:
+            while True:
+                try:
+                    while True:
+                        if not self.handle_line(lines.get_nowait()):
+                            return 0
+                except queue.Empty:
+                    pass
+                self.poll_inbox()
+                self.poll_log()
+                try:
+                    while True:
+                        kind, text = self.events.get_nowait()
+                        self.emit(kind, text)
+                except queue.Empty:
+                    pass
+                time.sleep(POLL_SECONDS)
+        except KeyboardInterrupt:
+            return 0
+        finally:
+            self.stop_children()
+            if self.children:
+                self.emit("sys", "stopped spawned routers; other routers untouched")
+
+
+def run_chat(node: str, roster_path: Path) -> int:
+    try:
+        roster = load_roster(roster_path)
+    except RosterError as e:
+        print(f"r4t chat: {e}", file=sys.stderr)
+        return 2
+    home = a8s_home()
+    try:
+        registry = load_a8s_registry(home)
+    except RuntimeError as e:
+        print(f"r4t chat: {e}", file=sys.stderr)
+        return 2
+    seat, problems = resolve_seat(registry, node, roster)
+    if seat is None:
+        print("r4t chat: not ready:", file=sys.stderr)
+        for p in problems:
+            print(f"  ✗ {p}", file=sys.stderr)
+        return 2
+    return ChatSession(seat, roster, home=home).run()

--- a/apps/r4t/chat.py
+++ b/apps/r4t/chat.py
@@ -1,177 +1,40 @@
-"""r4t chat — the human seat for a team, in one window.
+"""r4t chat — the roster human's seat at the team, in one window.
 
-Interleaves three streams: messages delivered to the roster's human member,
-r4t turn/event lines from the team's daily log, and router activity from any
-`a8s run` child this process spawns. Typed lines go out as tells from the
-human seat; slash commands inspect the team.
+Interleaves the seat mailbox (messages parked for the human by dispatch),
+r4t turn/event lines from the team's daily log, and an input line that
+speaks as the human. There is no a8s coupling: intra-team mail rides the
+node's own pending queue, sends invoke dispatch directly, and a presence
+file tells dispatch to skip the `Address:` doorbell while a session is
+attached. The walled garden works with zero routers; a8s only matters for
+traffic crossing the wall.
 
-Deliberately transport-respecting: chat never imports a8s code. It reads the
-same on-disk surfaces a8s documents (`~/.a8s/a8s.json`, pid files, the human
-agent's file-proxy inbox), spawns `a8s run` for unhandled agents, and sends
-via the `tell` CLI with TELL_OUTBOX_DIR pointed at the human agent's outbox.
-The human agent must use a file-proxy definition (`"proxy": "file"`) so the
-router delivers messages as JSON files instead of waking a CLI — chat checks
-this at startup and prints the fix if not.
+`r4t seat` exposes the same mailbox and voice as discrete commands — that
+is the surface for orchestrators impersonating the human; chat is the
+human-facing view over it.
 """
 from __future__ import annotations
 
 import json
-import os
 import queue
-import signal
-import subprocess
 import sys
 import threading
 import time
-from dataclasses import dataclass
 from datetime import datetime
-from pathlib import Path
 
 import state
+import tasks as taskmod
+from dispatch import DispatchContext, drain_until_quiet, handle_message
 from roster import Member, Roster, RosterError, load_roster
 
 POLL_SECONDS = 0.5
-RECENT_ON_START = 3
-
-
-def a8s_home() -> Path:
-    override = os.environ.get("A8S_HOME")
-    return Path(override) if override else Path.home() / ".a8s"
-
-
-def load_a8s_registry(home: Path) -> dict:
-    path = home / "a8s.json"
-    try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except FileNotFoundError:
-        return {"agents": {}, "aliases": {}, "namespaces": {}}
-    except (OSError, json.JSONDecodeError) as e:
-        raise RuntimeError(f"cannot read a8s registry at {path}: {e}") from e
-
-
-def handler_pid(home: Path, agent: str) -> int | None:
-    pid_file = home / "agents" / agent / "pid"
-    try:
-        pid = int(pid_file.read_text().strip())
-    except (OSError, ValueError):
-        return None
-    if pid <= 0:
-        return None
-    try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
-        return None
-    except PermissionError:
-        pass
-    return pid
-
-
-@dataclass
-class Seat:
-    node: str
-    node_agent: str
-    human: Member
-    human_agent: str
-    human_root: Path
-    inbox_dir: Path
-    outbox_dir: Path
-
-
-def resolve_seat(
-    registry: dict, node: str, roster: Roster
-) -> tuple[Seat | None, list[str]]:
-    """Map roster + a8s registry onto a chat seat, or explain what's missing.
-
-    Returns (seat, problems); seat is None whenever problems is non-empty."""
-    problems: list[str] = []
-    agents = registry.get("agents", {})
-    namespaces = {k.lower(): v for k, v in registry.get("namespaces", {}).items()}
-
-    node_agent = namespaces.get(node.lower())
-    if node_agent is None:
-        problems.append(
-            f"namespace {node!r} is not bound to an a8s agent"
-            f" (try: a8s namespace {node} <agent>)"
-        )
-    elif node_agent not in agents:
-        problems.append(
-            f"namespace {node!r} points at unregistered agent {node_agent!r}"
-            f" (try: a8s add {node_agent} <dir>)"
-        )
-
-    human = next((m for m in roster.members if m.is_human and m.address), None)
-    if human is None:
-        problems.append(
-            "roster has no human member with an Address:"
-            " — add one to ROSTER.md (Status: Human, Address: <a8s-agent>)"
-        )
-        return None, problems
-
-    entry = None
-    human_agent = None
-    for name, e in agents.items():
-        if name.lower() == human.address.lower():
-            human_agent, entry = name, e
-            break
-    if entry is None:
-        problems.append(
-            f"human address {human.address!r} is not a registered a8s agent"
-            f" (try: a8s add {human.address} <dir>)"
-        )
-        return None, problems
-
-    definition_path = Path(entry.get("definition", ""))
-    inbox_spec = None
-    try:
-        definition = json.loads(definition_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as e:
-        problems.append(f"cannot read {human_agent}'s definition: {e}")
-        definition = {}
-    if definition and definition.get("proxy") != "file":
-        problems.append(
-            f"{human_agent}'s definition is not a file-proxy, so the router"
-            f" would wake a CLI instead of delivering messages as files"
-            f" (try: a8s define {human_agent}"
-            f" $A8S_DIR/definitions/human.json)"
-        )
-    else:
-        inbox_spec = definition.get("inbox_dir")
-
-    if problems:
-        return None, problems
-
-    human_root = Path(entry["root"]).expanduser()
-    raw = (inbox_spec or ".inbox").strip() or ".inbox"
-    inbox = Path(raw).expanduser()
-    if not inbox.is_absolute():
-        inbox = human_root / inbox
-    return (
-        Seat(
-            node=node,
-            node_agent=node_agent,
-            human=human,
-            human_agent=human_agent,
-            human_root=human_root,
-            inbox_dir=inbox,
-            outbox_dir=human_root / ".outbox",
-        ),
-        [],
-    )
 
 
 def render_envelope(envelope: dict) -> str:
     sender = envelope.get("from", "?")
-    content = (envelope.get("content") or "").strip()
-    files = [
-        e.get("filename")
-        for e in (envelope.get("files") or [])
-        if e.get("filename")
-    ]
-    lines = content.splitlines() or ["(empty)"]
+    _, _, _, body = taskmod.parse_header(str(envelope.get("content", "")))
+    lines = body.strip().splitlines() or ["(empty)"]
     out = [f"{sender}: {lines[0]}"]
     out.extend(f"    {line}" for line in lines[1:])
-    if files:
-        out.append(f"    [files: {', '.join(files)}]")
     return "\n".join(out)
 
 
@@ -192,23 +55,18 @@ def filter_log_line(line: str) -> str | None:
 
 
 def format_tasks(node: str) -> list[str]:
-    tasks_dir = state.team_dir(node) / "tasks"
     rows: list[str] = []
-    for path in sorted(tasks_dir.glob("*.json")):
-        try:
-            t = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            continue
+    for t in taskmod.list_tasks(node):
         rows.append(
-            f"{t.get('id', path.stem)}  {t.get('status', '?'):8}"
+            f"{t.get('id', '?')}  {t.get('status', '?'):8}"
             f"  turns={t.get('turns', 0)}"
             f"  used={t.get('used', 0):.2f}/{t.get('budget', 0):.2f}"
             f"  creator={t.get('creator', '?')}"
         )
-    return rows or ["(no task ledgers)"]
+    return rows or ["(no open tasks)"]
 
 
-def format_who(node: str, roster: Roster, home: Path, seat: Seat) -> list[str]:
+def format_who(node: str, roster: Roster, human: Member) -> list[str]:
     locks = {
         lock.get("name", "").lower(): lock
         for lock in state.live_locks(node, prune=False)
@@ -216,44 +74,35 @@ def format_who(node: str, roster: Roster, home: Path, seat: Seat) -> list[str]:
     rows: list[str] = []
     for m in roster.members:
         if m.is_human:
-            handled = handler_pid(home, m.address or "") if m.address else None
-            via = f"address {m.address}" + (
-                f", routed by PID {handled}" if handled else ", no router"
-            )
-            rows.append(f"{m.name:12} human   {via}")
+            seat = "you" if m.name == human.name else "human"
+            bell = f", doorbell {m.address}" if m.address else ""
+            rows.append(f"{m.name:12} human   ({seat}{bell})")
             continue
         lock = locks.get(m.name.lower())
         status = f"ACTIVE (pid {lock.get('pid')})" if lock else "idle"
         leader = " leader" if m.leader else ""
         rows.append(f"{m.name:12} {m.rig or '?':7} {status}{leader}")
-    node_pid = handler_pid(home, seat.node_agent)
-    rows.append(
-        f"{'[' + seat.node_agent + ']':12} node    "
-        + (f"routed by PID {node_pid}" if node_pid else "NO ROUTER")
-    )
     return rows
 
 
 HELP = """\
-/to <name|node>   set message target (bare node = leader)
-/who              roster, live turn locks, router pids
+/to <name|team>   set message target (bare team = leader)
+/who              roster and live turn locks
 /tasks            task ledgers for this team
 /help             this help
-/quit             leave (spawned routers are stopped)"""
+/quit             leave the seat"""
 
 
 class ChatSession:
-    def __init__(self, seat: Seat, roster: Roster, *, home: Path | None = None):
-        self.seat = seat
+    def __init__(self, ctx: DispatchContext, roster: Roster, human: Member):
+        self.ctx = ctx
         self.roster = roster
-        self.home = home or a8s_home()
-        self.target = seat.node
+        self.human = human
+        self.target = ctx.node
         self.events: queue.Queue[tuple[str, str]] = queue.Queue()
-        self.children: list[subprocess.Popen] = []
-        self.seen: set[str] = set()
-        self.log_path: Path | None = None
+        self.sends: queue.Queue[tuple[str, str]] = queue.Queue()
+        self.log_path = None
         self.log_offset = 0
-        self.quitting = False
         self.tty = sys.stdout.isatty()
 
     # ---------- output ----------
@@ -269,103 +118,19 @@ class ChatSession:
                 print(f"{stamp} {line}")
         sys.stdout.flush()
 
-    # ---------- plumbing ----------
-
-    def ensure_routers(self) -> None:
-        """Human seat always gets a dedicated router: a shared handler drains
-        no inboxes while any wake is in flight, so replies to the human can
-        sit undelivered behind a teammate's long turn. The node keeps an
-        existing handler if it has one — its wakes are the team's business."""
-        human, node = self.seat.human_agent, self.seat.node_agent
-        human_holder = handler_pid(self.home, human)
-        if human_holder:
-            self.emit(
-                "sys",
-                f"{human}: taking over from PID {human_holder} for dedicated"
-                f" delivery (restart that router after /quit if you still need it)",
-            )
-        self._spawn_router(human)
-        if human != node:
-            node_pid = handler_pid(self.home, node)
-            if node_pid:
-                self.emit("sys", f"{node}: already routed by PID {node_pid}")
-            else:
-                self._spawn_router(node)
-
-    def _spawn_router(self, agent: str) -> None:
-        child = subprocess.Popen(
-            ["a8s", "run", agent],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            stdin=subprocess.DEVNULL,
-            text=True,
-            start_new_session=True,
-        )
-        self.children.append(child)
-        threading.Thread(
-            target=self._pump_child, args=(agent, child), daemon=True
-        ).start()
-        self.emit("sys", f"{agent}: started router (PID {child.pid})")
-
-    def _pump_child(self, agent: str, child: subprocess.Popen) -> None:
-        assert child.stdout is not None
-        for line in child.stdout:
-            self.events.put(("act", line.rstrip()))
-        if not self.quitting:
-            self.events.put(("sys", f"{agent}: router exited ({child.returncode})"))
-
-    def stop_children(self) -> None:
-        self.quitting = True
-        for child in self.children:
-            if child.poll() is None:
-                child.send_signal(signal.SIGINT)
-        deadline = time.monotonic() + 5
-        for child in self.children:
-            remaining = max(0.1, deadline - time.monotonic())
-            try:
-                child.wait(timeout=remaining)
-            except subprocess.TimeoutExpired:
-                child.kill()
-
     # ---------- polling ----------
 
-    def poll_inbox(self, *, announce: bool = True) -> None:
-        try:
-            files = sorted(
-                f for f in self.seat.inbox_dir.iterdir()
-                if f.is_file() and f.name.endswith(".json")
-            )
-        except OSError:
-            return
-        for f in files:
-            if f.name in self.seen:
-                continue
-            self.seen.add(f.name)
-            if not announce:
-                continue
+    def poll_inbox(self) -> None:
+        for path in state.list_seat_messages(self.ctx.node, self.human.name):
             try:
-                envelope = json.loads(f.read_text(encoding="utf-8"))
+                envelope = json.loads(path.read_text(encoding="utf-8"))
             except (OSError, json.JSONDecodeError):
                 continue
             self.events.put(("in", render_envelope(envelope)))
-
-    def seed_inbox(self) -> None:
-        """Mark pre-existing messages seen, replaying only the newest few."""
-        try:
-            files = sorted(
-                f for f in self.seat.inbox_dir.iterdir()
-                if f.is_file() and f.name.endswith(".json")
-            )
-        except OSError:
-            return
-        for f in files[:-RECENT_ON_START] if RECENT_ON_START else files:
-            self.seen.add(f.name)
-        if files[-RECENT_ON_START:]:
-            self.emit("sys", "recent messages:")
-        self.poll_inbox()
+            state.mark_seat_read(self.ctx.node, self.human.name, path)
 
     def poll_log(self) -> None:
-        path = state.team_dir(self.seat.node) / "log" / (
+        path = state.team_dir(self.ctx.node) / "log" / (
             datetime.now().strftime("%Y-%m-%d") + ".md"
         )
         if path != self.log_path:
@@ -386,6 +151,19 @@ class ChatSession:
             event = filter_log_line(line)
             if event:
                 self.events.put(("act", event))
+
+    # ---------- sending ----------
+
+    def _send_worker(self) -> None:
+        sender = f"{self.ctx.node}:{self.human.name.lower()}"
+        while True:
+            to, text = self.sends.get()
+            try:
+                drain_until_quiet(self.ctx)
+                handle_message(self.ctx, sender, to, text)
+                drain_until_quiet(self.ctx)
+            except Exception as e:  # noqa: BLE001 — surface, don't kill the seat
+                self.events.put(("sys", f"send failed: {e}"))
 
     # ---------- input ----------
 
@@ -408,13 +186,13 @@ class ChatSession:
                 self.emit("sys", HELP)
             elif cmd == "/to":
                 arg = arg.strip().lower()
-                if not arg or arg == self.seat.node:
-                    self.target = self.seat.node
+                if not arg or arg == self.ctx.node:
+                    self.target = self.ctx.node
                 elif any(
                     not m.is_human and m.name.lower() == arg
                     for m in self.roster.members
                 ):
-                    self.target = f"{self.seat.node}:{arg}"
+                    self.target = f"{self.ctx.node}:{arg}"
                 else:
                     self.emit("sys", f"no AI member named {arg!r} in the roster")
                     return True
@@ -422,45 +200,30 @@ class ChatSession:
             elif cmd == "/who":
                 self.emit(
                     "sys",
-                    "\n".join(
-                        format_who(self.seat.node, self.roster, self.home, self.seat)
-                    ),
+                    "\n".join(format_who(self.ctx.node, self.roster, self.human)),
                 )
             elif cmd == "/tasks":
-                self.emit("sys", "\n".join(format_tasks(self.seat.node)))
+                self.emit("sys", "\n".join(format_tasks(self.ctx.node)))
             else:
                 self.emit("sys", f"unknown command {cmd!r} (/help)")
             return True
-        self.send(line)
+        self.sends.put((self.target, line))
+        self.emit("you", f"you -> {self.target}: {line}")
         return True
-
-    def send(self, text: str) -> None:
-        env = dict(os.environ)
-        env["TELL_OUTBOX_DIR"] = str(self.seat.outbox_dir)
-        proc = subprocess.run(
-            ["tell", self.target, text],
-            env=env,
-            capture_output=True,
-            text=True,
-        )
-        if proc.returncode != 0:
-            self.emit("sys", f"tell failed: {proc.stderr.strip() or proc.stdout.strip()}")
-            return
-        self.emit("you", f"you -> {self.target}: {text}")
 
     # ---------- main loop ----------
 
     def run(self) -> int:
         self.emit(
             "sys",
-            f"chat: {self.seat.node} — you are {self.seat.human.name}"
-            f" ({self.seat.human_agent}); messages go to {self.target}"
-            f" (leader). /help for commands.",
+            f"seat: {self.human.name} on {self.ctx.node} — messages go to"
+            f" {self.target} (leader). /help for commands.",
         )
-        self.ensure_routers()
-        self.seed_inbox()
+        state.touch_seat_presence(self.ctx.node, self.human.name)
         self.poll_log()
+        self.poll_inbox()
 
+        threading.Thread(target=self._send_worker, daemon=True).start()
         lines: queue.Queue[str] = queue.Queue()
         threading.Thread(target=self._read_stdin, args=(lines,), daemon=True).start()
         try:
@@ -471,6 +234,7 @@ class ChatSession:
                             return 0
                 except queue.Empty:
                     pass
+                state.touch_seat_presence(self.ctx.node, self.human.name)
                 self.poll_inbox()
                 self.poll_log()
                 try:
@@ -483,27 +247,22 @@ class ChatSession:
         except KeyboardInterrupt:
             return 0
         finally:
-            self.stop_children()
-            if self.children:
-                self.emit("sys", "stopped spawned routers; other routers untouched")
+            state.clear_seat_presence(self.ctx.node, self.human.name)
+            self.emit("sys", "seat detached — mail parks and the doorbell rings again")
 
 
-def run_chat(node: str, roster_path: Path) -> int:
+def run_chat(ctx: DispatchContext) -> int:
     try:
-        roster = load_roster(roster_path)
+        roster = load_roster(ctx.roster_path)
     except RosterError as e:
         print(f"r4t chat: {e}", file=sys.stderr)
         return 2
-    home = a8s_home()
-    try:
-        registry = load_a8s_registry(home)
-    except RuntimeError as e:
-        print(f"r4t chat: {e}", file=sys.stderr)
+    human = next((m for m in roster.members if m.is_human), None)
+    if human is None:
+        print(
+            "r4t chat: no human member in the roster — add one to ROSTER.md "
+            "(Status: Human)",
+            file=sys.stderr,
+        )
         return 2
-    seat, problems = resolve_seat(registry, node, roster)
-    if seat is None:
-        print("r4t chat: not ready:", file=sys.stderr)
-        for p in problems:
-            print(f"  ✗ {p}", file=sys.stderr)
-        return 2
-    return ChatSession(seat, roster, home=home).run()
+    return ChatSession(ctx, roster, human).run()

--- a/apps/r4t/dispatch.py
+++ b/apps/r4t/dispatch.py
@@ -579,6 +579,23 @@ def _run_turn(
         ctx, config, roster, member, rig, task_id, hop, bulk_source=bulk_source,
         synthesis_response=synthesis_response,
     )
+    if (
+        release["released"] == 0
+        and release["violations"] == 0
+        and exit_code == 0
+        and not timed_out
+        and len(output.strip()) > 80
+    ):
+        # The classic weak-rig failure: the model answers on stdout instead
+        # of running `tell`, the turn "succeeds", and the answer vanishes
+        # into the log. Make it visible — the quiet-task backstop will close
+        # the task later, but the operator should see WHY it went quiet.
+        state.append_log(
+            ctx.node,
+            f"r4t: SILENT {member.name.lower()} (rig {rig.name}) exit 0 with "
+            f"{len(output.strip())} bytes of stdout but released no messages "
+            "— likely answered in text instead of running `tell`",
+        )
     if release["violations"]:
         level = state.bucket_drain(
             ctx.node, member.name, float(release["violations"]), config.bucket_max

--- a/apps/r4t/dispatch.py
+++ b/apps/r4t/dispatch.py
@@ -123,7 +123,8 @@ def _park_seat(ctx: DispatchContext, member: Member, sender: str, message: str) 
     state.park_seat_message(ctx.node, member.name, sender, message)
     bell = ""
     if member.address and not state.seat_attached(ctx.node, member.name):
-        ctx.tell_fn(member.address, message)
+        _, _, _, bell_body = tasks.parse_header(message)
+        ctx.tell_fn(member.address, bell_body)
         bell = f", doorbell -> {member.address}"
     state.append_log(
         ctx.node,
@@ -292,7 +293,6 @@ def _release_one(
     outbox: Path,
     staging: Path,
     envelope: dict,
-    stamped_content: str,
     sender_addr: str,
     task_id: str,
     next_hop: int,
@@ -325,7 +325,11 @@ def _release_one(
             f"r4t: RELEASED-internal {sender_addr} -> {to} task={task_id} hop={next_hop}",
         )
         return
-    envelope["content"] = stamped_content
+    # Egress protocol: the r4t header never leaves the garden. Other a8s
+    # nodes must not need to know whether a name is one agent, a human, a
+    # device, or a whole roster — class marking survives as envelope
+    # metadata only.
+    envelope["content"] = body
     envelope["x_r4t_class"] = "auto"
     envelope["from"] = sender_addr
     outbox.mkdir(parents=True, exist_ok=True)
@@ -461,7 +465,6 @@ def release_staging(
                     f"r4t: BULK-WINDOW {sender_addr} -> {to} task={task_id} repeat={count}",
                 )
                 continue
-        stamped = f"{tasks.format_header(task_id, next_hop, auto=True)} {body}"
         state.append_history(
             ctx.node,
             member.name,
@@ -474,7 +477,7 @@ def release_staging(
             and to.lower() == synthesis_creator.lower()
         )
         _release_one(
-            ctx, outbox, staging, envelope, stamped, sender_addr, task_id, next_hop,
+            ctx, outbox, staging, envelope, sender_addr, task_id, next_hop,
             body, final_response,
         )
         path.unlink(missing_ok=True)
@@ -740,6 +743,8 @@ def _handle(
     *,
     run_fn=run_harness,
     synthesis_response: bool = False,
+    trusted_header: bool = True,
+    suppression_checked: bool = False,
 ) -> str:
     _, sub = split_recipient(to)
 
@@ -793,7 +798,14 @@ def _handle(
 
     state.refresh_active(ctx.node, member.name, config.active_ttl_rotations)
 
-    task_id, hop, auto, body = tasks.parse_header(message)
+    if trusted_header:
+        task_id, hop, auto, body = tasks.parse_header(message)
+    else:
+        # Ingress protocol: headers never legitimately arrive from outside
+        # the garden (egress strips them), so an external header is either
+        # noise or a forgery aimed at an existing task's budget/breaker —
+        # treat the whole message as content.
+        task_id, hop, auto, body = None, None, False, message
     had_header = task_id is not None
     if task_id is None:
         task_id = tasks.new_task_id()
@@ -880,7 +892,13 @@ def _handle(
 
     # Intra-team traffic was already suppression-checked at release (same
     # store, same key) — re-checking here would suppress every delivery.
-    if (auto and not _is_internal(ctx.node, sender)) or bulk_source:
+    # External headers are untrusted, so machine/human can't be told apart:
+    # every external repeat within the window dead-letters (recorded, never
+    # silent). The check registers the pair key, so it must run at most
+    # once per message: a deferred message re-presented by drain would
+    # otherwise be suppressed as its own repeat (observed live — a phone
+    # message hit the throttle, deferred, and died on redispatch).
+    if not _is_internal(ctx.node, sender) and not suppression_checked:
         repeated, count = state.suppression_check(
             ctx.node,
             tasks.pair_key(sender, to, body),
@@ -896,6 +914,7 @@ def _handle(
                 f"r4t: SUPPRESSED inbound {sender} -> {to} task={task_id} repeat={count}",
             )
             return DEAD
+    envelope["checked"] = True
 
     breaker_blocked, failures = state.breaker_open(
         ctx.node, member.name, config.breaker_cap, config.breaker_cooldown_seconds
@@ -1079,7 +1098,10 @@ def handle_message(
     *,
     run_fn=run_harness,
 ) -> int:
-    _handle(ctx, sender, to, message, run_fn=run_fn)
+    _handle(
+        ctx, sender, to, message, run_fn=run_fn,
+        trusted_header=_is_internal(ctx.node, sender),
+    )
     return 0
 
 
@@ -1115,6 +1137,7 @@ def _redispatch(ctx: DispatchContext, envelope: dict, *, run_fn=run_harness) -> 
         message,
         run_fn=run_fn,
         synthesis_response=bool(envelope.get("synthesis_response", False)),
+        suppression_checked=bool(envelope.get("checked")),
     )
 
 

--- a/apps/r4t/dispatch.py
+++ b/apps/r4t/dispatch.py
@@ -1119,17 +1119,26 @@ def _redispatch(ctx: DispatchContext, envelope: dict, *, run_fn=run_harness) -> 
 
 
 def drain(ctx: DispatchContext, *, run_fn=run_harness) -> int:
-    """One pass over the pending queue. Each file is consumed before
-    redispatch so a re-defer creates a fresh entry instead of looping.
-    Returns the number of turns that actually RAN."""
+    """One pass over the pending queue. Each file is claimed by atomic
+    rename before redispatch: concurrent drainers (an a8s-woken dispatch
+    and a `seat send`, say) race on the rename and exactly one wins — a
+    read-then-unlink claim would let both redispatch the same envelope.
+    The claim is consumed before redispatch so a re-defer creates a fresh
+    entry instead of looping. Returns the number of turns that RAN."""
     ran = 0
+    state.recover_dead_claims(ctx.node)
     for path in state.list_pending(ctx.node):
+        claim = path.with_name(f"{path.name}.claim-{os.getpid()}")
         try:
-            envelope = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            path.unlink(missing_ok=True)
+            os.rename(str(path), str(claim))
+        except OSError:
             continue
-        path.unlink(missing_ok=True)
+        try:
+            envelope = json.loads(claim.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            claim.unlink(missing_ok=True)
+            continue
+        claim.unlink(missing_ok=True)
         if isinstance(envelope, dict):
             if _redispatch(ctx, envelope, run_fn=run_fn) in (RAN, SYNTHESIS):
                 ran += 1

--- a/apps/r4t/dispatch.py
+++ b/apps/r4t/dispatch.py
@@ -79,10 +79,11 @@ def _display_name(node: str, addr: str) -> str:
 
 def _canonical_recipient(node: str, roster: Roster, to: str) -> str:
     """Agents address the walled garden by bare first name; the wire uses
-    `node:name`. Bare roster names canonicalize to internal form, humans
-    (bare or prefixed) resolve to their real a8s address, and anything
-    else — `chatroom`, external addresses, unknown names — passes through
-    untouched."""
+    `node:name`. Bare roster names — humans included — canonicalize to
+    internal form; anything else (`chatroom`, external addresses, unknown
+    names) passes through untouched. Human members are internal on purpose:
+    their mail parks in the node's seat mailbox, and `Address:` is only a
+    doorbell copy when no seat session is attached."""
     t = to.strip()
     if ":" in t:
         prefix, _, sub = t.partition(":")
@@ -94,15 +95,40 @@ def _canonical_recipient(node: str, roster: Roster, to: str) -> str:
     member = roster.find(name)
     if member is None:
         return t
-    if member.is_human and member.address:
-        return member.address
     return f"{node}:{member.name.lower()}"
+
+
+def _human_member(node: str, roster: Roster, addr: str) -> Member | None:
+    """The roster human that `addr` (canonical or bare) names, if any."""
+    t = (addr or "").strip()
+    if ":" in t:
+        prefix, _, sub = t.partition(":")
+        if prefix.strip().lower() != node.lower():
+            return None
+        t = sub
+    member = roster.find(t)
+    return member if member is not None and member.is_human else None
 
 
 def _tell_error(ctx: DispatchContext, recipient: str, text: str) -> None:
     body = f"[r4t {ctx.node}] {text}"
     state.append_log(ctx.node, f"r4t: ERROR -> {recipient}: {text}")
     ctx.tell_fn(recipient, body)
+
+
+def _park_seat(ctx: DispatchContext, member: Member, sender: str, message: str) -> None:
+    """Deliver a message to a roster human: park it in the node's seat
+    mailbox, and ring the `Address:` doorbell (a forwarded copy over a8s)
+    only when no seat session is attached to read it live."""
+    state.park_seat_message(ctx.node, member.name, sender, message)
+    bell = ""
+    if member.address and not state.seat_attached(ctx.node, member.name):
+        ctx.tell_fn(member.address, message)
+        bell = f", doorbell -> {member.address}"
+    state.append_log(
+        ctx.node,
+        f"r4t: SEAT {member.name.lower()} <- {sender} (parked{bell})",
+    )
 
 
 def _load_roster(ctx: DispatchContext, sender: str) -> Roster | None:
@@ -131,8 +157,9 @@ def _teammate_lines(ctx: DispatchContext, roster: Roster, member: Member) -> lis
         if m.name.lower() == member.name.lower():
             continue
         if m.is_human:
-            reach = f"tell {m.name.lower()}" if m.address else "(unreachable)"
-            lines.append(f"    - {m.name} (Human, {reach}) — {m.role}".rstrip(" —"))
+            lines.append(
+                f"    - {m.name} (Human, tell {m.name.lower()}) — {m.role}".rstrip(" —")
+            )
         elif not m.errors:
             lines.append(
                 f"    - {m.name} (tell {m.name.lower()}) — {m.role}".rstrip(" —")
@@ -453,13 +480,19 @@ def release_staging(
         path.unlink(missing_ok=True)
         synthesis_available = synthesis_available and not final_response
         released += 1
-        if _is_internal(ctx.node, to):
+        # Humans are terminal: a release to them wakes no further turns, so
+        # it neither counts as internal delegation nor keeps the task alive.
+        if _is_internal(ctx.node, to) and _human_member(ctx.node, roster, to) is None:
             internal_released = True
         elif (
             not synthesis_response
             and synthesis_creator
-            and not _is_internal(ctx.node, synthesis_creator)
-            and to.lower() == synthesis_creator.strip().lower()
+            and (
+                not _is_internal(ctx.node, synthesis_creator)
+                or _human_member(ctx.node, roster, synthesis_creator) is not None
+            )
+            and to.lower()
+            == _canonical_recipient(ctx.node, roster, synthesis_creator).lower()
         ):
             answered = True
     shutil.rmtree(staging, ignore_errors=True)
@@ -738,16 +771,7 @@ def _handle(
             return SKIPPED
 
     if member.is_human:
-        reach = (
-            f"reach them directly: tell {member.address} \"...\""
-            if member.address
-            else "they have no a8s address in the roster"
-        )
-        _tell_error(
-            ctx,
-            sender,
-            f"{member.name} is Human — r4t never dispatches humans; {reach}.",
-        )
+        _park_seat(ctx, member, sender, message)
         return SKIPPED
 
     if member.errors:
@@ -840,12 +864,16 @@ def _handle(
             f"(rig {rig.name} hop_limit {rig.hop_limit})",
         )
         if cut_recipient:
-            ctx.tell_fn(
-                cut_recipient,
+            cut_body = (
                 f"[r4t {ctx.node}] task {task_id}: message chain cut at hop "
                 f"{hop} (rig {rig.name} hop_limit {rig.hop_limit}). The last "
-                f"message was {sender} -> {member.name} and was not dispatched.",
+                f"message was {sender} -> {member.name} and was not dispatched."
             )
+            cut_human = _human_member(ctx.node, roster, cut_recipient)
+            if cut_human is not None:
+                _park_seat(ctx, cut_human, f"r4t:{ctx.node}", cut_body)
+            else:
+                ctx.tell_fn(cut_recipient, cut_body)
         return DEAD
 
     bulk_source = sender.lower() if sender.lower() in config.rebroadcast_senders else None

--- a/apps/r4t/r4t.py
+++ b/apps/r4t/r4t.py
@@ -9,6 +9,8 @@ through the roster.
 from __future__ import annotations
 
 import argparse
+import json
+import os
 import re
 import sys
 from pathlib import Path
@@ -36,7 +38,7 @@ from rig import (
     resolve_config_path,
 )
 from notify import resolve_tell_fn, simulate_enabled
-from roster import RosterError, load_roster, resolve_roster_path
+from roster import Member, Roster, RosterError, load_roster, resolve_roster_path
 
 DEFAULT_TASK_TTL_SECONDS = 7 * 86400
 R4T_DIR = Path(__file__).resolve().parent
@@ -64,9 +66,11 @@ ROSTER_TEMPLATE = """\
 # Team Roster
 
 Members are `### <Name>` blocks. `Status: Human` members are never
-dispatched; `Rig:` names a SYMBOLIC rig defined in the out-of-repo
-rig config (~/.config/r4t/rigs.json). Free prose in a block becomes the
-member's persona.
+dispatched: mail to them parks in the team's seat mailbox (`r4t seat`,
+`r4t chat`), and the optional `Address:` is a doorbell — a copy forwarded
+over a8s when no seat session is attached. `Rig:` names a SYMBOLIC rig
+defined in the out-of-repo rig config (~/.config/r4t/rigs.json). Free
+prose in a block becomes the member's persona.
 
 ### Owner
 - **Status:** Human
@@ -536,14 +540,99 @@ def cmd_status(args: argparse.Namespace) -> int:
     return 0
 
 
+def _ensure_tell_outbox(ctx: DispatchContext) -> None:
+    """Directly-invoked seat/chat sessions have no a8s-injected outbox env;
+    give `tell` subprocesses (the Address: doorbell, error notices) the same
+    fallback dispatch itself uses for releases."""
+    os.environ.setdefault("TELL_OUTBOX_DIR", str(ctx.root / ".outbox"))
+
+
 def cmd_chat(args: argparse.Namespace) -> int:
     node = _resolve_node(args.node)
     if node is None:
         return 2
-    root = _resolve_root(args.root)
+    ctx = _context(args, node)
+    _ensure_tell_outbox(ctx)
     from chat import run_chat
 
-    return run_chat(node, resolve_roster_path(root, args.roster))
+    return run_chat(ctx)
+
+
+def _seat_human(roster: Roster) -> Member | None:
+    return next((m for m in roster.members if m.is_human), None)
+
+
+def cmd_seat(args: argparse.Namespace) -> int:
+    node = _resolve_node(args.node)
+    if node is None:
+        return 2
+    ctx = _context(args, node)
+    _ensure_tell_outbox(ctx)
+    try:
+        roster = load_roster(ctx.roster_path)
+    except RosterError as e:
+        print(f"seat: {e}", file=sys.stderr)
+        return 2
+    human = _seat_human(roster)
+    if human is None:
+        print(
+            "seat: no human member in the roster — add one to ROSTER.md "
+            "(Status: Human)",
+            file=sys.stderr,
+        )
+        return 2
+
+    if args.action == "send":
+        text = " ".join(args.message).strip()
+        if not text:
+            print("seat send: message is required", file=sys.stderr)
+            return 2
+        if args.to:
+            member = roster.find(args.to)
+            if member is None or member.is_human or member.errors:
+                print(f"seat send: no dispatchable member {args.to!r}", file=sys.stderr)
+                return 2
+            to = f"{node}:{member.name.lower()}"
+        else:
+            to = node
+        sender = f"{node}:{human.name.lower()}"
+        drain_until_quiet(ctx)
+        handle_message(ctx, sender, to, text)
+        drain_until_quiet(ctx)
+        return 0
+
+    if args.action == "inbox":
+        paths = state.list_seat_messages(node, human.name)
+        if not paths:
+            if not args.as_json:
+                print("(no unread messages)")
+            return 0
+        for path in paths:
+            try:
+                envelope = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if args.as_json:
+                print(json.dumps(envelope))
+            else:
+                print(
+                    f"── from {envelope.get('from', '?')}"
+                    f" ({envelope.get('parked_at', '?')})"
+                )
+                print(envelope.get("content", ""))
+                print()
+            if not args.peek:
+                state.mark_seat_read(node, human.name, path)
+        return 0
+
+    unread = len(state.list_seat_messages(node, human.name))
+    attached = state.seat_attached(node, human.name)
+    print(f"seat: {human.name} on {node}")
+    print(f"unread: {unread}  (try: r4t seat inbox)")
+    print(f"attached: {'yes' if attached else 'no'}")
+    if human.address:
+        print(f"doorbell: {human.address} (rings when not attached)")
+    return 0
 
 
 RIG_COMMAND_HELP = [
@@ -850,7 +939,28 @@ def build_parser() -> argparse.ArgumentParser:
         "chat", help="Interactive human seat: messages and team activity in one window."
     )
     _add_common(chat_p, with_node=True)
+    _add_tell_flags(chat_p)
     chat_p.set_defaults(func=cmd_chat)
+
+    seat_p = sub.add_parser(
+        "seat", help="The roster human's team mailbox and voice (bare: summary)."
+    )
+    seat_p.add_argument(
+        "action", nargs="?", choices=["inbox", "send"],
+        help="inbox: read parked messages; send: speak as the human.",
+    )
+    seat_p.add_argument("message", nargs="*", help="send: message text.")
+    seat_p.add_argument("--to", help="send: member first name (default: the leader).")
+    seat_p.add_argument(
+        "--peek", action="store_true", help="inbox: leave messages unread."
+    )
+    seat_p.add_argument(
+        "--json", action="store_true", dest="as_json",
+        help="inbox: one JSON object per message.",
+    )
+    _add_common(seat_p, with_node=True)
+    _add_tell_flags(seat_p)
+    seat_p.set_defaults(func=cmd_seat)
 
     rig_p = sub.add_parser(
         "rig",

--- a/apps/r4t/r4t.py
+++ b/apps/r4t/r4t.py
@@ -536,6 +536,16 @@ def cmd_status(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_chat(args: argparse.Namespace) -> int:
+    node = _resolve_node(args.node)
+    if node is None:
+        return 2
+    root = _resolve_root(args.root)
+    from chat import run_chat
+
+    return run_chat(node, resolve_roster_path(root, args.roster))
+
+
 RIG_COMMAND_HELP = [
     ("rig list", "Rig invoke lines, limits, and roster rig resolution"),
     ("rig presets", "Named CLI presets aligned with a8s definitions"),
@@ -835,6 +845,12 @@ def build_parser() -> argparse.ArgumentParser:
     _add_common(status_p, with_node=True)
     _add_tell_flags(status_p)
     status_p.set_defaults(func=cmd_status)
+
+    chat_p = sub.add_parser(
+        "chat", help="Interactive human seat: messages and team activity in one window."
+    )
+    _add_common(chat_p, with_node=True)
+    chat_p.set_defaults(func=cmd_chat)
 
     rig_p = sub.add_parser(
         "rig",

--- a/apps/r4t/state.py
+++ b/apps/r4t/state.py
@@ -285,6 +285,31 @@ def park_pending(node: str, envelope: dict) -> Path:
     return path
 
 
+def recover_dead_claims(node: str) -> int:
+    """Re-queue pending claims whose drainer died between claim and consume
+    (`<msg>.json.claim-<pid>` with a dead pid) — nothing is silently dropped."""
+    root = pending_dir(node)
+    if not root.is_dir():
+        return 0
+    recovered = 0
+    for f in root.iterdir():
+        if not f.is_file() or ".json.claim-" not in f.name:
+            continue
+        original, _, pid_text = f.name.rpartition(".claim-")
+        try:
+            pid = int(pid_text)
+        except ValueError:
+            continue
+        if pid == os.getpid() or _pid_alive(pid):
+            continue
+        try:
+            f.rename(root / original)
+            recovered += 1
+        except OSError:
+            continue
+    return recovered
+
+
 def list_pending(node: str) -> list[Path]:
     root = pending_dir(node)
     if not root.is_dir():

--- a/apps/r4t/state.py
+++ b/apps/r4t/state.py
@@ -292,6 +292,73 @@ def list_pending(node: str) -> list[Path]:
     return sorted(f for f in root.iterdir() if f.is_file() and f.name.endswith(".json"))
 
 
+# ---------- seat (the roster human's mailbox on the node) ----------
+
+def seat_dir(node: str, name: str) -> Path:
+    return team_dir(node) / "seat" / name.strip().lower()
+
+
+def seat_inbox_dir(node: str, name: str) -> Path:
+    return seat_dir(node, name) / "inbox"
+
+
+def seat_read_dir(node: str, name: str) -> Path:
+    return seat_dir(node, name) / "read"
+
+
+def park_seat_message(node: str, name: str, sender: str, content: str) -> Path:
+    envelope = {
+        "id": new_ulid(),
+        "from": sender,
+        "to": name.strip().lower(),
+        "content": content,
+        "parked_at": utc_now(),
+    }
+    path = seat_inbox_dir(node, name) / f"{envelope['id']}.json"
+    atomic_write_json(path, envelope)
+    return path
+
+
+def list_seat_messages(node: str, name: str, *, read: bool = False) -> list[Path]:
+    root = seat_read_dir(node, name) if read else seat_inbox_dir(node, name)
+    if not root.is_dir():
+        return []
+    return sorted(f for f in root.iterdir() if f.is_file() and f.name.endswith(".json"))
+
+
+def mark_seat_read(node: str, name: str, path: Path) -> Path:
+    dest_dir = seat_read_dir(node, name)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest = dest_dir / path.name
+    path.rename(dest)
+    return dest
+
+
+def seat_presence_path(node: str, name: str) -> Path:
+    return seat_dir(node, name) / "presence"
+
+
+def touch_seat_presence(node: str, name: str) -> None:
+    p = seat_presence_path(node, name)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    _atomic_write_text(p, str(os.getpid()))
+
+
+def clear_seat_presence(node: str, name: str) -> None:
+    try:
+        seat_presence_path(node, name).unlink()
+    except OSError:
+        pass
+
+
+def seat_attached(node: str, name: str) -> bool:
+    try:
+        pid = int(seat_presence_path(node, name).read_text().strip())
+    except (OSError, ValueError):
+        return False
+    return pid > 0 and _pid_alive(pid)
+
+
 # ---------- transcript log + velocity ----------
 
 def append_log(node: str, text: str) -> None:

--- a/apps/r4t/tests/test_chat.py
+++ b/apps/r4t/tests/test_chat.py
@@ -1,0 +1,165 @@
+"""r4t chat tests — seat resolution, rendering, log filtering, commands."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from chat import (
+    ChatSession,
+    Seat,
+    filter_log_line,
+    handler_pid,
+    render_envelope,
+    resolve_seat,
+)
+from roster import load_roster
+
+
+@pytest.fixture
+def roster(repo):
+    return load_roster(repo / "ROSTER.md")
+
+
+def _registry(tmp_path: Path, *, proxy: bool = True) -> dict:
+    definition = tmp_path / "human.json"
+    definition.write_text(
+        json.dumps({"proxy": "file"} if proxy else {"invoke": ["echo"]})
+    )
+    root = tmp_path / "seat-root"
+    root.mkdir(exist_ok=True)
+    return {
+        "agents": {
+            "neil": {"definition": str(definition), "root": str(root)},
+            "crew-node": {"definition": str(definition), "root": str(root)},
+        },
+        "aliases": {},
+        "namespaces": {"crew": "crew-node"},
+    }
+
+
+def test_resolve_seat_happy_path(tmp_path, roster):
+    seat, problems = resolve_seat(_registry(tmp_path), "crew", roster)
+    assert problems == []
+    assert seat.node_agent == "crew-node"
+    assert seat.human.name == "Neil"
+    assert seat.human_agent == "neil"
+    assert seat.inbox_dir == tmp_path / "seat-root" / ".inbox"
+    assert seat.outbox_dir == tmp_path / "seat-root" / ".outbox"
+
+
+def test_resolve_seat_missing_namespace(tmp_path, roster):
+    registry = _registry(tmp_path)
+    registry["namespaces"] = {}
+    seat, problems = resolve_seat(registry, "crew", roster)
+    assert seat is None
+    assert any("a8s namespace crew" in p for p in problems)
+
+
+def test_resolve_seat_unregistered_human(tmp_path, roster):
+    registry = _registry(tmp_path)
+    del registry["agents"]["neil"]
+    seat, problems = resolve_seat(registry, "crew", roster)
+    assert seat is None
+    assert any("'neil' is not a registered" in p for p in problems)
+
+
+def test_resolve_seat_rejects_waking_definition(tmp_path, roster):
+    seat, problems = resolve_seat(_registry(tmp_path, proxy=False), "crew", roster)
+    assert seat is None
+    assert any("file-proxy" in p for p in problems)
+
+
+def test_render_envelope_multiline_and_files():
+    text = render_envelope(
+        {
+            "from": "crew:gerry",
+            "content": "line one\nline two",
+            "files": [{"filename": "report.md"}, {"path": "x"}],
+        }
+    )
+    assert text == "crew:gerry: line one\n    line two\n    [files: report.md]"
+
+
+def test_filter_log_line_shapes():
+    assert filter_log_line("r4t: PARKED cadence 12s") == "r4t: PARKED cadence 12s"
+    assert (
+        filter_log_line("## 2026-07-11T15:23:35Z dispatch neil -> Ada (task X hop 0, rig o)")
+        == "turn: neil -> Ada (task X hop 0, rig o)"
+    )
+    assert filter_log_line("### Output (Ada, exit 0 in 13.7s)") == "done: Ada, exit 0 in 13.7s"
+    assert filter_log_line("### Prompt") is None
+    assert filter_log_line("You are Ada, a member of the crew team") is None
+
+
+def test_handler_pid_dead_and_missing(tmp_path):
+    assert handler_pid(tmp_path, "ghost") is None
+    pid_file = tmp_path / "agents" / "ghost" / "pid"
+    pid_file.parent.mkdir(parents=True)
+    pid_file.write_text("999999")
+    assert handler_pid(tmp_path, "ghost") is None
+    import os
+
+    pid_file.write_text(str(os.getpid()))
+    assert handler_pid(tmp_path, "ghost") == os.getpid()
+
+
+def _session(tmp_path, roster) -> ChatSession:
+    seat, problems = resolve_seat(_registry(tmp_path), "crew", roster)
+    assert problems == []
+    return ChatSession(seat, roster, home=tmp_path)
+
+
+def test_to_command_targets(tmp_path, roster, capsys):
+    session = _session(tmp_path, roster)
+    assert session.target == "crew"
+    session.handle_line("/to phil")
+    assert session.target == "crew:phil"
+    session.handle_line("/to nobody")
+    assert session.target == "crew:phil"
+    session.handle_line("/to neil")
+    assert session.target == "crew:phil"
+    assert "no AI member" in capsys.readouterr().out
+    session.handle_line("/to crew")
+    assert session.target == "crew"
+
+
+def test_quit_and_unknown_command(tmp_path, roster, capsys):
+    session = _session(tmp_path, roster)
+    assert session.handle_line("/quit") is False
+    assert session.handle_line("/bogus") is True
+    assert "unknown command" in capsys.readouterr().out
+    assert session.handle_line("") is True
+
+
+def test_send_uses_tell_with_seat_outbox(tmp_path, roster, monkeypatch):
+    session = _session(tmp_path, roster)
+    calls = {}
+
+    def fake_run(argv, **kwargs):
+        calls["argv"] = argv
+        calls["outbox"] = kwargs["env"]["TELL_OUTBOX_DIR"]
+
+        class R:
+            returncode = 0
+
+        return R()
+
+    monkeypatch.setattr("chat.subprocess.run", fake_run)
+    session.handle_line("hello team")
+    assert calls["argv"] == ["tell", "crew", "hello team"]
+    assert calls["outbox"] == str(session.seat.outbox_dir)
+
+
+def test_poll_inbox_announces_new_once(tmp_path, roster):
+    session = _session(tmp_path, roster)
+    inbox = session.seat.inbox_dir
+    inbox.mkdir(parents=True)
+    (inbox / "01A.json").write_text(json.dumps({"from": "crew:gerry", "content": "hi"}))
+    session.poll_inbox()
+    session.poll_inbox()
+    events = []
+    while not session.events.empty():
+        events.append(session.events.get())
+    assert events == [("in", "crew:gerry: hi")]

--- a/apps/r4t/tests/test_chat.py
+++ b/apps/r4t/tests/test_chat.py
@@ -1,20 +1,15 @@
-"""r4t chat tests — seat resolution, rendering, log filtering, commands."""
+"""r4t chat + seat tests — mailbox helpers, rendering, session commands."""
 from __future__ import annotations
 
 import json
-from pathlib import Path
 
 import pytest
 
-from chat import (
-    ChatSession,
-    Seat,
-    filter_log_line,
-    handler_pid,
-    render_envelope,
-    resolve_seat,
-)
+import state
+from chat import ChatSession, filter_log_line, render_envelope, run_chat
 from roster import load_roster
+
+NODE = "acme"
 
 
 @pytest.fixture
@@ -22,144 +17,101 @@ def roster(repo):
     return load_roster(repo / "ROSTER.md")
 
 
-def _registry(tmp_path: Path, *, proxy: bool = True) -> dict:
-    definition = tmp_path / "human.json"
-    definition.write_text(
-        json.dumps({"proxy": "file"} if proxy else {"invoke": ["echo"]})
-    )
-    root = tmp_path / "seat-root"
-    root.mkdir(exist_ok=True)
-    return {
-        "agents": {
-            "neil": {"definition": str(definition), "root": str(root)},
-            "crew-node": {"definition": str(definition), "root": str(root)},
-        },
-        "aliases": {},
-        "namespaces": {"crew": "crew-node"},
-    }
+@pytest.fixture
+def human(roster):
+    return next(m for m in roster.members if m.is_human)
 
 
-def test_resolve_seat_happy_path(tmp_path, roster):
-    seat, problems = resolve_seat(_registry(tmp_path), "crew", roster)
-    assert problems == []
-    assert seat.node_agent == "crew-node"
-    assert seat.human.name == "Neil"
-    assert seat.human_agent == "neil"
-    assert seat.inbox_dir == tmp_path / "seat-root" / ".inbox"
-    assert seat.outbox_dir == tmp_path / "seat-root" / ".outbox"
+@pytest.fixture
+def session(ctx, roster, human, r4t_home):
+    return ChatSession(ctx, roster, human)
 
 
-def test_resolve_seat_missing_namespace(tmp_path, roster):
-    registry = _registry(tmp_path)
-    registry["namespaces"] = {}
-    seat, problems = resolve_seat(registry, "crew", roster)
-    assert seat is None
-    assert any("a8s namespace crew" in p for p in problems)
+def drain_events(session):
+    events = []
+    while not session.events.empty():
+        events.append(session.events.get())
+    return events
 
 
-def test_resolve_seat_unregistered_human(tmp_path, roster):
-    registry = _registry(tmp_path)
-    del registry["agents"]["neil"]
-    seat, problems = resolve_seat(registry, "crew", roster)
-    assert seat is None
-    assert any("'neil' is not a registered" in p for p in problems)
+def test_seat_mailbox_roundtrip(r4t_home):
+    state.park_seat_message(NODE, "Neil", "acme:gerry", "hello")
+    unread = state.list_seat_messages(NODE, "neil")
+    assert len(unread) == 1
+    moved = state.mark_seat_read(NODE, "neil", unread[0])
+    assert moved.is_file()
+    assert state.list_seat_messages(NODE, "neil") == []
+    assert len(state.list_seat_messages(NODE, "neil", read=True)) == 1
 
 
-def test_resolve_seat_rejects_waking_definition(tmp_path, roster):
-    seat, problems = resolve_seat(_registry(tmp_path, proxy=False), "crew", roster)
-    assert seat is None
-    assert any("file-proxy" in p for p in problems)
+def test_seat_presence(r4t_home):
+    assert not state.seat_attached(NODE, "neil")
+    state.touch_seat_presence(NODE, "neil")
+    assert state.seat_attached(NODE, "neil")
+    state.clear_seat_presence(NODE, "neil")
+    assert not state.seat_attached(NODE, "neil")
 
 
-def test_render_envelope_multiline_and_files():
+def test_render_envelope_strips_header_and_indents():
     text = render_envelope(
         {
-            "from": "crew:gerry",
-            "content": "line one\nline two",
-            "files": [{"filename": "report.md"}, {"path": "x"}],
+            "from": "acme:gerry",
+            "content": "[r4t task=01KX0000000000000000000000 hop=2 auto] line one\nline two",
         }
     )
-    assert text == "crew:gerry: line one\n    line two\n    [files: report.md]"
+    assert text == "acme:gerry: line one\n    line two"
 
 
 def test_filter_log_line_shapes():
     assert filter_log_line("r4t: PARKED cadence 12s") == "r4t: PARKED cadence 12s"
     assert (
-        filter_log_line("## 2026-07-11T15:23:35Z dispatch neil -> Ada (task X hop 0, rig o)")
-        == "turn: neil -> Ada (task X hop 0, rig o)"
+        filter_log_line("## 2026-07-11T15:23:35Z dispatch neil -> Ada (task X hop 0)")
+        == "turn: neil -> Ada (task X hop 0)"
     )
     assert filter_log_line("### Output (Ada, exit 0 in 13.7s)") == "done: Ada, exit 0 in 13.7s"
     assert filter_log_line("### Prompt") is None
     assert filter_log_line("You are Ada, a member of the crew team") is None
 
 
-def test_handler_pid_dead_and_missing(tmp_path):
-    assert handler_pid(tmp_path, "ghost") is None
-    pid_file = tmp_path / "agents" / "ghost" / "pid"
-    pid_file.parent.mkdir(parents=True)
-    pid_file.write_text("999999")
-    assert handler_pid(tmp_path, "ghost") is None
-    import os
-
-    pid_file.write_text(str(os.getpid()))
-    assert handler_pid(tmp_path, "ghost") == os.getpid()
-
-
-def _session(tmp_path, roster) -> ChatSession:
-    seat, problems = resolve_seat(_registry(tmp_path), "crew", roster)
-    assert problems == []
-    return ChatSession(seat, roster, home=tmp_path)
-
-
-def test_to_command_targets(tmp_path, roster, capsys):
-    session = _session(tmp_path, roster)
-    assert session.target == "crew"
+def test_to_command_targets(session, capsys):
+    assert session.target == NODE
     session.handle_line("/to phil")
-    assert session.target == "crew:phil"
+    assert session.target == "acme:phil"
     session.handle_line("/to nobody")
-    assert session.target == "crew:phil"
+    assert session.target == "acme:phil"
     session.handle_line("/to neil")
-    assert session.target == "crew:phil"
+    assert session.target == "acme:phil"
     assert "no AI member" in capsys.readouterr().out
-    session.handle_line("/to crew")
-    assert session.target == "crew"
+    session.handle_line("/to acme")
+    assert session.target == NODE
 
 
-def test_quit_and_unknown_command(tmp_path, roster, capsys):
-    session = _session(tmp_path, roster)
+def test_quit_and_unknown_command(session, capsys):
     assert session.handle_line("/quit") is False
     assert session.handle_line("/bogus") is True
     assert "unknown command" in capsys.readouterr().out
     assert session.handle_line("") is True
 
 
-def test_send_uses_tell_with_seat_outbox(tmp_path, roster, monkeypatch):
-    session = _session(tmp_path, roster)
-    calls = {}
-
-    def fake_run(argv, **kwargs):
-        calls["argv"] = argv
-        calls["outbox"] = kwargs["env"]["TELL_OUTBOX_DIR"]
-
-        class R:
-            returncode = 0
-
-        return R()
-
-    monkeypatch.setattr("chat.subprocess.run", fake_run)
+def test_plain_line_queues_send(session, capsys):
     session.handle_line("hello team")
-    assert calls["argv"] == ["tell", "crew", "hello team"]
-    assert calls["outbox"] == str(session.seat.outbox_dir)
+    assert session.sends.get_nowait() == (NODE, "hello team")
+    assert "you -> acme: hello team" in capsys.readouterr().out
 
 
-def test_poll_inbox_announces_new_once(tmp_path, roster):
-    session = _session(tmp_path, roster)
-    inbox = session.seat.inbox_dir
-    inbox.mkdir(parents=True)
-    (inbox / "01A.json").write_text(json.dumps({"from": "crew:gerry", "content": "hi"}))
+def test_poll_inbox_consumes_and_renders(session, r4t_home):
+    state.park_seat_message(NODE, "Neil", "acme:gerry", "[r4t task=01KX0000000000000000000000 hop=1 auto] hi")
     session.poll_inbox()
+    assert drain_events(session) == [("in", "acme:gerry: hi")]
     session.poll_inbox()
-    events = []
-    while not session.events.empty():
-        events.append(session.events.get())
-    assert events == [("in", "crew:gerry: hi")]
+    assert drain_events(session) == []
+    assert len(state.list_seat_messages(NODE, "neil", read=True)) == 1
+
+
+def test_run_chat_requires_human(ctx, repo, r4t_home):
+    (repo / "ROSTER.md").write_text(
+        "# Roster\n\n### Gerry\n- **Status:** AI\n- **Rig:** leader\n"
+        "- **Leader:** yes\n",
+        encoding="utf-8",
+    )
+    assert run_chat(ctx) == 2

--- a/apps/r4t/tests/test_dispatch.py
+++ b/apps/r4t/tests/test_dispatch.py
@@ -130,6 +130,19 @@ class TestDispatchEndToEnd:
         assert after["used"] >= used_before  # no deliberate budget reset
         assert after["turns"] == task["turns"]  # forged hop never charged it
 
+    def test_silent_turn_is_logged(self, ctx, fake_harness, monkeypatch, r4t_home):
+        # Weak rig answers on stdout instead of running `tell`: turn exits 0,
+        # releases nothing — the operator must be able to see why the task
+        # went quiet.
+        def chatty_stdout(rig, prompt, cwd, *, env=None, variant=0):
+            return 0, "Here is my long detailed answer " * 5, 1.0, False
+
+        handle_message(ctx, "boss", "acme:gerry", "question", run_fn=chatty_stdout)
+        log = (state.team_dir(NODE) / "log").glob("*.md")
+        text = "".join(f.read_text(encoding="utf-8") for f in log)
+        assert "r4t: SILENT gerry" in text
+        assert "released no messages" in text
+
     def test_bare_node_goes_to_leader(self, ctx, fake_harness):
         handle_message(ctx, "neil", "acme", "status update please")
         prompt = read_prompt(harness_calls(fake_harness)[0])

--- a/apps/r4t/tests/test_dispatch.py
+++ b/apps/r4t/tests/test_dispatch.py
@@ -103,14 +103,32 @@ class TestDispatchEndToEnd:
         assert task["creator"] == "gerry"
         assert task["turns"] == 1
 
-    def test_incoming_header_adopted_and_stripped(self, ctx, fake_harness):
+    def test_internal_header_adopted_and_stripped(self, ctx, fake_harness):
+        task_id = new_ulid()
+        header = tasks.format_header(task_id, 1, auto=True)
+        handle_message(ctx, f"{NODE}:phil", "acme:gerry", f"{header} continue please")
+        prompt = read_prompt(harness_calls(fake_harness)[0])
+        assert header not in prompt
+        assert "## Incoming message\nFrom: phil\n\ncontinue please" in prompt
+        assert tasks.load_task(NODE, task_id)["turns"] == 1
+
+    def test_external_header_is_untrusted_content(self, ctx, fake_harness):
         task_id = new_ulid()
         header = tasks.format_header(task_id, 1, auto=True)
         handle_message(ctx, "gerry", "acme:gerry", f"{header} continue please")
         prompt = read_prompt(harness_calls(fake_harness)[0])
-        assert header not in prompt
-        assert "## Incoming message\nFrom: gerry\n\ncontinue please" in prompt
-        assert tasks.load_task(NODE, task_id)["turns"] == 1
+        assert header in prompt  # delivered as content, not adopted
+        assert tasks.load_task(NODE, task_id) is None  # fresh task minted
+
+    def test_forged_header_cannot_reset_existing_task(self, ctx, fake_harness):
+        handle_message(ctx, "boss", "acme:gerry", "real work")
+        task = tasks.list_tasks(NODE)[0]
+        used_before = task["used"]
+        forged = tasks.format_header(task["id"], 1, auto=False)
+        handle_message(ctx, "attacker", "acme:phil", f"{forged} reset please")
+        after = tasks.load_task(NODE, task["id"])
+        assert after["used"] >= used_before  # no deliberate budget reset
+        assert after["turns"] == task["turns"]  # forged hop never charged it
 
     def test_bare_node_goes_to_leader(self, ctx, fake_harness):
         handle_message(ctx, "neil", "acme", "status update please")
@@ -163,6 +181,12 @@ class TestDispatchRejections:
         parked = seat_messages()
         assert [(m["from"], m["content"]) for m in parked] == [("gerry", "hi")]
         assert sent == [("neil", "hi")]  # Address: doorbell — seat not attached
+
+    def test_doorbell_copy_is_headerless_egress(self, ctx, tells, fake_harness):
+        header = tasks.format_header(new_ulid(), 2, auto=True)
+        handle_message(ctx, f"{NODE}:gerry", "acme:neil", f"{header} ship report")
+        _sent_to, sent_body = tells[0][0]
+        assert sent_body == "ship report"  # the header never leaves the garden
 
     def test_human_doorbell_skipped_when_attached(self, ctx, tells, fake_harness):
         sent, _ = tells
@@ -221,9 +245,12 @@ class TestPins:
 
 
 class TestStagingRelease:
-    def test_external_release_stamps_header_and_class(
+    def test_external_release_strips_header_keeps_class(
         self, chatty_ctx, repo, chatty_harness, monkeypatch
     ):
+        # Egress protocol: the header never leaves the garden — other nodes
+        # must not need to know a name hides a roster. Class marking rides
+        # envelope metadata only.
         monkeypatch.setenv("CHATTY_TO", "outsider")
         monkeypatch.setenv("CHATTY_BODY", "the fix is deployed")
         assert _handle(chatty_ctx, "gerry", "acme:phil", "deploy the fix") == RAN
@@ -232,12 +259,8 @@ class TestStagingRelease:
         envelope = envelopes[0]
         assert envelope["to"] == "outsider"
         assert envelope["x_r4t_class"] == "auto"
-        task = tasks.list_tasks(NODE)[0]
-        task_id, hop, auto, body = tasks.parse_header(envelope["content"])
-        assert task_id == task["id"]
-        assert hop == 1
-        assert auto
-        assert body == "the fix is deployed"
+        assert envelope["content"] == "the fix is deployed"
+        assert not envelope["content"].startswith("[r4t")
         assert not state.staging_dir(NODE, "phil").exists()
 
     def test_outbound_attributed_to_history(self, chatty_ctx, chatty_harness, monkeypatch):
@@ -1066,7 +1089,7 @@ class TestAttachmentRelease:
         dispatch._release_one(
             ctx, outbox, staging,
             {"id": "message-1", "to": "outside", "files": ["report.txt"]},
-            "stamped", f"{NODE}:phil", new_ulid(), 1, "result", False,
+            f"{NODE}:phil", new_ulid(), 1, "result", False,
         )
 
         assert (outbox / "message-1.json").is_file()
@@ -1093,7 +1116,7 @@ class TestAttachmentRelease:
         dispatch._release_one(
             ctx, outbox, staging,
             {"id": "message-2", "to": "outside", "files": ["report.txt"]},
-            "stamped", f"{NODE}:phil", new_ulid(), 1, "result", False,
+            f"{NODE}:phil", new_ulid(), 1, "result", False,
         )
 
         assert attempted
@@ -1127,7 +1150,7 @@ class TestAttachmentRelease:
         envelope = {"id": "message-3", "to": "outside", "files": ["report.txt"]}
         try:
             dispatch._release_one(
-                ctx, outbox, staging, envelope, "stamped", f"{NODE}:phil",
+                ctx, outbox, staging, envelope, f"{NODE}:phil",
                 new_ulid(), 1, "result", False,
             )
         except OSError as exc:
@@ -1141,7 +1164,7 @@ class TestAttachmentRelease:
 
         monkeypatch.setattr(dispatch.shutil, "copytree", real_copytree)
         dispatch._release_one(
-            ctx, outbox, staging, envelope, "stamped", f"{NODE}:phil",
+            ctx, outbox, staging, envelope, f"{NODE}:phil",
             new_ulid(), 1, "result", False,
         )
         assert (outbox / "message-3" / "report.txt").read_text() == "result"
@@ -1173,7 +1196,7 @@ class TestAttachmentRelease:
         dispatch._release_one(
             ctx, outbox, staging,
             {"id": "message-4", "to": "outside", "files": ["report.txt"]},
-            "stamped", f"{NODE}:phil", new_ulid(), 1, "result", False,
+            f"{NODE}:phil", new_ulid(), 1, "result", False,
         )
 
         assert bundle.is_dir()

--- a/apps/r4t/tests/test_dispatch.py
+++ b/apps/r4t/tests/test_dispatch.py
@@ -52,6 +52,13 @@ def dead_reasons():
     return sorted(r["reason"] for r in state.list_dead_letters(NODE))
 
 
+def seat_messages(name="neil"):
+    return [
+        json.loads(f.read_text(encoding="utf-8"))
+        for f in state.list_seat_messages(NODE, name)
+    ]
+
+
 class TestSplitRecipient:
     def test_sub_address(self):
         assert split_recipient("acme:phil") == ("acme", "phil")
@@ -149,12 +156,20 @@ class TestDispatchRejections:
         assert agent == "gerry"
         assert "nobody" in body and "Gerry" in body and "Phil" in body
 
-    def test_human_never_dispatched(self, ctx, tells, fake_harness):
+    def test_human_message_parks_in_seat(self, ctx, tells, fake_harness):
         sent, _ = tells
         handle_message(ctx, "gerry", "acme:neil", "hi")
         assert not harness_calls(fake_harness)
-        assert "Human" in sent[0][1]
-        assert "tell neil" in sent[0][1]
+        parked = seat_messages()
+        assert [(m["from"], m["content"]) for m in parked] == [("gerry", "hi")]
+        assert sent == [("neil", "hi")]  # Address: doorbell — seat not attached
+
+    def test_human_doorbell_skipped_when_attached(self, ctx, tells, fake_harness):
+        sent, _ = tells
+        state.touch_seat_presence(NODE, "neil")
+        handle_message(ctx, "gerry", "acme:neil", "hi")
+        assert [m["content"] for m in seat_messages()] == ["hi"]
+        assert sent == []
 
     def test_malformed_member_disabled_with_error(self, ctx, tells, fake_harness):
         sent, _ = tells
@@ -209,13 +224,13 @@ class TestStagingRelease:
     def test_external_release_stamps_header_and_class(
         self, chatty_ctx, repo, chatty_harness, monkeypatch
     ):
-        monkeypatch.setenv("CHATTY_TO", "neil")
+        monkeypatch.setenv("CHATTY_TO", "outsider")
         monkeypatch.setenv("CHATTY_BODY", "the fix is deployed")
         assert _handle(chatty_ctx, "gerry", "acme:phil", "deploy the fix") == RAN
         envelopes = outbox_envelopes(repo)
         assert len(envelopes) == 1
         envelope = envelopes[0]
-        assert envelope["to"] == "neil"
+        assert envelope["to"] == "outsider"
         assert envelope["x_r4t_class"] == "auto"
         task = tasks.list_tasks(NODE)[0]
         task_id, hop, auto, body = tasks.parse_header(envelope["content"])
@@ -236,7 +251,7 @@ class TestStagingRelease:
     def test_quota_overflow_dead_letters_and_drains_bucket(
         self, chatty_ctx, repo, chatty_harness, monkeypatch
     ):
-        monkeypatch.setenv("CHATTY_TO", "neil")
+        monkeypatch.setenv("CHATTY_TO", "outsider")
         monkeypatch.setenv("CHATTY_SENDS", "4")  # max_sends_per_turn is 2
         _handle(chatty_ctx, "gerry", "acme:phil", "fan out")
         assert len(outbox_envelopes(repo)) == 2
@@ -272,14 +287,19 @@ class TestStagingRelease:
         pending = [json.loads(p.read_text()) for p in state.list_pending(NODE)]
         assert [p["to"] for p in pending] == ["acme:gerry"]
 
-    def test_bare_human_name_resolves_to_address(
+    def test_human_recipient_stays_internal_and_parks(
         self, chatty_ctx, repo, chatty_harness, monkeypatch
     ):
         monkeypatch.setenv("CHATTY_TO", "acme:neil")
         monkeypatch.setenv("CHATTY_BODY", "shipped")
         assert _handle(chatty_ctx, "gerry", "acme:phil", "ship it") == RAN
-        envelopes = outbox_envelopes(repo)
-        assert [e["to"] for e in envelopes] == ["neil"]
+        assert outbox_envelopes(repo) == []
+        pending = [json.loads(f.read_text()) for f in state.list_pending(NODE)]
+        assert [p["to"] for p in pending] == ["acme:neil"]
+        drain_until_quiet(chatty_ctx)
+        parked = seat_messages()
+        assert [m["from"] for m in parked] == ["acme:phil"]
+        assert "shipped" in parked[0]["content"]
 
     def test_bare_unknown_name_passes_through_external(
         self, chatty_ctx, repo, chatty_harness, monkeypatch
@@ -291,13 +311,23 @@ class TestStagingRelease:
         assert [e["to"] for e in envelopes] == ["chatroom"]
         assert not state.list_pending(NODE)
 
-    def test_reply_to_external_creator_closes_task(
+    def test_reply_to_human_creator_closes_task(
         self, chatty_ctx, repo, chatty_harness, monkeypatch
     ):
         monkeypatch.setenv("CHATTY_TO", "neil")
         monkeypatch.setenv("CHATTY_BODY", "done: shipped and verified")
-        assert _handle(chatty_ctx, "neil", "acme:phil", "ship it") == RAN
-        assert [e["to"] for e in outbox_envelopes(repo)] == ["neil"]
+        assert _handle(chatty_ctx, "acme:neil", "acme:phil", "ship it") == RAN
+        assert outbox_envelopes(repo) == []
+        task = tasks.list_tasks(NODE)[0]
+        assert task["status"] == tasks.STATUS_CLOSED
+
+    def test_reply_to_external_creator_closes_task(
+        self, chatty_ctx, repo, chatty_harness, monkeypatch
+    ):
+        monkeypatch.setenv("CHATTY_TO", "boss-agent")
+        monkeypatch.setenv("CHATTY_BODY", "done: shipped and verified")
+        assert _handle(chatty_ctx, "boss-agent", "acme:phil", "ship it") == RAN
+        assert [e["to"] for e in outbox_envelopes(repo)] == ["boss-agent"]
         task = tasks.list_tasks(NODE)[0]
         assert task["status"] == tasks.STATUS_CLOSED
 
@@ -338,7 +368,7 @@ class TestStagingRelease:
     def test_released_envelope_claims_namespaced_sender(
         self, chatty_ctx, repo, chatty_harness, monkeypatch
     ):
-        monkeypatch.setenv("CHATTY_TO", "neil")
+        monkeypatch.setenv("CHATTY_TO", "outsider")
         monkeypatch.setenv("CHATTY_BODY", "status: done")
         _handle(chatty_ctx, "gerry", "acme:phil", "report status")
         envelopes = outbox_envelopes(repo)
@@ -381,7 +411,7 @@ class TestPairSuppression:
     def test_repeat_within_window_dead_letters(
         self, chatty_ctx, repo, chatty_harness, monkeypatch
     ):
-        monkeypatch.setenv("CHATTY_TO", "neil")
+        monkeypatch.setenv("CHATTY_TO", "outsider")
         monkeypatch.setenv("CHATTY_BODY", "Deploy the fix")
         _handle(chatty_ctx, "gerry", "acme:phil", "job one")
         _handle(chatty_ctx, "gerry", "acme:phil", "job two")
@@ -390,11 +420,11 @@ class TestPairSuppression:
         record = state.list_dead_letters(NODE)[0]
         assert record["count"] == 2
         assert record["from"] == "acme:phil"
-        assert record["to"] == "neil"
+        assert record["to"] == "outsider"
         assert state.bucket_level(NODE, "phil", 8.0) == 7.0
 
     def test_different_content_passes(self, chatty_ctx, repo, chatty_harness, monkeypatch):
-        monkeypatch.setenv("CHATTY_TO", "neil")
+        monkeypatch.setenv("CHATTY_TO", "outsider")
         monkeypatch.setenv("CHATTY_BODY", "unique {i}")
         _handle(chatty_ctx, "gerry", "acme:phil", "job one")
         monkeypatch.setenv("CHATTY_BODY", "another thing entirely")

--- a/apps/r4t/tests/test_seat.py
+++ b/apps/r4t/tests/test_seat.py
@@ -2,9 +2,11 @@
 from __future__ import annotations
 
 import json
+import os
 
 import state
 import tasks
+from dispatch import drain
 from r4t import main as r4t_main
 
 NODE = "acme"
@@ -76,3 +78,35 @@ def test_seat_send_defaults_to_leader(repo, rig_config, r4t_home, fake_harness, 
 def test_seat_send_rejects_unknown_member(repo, rig_config, r4t_home, capsys):
     assert _seat(repo, rig_config, "send", "--to", "nobody", "hi") == 2
     assert "no dispatchable member" in capsys.readouterr().err
+
+
+def test_drain_claim_is_exclusive(ctx, r4t_home, fake_harness, monkeypatch):
+    state.park_pending(NODE, {"from": "boss", "to": "acme:phil", "body": "go"})
+    path = state.list_pending(NODE)[0]
+    real_rename = os.rename
+    stolen = {}
+
+    def racing_rename(src, dst):
+        # A second drainer wins the race for this envelope just before us.
+        if not stolen and src == str(path):
+            stolen["by"] = path.with_name(f"{path.name}.claim-99")
+            real_rename(src, str(stolen["by"]))
+        return real_rename(src, dst)
+
+    monkeypatch.setattr("dispatch.os.rename", racing_rename)
+    assert drain(ctx) == 0  # lost the claim: no duplicate redispatch
+    assert not harness_calls_exist(fake_harness)
+
+
+def test_drain_recovers_claims_from_dead_drainer(ctx, r4t_home, fake_harness):
+    state.park_pending(NODE, {"from": "boss", "to": "acme:phil", "body": "go"})
+    path = state.list_pending(NODE)[0]
+    os.rename(path, path.with_name(f"{path.name}.claim-999999"))
+    assert state.list_pending(NODE) == []
+    assert drain(ctx) == 1  # dead drainer's claim re-queued and dispatched
+    assert harness_calls_exist(fake_harness)
+
+
+def harness_calls_exist(fake_harness) -> bool:
+    _script, out = fake_harness
+    return bool(sorted(out.iterdir()))

--- a/apps/r4t/tests/test_seat.py
+++ b/apps/r4t/tests/test_seat.py
@@ -1,0 +1,78 @@
+"""r4t seat CLI tests — the orchestrator-facing mailbox/voice surface."""
+from __future__ import annotations
+
+import json
+
+import state
+import tasks
+from r4t import main as r4t_main
+
+NODE = "acme"
+
+
+def _seat(repo, rig_config, *args):
+    return r4t_main(
+        [
+            "seat",
+            *args,
+            "--node",
+            NODE,
+            "--root",
+            str(repo),
+            "--rig-config",
+            str(rig_config),
+            "--simulate-tell",
+        ]
+    )
+
+
+def test_seat_summary(repo, rig_config, r4t_home, capsys):
+    state.park_seat_message(NODE, "Neil", "acme:gerry", "hello")
+    assert _seat(repo, rig_config) == 0
+    out = capsys.readouterr().out
+    assert "seat: Neil on acme" in out
+    assert "unread: 1" in out
+    assert "attached: no" in out
+    assert "doorbell: neil" in out
+
+
+def test_seat_inbox_reads_and_marks(repo, rig_config, r4t_home, capsys):
+    state.park_seat_message(NODE, "Neil", "acme:gerry", "first")
+    state.park_seat_message(NODE, "Neil", "acme:phil", "second")
+    assert _seat(repo, rig_config, "inbox") == 0
+    out = capsys.readouterr().out
+    assert "from acme:gerry" in out and "first" in out
+    assert "from acme:phil" in out and "second" in out
+    assert state.list_seat_messages(NODE, "neil") == []
+    assert len(state.list_seat_messages(NODE, "neil", read=True)) == 2
+
+
+def test_seat_inbox_peek_and_json(repo, rig_config, r4t_home, capsys):
+    state.park_seat_message(NODE, "Neil", "acme:gerry", "hello")
+    assert _seat(repo, rig_config, "inbox", "--peek", "--json") == 0
+    envelope = json.loads(capsys.readouterr().out.strip())
+    assert envelope["from"] == "acme:gerry"
+    assert envelope["content"] == "hello"
+    assert len(state.list_seat_messages(NODE, "neil")) == 1
+
+
+def test_seat_send_creates_task_as_human(repo, rig_config, r4t_home, fake_harness):
+    assert _seat(repo, rig_config, "send", "--to", "phil", "ship", "it") == 0
+    listing = tasks.list_tasks(NODE)
+    assert len(listing) == 1
+    assert listing[0]["creator"] == "acme:neil"
+    _script, out = fake_harness
+    assert len(sorted(out.iterdir())) == 1
+
+
+def test_seat_send_defaults_to_leader(repo, rig_config, r4t_home, fake_harness, capsys):
+    assert _seat(repo, rig_config, "send", "hello") == 0
+    _script, out = fake_harness
+    calls = sorted(out.iterdir())
+    assert len(calls) == 1
+    assert "You are Gerry" in calls[0].read_text(encoding="utf-8")
+
+
+def test_seat_send_rejects_unknown_member(repo, rig_config, r4t_home, capsys):
+    assert _seat(repo, rig_config, "send", "--to", "nobody", "hi") == 2
+    assert "no dispatchable member" in capsys.readouterr().err


### PR DESCRIPTION
Implements #162, redesigned per review: **the human is a roster member, not an a8s agent.**

## The seat model
- `tell neil` (intra-team) and `tell acme:neil` (from anywhere — phone, another cluster) both canonicalize to the internal member address; dispatch **parks** human-bound mail in a seat mailbox under team state (`~/.config/r4t/teams/<node>/seat/<name>/inbox/`). No handler, no router, no pid file — there is no disconnected state; jump out for a week and the backlog is waiting.
- `Address:` demotes from delivery path to **doorbell**: a copy forwarded over a8s only while no seat session is attached (presence file). Chat attaches presence; detach and the doorbell rings again.
- Humans are **terminal** in closure logic: a reply to a human creator ANSWERS the task; a release to a human is not internal delegation.
- The walled garden now works with **zero routers** — intra-team mail rides the node's own pending queue; a8s only matters for traffic crossing the wall.

## Two surfaces, one mailbox
- **`r4t seat`** — discrete, scriptable: `seat` (summary), `seat inbox [--peek --json]`, `seat send [--to member] "…"` (runs the recipient's turn synchronously). This is how an orchestrating agent impersonates the human — no TTY, no long-lived process.
- **`r4t chat`** — the human view: seat messages, turn starts/completions, governance events, and an input line (`/to`, `/who`, `/tasks`, `/quit`) in one window. Zero a8s imports/coupling. (Textual TUI layer is a follow-up.)

## Concurrency hardening (87ea4b9)
`seat send` makes r4t a second dispatch process beside a8s wakes. Turn admission was already cross-process (every gate is an on-disk live-PID lockfile under a node-wide admission lock; losers park to `pending/` as DEFERRED), but the pending-drain claim was read-then-unlink — two overlapping drainers could double-dispatch one envelope. The claim is now an atomic rename (`<msg>.json.claim-<pid>`); claims orphaned by a dead drainer are re-queued every drain pass.

## History
First commit is the v0 cut (human as a global a8s file-proxy agent with dedicated-router takeover); the second reworks it after v0's live run showed why the roster-member model is right — the takeover delivered 8 envelopes a shared router had silently stranded (filed #163), and the seat model makes stranding structurally impossible. Third commit is the drain-claim fix.

## Verified
- 230 r4t tests pass (seat mailbox/presence, parking, doorbell + attached-skip, human-creator closure, seat CLI, chat session, drain claim race + dead-drainer recovery)
- Live on the ttt team, as the human: a question answered in one turn, and a change request ("index labels around the board") carried through the full chain — Ada → Linus → Grace (verify) → Ada → seat — inside a single `seat send`, with cadence deferrals and pair-repeat suppression visible; deliverable verified independently and committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)