### PR TITLE
fix(a8s): let a node own a namespace matching its own name (#175)

### DIFF
--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -158,11 +158,15 @@ tell acme:team:ops "deploy done"     # same node; sub-address opaque to a8s
 ```
 
 Prefixes share the agent/alias name grammar (lowercase canonical form,
-case-insensitive match) and the three name pools are disjoint — a prefix
-can't collide with an agent or alias name and vice versa. An unknown prefix
-behaves like any unknown recipient: published to configured remotes (another
-cluster may own the binding), or trashed when there are none. Removing an
-agent unbinds any prefixes pointing at it.
+case-insensitive match). A prefix may match the name of the agent it binds to
+— a node owning its own namespace, so `s1l` registers as agent `s1l` and binds
+prefix `s1l` to itself, and cross-wall traffic is attributed to `s1l` rather
+than a `s1l-node` stand-in. A prefix still can't collide with an alias or with
+a *different* agent's name (a bare `tell <prefix>` resolves to the namespace,
+which would otherwise silently shadow that agent). An unknown prefix behaves
+like any unknown recipient: published to configured remotes (another cluster
+may own the binding), or trashed when there are none. Removing an agent unbinds
+any prefixes pointing at it.
 
 ### Handlers
 

--- a/apps/a8s/commands.py
+++ b/apps/a8s/commands.py
@@ -201,9 +201,12 @@ def cmd_add(args: list[str]) -> int:
             print(f"alias already exists with name: {k} — pick a different agent name", file=sys.stderr)
             return 1
     namespaces = load_namespaces()
-    for k in namespaces:
-        if k.lower() == name:
-            print(f"namespace already exists with prefix: {k} — pick a different agent name", file=sys.stderr)
+    # A prefix already bound to this exact name is the agent's own namespace
+    # (#175) — re-adding the node is fine. A prefix bound to a *different* agent
+    # would be shadowed by `tell <name>` (namespace beats agent), so it stands.
+    for k, bound in namespaces.items():
+        if k.lower() == name and str(bound).strip().lower() != name:
+            print(f"namespace already exists with prefix: {k} (bound to {bound}) — pick a different agent name", file=sys.stderr)
             return 1
 
     if definition_arg:
@@ -813,7 +816,9 @@ def cmd_namespace(args: list[str]) -> int:
     internally. The target must be a registered agent, not an alias —
     namespace delegation is single-delivery by design, the opposite of
     alias fan-out. Prefixes share the agent/alias name grammar (lowercase
-    canonical form) and must not collide with either pool."""
+    canonical form). A prefix may match the name of the agent it binds to (a
+    node owning its own namespace, #175) but must not collide with an alias or
+    with any other agent."""
     if len(args) == 0:
         return cmd_namespaces()
     if len(args) == 1:
@@ -836,8 +841,12 @@ def cmd_namespace(args: list[str]) -> int:
         return 2
     agents = load_registry()
     aliases = load_aliases()
+    # A prefix may match the name of the agent it binds to — that's a node
+    # owning its own namespace (#175), so cross-wall traffic is attributed to
+    # `s1l`, not `s1l-node`. It must not match any *other* agent's name, which
+    # `tell <prefix>` would silently shadow (namespace beats agent in resolve).
     for k in agents:
-        if k.lower() == prefix:
+        if k.lower() == prefix and k.lower() != target:
             print(f"agent already exists with name: {k} — pick a different prefix", file=sys.stderr)
             return 1
     for k in aliases:

--- a/apps/a8s/registry.py
+++ b/apps/a8s/registry.py
@@ -10,8 +10,10 @@ Schema:
   attachments may originate at routing time, in addition to `root`.
   `namespaces` — prefix routing (#148): a recipient `<PREFIX>:<sub-address>`
   routes to the single bound agent with the full address preserved in `to`.
-Agent, alias, and namespace name pools are disjoint (`cmd_add`, `cmd_alias`,
-and `cmd_namespace` reject collisions).
+Aliases are disjoint from both agents and namespaces. A namespace prefix may
+match the name of the agent it binds to (a node owning its own namespace, #175);
+it may not match an alias or a *different* agent (`cmd_add` / `cmd_namespace`
+reject those).
 
 Also hosts the read-only marker-file scan used by `cmd_discover` and the
 auto-detect path in `cmd_add`.
@@ -180,6 +182,10 @@ def resolve_name(query: str) -> tuple[str, list[str]]:
             raise KeyError(f"namespace {prefix!r} is bound to unknown agent {bound_agent!r}")
         return "namespace", [agent_lookup[bound_key]]
     q = query.strip().lower()
+    # Namespace beats agent: when a node owns a namespace matching its own name
+    # (#175, e.g. agent `s1l` bound to prefix `s1l`), both routes land on the
+    # same node — the namespace path just delivers `to` as the bare prefix so
+    # the node self-routes, which is exactly what a bare `tell s1l` should do.
     if q in namespace_lookup:
         _prefix_canon, bound_agent = namespace_lookup[q]
         bound_key = str(bound_agent).strip().lower()

--- a/apps/a8s/tests/test_commands.py
+++ b/apps/a8s/tests/test_commands.py
@@ -203,9 +203,22 @@ class TestCmdNamespace:
         assert "not an alias" in capsys.readouterr().err
         assert load_namespaces() == {}
 
-    def test_prefix_collides_with_agent(self, agent_root, capsys):
+    def test_prefix_may_match_own_agent(self, agent_root, capsys):
+        # A node owning its own namespace (#175): agent `s1l` binds prefix
+        # `s1l` to itself so cross-wall traffic is attributed to `s1l`.
+        cmd_add(["s1l", str(agent_root)])
+        rc = cmd_namespace(["s1l", "s1l"])
+        assert rc == 0
+        assert load_namespaces() == {"s1l": "s1l"}
+
+    def test_prefix_collides_with_other_agent(self, agent_root, tmp_path, capsys):
         cmd_add(["node", str(agent_root)])
-        rc = cmd_namespace(["node", "node"])
+        other = tmp_path / "other"
+        other.mkdir()
+        cmd_add(["s1l", str(other)])
+        # Binding prefix `node` to a *different* agent would shadow the `node`
+        # agent on a bare `tell node`, so it's still rejected.
+        rc = cmd_namespace(["node", "s1l"])
         assert rc == 1
         assert "agent already exists" in capsys.readouterr().err
 
@@ -269,11 +282,12 @@ class TestCmdUnnamespace:
 
 
 class TestNamespaceCollisionsElsewhere:
-    """Disjointness is enforced in both directions: `a8s add` / `a8s alias`
-    refuse names already bound as prefixes, and removing an agent unbinds
-    its prefixes (no orphans)."""
+    """Aliases stay disjoint from namespaces in both directions. Agent names
+    may match a prefix only when it's the agent's own namespace (#175); a
+    prefix bound to a different agent still blocks the name. Removing an agent
+    unbinds its prefixes (no orphans)."""
 
-    def test_add_rejects_existing_namespace_prefix(self, fake_home, tmp_path, capsys):
+    def test_add_rejects_namespace_bound_to_other_agent(self, fake_home, tmp_path, capsys):
         node = tmp_path / "node"
         node.mkdir()
         cmd_add(["node", str(node)])
@@ -284,6 +298,16 @@ class TestNamespaceCollisionsElsewhere:
         assert rc == 1
         assert "namespace already exists" in capsys.readouterr().err
         assert "acme" not in load_registry()
+
+    def test_add_allows_own_namespace_prefix(self, fake_home, tmp_path):
+        # A dangling self-namespace (`s1l` -> `s1l` with no agent yet) doesn't
+        # block re-materializing the node; `tell s1l` still lands on `s1l`.
+        save_namespaces({"s1l": "s1l"})
+        root = tmp_path / "s1l"
+        root.mkdir()
+        rc = cmd_add(["s1l", str(root)])
+        assert rc == 0
+        assert "s1l" in load_registry()
 
     def test_alias_rejects_existing_namespace_prefix(self, fake_home, tmp_path, capsys):
         node = tmp_path / "node"

--- a/apps/a8s/tests/test_registry.py
+++ b/apps/a8s/tests/test_registry.py
@@ -254,6 +254,15 @@ class TestResolveNamespace:
         save_namespaces({"acme": "NODE"})
         assert resolve_name("ACME") == ("namespace", ["NODE"])
 
+    def test_self_owned_namespace_both_forms_resolve_to_node(self, fake_home):
+        # #175: a node IS `s1l` — agent `s1l` binds prefix `s1l` to itself.
+        # Bare and colon forms both land on the one node; namespace precedence
+        # over the agent name is intentional and harmless here.
+        save_registry({"s1l": {"root": "/r"}})
+        save_namespaces({"s1l": "s1l"})
+        assert resolve_name("s1l") == ("namespace", ["s1l"])
+        assert resolve_name("s1l:gerry") == ("namespace", ["s1l"])
+
 
 # ---------- find_participant + sender_from_cwd ----------
 


### PR DESCRIPTION
## Problem

Teams had to register as `s1l-node` owning namespace `s1l`, because a8s enforced the three name pools (agents, aliases, namespaces) as **fully disjoint** at registration time. The annoyance surfaced on egress: cross-wall messages arrived attributed to `s1l-node` instead of `s1l`, since `from` is force-stamped from the sending agent's registry name.

## Root cause

The disjointness was pure **registration-time validation** — three explicit collision checks in `cmd_add` and `cmd_namespace` — not a shared resolution map. Agents, aliases, and namespaces live in three separate dicts in `a8s.json`, and `resolve_name` already checks namespace before agent. So there was never a storage collision preventing a node from being `s1l`; only the validation rule stood in the way.

## Resolution rule

A namespace prefix **may** match the name of the agent it binds to — a node owning its own namespace. It **may not** match an alias, or a *different* agent's name (a bare `tell <prefix>` resolves to the namespace and would otherwise silently shadow that agent). `cmd_add` and `cmd_namespace` relax only the self case; the alias pool stays fully disjoint.

Concretely, a node now simply IS `s1l`:

```
a8s add s1l ~/projects/s1l
a8s namespace s1l s1l
```

Both `tell s1l` and `tell s1l:gerry` resolve to the one node (the bare form delivers `to` as the prefix so the node self-routes), and egress attributes to `s1l`. The owned-namespace `from`-claim path in `mailbox.route` already anticipated this exact case, so no routing/egress code changed.

## Pre-v1

No migration code — the registry shape is unchanged (a namespace whose value equals its own key). Existing state keeps working; nothing to wipe.

## Tests

Full a8s suite green (646 passed) plus `tests/test_pii.py` (3 passed). Added/adjusted coverage for: self-owned prefix binding accepted, prefix bound to a different agent still rejected, `add` allowing a dangling self-namespace, and both address forms resolving to the one node.

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)