### PR TITLE
feat(n0b): ai speak — local Kokoro text-to-speech

### DIFF
--- a/apps/n0b/README.md
+++ b/apps/n0b/README.md
@@ -24,6 +24,7 @@ Detailed docs live in [`docs/`](docs/):
 | [ltx-video.md](docs/ltx-video.md) | `n0b ai video` | LTX-Video generation, models, setup guide |
 | [research.md](docs/research.md) | `n0b ai research` | OpenAI o4-mini-deep-research |
 | [secrets.md](docs/secrets.md) | `n0b secrets` | Get/set secrets — env, `~/lib`, Keychain, dotenv |
+| [ai-speak.md](docs/ai-speak.md) | `n0b ai speak` | Local Kokoro text-to-speech, markdown-aware |
 | [transcribe.md](docs/transcribe.md) | `n0b ai transcribe` | Local Whisper speech-to-text, hints + replacement files |
 
 ### Quick reference (no separate doc yet)
@@ -34,7 +35,7 @@ Detailed docs live in [`docs/`](docs/):
 | `ports` | `free`, `listen <port>` | Ephemeral free port; list process on a port (`lsof` / `netstat`) |
 | `gpu` | `cuda`, `mps`, `mlx`, `mb-free` | GPU / MLX checks; free MiB |
 | `mqtt` | `pub`, `sub` | `mosquitto_*` with `MQTT_HOST`, `MQTT_PORT`, `MQTT_USER`, `MQTT_PASS` |
-| `ai` | `image`, `video`, `audio`, `research`, `transcribe` | See [ltx-video.md](docs/ltx-video.md) for video; [research.md](docs/research.md) for deep research; [transcribe.md](docs/transcribe.md) for speech-to-text |
+| `ai` | `image`, `video`, `audio`, `research`, `speak`, `transcribe` | See [ltx-video.md](docs/ltx-video.md) for video; [research.md](docs/research.md) for deep research; [ai-speak.md](docs/ai-speak.md) for text-to-speech; [transcribe.md](docs/transcribe.md) for speech-to-text |
 | `video` | `last-frame` | Extract last frame with `ffmpeg` |
 
 ### AI model defaults
@@ -44,6 +45,7 @@ Detailed docs live in [`docs/`](docs/):
 | `n0b ai image` | Z-Image (`z-image.sh`) | `--model z-image` |
 | `n0b ai video` | LTX-Video 1, LTX-2 (PyTorch), MLX-Video (Apple Silicon) | `--model ltx-2`, `--model ltx-1`, or `-2`/`-1` flags |
 | `n0b ai audio` | AudioLDM (`audioldm.sh`) | `--model bark` for Suno Bark |
+| `n0b ai speak` | Kokoro-82M (local, no API key) | `--voice af_heart`, `--speed` |
 | `n0b ai transcribe` | Whisper `turbo` (local, no API key) | `--model tiny|base|small|medium|large` |
 
 ## Layout

--- a/apps/n0b/cli.py
+++ b/apps/n0b/cli.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import argparse
 import sys
 
-from commands.ai_cmd import cmd_ai, cmd_research, cmd_transcribe
+from commands.ai_cmd import cmd_ai, cmd_research, cmd_speak, cmd_transcribe
 from commands.az_cmd import cmd_tail
 from commands.gpu_cmd import cmd_cuda, cmd_mb_free, cmd_mlx, cmd_mps
 from commands.json_cmd import cmd_json
@@ -80,6 +80,25 @@ def build_parser() -> argparse.ArgumentParser:
     ai_sub = ai_p.add_subparsers(dest="ai_kind", required=True)
     ai_research = ai_sub.add_parser("research", help="Deep research via o4-mini-deep-research")
     ai_research.add_argument("prompt", nargs=argparse.REMAINDER)
+    ai_speak = ai_sub.add_parser(
+        "speak", help="Synthesize speech from text locally with Kokoro"
+    )
+    ai_speak.add_argument(
+        "text", nargs="?", help="Text/markdown file to read aloud (- or omit for stdin)"
+    )
+    ai_speak.add_argument(
+        "-o", "--out",
+        help="Output audio file: .wav, or .m4a via afconvert (default: <input>.wav)",
+    )
+    ai_speak.add_argument(
+        "--voice", default="af_heart", help="Kokoro voice (default: af_heart)"
+    )
+    ai_speak.add_argument(
+        "--speed", type=float, default=1.0, help="Speech speed multiplier"
+    )
+    ai_speak.add_argument(
+        "--raw", action="store_true", help="Skip markdown-to-prose cleanup"
+    )
     ai_transcribe = ai_sub.add_parser(
         "transcribe", help="Transcribe an audio file locally with Whisper"
     )
@@ -189,6 +208,10 @@ def dispatch(args: argparse.Namespace) -> int:
     if group == "ai":
         if args.ai_kind == "research":
             return cmd_research(args.prompt)
+        if args.ai_kind == "speak":
+            return cmd_speak(
+                args.text, args.out, args.voice, args.speed, raw=args.raw
+            )
         if args.ai_kind == "transcribe":
             return cmd_transcribe(
                 args.audio,

--- a/apps/n0b/commands/ai_cmd.py
+++ b/apps/n0b/commands/ai_cmd.py
@@ -6,6 +6,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 from paths import BIN_ROOT, SCRIPTS_DIR
@@ -73,6 +74,159 @@ result = model.transcribe(
 )
 print(result["text"].strip())
 """
+
+
+_KOKORO_SNIPPET = """\
+import sys
+
+import numpy as np
+import soundfile as sf
+from kokoro import KPipeline
+
+text_path, out_path, voice, speed = sys.argv[1:5]
+text = open(text_path, encoding="utf-8").read()
+pipeline = KPipeline(lang_code=voice[0])
+chunks = []
+for i, result in enumerate(pipeline(text, voice=voice, speed=float(speed))):
+    audio = result[2]
+    chunks.append(audio.numpy() if hasattr(audio, "numpy") else audio)
+    print(f"  segment {i + 1}", file=sys.stderr)
+if not chunks:
+    print("no audio produced", file=sys.stderr)
+    sys.exit(1)
+sf.write(out_path, np.concatenate(chunks), 24000)
+"""
+
+_MD_LINK_RE = re.compile(r"\[([^\]]+)\]\([^)]*\)")
+_MD_NOISE_RE = re.compile(r"[*_`#>|]+")
+
+
+def speakable(markdown: str) -> str:
+    """Reduce markdown to prose worth hearing: drop code fences and table
+    rows, unwrap links, strip emphasis markers."""
+    out: list[str] = []
+    fenced = False
+    for line in markdown.splitlines():
+        s = line.strip()
+        if s.startswith("```"):
+            fenced = not fenced
+            continue
+        if fenced or s.startswith("|"):
+            continue
+        line = _MD_LINK_RE.sub(r"\1", line)
+        line = _MD_NOISE_RE.sub("", line)
+        out.append(line)
+    return "\n".join(out)
+
+
+KOKORO_VENV = Path.home() / ".cache" / "n0b" / "kokoro-venv"
+
+
+def _kokoro_base_python() -> str:
+    # kokoro -> misaki[en] -> spacy, which trails new CPython releases;
+    # prefer an interpreter old enough to have wheels.
+    for name in ("python3.13", "python3.12", "python3.11"):
+        if shutil.which(name):
+            return name
+    return sys.executable
+
+
+def _kokoro_python() -> Path:
+    python = KOKORO_VENV / "bin" / "python3"
+    if python.is_file():
+        probe = subprocess.run(
+            [str(python), "-c", "import kokoro, soundfile"], capture_output=True
+        )
+        if probe.returncode == 0:
+            return python
+    else:
+        print(f"Setting up Kokoro venv at {KOKORO_VENV} (one-time)...", file=sys.stderr)
+        KOKORO_VENV.parent.mkdir(parents=True, exist_ok=True)
+        subprocess.run(
+            [_kokoro_base_python(), "-m", "venv", str(KOKORO_VENV)],
+            check=True, stdout=sys.stderr,
+        )
+    subprocess.run(
+        [str(python), "-m", "pip", "install", "--upgrade", "pip"],
+        check=True, stdout=sys.stderr,
+    )
+    # spacy 4.x ships sdist-only for this platform and its build chain is
+    # broken; the <4 pin keeps pip on the 3.8 wheels misaki actually needs.
+    # phonemizer enables misaki's espeak fallback for names and other
+    # out-of-dictionary words (the library itself comes from espeak-ng).
+    subprocess.run(
+        [str(python), "-m", "pip", "install", "spacy<4", "kokoro", "soundfile",
+         "phonemizer"],
+        check=True, stdout=sys.stderr,
+    )
+    return python
+
+
+def cmd_speak(
+    source: str | None,
+    out: str | None,
+    voice: str,
+    speed: float,
+    raw: bool = False,
+) -> int:
+    if source is None or source == "-":
+        text = sys.stdin.read()
+        stem = "speech"
+    else:
+        path = Path(source).expanduser()
+        if not path.is_file():
+            print(f"n0b ai speak: no such file: {source}", file=sys.stderr)
+            return 1
+        text = path.read_text(encoding="utf-8")
+        stem = path.stem
+    if not raw:
+        text = speakable(text)
+    if not text.strip():
+        print("n0b ai speak: nothing to say after cleanup", file=sys.stderr)
+        return 2
+    out_path = Path(out).expanduser() if out else Path(f"{stem}.wav")
+    convert = out_path.suffix.lower() in (".m4a", ".aac", ".mp4")
+    if convert and shutil.which("afconvert") is None:
+        print(
+            "n0b ai speak: compressed output needs afconvert (macOS) — "
+            "use a .wav path",
+            file=sys.stderr,
+        )
+        return 1
+    if not convert and out_path.suffix.lower() != ".wav":
+        print(f"n0b ai speak: unsupported output format {out_path.suffix!r} "
+              "(use .wav or .m4a)", file=sys.stderr)
+        return 2
+    try:
+        python = _kokoro_python()
+    except subprocess.CalledProcessError as exc:
+        print(f"n0b ai speak: Kokoro setup failed: {exc}", file=sys.stderr)
+        return 1
+    wav_path = out_path.with_suffix(".tmp.wav") if convert else out_path
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".txt", encoding="utf-8", delete=False
+    ) as f:
+        f.write(text)
+        text_file = Path(f.name)
+    try:
+        proc = subprocess.run(
+            [str(python), "-c", _KOKORO_SNIPPET, str(text_file), str(wav_path),
+             voice, str(speed)],
+        )
+        if proc.returncode != 0:
+            return proc.returncode
+        if convert:
+            conv = subprocess.run(
+                ["afconvert", "-f", "m4af", "-d", "aac", str(wav_path),
+                 str(out_path)],
+            )
+            wav_path.unlink(missing_ok=True)
+            if conv.returncode != 0:
+                return conv.returncode
+    finally:
+        text_file.unlink(missing_ok=True)
+    print(out_path)
+    return 0
 
 
 def read_hints(hints_file: Path) -> list[str]:

--- a/apps/n0b/docs/ai-speak.md
+++ b/apps/n0b/docs/ai-speak.md
@@ -1,0 +1,40 @@
+---
+name: "n0b-speak"
+description: "Synthesize text or markdown into spoken audio with a local Kokoro model. Use when the user wants a document read aloud or an audio file of some text."
+allowed-tools: Bash(n0b ai speak *)
+---
+
+# n0b ai speak
+
+Local text-to-speech: reads a text or markdown file (or stdin) aloud into
+an audio file with the Kokoro-82M model. Fully offline after first-run
+setup; no API keys.
+
+```bash
+n0b ai speak notes.md -o notes.m4a          # markdown -> spoken m4a
+echo "ship it" | n0b ai speak - -o say.wav  # stdin -> wav
+n0b ai speak brief.txt --voice am_adam --speed 1.1
+```
+
+- **Input** is cleaned for listening by default: code fences and table
+  rows are dropped, links unwrapped, emphasis markers stripped. Pass
+  `--raw` to synthesize the text exactly as given.
+- **Output** format follows the extension: `.wav` (native, 24 kHz) or
+  `.m4a`/`.aac` (converted with macOS `afconvert`). Default is
+  `<input>.wav`.
+- **Voices**: any Kokoro voice id (default `af_heart`; e.g. `am_adam`,
+  `bf_emma` — the leading letter picks the language/accent pipeline).
+- `--speed` is a multiplier (1.0 = normal).
+
+## Setup (automatic, one-time)
+
+First run creates `~/.cache/n0b/kokoro-venv` (needs a Python with spacy
+wheels — 3.13/3.12 preferred over newer), installs `kokoro`, `soundfile`,
+and `phonemizer`, and downloads the model from Hugging Face (~330 MB).
+Names and other out-of-dictionary words also need the espeak-ng library:
+`brew install espeak-ng` (one manual step — without it, synthesis fails
+on unusual words).
+
+Pairs with [n0b ai transcribe](transcribe.md) (speech-to-text) for a full
+local audio round trip, and with `tell <agent> --attach out.m4a` to ship
+the audio anywhere on the a8s network.


### PR DESCRIPTION
Counterpart to `n0b ai transcribe` — the other half of a fully local audio round trip.

```bash
n0b ai speak notes.md -o notes.m4a          # markdown -> spoken m4a
echo "ship it" | n0b ai speak - -o say.wav  # stdin -> wav
n0b ai speak brief.txt --voice am_adam --speed 1.1
```

- **Markdown-aware**: fences/tables dropped, links unwrapped, emphasis stripped; `--raw` for verbatim.
- **Output by extension**: `.wav` native, `.m4a`/`.aac` via macOS `afconvert`.
- **Self-managing venv** at `~/.cache/n0b/kokoro-venv` (mirrors the whisper-venv pattern): prefers python3.13/3.12 because kokoro→misaki→spacy trails new CPython (3.14 has no spacy wheels); pins `spacy<4` (4.x is sdist-only, broken build); installs `phonemizer` for the espeak fallback that names/OOV words require. One manual step documented: `brew install espeak-ng`.

Docs: `apps/n0b/docs/ai-speak.md` (quoted YAML frontmatter), README index rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)