### PR TITLE
feat(r4t): observability for humans — verdicts, dead-letter rollup, Textual chat

### DIFF
--- a/apps/r4t/README.md
+++ b/apps/r4t/README.md
@@ -77,8 +77,12 @@ tell acme:gerry "Ship the payload refactor; report when reviewed."
 ```
 
 Watch it: `a8s logs acme-node -f` (traffic + every governance decision line),
-`r4t status --node acme` (locks, buckets, tasks, dead letters), and the
-dead-letter dir under `~/.config/r4t/teams/acme/`.
+`r4t status --node acme` (leads with plain-English health verdicts — waiting
+on you? runaway? member broken/muted/stalled? task starved on hops? — then
+locks, buckets, tasks, and dead letters rolled up by meaning), and the
+dead-letter dir under `~/.config/r4t/teams/acme/`. The first dispatch stamps
+the repo root into team state, so `--node` works from any directory — and
+from inside a team repo the `--node` flag itself is optional.
 
 ## The seat: being the human in the roster
 
@@ -97,12 +101,18 @@ r4t seat send --to phil "…" # or to a member (runs their turn synchronously)
 
 `r4t seat` is the scriptable surface — an orchestrating agent impersonates
 the human with it directly. `r4t chat` is the human view over the same
-mailbox: one window interleaving seat messages, turn starts/completions,
-and governance events, with an input line (`/to`, `/who`, `/tasks`,
-`/quit`). While chat (or anything touching the presence file) is attached,
-dispatch skips the `Address:` doorbell; detach and the doorbell rings
-again. Training wheels, not a replacement for autonomy — everything still
-flows through normal dispatch and governance.
+mailbox: a full-screen TUI with a health header fed by the same verdict
+engine as `r4t status` (worst-level summary, live warnings, open-task
+budget bars), a conversation pane beside a fly-on-the-wall activity pane
+(turn starts/completions and every governance decision line), and an
+input line (`/to`, `/who`, `/tasks`, `/quit`). The TUI needs
+[textual](https://textual.textualize.io/) (`python3 -m pip install
+textual`); without it — or with `--plain`, or piped — chat falls back to
+a line UI over the same feed. While chat (or anything touching the
+presence file) is attached, dispatch skips the `Address:` doorbell;
+detach and the doorbell rings again. Training wheels, not a replacement
+for autonomy — everything still flows through normal dispatch and
+governance.
 
 ## Governance knobs
 
@@ -186,6 +196,8 @@ python3 -m pytest apps/r4t/tests/     # from anywhere in ~/bin — the repo
 Layout: `r4t.py` (CLI) · `dispatch.py` (turns, staging release, forced
 synthesis, idle recovery) · `tasks.py` (header + ledger) · `state.py`
 (all on-disk state under `$R4T_HOME`) · `harness.py` (rig config) ·
-`roster.py` · `sandbox.py` + `sandbox/` (the end-to-end harness).
+`roster.py` · `verdict.py` (health verdicts + dead-letter rollup, shared
+by status and chat) · `chat.py` (seat feed + line UI) · `chat_tui.py`
+(Textual front end) · `sandbox.py` + `sandbox/` (the end-to-end harness).
 Observability rides on a8s: traffic in the a8s txlog/convo, r4t decision
 lines in the node log via dispatch stdout, r4t-only state via `r4t status`.

--- a/apps/r4t/README.md
+++ b/apps/r4t/README.md
@@ -76,13 +76,20 @@ a8s start acme-node
 tell acme:gerry "Ship the payload refactor; report when reviewed."
 ```
 
-Watch it: `a8s logs acme-node -f` (traffic + every governance decision line),
-`r4t status --node acme` (leads with plain-English health verdicts — waiting
-on you? runaway? member broken/muted/stalled? task starved on hops? — then
-locks, buckets, tasks, and dead letters rolled up by meaning), and the
-dead-letter dir under `~/.config/r4t/teams/acme/`. The first dispatch stamps
-the repo root into team state, so `--node` works from any directory — and
-from inside a team repo the `--node` flag itself is optional.
+Watch it — one surface per way of looking:
+
+- `r4t status` — the snapshot. Leads with plain-English health verdicts
+  (waiting on you? runaway? member broken/muted/stalled? task starved on
+  hops?), then locks, buckets, tasks, and dead letters rolled up by meaning.
+- `r4t logs -f` — the stream. The team's own event log: every governance
+  decision and turn boundary, including walled-garden traffic that never
+  reaches a8s. `--full` includes prompts and transcripts.
+- `r4t chat` — the human, interactively (see the seat section below).
+- `r4t seat` — an orchestrating agent, programmatically.
+
+The first dispatch stamps the repo root into team state, so `--node` works
+from any directory — and from inside a team repo the `--node` flag itself
+is optional. (`a8s logs acme-node -f` still shows the cross-wall view.)
 
 ## The seat: being the human in the roster
 

--- a/apps/r4t/chat.py
+++ b/apps/r4t/chat.py
@@ -21,7 +21,7 @@ import queue
 import sys
 import threading
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 
 import state
 import tasks as taskmod
@@ -118,8 +118,10 @@ class SeatFeed:
         return events
 
     def poll_log(self) -> list[tuple[str, str]]:
+        # append_log names day files by UTC date — matching local time here
+        # would watch a file that stops receiving writes after UTC midnight.
         path = state.team_dir(self.node) / "log" / (
-            datetime.now().strftime("%Y-%m-%d") + ".md"
+            datetime.now(timezone.utc).strftime("%Y-%m-%d") + ".md"
         )
         if path != self.log_path:
             self.log_path = path

--- a/apps/r4t/chat.py
+++ b/apps/r4t/chat.py
@@ -10,7 +10,9 @@ traffic crossing the wall.
 
 `r4t seat` exposes the same mailbox and voice as discrete commands — that
 is the surface for orchestrators impersonating the human; chat is the
-human-facing view over it.
+human-facing view over it. This module is the line UI plus the shared
+seat machinery (SeatFeed, sending, target resolution); chat_tui.py is the
+Textual front end over the same pieces.
 """
 from __future__ import annotations
 
@@ -27,6 +29,23 @@ from dispatch import DispatchContext, drain_until_quiet, handle_message
 from roster import Member, Roster, RosterError, load_roster
 
 POLL_SECONDS = 0.5
+
+
+class SeatError(Exception):
+    pass
+
+
+def load_seat(ctx: DispatchContext) -> tuple[Roster, Member]:
+    try:
+        roster = load_roster(ctx.roster_path)
+    except RosterError as e:
+        raise SeatError(str(e)) from e
+    human = next((m for m in roster.members if m.is_human), None)
+    if human is None:
+        raise SeatError(
+            "no human member in the roster — add one to ROSTER.md (Status: Human)"
+        )
+    return roster, human
 
 
 def render_envelope(envelope: dict) -> str:
@@ -52,6 +71,79 @@ def filter_log_line(line: str) -> str | None:
     if line.startswith("### Output ("):
         return f"done: {line[len('### Output ('):].rstrip(')')}"
     return None
+
+
+def resolve_target(roster: Roster, node: str, arg: str) -> str | None:
+    """A /to argument as a dispatchable address: bare team name = leader,
+    a member name = that member; None when nothing in the roster matches."""
+    arg = arg.strip().lower()
+    if not arg or arg == node:
+        return node
+    if any(not m.is_human and m.name.lower() == arg for m in roster.members):
+        return f"{node}:{arg}"
+    return None
+
+
+def send_as_human(ctx: DispatchContext, human: Member, to: str, text: str) -> None:
+    """Speak as the seat: drain anything parked, run the recipient's turn
+    synchronously, then drain the fallout. Blocks for the whole exchange —
+    callers own threading."""
+    sender = f"{ctx.node}:{human.name.lower()}"
+    drain_until_quiet(ctx)
+    handle_message(ctx, sender, to, text)
+    drain_until_quiet(ctx)
+
+
+class SeatFeed:
+    """Polls the seat inbox and the team's daily log into (kind, text)
+    events: 'in' = message parked for the human (marked read on read),
+    'act' = compacted activity line. Log history before the first poll is
+    skipped; unread inbox backlog is always delivered."""
+
+    def __init__(self, node: str, human_name: str):
+        self.node = node
+        self.human_name = human_name
+        self.log_path = None
+        self.log_offset = 0
+
+    def poll_inbox(self) -> list[tuple[str, str]]:
+        events: list[tuple[str, str]] = []
+        for path in state.list_seat_messages(self.node, self.human_name):
+            try:
+                envelope = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            events.append(("in", render_envelope(envelope)))
+            state.mark_seat_read(self.node, self.human_name, path)
+        return events
+
+    def poll_log(self) -> list[tuple[str, str]]:
+        path = state.team_dir(self.node) / "log" / (
+            datetime.now().strftime("%Y-%m-%d") + ".md"
+        )
+        if path != self.log_path:
+            self.log_path = path
+            self.log_offset = path.stat().st_size if path.is_file() else 0
+            return []
+        if not path.is_file():
+            return []
+        size = path.stat().st_size
+        if size <= self.log_offset:
+            self.log_offset = min(self.log_offset, size)
+            return []
+        with path.open("r", encoding="utf-8") as f:
+            f.seek(self.log_offset)
+            chunk = f.read()
+            self.log_offset = f.tell()
+        events: list[tuple[str, str]] = []
+        for line in chunk.splitlines():
+            event = filter_log_line(line)
+            if event:
+                events.append(("act", event))
+        return events
+
+    def poll(self) -> list[tuple[str, str]]:
+        return self.poll_inbox() + self.poll_log()
 
 
 def format_tasks(node: str) -> list[str]:
@@ -99,10 +191,9 @@ class ChatSession:
         self.roster = roster
         self.human = human
         self.target = ctx.node
+        self.feed = SeatFeed(ctx.node, human.name)
         self.events: queue.Queue[tuple[str, str]] = queue.Queue()
         self.sends: queue.Queue[tuple[str, str]] = queue.Queue()
-        self.log_path = None
-        self.log_offset = 0
         self.tty = sys.stdout.isatty()
 
     # ---------- output ----------
@@ -118,50 +209,13 @@ class ChatSession:
                 print(f"{stamp} {line}")
         sys.stdout.flush()
 
-    # ---------- polling ----------
-
-    def poll_inbox(self) -> None:
-        for path in state.list_seat_messages(self.ctx.node, self.human.name):
-            try:
-                envelope = json.loads(path.read_text(encoding="utf-8"))
-            except (OSError, json.JSONDecodeError):
-                continue
-            self.events.put(("in", render_envelope(envelope)))
-            state.mark_seat_read(self.ctx.node, self.human.name, path)
-
-    def poll_log(self) -> None:
-        path = state.team_dir(self.ctx.node) / "log" / (
-            datetime.now().strftime("%Y-%m-%d") + ".md"
-        )
-        if path != self.log_path:
-            self.log_path = path
-            self.log_offset = path.stat().st_size if path.is_file() else 0
-            return
-        if not path.is_file():
-            return
-        size = path.stat().st_size
-        if size <= self.log_offset:
-            self.log_offset = min(self.log_offset, size)
-            return
-        with path.open("r", encoding="utf-8") as f:
-            f.seek(self.log_offset)
-            chunk = f.read()
-            self.log_offset = f.tell()
-        for line in chunk.splitlines():
-            event = filter_log_line(line)
-            if event:
-                self.events.put(("act", event))
-
     # ---------- sending ----------
 
     def _send_worker(self) -> None:
-        sender = f"{self.ctx.node}:{self.human.name.lower()}"
         while True:
             to, text = self.sends.get()
             try:
-                drain_until_quiet(self.ctx)
-                handle_message(self.ctx, sender, to, text)
-                drain_until_quiet(self.ctx)
+                send_as_human(self.ctx, self.human, to, text)
             except Exception as e:  # noqa: BLE001 — surface, don't kill the seat
                 self.events.put(("sys", f"send failed: {e}"))
 
@@ -185,17 +239,13 @@ class ChatSession:
             if cmd == "/help":
                 self.emit("sys", HELP)
             elif cmd == "/to":
-                arg = arg.strip().lower()
-                if not arg or arg == self.ctx.node:
-                    self.target = self.ctx.node
-                elif any(
-                    not m.is_human and m.name.lower() == arg
-                    for m in self.roster.members
-                ):
-                    self.target = f"{self.ctx.node}:{arg}"
-                else:
-                    self.emit("sys", f"no AI member named {arg!r} in the roster")
+                target = resolve_target(self.roster, self.ctx.node, arg)
+                if target is None:
+                    self.emit(
+                        "sys", f"no AI member named {arg.strip().lower()!r} in the roster"
+                    )
                     return True
+                self.target = target
                 self.emit("sys", f"target: {self.target}")
             elif cmd == "/who":
                 self.emit(
@@ -220,8 +270,8 @@ class ChatSession:
             f" {self.target} (leader). /help for commands.",
         )
         state.touch_seat_presence(self.ctx.node, self.human.name)
-        self.poll_log()
-        self.poll_inbox()
+        for event in self.feed.poll():
+            self.events.put(event)
 
         threading.Thread(target=self._send_worker, daemon=True).start()
         lines: queue.Queue[str] = queue.Queue()
@@ -235,8 +285,8 @@ class ChatSession:
                 except queue.Empty:
                     pass
                 state.touch_seat_presence(self.ctx.node, self.human.name)
-                self.poll_inbox()
-                self.poll_log()
+                for event in self.feed.poll():
+                    self.events.put(event)
                 try:
                     while True:
                         kind, text = self.events.get_nowait()
@@ -253,16 +303,8 @@ class ChatSession:
 
 def run_chat(ctx: DispatchContext) -> int:
     try:
-        roster = load_roster(ctx.roster_path)
-    except RosterError as e:
+        roster, human = load_seat(ctx)
+    except SeatError as e:
         print(f"r4t chat: {e}", file=sys.stderr)
-        return 2
-    human = next((m for m in roster.members if m.is_human), None)
-    if human is None:
-        print(
-            "r4t chat: no human member in the roster — add one to ROSTER.md "
-            "(Status: Human)",
-            file=sys.stderr,
-        )
         return 2
     return ChatSession(ctx, roster, human).run()

--- a/apps/r4t/chat.py
+++ b/apps/r4t/chat.py
@@ -95,10 +95,11 @@ def send_as_human(ctx: DispatchContext, human: Member, to: str, text: str) -> No
 
 
 class SeatFeed:
-    """Polls the seat inbox and the team's daily log into (kind, text)
-    events: 'in' = message parked for the human (marked read on read),
-    'act' = compacted activity line. Log history before the first poll is
-    skipped; unread inbox backlog is always delivered."""
+    """Polls the seat inbox and the team's daily log into (kind, payload)
+    events: 'in' = the raw envelope dict parked for the human (marked read
+    on read) — consumers render it (the line UI flattens, the TUI draws
+    markdown); 'act' = compacted activity line as text. Log history before
+    the first poll is skipped; unread inbox backlog is always delivered."""
 
     def __init__(self, node: str, human_name: str):
         self.node = node
@@ -106,14 +107,14 @@ class SeatFeed:
         self.log_path = None
         self.log_offset = 0
 
-    def poll_inbox(self) -> list[tuple[str, str]]:
-        events: list[tuple[str, str]] = []
+    def poll_inbox(self) -> list[tuple[str, dict]]:
+        events: list[tuple[str, dict]] = []
         for path in state.list_seat_messages(self.node, self.human_name):
             try:
                 envelope = json.loads(path.read_text(encoding="utf-8"))
             except (OSError, json.JSONDecodeError):
                 continue
-            events.append(("in", render_envelope(envelope)))
+            events.append(("in", envelope))
             state.mark_seat_read(self.node, self.human_name, path)
         return events
 
@@ -144,8 +145,8 @@ class SeatFeed:
                 events.append(("act", event))
         return events
 
-    def poll(self) -> list[tuple[str, str]]:
-        return self.poll_inbox() + self.poll_log()
+    def poll(self) -> list[tuple[str, object]]:
+        return [*self.poll_inbox(), *self.poll_log()]
 
 
 def format_tasks(node: str) -> list[str]:
@@ -265,6 +266,11 @@ class ChatSession:
 
     # ---------- main loop ----------
 
+    def _pump_feed(self) -> None:
+        for kind, payload in self.feed.poll():
+            text = render_envelope(payload) if kind == "in" else payload
+            self.events.put((kind, text))
+
     def run(self) -> int:
         self.emit(
             "sys",
@@ -272,8 +278,7 @@ class ChatSession:
             f" {self.target} (leader). /help for commands.",
         )
         state.touch_seat_presence(self.ctx.node, self.human.name)
-        for event in self.feed.poll():
-            self.events.put(event)
+        self._pump_feed()
 
         threading.Thread(target=self._send_worker, daemon=True).start()
         lines: queue.Queue[str] = queue.Queue()
@@ -287,8 +292,7 @@ class ChatSession:
                 except queue.Empty:
                     pass
                 state.touch_seat_presence(self.ctx.node, self.human.name)
-                for event in self.feed.poll():
-                    self.events.put(event)
+                self._pump_feed()
                 try:
                     while True:
                         kind, text = self.events.get_nowait()

--- a/apps/r4t/chat_tui.py
+++ b/apps/r4t/chat_tui.py
@@ -54,7 +54,7 @@ LEVEL_STYLE = {verdict.OK: "green", verdict.WARN: "yellow", verdict.BAD: "red"}
 def budget_bar(used: float, budget: float, width: int = 8) -> str:
     frac = 0.0 if budget <= 0 else min(1.0, used / budget)
     filled = round(frac * width)
-    return "▮" * filled + "▯" * (width - filled)
+    return "█" * filled + "░" * (width - filled)
 
 
 class ChatApp(App):

--- a/apps/r4t/chat_tui.py
+++ b/apps/r4t/chat_tui.py
@@ -18,6 +18,8 @@ import sys
 import threading
 from datetime import datetime
 
+from rich.markdown import Markdown
+from rich.padding import Padding
 from rich.text import Text
 from textual.app import App, ComposeResult
 from textual.containers import Horizontal
@@ -99,8 +101,7 @@ class ChatApp(App):
             f"seat: {self.human.name} on {self.ctx.node} — messages go to "
             f"{self.target} (leader). /help for commands.",
         )
-        for kind, text in self.feed.poll():
-            self._emit(kind, text)
+        self._pump_feed()
         self._refresh_header()
         threading.Thread(target=self._send_worker, daemon=True).start()
         self.set_interval(FEED_POLL_SECONDS, self._poll_feed)
@@ -117,12 +118,28 @@ class ChatApp(App):
         for line in text.splitlines():
             log.write(Text.assemble((stamp + " ", "dim"), (line, KIND_STYLE[kind])))
 
+    def _emit_message(self, envelope: dict) -> None:
+        """An inbound message: sender header line, then the body as rendered
+        markdown — agents write markdown, and raw ** and # are noise."""
+        log = self.query_one("#conversation", RichLog)
+        stamp = datetime.now().strftime("%H:%M:%S")
+        sender = str(envelope.get("from", "?"))
+        _, _, _, body = taskmod.parse_header(str(envelope.get("content", "")))
+        log.write(Text.assemble((stamp + " ", "dim"), (sender, "bold cyan")))
+        log.write(Padding(Markdown(body.strip() or "(empty)"), (0, 0, 1, 9)))
+
     # ---------- polling ----------
+
+    def _pump_feed(self) -> None:
+        for kind, payload in self.feed.poll():
+            if kind == "in":
+                self._emit_message(payload)
+            else:
+                self._emit(kind, payload)
 
     def _poll_feed(self) -> None:
         state.touch_seat_presence(self.ctx.node, self.human.name)
-        for kind, text in self.feed.poll():
-            self._emit(kind, text)
+        self._pump_feed()
 
     def _refresh_header(self) -> None:
         verdicts = verdict.team_verdicts(self.ctx.node, self.roster, self.rig_config)

--- a/apps/r4t/chat_tui.py
+++ b/apps/r4t/chat_tui.py
@@ -1,0 +1,232 @@
+"""r4t chat — Textual front end over the seat.
+
+One window, three regions: a health header fed by the same verdict engine
+as `r4t status` (worst-level summary, non-ok verdicts, open-task budget
+bars), a conversation pane (seat messages and what you say) beside a
+fly-on-the-wall activity pane (turn starts/completions and every
+governance decision line), and an input line that speaks as the roster
+human. Sends run on a background thread — dispatch turns are synchronous
+and slow, and the wall must keep scrolling while a rig thinks.
+
+Importing this module requires textual; cmd_chat falls back to the line
+UI in chat.py when it is missing.
+"""
+from __future__ import annotations
+
+import queue
+import sys
+import threading
+from datetime import datetime
+
+from rich.text import Text
+from textual.app import App, ComposeResult
+from textual.containers import Horizontal
+from textual.widgets import Footer, Input, RichLog, Static
+
+import state
+import tasks as taskmod
+import verdict
+from chat import (
+    HELP,
+    SeatError,
+    SeatFeed,
+    format_tasks,
+    format_who,
+    load_seat,
+    resolve_target,
+    send_as_human,
+)
+from dispatch import DispatchContext
+from rig import RigError, load_rig_config
+from roster import Member, Roster
+
+FEED_POLL_SECONDS = 0.5
+HEADER_REFRESH_SECONDS = 5.0
+MAX_HEADER_VERDICTS = 4
+MAX_HEADER_TASKS = 3
+
+KIND_STYLE = {"in": "cyan", "you": "green", "sys": "yellow", "act": "dim"}
+LEVEL_STYLE = {verdict.OK: "green", verdict.WARN: "yellow", verdict.BAD: "red"}
+
+
+def budget_bar(used: float, budget: float, width: int = 8) -> str:
+    frac = 0.0 if budget <= 0 else min(1.0, used / budget)
+    filled = round(frac * width)
+    return "▮" * filled + "▯" * (width - filled)
+
+
+class ChatApp(App):
+    TITLE = "r4t chat"
+
+    CSS = """
+    Screen { layout: vertical; }
+    #header { height: auto; padding: 0 1; background: $panel; }
+    #panes { height: 1fr; }
+    #conversation { width: 2fr; }
+    #activity { width: 1fr; border-left: solid $panel; }
+    #composer { dock: bottom; }
+    """
+
+    BINDINGS = [("ctrl+q", "quit", "Quit")]
+
+    def __init__(self, ctx: DispatchContext, roster: Roster, human: Member):
+        super().__init__()
+        self.ctx = ctx
+        self.roster = roster
+        self.human = human
+        self.target = ctx.node
+        self.feed = SeatFeed(ctx.node, human.name)
+        self.sends: queue.Queue[tuple[str, str]] = queue.Queue()
+        try:
+            self.rig_config = load_rig_config(ctx.config_path)
+        except RigError:
+            self.rig_config = None
+
+    def compose(self) -> ComposeResult:
+        yield Static(id="header")
+        with Horizontal(id="panes"):
+            yield RichLog(id="conversation", wrap=True)
+            yield RichLog(id="activity", wrap=True, max_lines=2000)
+        yield Input(
+            id="composer",
+            placeholder=f"message {self.target} (leader) — /help for commands",
+        )
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self._emit(
+            "sys",
+            f"seat: {self.human.name} on {self.ctx.node} — messages go to "
+            f"{self.target} (leader). /help for commands.",
+        )
+        for kind, text in self.feed.poll():
+            self._emit(kind, text)
+        self._refresh_header()
+        threading.Thread(target=self._send_worker, daemon=True).start()
+        self.set_interval(FEED_POLL_SECONDS, self._poll_feed)
+        self.set_interval(HEADER_REFRESH_SECONDS, self._refresh_header)
+        self.query_one("#composer", Input).focus()
+
+    # ---------- output ----------
+
+    def _emit(self, kind: str, text: str) -> None:
+        log = self.query_one(
+            "#activity" if kind == "act" else "#conversation", RichLog
+        )
+        stamp = datetime.now().strftime("%H:%M:%S")
+        for line in text.splitlines():
+            log.write(Text.assemble((stamp + " ", "dim"), (line, KIND_STYLE[kind])))
+
+    # ---------- polling ----------
+
+    def _poll_feed(self) -> None:
+        state.touch_seat_presence(self.ctx.node, self.human.name)
+        for kind, text in self.feed.poll():
+            self._emit(kind, text)
+
+    def _refresh_header(self) -> None:
+        verdicts = verdict.team_verdicts(self.ctx.node, self.roster, self.rig_config)
+        worst = verdict.worst_level(verdicts)
+        open_tasks = [
+            t for t in taskmod.list_tasks(self.ctx.node)
+            if t.get("status") == taskmod.STATUS_OPEN
+        ]
+
+        header = Text()
+        header.append(self.ctx.node, style="bold")
+        header.append(f" · seat {self.human.name} → {self.target}", style="")
+        header.append("  ")
+        header.append(
+            f"{verdict.MARKS[worst]} "
+            + {"ok": "healthy", "warn": "attention", "bad": "action needed"}[worst],
+            style=LEVEL_STYLE[worst],
+        )
+        header.append(f" · {len(open_tasks)} open task(s)", style="dim")
+
+        shown = [v for v in verdicts if v.level != verdict.OK]
+        for v in shown[:MAX_HEADER_VERDICTS]:
+            header.append("\n")
+            header.append(f"{verdict.MARKS[v.level]} {v.text}", style=LEVEL_STYLE[v.level])
+        if len(shown) > MAX_HEADER_VERDICTS:
+            header.append(
+                f"\n… {len(shown) - MAX_HEADER_VERDICTS} more (r4t status)", style="dim"
+            )
+        for t in open_tasks[:MAX_HEADER_TASKS]:
+            used = float(t.get("used", 0.0))
+            budget = float(t.get("budget", 1.0) or 1.0)
+            header.append("\n")
+            header.append(budget_bar(used, budget), style="magenta")
+            header.append(
+                f" {100 * used / budget:3.0f}% {t.get('id', '?')}"
+                f"  turns={t.get('turns', 0)} creator={t.get('creator', '?')}",
+                style="dim",
+            )
+        self.query_one("#header", Static).update(header)
+
+    # ---------- sending ----------
+
+    def _send_worker(self) -> None:
+        while True:
+            to, text = self.sends.get()
+            try:
+                send_as_human(self.ctx, self.human, to, text)
+            except Exception as e:  # noqa: BLE001 — surface, don't kill the seat
+                self.call_from_thread(self._emit, "sys", f"send failed: {e}")
+
+    # ---------- input ----------
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        line = event.value.strip()
+        event.input.clear()
+        if not line:
+            return
+        if line.startswith("/"):
+            self._command(line)
+            return
+        self.sends.put((self.target, line))
+        self._emit("you", f"you -> {self.target}: {line}")
+
+    def _command(self, line: str) -> None:
+        cmd, _, arg = line.partition(" ")
+        cmd = cmd.lower()
+        if cmd == "/quit":
+            self.exit(0)
+        elif cmd == "/help":
+            self._emit("sys", HELP)
+        elif cmd == "/to":
+            target = resolve_target(self.roster, self.ctx.node, arg)
+            if target is None:
+                self._emit(
+                    "sys", f"no AI member named {arg.strip().lower()!r} in the roster"
+                )
+                return
+            self.target = target
+            suffix = " (leader)" if target == self.ctx.node else ""
+            self.query_one("#composer", Input).placeholder = (
+                f"message {self.target}{suffix} — /help for commands"
+            )
+            self._emit("sys", f"target: {self.target}")
+            self._refresh_header()
+        elif cmd == "/who":
+            self._emit(
+                "sys", "\n".join(format_who(self.ctx.node, self.roster, self.human))
+            )
+        elif cmd == "/tasks":
+            self._emit("sys", "\n".join(format_tasks(self.ctx.node)))
+        else:
+            self._emit("sys", f"unknown command {cmd!r} (/help)")
+
+
+def run_chat_tui(ctx: DispatchContext) -> int:
+    try:
+        roster, human = load_seat(ctx)
+    except SeatError as e:
+        print(f"r4t chat: {e}", file=sys.stderr)
+        return 2
+    app = ChatApp(ctx, roster, human)
+    try:
+        state.touch_seat_presence(ctx.node, human.name)
+        result = app.run()
+    finally:
+        state.clear_seat_presence(ctx.node, human.name)
+    return int(result or 0)

--- a/apps/r4t/chat_tui.py
+++ b/apps/r4t/chat_tui.py
@@ -152,13 +152,13 @@ class ChatApp(App):
         header = Text()
         header.append(self.ctx.node, style="bold")
         header.append(f" · seat {self.human.name} → {self.target}", style="")
-        header.append("  ")
+        header.append(f" · {len(open_tasks)} open task(s)", style="dim")
+        header.append("   ")
         header.append(
             f"{verdict.MARKS[worst]} "
             + {"ok": "healthy", "warn": "attention", "bad": "action needed"}[worst],
             style=LEVEL_STYLE[worst],
         )
-        header.append(f" · {len(open_tasks)} open task(s)", style="dim")
 
         shown = [v for v in verdicts if v.level != verdict.OK]
         for v in shown[:MAX_HEADER_VERDICTS]:

--- a/apps/r4t/dispatch.py
+++ b/apps/r4t/dispatch.py
@@ -209,7 +209,8 @@ def build_prompt(
         f"    - reply to the sender: tell {_display_name(ctx.node, sender)} \"<message>\"",
         "    - a teammate: tell <name> \"<message>\". Teammates:",
         *(teammates or ["    - (none)"]),
-        "    - group discussion: tell chatroom '#<room> <message>'",
+        "- Speak to teammates directly and one at a time — do not post to "
+        "chat rooms or broadcast channels.",
         "- Never use `tell --sync` with teammates — it blocks your turn "
         "waiting for a reply that arrives by waking you instead.",
         "- Do not send acknowledgment-only messages. If you have nothing "

--- a/apps/r4t/r4t.py
+++ b/apps/r4t/r4t.py
@@ -13,6 +13,8 @@ import json
 import os
 import re
 import sys
+import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 import state
@@ -574,6 +576,64 @@ def cmd_status(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_logs(args: argparse.Namespace) -> int:
+    node = _resolve_node(args.node)
+    if node is None:
+        return 2
+    from chat import filter_log_line
+
+    log_dir = state.team_dir(node) / "log"
+
+    def rendered(raw: str) -> list[str]:
+        if args.full:
+            return [raw]
+        event = filter_log_line(raw)
+        return [event] if event else []
+
+    files = sorted(log_dir.glob("*.md")) if log_dir.is_dir() else []
+    collected: list[str] = []
+    offset = 0
+    for path in files[-2:]:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if path == files[-1]:
+            offset = len(text.encode("utf-8"))
+        for raw in text.splitlines():
+            collected.extend(rendered(raw))
+    for line in collected[-args.lines:] if args.lines else collected:
+        print(line)
+    if not args.follow:
+        if not files:
+            print(f"(no log yet under {log_dir})", file=sys.stderr)
+        return 0
+
+    current = files[-1] if files else None
+    try:
+        while True:
+            today = log_dir / (
+                datetime.now(timezone.utc).strftime("%Y-%m-%d") + ".md"
+            )
+            if today != current:
+                current, offset = today, 0
+            if current.is_file():
+                size = current.stat().st_size
+                if size > offset:
+                    with current.open("r", encoding="utf-8") as f:
+                        f.seek(offset)
+                        chunk = f.read()
+                        offset = f.tell()
+                    for raw in chunk.splitlines():
+                        for line in rendered(raw):
+                            print(line, flush=True)
+                elif size < offset:
+                    offset = size
+            time.sleep(0.5)
+    except KeyboardInterrupt:
+        return 0
+
+
 def _ensure_tell_outbox(ctx: DispatchContext) -> None:
     """Directly-invoked seat/chat sessions have no a8s-injected outbox env;
     give `tell` subprocesses (the Address: doorbell, error notices) the same
@@ -979,6 +1039,24 @@ def build_parser() -> argparse.ArgumentParser:
     _add_common(status_p, with_node=True)
     _add_tell_flags(status_p)
     status_p.set_defaults(func=cmd_status)
+
+    logs_p = sub.add_parser(
+        "logs", help="The team's own event log: every governance decision "
+        "and turn boundary, including traffic that never reaches a8s."
+    )
+    _add_common(logs_p, with_node=True)
+    logs_p.add_argument(
+        "-f", "--follow", action="store_true", help="Keep streaming new events."
+    )
+    logs_p.add_argument(
+        "-n", "--lines", type=int, default=40,
+        help="Backfill this many lines first (0 = everything kept on disk).",
+    )
+    logs_p.add_argument(
+        "--full", action="store_true",
+        help="Raw daily log, prompts and transcripts included.",
+    )
+    logs_p.set_defaults(func=cmd_logs)
 
     chat_p = sub.add_parser(
         "chat", help="Interactive human seat: messages and team activity in one window."

--- a/apps/r4t/r4t.py
+++ b/apps/r4t/r4t.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import state
 import tasks
+import verdict
 from dispatch import (
     DispatchContext,
     drain_until_quiet,
@@ -107,6 +108,9 @@ def _resolve_node(raw: str | None) -> str | None:
     teams = state.known_teams()
     if len(teams) == 1:
         return teams[0]
+    match = state.node_for_root(Path.cwd())
+    if match:
+        return match
     if not teams:
         print("no teams found under ~/.config/r4t/teams — pass --node", file=sys.stderr)
     else:
@@ -116,10 +120,16 @@ def _resolve_node(raw: str | None) -> str | None:
 
 def _context(args: argparse.Namespace, node: str) -> DispatchContext:
     root = _resolve_root(args.root)
+    roster_path = resolve_roster_path(root, getattr(args, "roster", None))
+    if not getattr(args, "root", None) and not roster_path.is_file():
+        stamped = state.read_root(node)
+        if stamped is not None and stamped.is_dir():
+            root = stamped
+            roster_path = resolve_roster_path(root, getattr(args, "roster", None))
     return DispatchContext(
         root=root,
         node=node,
-        roster_path=resolve_roster_path(root, getattr(args, "roster", None)),
+        roster_path=roster_path,
         config_path=resolve_config_path(getattr(args, "rig_config", None)),
         tell_fn=resolve_tell_fn(
             notify=getattr(args, "notify", True),
@@ -294,6 +304,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         print("dispatch: --to must carry the node name", file=sys.stderr)
         return 2
     ctx = _context(args, node.lower())
+    state.stamp_root(ctx.node, ctx.root)
     if not args.no_drain:
         drain_until_quiet(ctx)
     rc = handle_message(ctx, args.from_agent, args.to, args.message)
@@ -478,16 +489,31 @@ def _activity_rows(node: str) -> list[tuple[bool | None, str, str, str | None]]:
     if not open_tasks:
         rows.append((None, "tasks", "none", None))
     rows.append((None, "pending", f"{len(state.list_pending(node))} deferred message(s)", None))
-    dead = state.list_dead_letters(node)
-    reasons: dict[str, int] = {}
-    for record in dead:
-        reasons[record.get("reason", "?")] = reasons.get(record.get("reason", "?"), 0) + 1
-    breakdown = ", ".join(f"{k}: {v}" for k, v in sorted(reasons.items()))
-    rows.append((
-        None, "dead letters",
-        f"{len(dead)}" + (f"  ({breakdown})" if breakdown else ""),
-        f"ls {state.dead_letter_dir(node)}" if dead else None,
-    ))
+    roll = verdict.rollup_dead_letters(state.list_dead_letters(node))
+    if not roll.routine_total and not roll.signal_total:
+        rows.append((None, "dead letters", "0", None))
+    if roll.routine_total:
+        breakdown = ", ".join(f"{k} {v}" for k, v in sorted(roll.routine.items()))
+        rows.append((
+            None, "dead letters",
+            f"{roll.routine_total} routine ({breakdown}) — governance debris, "
+            "not failures",
+            None,
+        ))
+    for reason in sorted(roll.signals):
+        records = roll.signals[reason]
+        pairs: dict[str, int] = {}
+        for record in records:
+            key = f"{record.get('from', '?')} -> {record.get('to', '?')}"
+            pairs[key] = pairs.get(key, 0) + 1
+        worst = max(pairs, key=pairs.get)  # type: ignore[arg-type]
+        others = f" +{len(pairs) - 1} pair(s)" if len(pairs) > 1 else ""
+        rows.append((
+            False, "dead letters",
+            f"{len(records)} {reason} ({worst}{others}) — "
+            f"{verdict.REASON_GLOSS.get(reason, reason)}",
+            f"ls {state.dead_letter_dir(node)}",
+        ))
     active = state.load_active(node)
     for agent in sorted(active):
         entry = active[agent] if isinstance(active[agent], dict) else {}
@@ -521,6 +547,14 @@ def cmd_status(args: argparse.Namespace) -> int:
     except RigError as e:
         config_err = str(e)
 
+    print("Health")
+    for v in verdict.team_verdicts(node, roster, config):
+        line = f"  {verdict.MARKS[v.level]} {v.text}"
+        if v.hint:
+            line += f"   (try: {v.hint})"
+        print(line)
+    print()
+
     print(f"Roster  (repo settings: {ctx.roster_path})")
     if roster_err:
         _print_rows([(False, "roster", roster_err, "r4t init")])
@@ -553,6 +587,17 @@ def cmd_chat(args: argparse.Namespace) -> int:
         return 2
     ctx = _context(args, node)
     _ensure_tell_outbox(ctx)
+    if not args.plain and sys.stdout.isatty():
+        try:
+            from chat_tui import run_chat_tui
+        except ImportError:
+            print(
+                "textual not installed — line UI instead"
+                " (try: python3 -m pip install textual)",
+                file=sys.stderr,
+            )
+        else:
+            return run_chat_tui(ctx)
     from chat import run_chat
 
     return run_chat(ctx)
@@ -940,6 +985,10 @@ def build_parser() -> argparse.ArgumentParser:
     )
     _add_common(chat_p, with_node=True)
     _add_tell_flags(chat_p)
+    chat_p.add_argument(
+        "--plain", action="store_true",
+        help="Line UI instead of the full-screen TUI.",
+    )
     chat_p.set_defaults(func=cmd_chat)
 
     seat_p = sub.add_parser(

--- a/apps/r4t/state.py
+++ b/apps/r4t/state.py
@@ -73,6 +73,43 @@ def known_teams() -> list[str]:
     return sorted(p.name for p in root.iterdir() if p.is_dir())
 
 
+def root_path(node: str) -> Path:
+    return team_dir(node) / "root"
+
+
+def stamp_root(node: str, root: Path) -> None:
+    path = root_path(node)
+    text = str(root)
+    try:
+        if path.is_file() and path.read_text(encoding="utf-8").strip() == text:
+            return
+    except OSError:
+        pass
+    _atomic_write_text(path, text + "\n")
+
+
+def read_root(node: str) -> Path | None:
+    try:
+        text = root_path(node).read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    return Path(text) if text else None
+
+
+def node_for_root(cwd: Path) -> str | None:
+    """The team whose stamped repo root is cwd or an ancestor of it."""
+    by_root = {}
+    for node in known_teams():
+        root = read_root(node)
+        if root is not None:
+            by_root[root] = node
+    cwd = cwd.resolve()
+    for candidate in (cwd, *cwd.parents):
+        if candidate in by_root:
+            return by_root[candidate]
+    return None
+
+
 def _atomic_write_text(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_name(f".{path.name}.{new_ulid()}.tmp")

--- a/apps/r4t/tests/test_chat.py
+++ b/apps/r4t/tests/test_chat.py
@@ -101,7 +101,10 @@ def test_plain_line_queues_send(session, capsys):
 
 def test_poll_inbox_consumes_and_renders(session, r4t_home):
     state.park_seat_message(NODE, "Neil", "acme:gerry", "[r4t task=01KX0000000000000000000000 hop=1 auto] hi")
-    assert session.feed.poll_inbox() == [("in", "acme:gerry: hi")]
+    events = session.feed.poll_inbox()
+    assert [(kind, render_envelope(e)) for kind, e in events] == [
+        ("in", "acme:gerry: hi")
+    ]
     assert session.feed.poll_inbox() == []
     assert len(state.list_seat_messages(NODE, "neil", read=True)) == 1
 

--- a/apps/r4t/tests/test_chat.py
+++ b/apps/r4t/tests/test_chat.py
@@ -101,10 +101,8 @@ def test_plain_line_queues_send(session, capsys):
 
 def test_poll_inbox_consumes_and_renders(session, r4t_home):
     state.park_seat_message(NODE, "Neil", "acme:gerry", "[r4t task=01KX0000000000000000000000 hop=1 auto] hi")
-    session.poll_inbox()
-    assert drain_events(session) == [("in", "acme:gerry: hi")]
-    session.poll_inbox()
-    assert drain_events(session) == []
+    assert session.feed.poll_inbox() == [("in", "acme:gerry: hi")]
+    assert session.feed.poll_inbox() == []
     assert len(state.list_seat_messages(NODE, "neil", read=True)) == 1
 
 

--- a/apps/r4t/tests/test_chat_tui.py
+++ b/apps/r4t/tests/test_chat_tui.py
@@ -75,6 +75,29 @@ def test_tui_consumes_inbox_and_routes_commands(seat, monkeypatch):
     asyncio.run(scenario())
 
 
+def test_tui_renders_markdown_bodies(seat):
+    ctx, roster, human = seat
+    state.park_seat_message(
+        NODE, "Neil", "acme:gerry",
+        "[r4t task=01KX0000000000000000000000 hop=1 auto] "
+        "# Report\n\n**bold claim** and `code()`",
+    )
+
+    async def scenario():
+        from textual.widgets import RichLog
+
+        app = ChatApp(ctx, roster, human)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            conv = app.query_one("#conversation", RichLog)
+            text = "\n".join(strip.text for strip in conv.lines)
+            assert "acme:gerry" in text
+            assert "bold claim" in text and "Report" in text
+            assert "**" not in text and "# Report" not in text
+
+    asyncio.run(scenario())
+
+
 def test_tui_header_surfaces_trouble(seat):
     ctx, roster, human = seat
     state.record_dead_letter(

--- a/apps/r4t/tests/test_chat_tui.py
+++ b/apps/r4t/tests/test_chat_tui.py
@@ -1,0 +1,94 @@
+"""Textual chat TUI tests — headless via textual's pilot. Skipped when
+textual is not installed (the CLI falls back to the line UI then too)."""
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+pytest.importorskip("textual")
+
+import chat_tui
+import state
+from chat_tui import ChatApp, budget_bar
+from roster import load_roster
+
+NODE = "acme"
+
+
+@pytest.fixture
+def seat(ctx, repo, r4t_home):
+    roster = load_roster(repo / "ROSTER.md")
+    human = next(m for m in roster.members if m.is_human)
+    return ctx, roster, human
+
+
+def test_budget_bar_shapes():
+    assert budget_bar(0.0, 1.0) == "▯" * 8
+    assert budget_bar(1.0, 1.0) == "▮" * 8
+    assert budget_bar(0.5, 1.0).count("▮") == 4
+    assert budget_bar(5.0, 1.0) == "▮" * 8
+    assert budget_bar(1.0, 0.0) == "▯" * 8
+
+
+def test_tui_consumes_inbox_and_routes_commands(seat, monkeypatch):
+    ctx, roster, human = seat
+    state.park_seat_message(
+        NODE, "Neil", "acme:gerry",
+        "[r4t task=01KX0000000000000000000000 hop=1 auto] ready for review",
+    )
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        chat_tui, "send_as_human",
+        lambda ctx, human, to, text: calls.append((to, text)),
+    )
+
+    async def scenario():
+        from textual.widgets import Input, Static
+
+        app = ChatApp(ctx, roster, human)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert len(state.list_seat_messages(NODE, "neil", read=True)) == 1
+
+            header = str(app.query_one("#header", Static).content)
+            assert NODE in header and "seat Neil" in header
+
+            composer = app.query_one("#composer", Input)
+            composer.value = "/to phil"
+            await pilot.press("enter")
+            assert app.target == "acme:phil"
+
+            composer.value = "/to nobody"
+            await pilot.press("enter")
+            assert app.target == "acme:phil"
+
+            composer.value = "ship it"
+            await pilot.press("enter")
+            deadline = time.time() + 5
+            while not calls and time.time() < deadline:
+                await asyncio.sleep(0.05)
+            assert calls == [("acme:phil", "ship it")]
+            assert composer.value == ""
+
+    asyncio.run(scenario())
+
+
+def test_tui_header_surfaces_trouble(seat):
+    ctx, roster, human = seat
+    state.record_dead_letter(
+        NODE, reason="pair-repeat", sender="acme:gerry", to="phil",
+        task="01X", content="x",
+    )
+
+    async def scenario():
+        from textual.widgets import Static
+
+        app = ChatApp(ctx, roster, human)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            header = str(app.query_one("#header", Static).content)
+            assert "pair-repeat" in header
+
+    asyncio.run(scenario())

--- a/apps/r4t/tests/test_chat_tui.py
+++ b/apps/r4t/tests/test_chat_tui.py
@@ -25,11 +25,11 @@ def seat(ctx, repo, r4t_home):
 
 
 def test_budget_bar_shapes():
-    assert budget_bar(0.0, 1.0) == "▯" * 8
-    assert budget_bar(1.0, 1.0) == "▮" * 8
-    assert budget_bar(0.5, 1.0).count("▮") == 4
-    assert budget_bar(5.0, 1.0) == "▮" * 8
-    assert budget_bar(1.0, 0.0) == "▯" * 8
+    assert budget_bar(0.0, 1.0) == "░" * 8
+    assert budget_bar(1.0, 1.0) == "█" * 8
+    assert budget_bar(0.5, 1.0).count("█") == 4
+    assert budget_bar(5.0, 1.0) == "█" * 8
+    assert budget_bar(1.0, 0.0) == "░" * 8
 
 
 def test_tui_consumes_inbox_and_routes_commands(seat, monkeypatch):

--- a/apps/r4t/tests/test_logs.py
+++ b/apps/r4t/tests/test_logs.py
@@ -1,0 +1,52 @@
+"""r4t logs — the team's own event stream, compact by default."""
+from __future__ import annotations
+
+import state
+from r4t import main as r4t_main
+
+NODE = "acme"
+
+
+def seed_log():
+    state.append_log(NODE, "## 2026-07-11T10:00:00Z dispatch gerry -> Phil (task 01X hop 1, rig junior-dev)")
+    state.append_log(NODE, "### Prompt\n\nYou are Phil, a member of the acme team.\nSecret persona details here.")
+    state.append_log(NODE, "### Output (Phil, exit 0 in 2.0s)")
+    state.append_log(NODE, "r4t: RELEASED-internal acme:phil -> acme:gerry task=01X hop=2")
+    state.append_log(NODE, "r4t: SUPPRESSED acme:phil -> acme:gerry task=01X repeat=2")
+
+
+def run_logs(*args):
+    return r4t_main(["logs", "--node", NODE, *args])
+
+
+def test_compact_shows_events_hides_transcripts(r4t_home, capsys):
+    seed_log()
+    assert run_logs() == 0
+    out = capsys.readouterr().out
+    assert "turn: gerry -> Phil (task 01X hop 1, rig junior-dev)" in out
+    assert "done: Phil, exit 0 in 2.0s" in out
+    assert "r4t: RELEASED-internal acme:phil -> acme:gerry task=01X hop=2" in out
+    assert "r4t: SUPPRESSED" in out
+    assert "Secret persona" not in out
+    assert "### Prompt" not in out
+
+
+def test_full_shows_raw_log(r4t_home, capsys):
+    seed_log()
+    assert run_logs("--full") == 0
+    out = capsys.readouterr().out
+    assert "Secret persona details here." in out
+    assert "### Prompt" in out
+
+
+def test_lines_limits_backfill(r4t_home, capsys):
+    seed_log()
+    assert run_logs("-n", "1") == 0
+    out = capsys.readouterr().out.strip().splitlines()
+    assert out == ["r4t: SUPPRESSED acme:phil -> acme:gerry task=01X repeat=2"]
+
+
+def test_no_log_yet(r4t_home, capsys):
+    assert run_logs() == 0
+    err = capsys.readouterr().err
+    assert "no log yet" in err

--- a/apps/r4t/tests/test_node_root.py
+++ b/apps/r4t/tests/test_node_root.py
@@ -1,0 +1,76 @@
+"""node→root stamping — `--node` works from anywhere, CWD finds the node."""
+from __future__ import annotations
+
+import state
+from r4t import main as r4t_main
+
+NODE = "acme"
+
+
+def test_stamp_and_read_root(r4t_home, repo):
+    assert state.read_root(NODE) is None
+    state.stamp_root(NODE, repo)
+    assert state.read_root(NODE) == repo
+    state.stamp_root(NODE, repo)  # idempotent rewrite
+    assert state.read_root(NODE) == repo
+
+
+def test_node_for_root_matches_subdirs(r4t_home, repo, tmp_path):
+    state.stamp_root(NODE, repo)
+    state.stamp_root("other", tmp_path / "elsewhere")
+    sub = repo / "src" / "deep"
+    sub.mkdir(parents=True)
+    assert state.node_for_root(sub) == NODE
+    assert state.node_for_root(repo) == NODE
+    assert state.node_for_root(tmp_path) is None
+
+
+def test_dispatch_stamps_root(r4t_home, repo, rig_config, fake_harness):
+    rc = r4t_main([
+        "dispatch",
+        "--root", str(repo),
+        "--from", "gerry",
+        "--to", f"{NODE}:phil",
+        "--message", "stamp me",
+        "--rig-config", str(rig_config),
+        "--no-notify",
+    ])
+    assert rc == 0
+    assert state.read_root(NODE) == repo
+
+
+def test_status_from_unrelated_cwd_uses_stamped_root(
+    r4t_home, repo, rig_config, tmp_path, monkeypatch, capsys
+):
+    state.stamp_root(NODE, repo)
+    elsewhere = tmp_path / "unrelated"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+    rc = r4t_main(["status", "--node", NODE, "--rig-config", str(rig_config)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "roster not found" not in out
+    assert "Health" in out
+    assert "Gerry" in out
+
+
+def test_bare_node_resolves_from_cwd(
+    r4t_home, repo, rig_config, monkeypatch, capsys
+):
+    state.stamp_root(NODE, repo)
+    state.team_dir("other").mkdir(parents=True)  # two teams: ambiguity is real
+    monkeypatch.chdir(repo)
+    rc = r4t_main(["status", "--rig-config", str(rig_config)])
+    assert rc == 0
+    assert "team: acme" in capsys.readouterr().out
+
+
+def test_bare_node_still_errors_outside_any_root(
+    r4t_home, repo, tmp_path, monkeypatch, capsys
+):
+    state.team_dir(NODE).mkdir(parents=True)
+    state.team_dir("other").mkdir(parents=True)
+    monkeypatch.chdir(tmp_path)
+    rc = r4t_main(["status"])
+    assert rc == 2
+    assert "pass --node" in capsys.readouterr().err

--- a/apps/r4t/tests/test_verdict.py
+++ b/apps/r4t/tests/test_verdict.py
@@ -1,0 +1,200 @@
+"""Verdict engine tests — plain-English health lines and dead-letter rollup."""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+import state
+import tasks
+import verdict
+from rig import load_rig_config
+from roster import load_roster
+from ulid import new as new_ulid
+
+NODE = "acme"
+
+
+@pytest.fixture
+def roster(repo):
+    return load_roster(repo / "ROSTER.md")
+
+
+@pytest.fixture
+def config(rig_config):
+    return load_rig_config(rig_config)
+
+
+def open_task(creator: str = "acme:neil", **fields) -> dict:
+    task = tasks.ensure_task(NODE, new_ulid(), creator)
+    task.update(fields)
+    tasks.save_task(NODE, task)
+    return task
+
+
+def by_level(verdicts, level):
+    return [v for v in verdicts if v.level == level]
+
+
+def texts(verdicts):
+    return "\n".join(v.text for v in verdicts)
+
+
+class TestRollup:
+    def test_routine_vs_signals(self):
+        records = [
+            {"reason": "task-closed"},
+            {"reason": "task-closed"},
+            {"reason": "hop-cut"},
+            {"reason": "pair-repeat", "from": "a", "to": "b"},
+            {"reason": "quota", "from": "a", "to": "b"},
+        ]
+        roll = verdict.rollup_dead_letters(records)
+        assert roll.routine == {"task-closed": 2, "hop-cut": 1}
+        assert roll.routine_total == 3
+        assert set(roll.signals) == {"pair-repeat", "quota"}
+        assert roll.signal_total == 2
+
+    def test_empty(self):
+        roll = verdict.rollup_dead_letters([])
+        assert roll.routine_total == 0 and roll.signal_total == 0
+
+
+class TestSeatVerdict:
+    def test_unread_waits_on_you(self, r4t_home, roster, config):
+        state.park_seat_message(NODE, "Neil", "acme:gerry", "look at this")
+        verdicts = verdict.team_verdicts(NODE, roster, config)
+        bad = by_level(verdicts, verdict.BAD)
+        assert any("waiting on YOU" in v.text for v in bad)
+        assert any("seat inbox" in (v.hint or "") for v in bad)
+
+    def test_quiet_seat_is_ok(self, r4t_home, roster, config):
+        verdicts = verdict.team_verdicts(NODE, roster, config)
+        assert any("nothing waiting on you" in v.text for v in verdicts)
+
+    def test_no_roster_skips_seat(self, r4t_home):
+        verdicts = verdict.team_verdicts(NODE, None, None)
+        assert "waiting on you" not in texts(verdicts)
+
+
+class TestRunawayVerdict:
+    def test_quiet_team_no_runaway(self, r4t_home, roster, config):
+        verdicts = verdict.team_verdicts(NODE, roster, config)
+        assert any("no runaway signs" in v.text for v in verdicts)
+
+    def test_high_turn_rate_warns(self, r4t_home, roster, config):
+        for _ in range(verdict.RUNAWAY_TURNS_PER_WINDOW):
+            state.record_velocity(
+                NODE, agent="phil", rig="junior-dev", task="01X",
+                hop=1, duration_seconds=1.0, exit_code=0,
+            )
+        verdicts = verdict.team_verdicts(NODE, roster, config)
+        warn = by_level(verdicts, verdict.WARN)
+        assert any("hot:" in v.text for v in warn)
+        assert not any("no runaway signs" in v.text for v in verdicts)
+
+    def test_old_turns_do_not_count(self, r4t_home, roster, config):
+        for _ in range(verdict.RUNAWAY_TURNS_PER_WINDOW):
+            state.record_velocity(
+                NODE, agent="phil", rig="junior-dev", task="01X",
+                hop=1, duration_seconds=1.0, exit_code=0,
+            )
+        later = time.time() + verdict.RECENT_WINDOW_SECONDS + 60
+        verdicts = verdict.team_verdicts(NODE, roster, config, now=later)
+        assert any("no runaway signs" in v.text for v in verdicts)
+
+    def test_hot_budget_warns(self, r4t_home, roster, config):
+        task = open_task(used=0.8, budget=1.0)
+        verdicts = verdict.team_verdicts(NODE, roster, config)
+        warn = by_level(verdicts, verdict.WARN)
+        assert any(task["id"] in v.text and "budget" in v.text for v in warn)
+
+
+class TestMemberVerdicts:
+    def test_all_healthy(self, r4t_home, roster, config):
+        verdicts = verdict.team_verdicts(NODE, roster, config)
+        assert any("member(s) healthy" in v.text for v in verdicts)
+
+    def test_breaker_open_is_bad(self, r4t_home, roster, config):
+        state.update_meta(
+            NODE, "phil",
+            consecutive_failures=config.breaker_cap,
+            last_failure_at=state.utc_now(),
+        )
+        verdicts = verdict.team_verdicts(NODE, roster, config)
+        bad = by_level(verdicts, verdict.BAD)
+        assert any("Phil broken" in v.text for v in bad)
+        assert not any("member(s) healthy" in v.text for v in verdicts)
+
+    def test_muted_is_bad(self, r4t_home, roster, config):
+        state.bucket_drain(NODE, "phil", config.bucket_max, config.bucket_max)
+        verdicts = verdict.team_verdicts(NODE, roster, config)
+        assert any("Phil muted" in v.text for v in by_level(verdicts, verdict.BAD))
+
+    def test_nudged_member_is_stalled(self, r4t_home, roster, config):
+        task = open_task(nudges={"phil": 1})
+        verdicts = verdict.team_verdicts(NODE, roster, config)
+        warn = by_level(verdicts, verdict.WARN)
+        assert any(
+            "Phil stalled" in v.text and task["id"] in v.text for v in warn
+        )
+
+    def test_nudge_cap_reached_says_so(self, r4t_home, roster, config):
+        open_task(nudges={"phil": config.nudge_cap})
+        verdicts = verdict.team_verdicts(NODE, roster, config)
+        assert any("next silence closes the task" in v.text for v in verdicts)
+
+
+class TestHopStarvation:
+    def test_hop_cuts_on_open_task_warn(self, r4t_home, roster, config):
+        task = open_task()
+        for _ in range(3):
+            state.record_dead_letter(
+                NODE, reason="hop-cut", sender="acme:gerry", to="phil",
+                task=task["id"], content="x",
+            )
+        verdicts = verdict.team_verdicts(NODE, roster, config)
+        warn = by_level(verdicts, verdict.WARN)
+        assert any(
+            "ran out of hops" in v.text and task["id"] in v.text for v in warn
+        )
+        assert any("hop_limit" in (v.hint or "") for v in warn)
+
+    def test_hop_cuts_on_closed_task_are_quiet(self, r4t_home, roster, config):
+        task = open_task(status=tasks.STATUS_CLOSED)
+        state.record_dead_letter(
+            NODE, reason="hop-cut", sender="acme:gerry", to="phil",
+            task=task["id"], content="x",
+        )
+        verdicts = verdict.team_verdicts(NODE, roster, config)
+        assert "ran out of hops" not in texts(verdicts)
+
+
+class TestSignalDeadLetters:
+    def test_recent_signal_warns_with_gloss(self, r4t_home, roster, config):
+        state.record_dead_letter(
+            NODE, reason="pair-repeat", sender="acme:gerry", to="phil",
+            task="01X", content="x",
+        )
+        verdicts = verdict.team_verdicts(NODE, roster, config)
+        warn = by_level(verdicts, verdict.WARN)
+        assert any(
+            "pair-repeat" in v.text and "looping" in v.text for v in warn
+        )
+
+    def test_stale_signal_is_quiet(self, r4t_home, roster, config):
+        state.record_dead_letter(
+            NODE, reason="pair-repeat", sender="acme:gerry", to="phil",
+            task="01X", content="x",
+        )
+        later = time.time() + verdict.SIGNAL_RECENT_SECONDS + 60
+        verdicts = verdict.team_verdicts(NODE, roster, config, now=later)
+        assert "pair-repeat" not in texts(verdicts)
+
+
+def test_worst_level():
+    v = verdict.Verdict
+    assert verdict.worst_level([v("ok", "a")]) == "ok"
+    assert verdict.worst_level([v("ok", "a"), v("warn", "b")]) == "warn"
+    assert verdict.worst_level([v("warn", "a"), v("bad", "b")]) == "bad"
+    assert verdict.worst_level([]) == "ok"

--- a/apps/r4t/verdict.py
+++ b/apps/r4t/verdict.py
@@ -1,0 +1,243 @@
+"""Team health verdicts and dead-letter rollup — the shared brain behind
+`r4t status` and the chat header.
+
+Everything here is read-only over team state. Callers render the marks;
+levels are `ok`/`warn`/`bad`. Thresholds are heuristics tuned for an
+operator glancing at a team, not alerting SLOs.
+"""
+from __future__ import annotations
+
+import csv
+import time
+from dataclasses import dataclass
+from datetime import datetime
+
+import state
+import tasks as taskmod
+
+OK = "ok"
+WARN = "warn"
+BAD = "bad"
+MARKS = {OK: "✓", WARN: "⚠", BAD: "✗"}
+
+RECENT_WINDOW_SECONDS = 600.0
+RUNAWAY_TURNS_PER_WINDOW = 20
+BUDGET_HOT_RATIO = 0.75
+SIGNAL_RECENT_SECONDS = 3600.0
+
+ROUTINE_REASONS = {"task-closed", "hop-cut"}
+
+REASON_GLOSS = {
+    "task-closed": "in-flight replies to already-closed tasks",
+    "hop-cut": "chains clipped at hop_limit",
+    "pair-repeat": "the same message looping between two agents; suppression held it",
+    "bucket-muted": "sender was out of reply privilege after violations",
+    "breaker-open": "harness kept failing; the breaker blocked the turn",
+    "budget-exhausted": "task hit its turn budget and closed through synthesis",
+    "quota": "one turn tried to send past max_sends_per_turn",
+    "bulk-window": "room re-broadcast held to once per window",
+}
+
+
+@dataclass
+class Verdict:
+    level: str
+    text: str
+    hint: str | None = None
+
+
+@dataclass
+class Rollup:
+    routine: dict[str, int]
+    signals: dict[str, list[dict]]
+
+    @property
+    def routine_total(self) -> int:
+        return sum(self.routine.values())
+
+    @property
+    def signal_total(self) -> int:
+        return sum(len(v) for v in self.signals.values())
+
+
+def _ts(iso: object) -> float:
+    try:
+        return datetime.fromisoformat(str(iso).replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return 0.0
+
+
+def rollup_dead_letters(records: list[dict]) -> Rollup:
+    routine: dict[str, int] = {}
+    signals: dict[str, list[dict]] = {}
+    for record in records:
+        reason = str(record.get("reason", "?"))
+        if reason in ROUTINE_REASONS:
+            routine[reason] = routine.get(reason, 0) + 1
+        else:
+            signals.setdefault(reason, []).append(record)
+    return Rollup(routine, signals)
+
+
+def recent_turns(
+    node: str, now: float, window: float = RECENT_WINDOW_SECONDS
+) -> tuple[int, set[str]]:
+    """(turn count, distinct task ids) from velocity.csv within the window."""
+    path = state.team_dir(node) / "velocity.csv"
+    if not path.is_file():
+        return 0, set()
+    count, seen = 0, set()
+    try:
+        with path.open(encoding="utf-8", newline="") as f:
+            for row in csv.DictReader(f):
+                if now - _ts(row.get("timestamp", "")) <= window:
+                    count += 1
+                    seen.add(row.get("task", "?"))
+    except OSError:
+        return 0, set()
+    return count, seen
+
+
+def team_verdicts(
+    node: str, roster=None, config=None, *, now: float | None = None
+) -> list[Verdict]:
+    """One plain-English line per operator concern: is anything waiting on
+    the human, is the team runaway, is a member broken/muted/stalled, did a
+    task starve on hops. Roster/config are optional; concerns that need
+    them are skipped when they are unavailable."""
+    now = time.time() if now is None else now
+    out: list[Verdict] = []
+    open_tasks = [
+        t for t in taskmod.list_tasks(node)
+        if t.get("status") == taskmod.STATUS_OPEN
+    ]
+    dead = state.list_dead_letters(node)
+
+    human = None
+    if roster is not None:
+        human = next((m for m in roster.members if m.is_human), None)
+    if human is not None:
+        unread = len(state.list_seat_messages(node, human.name))
+        if unread:
+            out.append(Verdict(
+                BAD, f"{unread} message(s) waiting on YOU",
+                f"r4t seat inbox --node {node}",
+            ))
+        else:
+            out.append(Verdict(OK, "nothing waiting on you"))
+
+    turns, active_tasks = recent_turns(node, now)
+    live = state.live_locks(node, prune=False)
+    hot = [
+        t for t in open_tasks
+        if float(t.get("budget", 0.0) or 0.0)
+        and float(t.get("used", 0.0)) / float(t["budget"]) >= BUDGET_HOT_RATIO
+    ]
+    if turns >= RUNAWAY_TURNS_PER_WINDOW:
+        out.append(Verdict(
+            WARN,
+            f"hot: {turns} turns in the last 10m across "
+            f"{len(active_tasks)} task(s)",
+            "watch it live: r4t chat",
+        ))
+    else:
+        detail = f"{turns} turn(s) last 10m"
+        if live:
+            detail += f", {len(live)} live now"
+        if not hot:
+            detail += "; budgets healthy"
+        out.append(Verdict(OK, f"no runaway signs ({detail})"))
+    for t in hot:
+        pct = 100.0 * float(t.get("used", 0.0)) / float(t["budget"])
+        out.append(Verdict(
+            WARN,
+            f"task {t['id']} at {pct:.0f}% of its turn budget "
+            f"(creator {t.get('creator', '?')})",
+            "at 100% it closes through forced leader synthesis",
+        ))
+
+    if roster is not None and config is not None:
+        flagged = 0
+        members = [m for m in roster.members if not m.is_human and not m.errors]
+        for m in members:
+            blocked, failures = state.breaker_open(
+                node, m.name, config.breaker_cap, config.breaker_cooldown_seconds
+            )
+            if blocked:
+                rig, _err, _pinned = config.rig_for(m)
+                out.append(Verdict(
+                    BAD,
+                    f"{m.name} broken — {failures} straight harness failures; "
+                    "turns paused",
+                    f"fix the {rig.name if rig else '?'} rig; "
+                    "a deliberate message retries it",
+                ))
+                flagged += 1
+                continue
+            level = state.bucket_level(node, m.name, config.bucket_max)
+            if state.bucket_muted(level, config.bucket_max):
+                out.append(Verdict(
+                    BAD,
+                    f"{m.name} muted — reply bucket drained to "
+                    f"{level:.1f}/{config.bucket_max:g}",
+                    "self-heals: clean turns re-earn reply privilege",
+                ))
+                flagged += 1
+                continue
+            key = m.name.lower()
+            for t in open_tasks:
+                count = int((t.get("nudges") or {}).get(key, 0))
+                if not count:
+                    continue
+                left = max(0, config.nudge_cap - count)
+                tail = (
+                    f", {left} nudge(s) left" if left
+                    else "; next silence closes the task"
+                )
+                out.append(Verdict(
+                    WARN,
+                    f"{m.name} stalled on task {t['id']} — "
+                    f"nudged {count}/{config.nudge_cap}{tail}",
+                ))
+                flagged += 1
+        if members and not flagged:
+            out.append(Verdict(OK, f"all {len(members)} member(s) healthy"))
+
+    open_ids = {t["id"] for t in open_tasks}
+    cuts: dict[str, int] = {}
+    for record in dead:
+        if record.get("reason") == "hop-cut" and record.get("task") in open_ids:
+            task_id = str(record["task"])
+            cuts[task_id] = cuts.get(task_id, 0) + int(record.get("count", 1) or 1)
+    for task_id in sorted(cuts):
+        out.append(Verdict(
+            WARN,
+            f"task {task_id} ran out of hops relaying through the leader "
+            f"({cuts[task_id]} message(s) cut)",
+            "weak-rig teams star through the leader (~2 hops per delegation)"
+            " — raise hop_limit",
+        ))
+
+    roll = rollup_dead_letters(dead)
+    for reason in sorted(roll.signals):
+        recent = [
+            r for r in roll.signals[reason]
+            if now - _ts(r.get("time", "")) <= SIGNAL_RECENT_SECONDS
+        ]
+        if recent:
+            out.append(Verdict(
+                WARN,
+                f"{len(recent)} {reason} dead letter(s) in the last hour — "
+                f"{REASON_GLOSS.get(reason, reason)}",
+                f"ls {state.dead_letter_dir(node)}",
+            ))
+    return out
+
+
+def worst_level(verdicts: list[Verdict]) -> str:
+    levels = {v.level for v in verdicts}
+    if BAD in levels:
+        return BAD
+    if WARN in levels:
+        return WARN
+    return OK


### PR DESCRIPTION
Implements #169.

## What changed

**`verdict.py` — one shared brain.** Plain-English health verdicts computed from team state, used by both `r4t status` and the chat TUI:

- `✗ 2 message(s) waiting on YOU (try: r4t seat inbox --node ttt)`
- `✓ no runaway signs (0 turn(s) last 10m; budgets healthy)` / `⚠ hot: 24 turns in the last 10m across 2 task(s)`
- `✗ Gerry muted — reply bucket drained to 0.8/8` / `✗ Phil broken — 5 straight harness failures` / `⚠ Phil stalled on task … — nudged 1/2`
- `⚠ task … ran out of hops relaying through the leader (4 message(s) cut)` — the star-topology learning from #168, in operator terms, pointing at `hop_limit`.

Dead letters roll up by meaning: `task-closed`/`hop-cut` collapse to one dim "governance debris" line; `pair-repeat`, `bucket-muted`, `budget-exhausted`, `quota`, `breaker-open`, `bulk-window` are called out with the offending pair and a one-clause gloss.

**`r4t status` leads with the verdict panel.** Detail tables unchanged below.

**node→root in team state.** The first dispatch stamps the repo root; `--node` now works from any directory (no more `✗ roster not found` from an unrelated CWD), and from inside a team repo the flag is optional — CWD matches the stamped root. Fixes the paper cut hit twice during #168 testing.

**`r4t chat` is now a Textual TUI** — the pane of glass: health header (worst-level summary, live warnings, open-task budget bars), conversation pane beside a fly-on-the-wall activity pane (turn starts/completions + every governance decision line), seat input with `/to` `/who` `/tasks` `/quit`. Sends run on a worker thread so the wall keeps scrolling while a rig thinks. `textual` is optional: missing/`--plain`/piped falls back to the line UI over the same `SeatFeed` (extracted from the old session as shared machinery).

## Evidence (live teams)

`r4t status --node ttt` from an unrelated directory:

```
Health
  ✗ 2 message(s) waiting on YOU   (try: r4t seat inbox --node ttt)
  ✓ no runaway signs (0 turn(s) last 10m; budgets healthy)
  ✓ all 4 member(s) healthy
  ⚠ task 01KX9C8AB782VAZ56P03H1GC5Z ran out of hops relaying through the leader (4 message(s) cut)
```

`--node s1l` immediately surfaced `✗ Gerry muted — reply bucket drained to 0.8/8` — the team leader sitting muted, invisible before without reading buckets.json.

Headless TUI run against live ttt rendered the hop-starvation verdict + 44% budget bar in the header and delivered both parked seat messages (the two doorbell texts) in the conversation pane.

## Tests

274 passed (+28): verdict engine (rollup classification, each verdict shape, time windows), node→root (stamping at dispatch, status from unrelated CWD, bare-node CWD detection, ambiguity still errors), TUI via textual pilot (inbox consumption, /to routing, send worker, trouble surfacing in header), line-chat refactor intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)