### PR TITLE
feat(r4t): stdout fallback — tell always wins, silence + stdout becomes the reply

### DIFF
--- a/apps/r4t/README.md
+++ b/apps/r4t/README.md
@@ -51,6 +51,14 @@ fail closed — see the [tutorial](docs/tutorial.md#missing-rig-no-default--fail
    the turn, get woken when replies arrive, answer the originator when
    there is enough. `tell --sync` to teammates is prohibited by prompt and
    pointless by design.
+5. Stdout fallback — `tell` always wins. A turn that staged even one
+   envelope keeps its stdout as transcript. But a turn that exits 0,
+   releases nothing, and printed a non-trivial answer (the classic
+   weak-rig shape: small local models reliably answer in text and never
+   run `tell`) gets its cleaned stdout — ANSI and harness chrome stripped —
+   staged as one reply to the inbound sender, riding every gate in step 3.
+   No configuration; strong models never trigger it, and stdout-only
+   models participate without knowing the protocol exists.
 
 Governance defaults apply with no extra configuration — a rig config
 with only rig invoke lines is a fully governed team.

--- a/apps/r4t/dispatch.py
+++ b/apps/r4t/dispatch.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import errno
 import json
 import os
+import re
 import shutil
 import signal
 import subprocess
@@ -518,6 +519,31 @@ def release_staging(
 
 # ---------- the turn ----------
 
+STDOUT_REPLY_MIN_CHARS = 80
+
+_ANSI_RE = re.compile(r"\x1b(?:\[[0-9;?]*[ -/]*[@-~]|\][^\x07\x1b]*(?:\x07|\x1b\\)?)")
+_HARNESS_NOISE_RE = re.compile(
+    r"^(?:"
+    r">\s+\S+\s+·\s"          # opencode banner: "> build · qwen3.6:latest"
+    r"|[→✱✳✻●⏺✓✔✖|]\s"  # tool-trace glyphs
+    r"|Shell cwd was reset\b"
+    r")"
+)
+
+
+def clean_transcript(output: str) -> str:
+    """Reduce a harness transcript to what the model actually said: strip
+    ANSI escapes, then drop harness chrome — the rig banner, tool-trace
+    lines, cwd-reset notices. Heuristic by design; noise that slips through
+    goes out once and pair suppression catches recurrence."""
+    text = _ANSI_RE.sub("", output)
+    kept = [
+        line for line in text.splitlines()
+        if not _HARNESS_NOISE_RE.match(line.strip())
+    ]
+    return "\n".join(kept).strip()
+
+
 def _run_turn(
     ctx: DispatchContext,
     config: RigConfig,
@@ -575,27 +601,41 @@ def _run_turn(
         f"### Output ({member.name}, {outcome})\n\n{output.strip() or '(no output)'}",
     )
 
+    if (
+        exit_code == 0
+        and not timed_out
+        and not state.staged_envelopes(ctx.node, member.name)
+    ):
+        # The classic weak-rig shape: the model answers on stdout instead of
+        # running `tell`. `tell` always wins — a turn that staged anything
+        # keeps its stdout as transcript — but a clean turn that released
+        # nothing gets its cleaned stdout staged as ONE reply to the inbound
+        # sender, riding every normal release gate below.
+        reply = clean_transcript(output)
+        if len(reply) > STDOUT_REPLY_MIN_CHARS:
+            msg_id = tasks.new_task_id()
+            state.atomic_write_json(
+                state.staging_dir(ctx.node, member.name) / f"{msg_id}.json",
+                {"id": msg_id, "to": sender, "content": reply, "files": []},
+            )
+            state.append_log(
+                ctx.node,
+                f"r4t: STDOUT-REPLY {member.name.lower()} (rig {rig.name}) "
+                f"released nothing; {len(reply)} bytes of cleaned stdout "
+                f"staged as a reply to {sender}",
+            )
+        elif len(output.strip()) > STDOUT_REPLY_MIN_CHARS:
+            state.append_log(
+                ctx.node,
+                f"r4t: SILENT {member.name.lower()} (rig {rig.name}) exit 0 "
+                f"with {len(output.strip())} bytes of stdout but nothing "
+                "worth relaying survived transcript cleaning",
+            )
+
     release = release_staging(
         ctx, config, roster, member, rig, task_id, hop, bulk_source=bulk_source,
         synthesis_response=synthesis_response,
     )
-    if (
-        release["released"] == 0
-        and release["violations"] == 0
-        and exit_code == 0
-        and not timed_out
-        and len(output.strip()) > 80
-    ):
-        # The classic weak-rig failure: the model answers on stdout instead
-        # of running `tell`, the turn "succeeds", and the answer vanishes
-        # into the log. Make it visible — the quiet-task backstop will close
-        # the task later, but the operator should see WHY it went quiet.
-        state.append_log(
-            ctx.node,
-            f"r4t: SILENT {member.name.lower()} (rig {rig.name}) exit 0 with "
-            f"{len(output.strip())} bytes of stdout but released no messages "
-            "— likely answered in text instead of running `tell`",
-        )
     if release["violations"]:
         level = state.bucket_drain(
             ctx.node, member.name, float(release["violations"]), config.bucket_max

--- a/apps/r4t/tests/conftest.py
+++ b/apps/r4t/tests/conftest.py
@@ -75,7 +75,7 @@ def fake_harness(tmp_path):
             n = len(os.listdir(calls_dir))
             with open(os.path.join(calls_dir, f"call-{{n:03d}}.txt"), "w") as f:
                 f.write(sys.argv[1])
-            print("fake harness ran in", os.getcwd())
+            print("fake harness ran")  # short: stays under the stdout-reply threshold
             """
         ),
         encoding="utf-8",

--- a/apps/r4t/tests/test_dispatch.py
+++ b/apps/r4t/tests/test_dispatch.py
@@ -130,19 +130,6 @@ class TestDispatchEndToEnd:
         assert after["used"] >= used_before  # no deliberate budget reset
         assert after["turns"] == task["turns"]  # forged hop never charged it
 
-    def test_silent_turn_is_logged(self, ctx, fake_harness, monkeypatch, r4t_home):
-        # Weak rig answers on stdout instead of running `tell`: turn exits 0,
-        # releases nothing — the operator must be able to see why the task
-        # went quiet.
-        def chatty_stdout(rig, prompt, cwd, *, env=None, variant=0):
-            return 0, "Here is my long detailed answer " * 5, 1.0, False
-
-        handle_message(ctx, "boss", "acme:gerry", "question", run_fn=chatty_stdout)
-        log = (state.team_dir(NODE) / "log").glob("*.md")
-        text = "".join(f.read_text(encoding="utf-8") for f in log)
-        assert "r4t: SILENT gerry" in text
-        assert "released no messages" in text
-
     def test_bare_node_goes_to_leader(self, ctx, fake_harness):
         handle_message(ctx, "neil", "acme", "status update please")
         prompt = read_prompt(harness_calls(fake_harness)[0])
@@ -441,6 +428,149 @@ class TestStagingRelease:
         monkeypatch.setenv("CHATTY_TO", "neil")
         _handle(chatty_ctx, "gerry", "acme:phil", "one clean job")
         assert state.bucket_level(NODE, "phil", 8.0) == 7.1
+
+
+ANSWER = "Here is my long detailed answer about the payload format. " * 3
+
+
+def stdout_only(rig, prompt, cwd, *, env=None, variant=0):
+    return 0, ANSWER, 1.0, False
+
+
+def read_log():
+    files = (state.team_dir(NODE) / "log").glob("*.md")
+    return "".join(f.read_text(encoding="utf-8") for f in files)
+
+
+class TestStdoutFallback:
+    def test_stdout_becomes_reply_to_external_sender(self, ctx, repo, r4t_home):
+        # The classic weak-rig shape: exit 0, no tell, answer on stdout —
+        # the cleaned transcript goes back to the sender as one reply.
+        handle_message(ctx, "boss", "acme:gerry", "question", run_fn=stdout_only)
+        envelopes = outbox_envelopes(repo)
+        assert [e["to"] for e in envelopes] == ["boss"]
+        assert envelopes[0]["content"] == ANSWER.strip()
+        assert envelopes[0]["x_r4t_class"] == "auto"
+        assert "[r4t" not in envelopes[0]["content"]
+        assert "r4t: STDOUT-REPLY gerry" in read_log()
+
+    def test_stdout_reply_to_creator_answers_the_task(self, ctx, r4t_home):
+        handle_message(ctx, "boss", "acme:gerry", "question", run_fn=stdout_only)
+        task = tasks.list_tasks(NODE)[0]
+        assert task["status"] == tasks.STATUS_CLOSED
+        assert "r4t: ANSWERED" in read_log()
+
+    def test_tell_always_wins(self, ctx, repo, r4t_home):
+        # A turn that stages even one envelope has declared its intent:
+        # stdout is transcript-only, never a message.
+        def tell_and_chatter(rig, prompt, cwd, *, env=None, variant=0):
+            outbox = dispatch.Path(env["TELL_OUTBOX_DIR"])
+            msg_id = new_ulid()
+            (outbox / f"{msg_id}.json").write_text(
+                json.dumps({"id": msg_id, "to": "outsider", "content": "the real reply"}),
+                encoding="utf-8",
+            )
+            return 0, ANSWER, 1.0, False
+
+        handle_message(ctx, "boss", "acme:gerry", "question", run_fn=tell_and_chatter)
+        envelopes = outbox_envelopes(repo)
+        assert [e["to"] for e in envelopes] == ["outsider"]
+        assert envelopes[0]["content"] == "the real reply"
+        assert "STDOUT-REPLY" not in read_log()
+
+    def test_chrome_only_stdout_stays_silent(self, ctx, repo, r4t_home):
+        chrome = (
+            "\x1b[0m\n> build · qwen3:0.6b\n\x1b[0m\n"
+            '\x1b[0m✱ \x1b[0mGlob "**/sample.txt"\x1b[90m 1 match\x1b[0m\n'
+            "\x1b[0m→ \x1b[0mRead sample.txt\n"
+            "Shell cwd was reset to /Users/neilo/bin\n"
+        )
+        def chrome_only(rig, prompt, cwd, *, env=None, variant=0):
+            return 0, chrome, 1.0, False
+
+        handle_message(ctx, "boss", "acme:gerry", "question", run_fn=chrome_only)
+        assert outbox_envelopes(repo) == []
+        text = read_log()
+        assert "r4t: SILENT gerry" in text
+        assert "STDOUT-REPLY" not in text
+
+    def test_reply_is_cleaned_of_chrome(self, ctx, repo, r4t_home):
+        noisy = (
+            "\x1b[0m\n> build · qwen3.6:latest\n\x1b[0m\n"
+            "\x1b[0m→ \x1b[0mRead GOAL.md\n"
+            + ANSWER
+            + "\nShell cwd was reset to /Users/neilo/bin\n"
+        )
+        def noisy_answer(rig, prompt, cwd, *, env=None, variant=0):
+            return 0, noisy, 1.0, False
+
+        handle_message(ctx, "boss", "acme:gerry", "question", run_fn=noisy_answer)
+        assert outbox_envelopes(repo)[0]["content"] == ANSWER.strip()
+
+    def test_fallback_reply_to_internal_sender_wakes_them(
+        self, ctx, fake_harness, r4t_home
+    ):
+        # phil answers gerry on stdout; the reply parks internal and gerry's
+        # turn runs on drain with the cleaned stdout as the inbound body.
+        task_id = new_ulid()
+        header = tasks.format_header(task_id, 1, auto=True)
+        handle_message(ctx, f"{NODE}:gerry", "acme:phil", f"{header} question",
+                       run_fn=stdout_only)
+        drain(ctx)
+        prompts = [read_prompt(p) for p in harness_calls(fake_harness)]
+        assert any("From: phil" in p and ANSWER.strip() in p for p in prompts)
+
+    def test_fallback_reply_to_human_parks_in_seat(self, ctx, fake_harness, r4t_home):
+        handle_message(ctx, "acme:neil", "acme:gerry", "question", run_fn=stdout_only)
+        drain_until_quiet(ctx)
+        parked = seat_messages()
+        assert [m["from"] for m in parked] == ["acme:gerry"]
+        _, _, _, body = tasks.parse_header(parked[0]["content"])
+        assert body == ANSWER.strip()
+        assert tasks.list_tasks(NODE)[0]["status"] == tasks.STATUS_CLOSED
+
+    def test_fallback_obeys_pair_suppression(self, ctx, repo, r4t_home):
+        handle_message(ctx, "boss", "acme:gerry", "question one", run_fn=stdout_only)
+        handle_message(ctx, "boss", "acme:gerry", "question two", run_fn=stdout_only)
+        assert len(outbox_envelopes(repo)) == 1
+        assert "pair-repeat" in dead_reasons()
+
+    def test_short_stdout_is_just_a_quiet_turn(self, ctx, repo, r4t_home):
+        def terse(rig, prompt, cwd, *, env=None, variant=0):
+            return 0, "ok.", 1.0, False
+
+        handle_message(ctx, "boss", "acme:gerry", "question", run_fn=terse)
+        assert outbox_envelopes(repo) == []
+        text = read_log()
+        assert "SILENT" not in text
+        assert "STDOUT-REPLY" not in text
+
+    def test_failed_turn_gets_no_fallback(self, ctx, repo, r4t_home):
+        def crashed(rig, prompt, cwd, *, env=None, variant=0):
+            return 1, ANSWER, 1.0, False
+
+        handle_message(ctx, "boss", "acme:gerry", "question", run_fn=crashed)
+        assert outbox_envelopes(repo) == []
+        assert "STDOUT-REPLY" not in read_log()
+
+
+class TestCleanTranscript:
+    def test_strips_ansi_and_chrome(self):
+        raw = (
+            "\x1b[0m\n> build · qwen3.6:latest\n"
+            '\x1b[0m✱ \x1b[0mGlob "**/x.txt"\x1b[90m 1 match\x1b[0m\n'
+            "\x1b[0m→ \x1b[0mRead x.txt\n"
+            "The contents are fine.\n"
+            "Shell cwd was reset to /Users/neilo/bin\n"
+        )
+        assert dispatch.clean_transcript(raw) == "The contents are fine."
+
+    def test_keeps_markdown_blockquotes(self):
+        raw = "As GOAL.md says:\n> the game must exit 0\nDone."
+        assert dispatch.clean_transcript(raw) == raw
+
+    def test_keeps_plain_text_untouched(self):
+        assert dispatch.clean_transcript("hello\nworld") == "hello\nworld"
 
 
 class TestPairSuppression:


### PR DESCRIPTION
Closes #168.

## The rule

**`tell` always wins.** A turn that staged even one envelope keeps its stdout as transcript. A turn that exits 0, releases nothing, and printed a non-trivial answer gets its cleaned stdout staged as ONE reply to the inbound sender. No per-rig knob: strong models never trigger it, stdout-only models participate without knowing the protocol exists.

## Mechanics

- The synthetic envelope is written into the turn's staging dir **before** `release_staging` runs, so quota, pair suppression, attribution, hop+1, `auto` class, and egress strip all apply unchanged — governance never special-cases the fallback.
- `clean_transcript` strips ANSI escapes and harness chrome observed in real opencode/ollama output (the `> build · <model>` banner, glyph tool-trace lines like `→ Read x.txt` / `✱ Glob "**/x.txt"`, cwd-reset notices). Markdown blockquotes in real answers survive.
- Cleaning leaves nothing → the `r4t: SILENT` line survives for the operator; fallback fires → `r4t: STDOUT-REPLY`.
- `_forced_synthesis` and nudge turns route through `_run_turn` with the real sender, so weak-rig synthesis and recovery turns complete their loops for free.

## Live evidence (ttt, today)

- New roster member **Dot** (rig `dumb` = qwen3:0.6b, cannot run tools) drafted how-to-play text; the draft reached the seat via `STDOUT-REPLY dot` → `ANSWERED`.
- Full delegation: seat → Ada → {Dot, Linus, Grace} → Ada. All three weak-rig members replied via `STDOUT-REPLY`; Linus took Dot's draft, fixed its factual errors, and committed a real `README.md`. Linus also ran `tell grace` on a later turn — tell-capable members keep full capability and their tells preempt.
- Closing loop: seat → Ada → Grace (verify README against actual gameplay) → Ada → seat `ANSWERED`, Grace's verdict riding the fallback the whole way.

## Observation for tuning (not code)

Fallback replies always route back through the delegator — a star, not a chain. A weak team burns ~2 hops per delegation round trip, so the wide test above hit `hop_limit 4` and closed via the hop-cut doorbell + backstop instead of a direct report. Weak-rig teams want a higher `hop_limit` in their rig config; worth a line in the #169 status/docs work.

## Tests

246 r4t + 639 a8s passing. New: `TestStdoutFallback` (external/internal/human-seat senders, tell-wins, chrome-only silence, pair suppression, failed turns) and `TestCleanTranscript` (real captured opencode output shapes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)