### PR TITLE
feat(r4t): external ingress enters at the top; r4t chat gains gemba attach

### DIFF
--- a/apps/r4t/README.md
+++ b/apps/r4t/README.md
@@ -30,14 +30,23 @@ fail closed — see the [tutorial](docs/tutorial.md#missing-rig-no-default--fail
 
 ### How a message flows
 
-1. `tell acme:phil "..."` routes through a8s to the team node; the node's
-   definition invokes `r4t dispatch`.
-2. r4t parses the `[r4t task=<ulid> hop=<n> auto]` header (a thread label,
-   creating a new thread if absent) and ENQUEUES the message into Phil's
-   durable queue — unconditionally. When Phil is runnable (both his spend
-   bucket and the cell bucket hold ≥1, his breaker is closed, the throttle
-   admits a start), ONE turn drains his whole queue: the prompt carries his
-   persona, rolling history, and every waiting message at once.
+1. `tell acme "..."` routes through a8s to the team node; the node's
+   definition invokes `r4t dispatch`. **The topmost leader IS the garden
+   from outside** — every external message enters at the top, no matter how
+   it is addressed. A `node:member` sub-address from an outside sender is
+   ignored (the namespace is the garden's outside address, not a way in to a
+   specific member); the leader is the one who decides what to relay inward.
+   The lone exception is the roster human's own `Address:` — a reply from it
+   is the human speaking, so it lands in the seat path and routes exactly
+   like a chat/seat send (see the seat section).
+2. r4t opens or continues a thread (the `[r4t task=<ulid> hop=<n> auto]`
+   header is a thread label; a fresh thread opens when absent) and ENQUEUES
+   the message into the leader's durable queue — unconditionally. When the
+   leader is runnable (both its spend bucket and the cell bucket hold ≥1, its
+   breaker is closed, the throttle admits a start), ONE turn drains its whole
+   queue: the prompt carries its persona, rolling history, and every waiting
+   message at once. Intra-team routing (below) is what delivers to a named
+   member — from *inside* the garden, addressing is honored.
 3. The harness's `$TELL_OUTBOX_DIR` points at a per-turn staging dir, so
    Phil replies with the ordinary `tell` — unmodified. After the turn r4t
    releases the staged envelopes: sender attribution is free (only that
@@ -79,7 +88,7 @@ r4t init --root ~/repos/acme
 a8s add acme-node ~/repos/acme ~/bin/apps/r4t/example-definition.json
 a8s namespace acme acme-node
 a8s start acme-node
-tell acme:gerry "Ship the payload refactor; report when reviewed."
+tell acme "Ship the payload refactor; report when reviewed."
 ```
 
 Watch it — one surface per way of looking:
@@ -101,10 +110,14 @@ is optional. (`a8s logs acme-node -f` still shows the cross-wall view.)
 ## The seat: being the human in the roster
 
 A human roster member is a first-class team address: teammates just
-`tell neil`, outsiders (your phone, another cluster) `tell acme:neil`, and
-both park in the node's seat mailbox under `~/.config/r4t/teams/acme/seat/` —
-no handler, no router, nothing to disconnect. Two surfaces read and speak
-for it:
+`tell neil`, and messages park in the node's seat mailbox under
+`~/.config/r4t/teams/acme/seat/` — no handler, no router, nothing to
+disconnect. When the seat is unattended dispatch rings the `Address:`
+doorbell (a copy forwarded over a8s to the human's phone); a reply from that
+Address is the human speaking, so it re-enters through the seat path and
+routes like a chat send. Outsiders other than the human do not reach the
+seat directly — like all external traffic they enter through the top lead.
+Two surfaces read and speak for it:
 
 ```bash
 r4t seat                    # summary: unread count, attached, doorbell
@@ -115,18 +128,25 @@ r4t seat send --to phil "…" # or to a member (runs their turn synchronously)
 
 `r4t seat` is the scriptable surface — an orchestrating agent impersonates
 the human with it directly. `r4t chat` is the human view over the same
-mailbox: a full-screen TUI with a health header fed by the same verdict
-engine as `r4t status` (worst-level summary, live warnings, member budget
-bars for whoever you're talking to), a conversation pane beside a
-fly-on-the-wall activity pane (turn starts/completions and every governance
-decision line), and an input line (`/to`, `/who`, `/tasks`, `/quit`). The TUI needs
-[textual](https://textual.textualize.io/) (`python3 -m pip install
+mailbox, and the team's **control plane**: a full-screen TUI with a health
+header fed by the same verdict engine as `r4t status`, a clickable member
+status panel (who is active, resting, or broken and how deep each queue is),
+a conversation pane beside a fly-on-the-wall activity pane, and an input line
+(`/to`, `/attach`, `/detach`, `/who`, `/threads`, `/help`, `/quit`). The TUI
+needs [textual](https://textual.textualize.io/) (`python3 -m pip install
 textual`); without it — or with `--plain`, or piped — chat falls back to
 a line UI over the same feed. While chat (or anything touching the
 presence file) is attached, dispatch skips the `Address:` doorbell;
-detach and the doorbell rings again. Training wheels, not a replacement
-for autonomy — everything still flows through normal dispatch and
-governance.
+detach and the doorbell rings again.
+
+**Gemba attach — walk the floor, read-only.** Click a member or type
+`/attach vela` (`r4t chat --attach vela` to open straight into it) for a live
+view of one member: every message it receives as it is enqueued, and its
+turn output streaming as it comes out (teed to `agents/<member>/live.log`,
+truncated at each turn start). Attaching is observation only — it never sends
+to that member; the composer keeps talking to the seat's usual
+counterparties. `/detach` steps back out. Training wheels, not a replacement
+for autonomy — everything still flows through normal dispatch and governance.
 
 ## The tree: cells, leads, and information hiding
 
@@ -235,8 +255,11 @@ released envelope carries `auto` in its `[r4t task=<ulid> hop=<n>]` header
 header never crosses egress — external releases carry the bare body (class
 survives as `x_r4t_class` envelope metadata), because other a8s nodes must
 not need to know whether a name is one agent, a human, a device, or a whole
-roster. Symmetrically, headers on inbound external messages are untrusted
-content: a forged header can't attach to an existing thread.
+roster. Symmetrically, external ingress is untrusted end to end: headers on
+inbound external messages are content (a forged header can't attach to an
+existing thread), and a sub-address can't pick a member — everything from
+outside enters at the top lead. One ingress point means one thing to reason
+about.
 
 ## Security model
 

--- a/apps/r4t/chat.py
+++ b/apps/r4t/chat.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import queue
+import re
 import sys
 import threading
 import time
@@ -191,11 +192,63 @@ def format_threads(node: str) -> list[str]:
     return rows or ["(no open threads)"]
 
 
+ACTIVE = "active"
+RESTING = "resting"
+BROKEN = "broken"
+IDLE = "idle"
+
+
+@dataclass
+class MemberStatus:
+    """One AI member's live state for the control-plane panel: whether it is
+    running a turn, resting on an empty budget, broken, or idle, and how deep
+    its queue is. Built entirely from state.py/verdict-grade signals."""
+
+    name: str
+    rig: str
+    state: str
+    queue: int
+    detail: str = ""
+
+
+def member_statuses(node: str, roster: Roster, config=None) -> list[MemberStatus]:
+    locks = {lock["agent"]: lock for lock in state.live_locks(node, prune=False)}
+    rows: list[MemberStatus] = []
+    for m in roster.members:
+        if m.is_human or m.errors:
+            continue
+        depth = state.queue_depth(node, m.name)
+        lock = locks.get(m.name.lower())
+        rig = None
+        if config is not None:
+            rig, _err, _pinned = config.rig_for(m)
+        if lock is not None:
+            st, detail = ACTIVE, f"pid {lock.get('pid')}"
+        elif config is not None and rig is not None:
+            blocked, failures = state.breaker_open(
+                node, m.name, config.breaker_cap, config.breaker_cooldown_seconds
+            )
+            if blocked:
+                st, detail = BROKEN, f"{failures} straight failures"
+            else:
+                level = state.budget_level(
+                    node, m.name, rig.budget_max, rig.budget_earn_per_hour
+                )
+                if depth and level < 1.0:
+                    wait = state.budget_seconds_until(
+                        node, m.name, rig.budget_max, rig.budget_earn_per_hour
+                    )
+                    st, detail = RESTING, f"ready ~{wait / 60:.0f}m"
+                else:
+                    st, detail = IDLE, ""
+        else:
+            st, detail = IDLE, ""
+        rows.append(MemberStatus(m.name, rig.name if rig else (m.rig or "?"), st, depth, detail))
+    return rows
+
+
 def format_who(node: str, roster: Roster, human: Member) -> list[str]:
-    locks = {
-        lock.get("name", "").lower(): lock
-        for lock in state.live_locks(node, prune=False)
-    }
+    locks = {lock["agent"]: lock for lock in state.live_locks(node, prune=False)}
     rows: list[str] = []
     for m in roster.members:
         if m.is_human:
@@ -204,14 +257,80 @@ def format_who(node: str, roster: Roster, human: Member) -> list[str]:
             rows.append(f"{m.name:12} human   ({seat}{bell})")
             continue
         lock = locks.get(m.name.lower())
+        depth = state.queue_depth(node, m.name)
         status = f"ACTIVE (pid {lock.get('pid')})" if lock else "idle"
+        if depth:
+            status += f", {depth} queued"
         leader = " leader" if m.leader else ""
         rows.append(f"{m.name:12} {m.rig or '?':7} {status}{leader}")
     return rows
 
 
+def member_log_event(line: str, name: str) -> str | None:
+    """Compact a team-log line into a gemba event for one member, or None when
+    the line does not name it — messages enqueued for it, its turn boundaries,
+    and the governance lines that mention it, nothing else."""
+    event = filter_log_line(line)
+    if event is None:
+        return None
+    key = name.strip().lower()
+    if re.search(rf"\b{re.escape(key)}\b", event.lower()):
+        return event
+    return None
+
+
+class MemberWatch:
+    """Read-only live view of one AI member for a gemba attach: the team-log
+    events that name it (every message enqueued for it, its turn boundaries)
+    plus its turn output tailed live from agents/<name>/live.log as it streams.
+    Observation only — attaching never sends to the member."""
+
+    def __init__(self, node: str, name: str):
+        self.node = node
+        self.name = name.strip().lower()
+        self._log_path = None
+        self._log_offset = 0
+        self._live_offset = 0
+
+    def _poll_log(self) -> list[tuple[str, str]]:
+        path = state.team_dir(self.node) / "log" / (
+            datetime.now(timezone.utc).strftime("%Y-%m-%d") + ".md"
+        )
+        if path != self._log_path:
+            self._log_path = path
+            self._log_offset = path.stat().st_size if path.is_file() else 0
+            return []
+        if not path.is_file():
+            return []
+        size = path.stat().st_size
+        if size <= self._log_offset:
+            self._log_offset = min(self._log_offset, size)
+            return []
+        with path.open("r", encoding="utf-8") as f:
+            f.seek(self._log_offset)
+            chunk = f.read()
+            self._log_offset = f.tell()
+        out: list[tuple[str, str]] = []
+        for line in chunk.splitlines():
+            event = member_log_event(line, self.name)
+            if event:
+                out.append(("recv", event))
+        return out
+
+    def _poll_live(self) -> list[tuple[str, str]]:
+        chunk, self._live_offset = state.read_live_log_tail(
+            self.node, self.name, self._live_offset
+        )
+        return [("out", line) for line in chunk.splitlines() if line.strip()]
+
+    def poll(self) -> list[tuple[str, str]]:
+        return [*self._poll_log(), *self._poll_live()]
+
+
 HELP = """\
 /to <name|team>   set message target (bare team = leader)
+/attach <name>    watch a member read-only (messages in + turn output live)
+/detach           stop watching
 /who              roster and live turn locks
 /threads          open threads for this team
 /help             this help
@@ -221,11 +340,14 @@ HELP = """\
 @dataclass
 class CommandResult:
     """Outcome of a shared /command: system lines both surfaces display, plus
-    any state change the surface applies itself (quit, adopt a new target)."""
+    any state change the surface applies itself (quit, adopt a new target,
+    attach to / detach from a member)."""
 
     lines: list[str] = field(default_factory=list)
     quit: bool = False
     target: str | None = None
+    attach: str | None = None
+    detach: bool = False
 
 
 def handle_command(roster: Roster, node: str, human: Member, line: str) -> CommandResult:
@@ -248,11 +370,25 @@ def handle_command(roster: Roster, node: str, human: Member, line: str) -> Comma
                 lines=[f"no AI member named {arg.strip().lower()!r} in the roster"]
             )
         return CommandResult(lines=[f"target: {target}"], target=target)
+    if cmd == "/attach":
+        member = roster.find(arg)
+        if member is None or member.is_human or member.errors:
+            return CommandResult(
+                lines=[f"no AI member named {arg.strip().lower()!r} to attach to"]
+            )
+        name = member.name.lower()
+        return CommandResult(
+            lines=[f"attached to {name} — read-only; /detach to stop"], attach=name
+        )
+    if cmd == "/detach":
+        return CommandResult(lines=["detached"], detach=True)
     return CommandResult(lines=[f"unknown command: {cmd} (try /help)"])
 
 
 class ChatSession:
-    def __init__(self, ctx: DispatchContext, roster: Roster, human: Member):
+    def __init__(
+        self, ctx: DispatchContext, roster: Roster, human: Member, attach: str | None = None
+    ):
         self.ctx = ctx
         self.roster = roster
         self.human = human
@@ -261,10 +397,14 @@ class ChatSession:
         self.events: queue.Queue[tuple[str, str]] = queue.Queue()
         self.sends: queue.Queue[tuple[str, str]] = queue.Queue()
         self.tty = sys.stdout.isatty()
+        self.watch = MemberWatch(ctx.node, attach) if attach else None
 
     # ---------- output ----------
 
-    _STYLE = {"in": "\x1b[36m", "you": "\x1b[32m", "sys": "\x1b[33m", "act": "\x1b[2m"}
+    _STYLE = {
+        "in": "\x1b[36m", "you": "\x1b[32m", "sys": "\x1b[33m", "act": "\x1b[2m",
+        "recv": "\x1b[35m", "out": "\x1b[37m",
+    }
 
     def emit(self, kind: str, text: str) -> None:
         stamp = datetime.now().strftime("%H:%M:%S")
@@ -305,6 +445,10 @@ class ChatSession:
                 return False
             if result.target is not None:
                 self.target = result.target
+            if result.attach is not None:
+                self.watch = MemberWatch(self.ctx.node, result.attach)
+            if result.detach:
+                self.watch = None
             if result.lines:
                 self.emit("sys", "\n".join(result.lines))
             return True
@@ -319,14 +463,23 @@ class ChatSession:
             text = render_envelope(payload, self.roster) if kind == "in" else payload
             self.events.put((kind, text))
 
+    def _pump_watch(self) -> None:
+        if self.watch is None:
+            return
+        for kind, text in self.watch.poll():
+            self.events.put((kind, f"[{self.watch.name}] {text}"))
+
     def run(self) -> int:
         self.emit(
             "sys",
             f"seat: {self.human.name} on {self.ctx.node} — messages go to"
             f" {self.target} (leader). /help for commands.",
         )
+        if self.watch is not None:
+            self.emit("sys", f"attached to {self.watch.name} — read-only; /detach to stop")
         state.touch_seat_presence(self.ctx.node, self.human.name)
         self._pump_feed()
+        self._pump_watch()
 
         threading.Thread(target=self._send_worker, daemon=True).start()
         lines: queue.Queue[str] = queue.Queue()
@@ -341,6 +494,7 @@ class ChatSession:
                     pass
                 state.touch_seat_presence(self.ctx.node, self.human.name)
                 self._pump_feed()
+                self._pump_watch()
                 try:
                     while True:
                         kind, text = self.events.get_nowait()
@@ -355,10 +509,16 @@ class ChatSession:
             self.emit("sys", "seat detached — mail parks and the doorbell rings again")
 
 
-def run_chat(ctx: DispatchContext) -> int:
+def run_chat(ctx: DispatchContext, attach: str | None = None) -> int:
     try:
         roster, human = load_seat(ctx)
     except SeatError as e:
         print(f"r4t chat: {e}", file=sys.stderr)
         return 2
-    return ChatSession(ctx, roster, human).run()
+    if attach:
+        member = roster.find(attach)
+        if member is None or member.is_human or member.errors:
+            print(f"r4t chat: no AI member named {attach!r} to attach to", file=sys.stderr)
+            return 2
+        attach = member.name.lower()
+    return ChatSession(ctx, roster, human, attach=attach).run()

--- a/apps/r4t/chat_tui.py
+++ b/apps/r4t/chat_tui.py
@@ -1,12 +1,17 @@
-"""r4t chat — Textual front end over the seat.
+"""r4t chat — Textual front end over the seat, and the team's control plane.
 
-One window, three regions: a health header fed by the same verdict engine
-as `r4t status` (worst-level summary, non-ok verdicts, open-task budget
-bars), a conversation pane (seat messages and what you say) beside a
-fly-on-the-wall activity pane (turn starts/completions and every
-governance decision line), and an input line that speaks as the roster
-human. Sends run on a background thread — dispatch turns are synchronous
-and slow, and the wall must keep scrolling while a rig thinks.
+One window: a health header fed by the same verdict engine as `r4t status`,
+a clickable member status panel (who is active, resting, or broken and how
+deep each queue is), a conversation pane (seat messages and what you say)
+beside a fly-on-the-wall activity pane, and an input line that speaks as the
+roster human. Sends run on a background thread — dispatch turns are
+synchronous and slow, and the wall must keep scrolling while a rig thinks.
+
+Gemba attach (`/attach <member>` or clicking a member) opens a read-only live
+view of one member: every message it receives as it is enqueued, and its turn
+output streaming as it comes out (tailed from agents/<member>/live.log).
+Attaching is observation only — it never sends to the member; the composer
+keeps talking to the seat's usual counterparties.
 
 Importing this module requires textual; cmd_chat falls back to the line
 UI in chat.py when it is missing.
@@ -22,17 +27,23 @@ from rich.markdown import Markdown
 from rich.padding import Padding
 from rich.text import Text
 from textual.app import App, ComposeResult
-from textual.containers import Horizontal
+from textual.containers import Horizontal, Vertical
+from textual.message import Message
 from textual.widgets import Footer, Input, RichLog, Static
 
 import state
 import tasks as taskmod
 import verdict
 from chat import (
+    ACTIVE,
+    BROKEN,
+    RESTING,
+    MemberWatch,
     SeatError,
     SeatFeed,
     handle_command,
     load_seat,
+    member_statuses,
     send_as_human,
     sender_label,
 )
@@ -45,8 +56,29 @@ HEADER_REFRESH_SECONDS = 5.0
 MAX_HEADER_VERDICTS = 4
 MAX_HEADER_TASKS = 3
 
-KIND_STYLE = {"in": "cyan", "you": "green", "sys": "yellow", "act": "dim"}
+KIND_STYLE = {
+    "in": "cyan", "you": "green", "sys": "yellow", "act": "dim",
+    "recv": "magenta", "out": "white",
+}
 LEVEL_STYLE = {verdict.OK: "green", verdict.WARN: "yellow", verdict.BAD: "red"}
+STATE_STYLE = {ACTIVE: "green", RESTING: "yellow", BROKEN: "red"}
+
+
+class MemberRow(Static):
+    """A clickable member line in the status panel: click to attach a read-only
+    gemba view of that member."""
+
+    class Clicked(Message):
+        def __init__(self, name: str) -> None:
+            self.name = name
+            super().__init__()
+
+    def __init__(self, name: str) -> None:
+        super().__init__(id=f"member-{name.lower()}")
+        self.member_name = name
+
+    def on_click(self) -> None:
+        self.post_message(self.Clicked(self.member_name))
 
 
 def budget_bar(level: float, budget: float, width: int = 8) -> str:
@@ -64,14 +96,19 @@ class ChatApp(App):
     Screen { layout: vertical; }
     #header { height: auto; padding: 0 1; background: $panel; }
     #panes { height: 1fr; }
+    #roster { width: 26; border-right: solid $panel; padding: 0 1; }
+    #roster MemberRow { height: 1; }
     #conversation { width: 2fr; }
     #activity { width: 1fr; border-left: solid $panel; }
+    #attach { width: 2fr; border-left: solid $panel; display: none; }
     #composer { dock: bottom; }
     """
 
     BINDINGS = [("ctrl+q", "quit", "Quit")]
 
-    def __init__(self, ctx: DispatchContext, roster: Roster, human: Member):
+    def __init__(
+        self, ctx: DispatchContext, roster: Roster, human: Member, attach: str | None = None
+    ):
         super().__init__()
         self.ctx = ctx
         self.roster = roster
@@ -79,6 +116,9 @@ class ChatApp(App):
         self.target = ctx.node
         self.feed = SeatFeed(ctx.node, human.name)
         self.sends: queue.Queue[tuple[str, str]] = queue.Queue()
+        self.attached: str | None = None
+        self.watch: MemberWatch | None = None
+        self._pending_attach = attach.lower() if attach else None
         try:
             self.rig_config = load_rig_config(ctx.config_path)
         except RigError:
@@ -87,8 +127,13 @@ class ChatApp(App):
     def compose(self) -> ComposeResult:
         yield Static(id="header")
         with Horizontal(id="panes"):
+            with Vertical(id="roster"):
+                for m in self.roster.members:
+                    if not m.is_human and not m.errors:
+                        yield MemberRow(m.name)
             yield RichLog(id="conversation", wrap=True)
             yield RichLog(id="activity", wrap=True, max_lines=2000)
+            yield RichLog(id="attach", wrap=True, max_lines=4000)
         yield Input(
             id="composer",
             placeholder=f"message {self.target} (leader) — /help for commands",
@@ -103,17 +148,25 @@ class ChatApp(App):
         )
         self._pump_feed()
         self._refresh_header()
+        self._refresh_roster()
         threading.Thread(target=self._send_worker, daemon=True).start()
         self.set_interval(FEED_POLL_SECONDS, self._poll_feed)
         self.set_interval(HEADER_REFRESH_SECONDS, self._refresh_header)
+        self.set_interval(HEADER_REFRESH_SECONDS, self._refresh_roster)
         self.query_one("#composer", Input).focus()
+        if self._pending_attach is not None:
+            self._attach(self._pending_attach)
 
     # ---------- output ----------
 
     def _emit(self, kind: str, text: str) -> None:
-        log = self.query_one(
-            "#activity" if kind == "act" else "#conversation", RichLog
-        )
+        if kind in ("recv", "out"):
+            log_id = "#attach"
+        elif kind == "act":
+            log_id = "#activity"
+        else:
+            log_id = "#conversation"
+        log = self.query_one(log_id, RichLog)
         stamp = datetime.now().strftime("%H:%M:%S")
         for line in text.splitlines():
             log.write(Text.assemble((stamp + " ", "dim"), (line, KIND_STYLE[kind])))
@@ -140,6 +193,59 @@ class ChatApp(App):
     def _poll_feed(self) -> None:
         state.touch_seat_presence(self.ctx.node, self.human.name)
         self._pump_feed()
+        self._pump_watch()
+
+    # ---------- control plane: status panel + gemba attach ----------
+
+    def _refresh_roster(self) -> None:
+        for row in member_statuses(self.ctx.node, self.roster, self.rig_config):
+            try:
+                widget = self.query_one(f"#member-{row.name.lower()}", MemberRow)
+            except Exception:  # noqa: BLE001 — panel is best-effort
+                continue
+            marker = "▶ " if row.name.lower() == self.attached else "  "
+            label = Text(marker, style="bold cyan" if row.name.lower() == self.attached else "")
+            label.append(f"{row.name} ", style=STATE_STYLE.get(row.state, "dim"))
+            tail = row.state
+            if row.queue:
+                tail += f" · {row.queue}q"
+            if row.detail:
+                tail += f" · {row.detail}"
+            label.append(tail, style="dim")
+            widget.update(label)
+
+    def _attach(self, name: str) -> None:
+        member = self.roster.find(name)
+        if member is None or member.is_human or member.errors:
+            self._emit("sys", f"no AI member named {name!r} to attach to")
+            return
+        self.attached = member.name.lower()
+        self.watch = MemberWatch(self.ctx.node, self.attached)
+        self.query_one("#activity", RichLog).display = False
+        attach_log = self.query_one("#attach", RichLog)
+        attach_log.display = True
+        attach_log.clear()
+        self._emit("sys", f"── attached to {self.attached} (read-only) ──")
+        self._pump_watch()
+        self._refresh_roster()
+
+    def _detach(self) -> None:
+        if self.attached is None:
+            return
+        self.attached = None
+        self.watch = None
+        self.query_one("#attach", RichLog).display = False
+        self.query_one("#activity", RichLog).display = True
+        self._refresh_roster()
+
+    def _pump_watch(self) -> None:
+        if self.watch is None:
+            return
+        for kind, text in self.watch.poll():
+            self._emit(kind, text)
+
+    def on_member_row_clicked(self, message: MemberRow.Clicked) -> None:
+        self._attach(message.name)
 
     def _member_budget_rows(self) -> list[tuple[str, float, float]]:
         """(name, level, max) for the members you're talking to. The target is
@@ -232,17 +338,21 @@ class ChatApp(App):
                 f"message {self.target}{suffix} — /help for commands"
             )
             self._refresh_header()
+        if result.attach is not None:
+            self._attach(result.attach)
+        if result.detach:
+            self._detach()
         if result.lines:
             self._emit("sys", "\n".join(result.lines))
 
 
-def run_chat_tui(ctx: DispatchContext) -> int:
+def run_chat_tui(ctx: DispatchContext, attach: str | None = None) -> int:
     try:
         roster, human = load_seat(ctx)
     except SeatError as e:
         print(f"r4t chat: {e}", file=sys.stderr)
         return 2
-    app = ChatApp(ctx, roster, human)
+    app = ChatApp(ctx, roster, human, attach=attach)
     try:
         state.touch_seat_presence(ctx.node, human.name)
         result = app.run()

--- a/apps/r4t/dispatch.py
+++ b/apps/r4t/dispatch.py
@@ -3,7 +3,10 @@
 Every inbound message to a member ENQUEUES, unconditionally, into that
 member's durable queue (state.enqueue). No gate ever drops or dead-letters a
 deliverable message; dead letters are for undeliverable mail only (unknown
-recipient, disabled member, no rig). A separate drain loop picks a runnable
+recipient, disabled member, no rig). External mail always enters at the top:
+the topmost leader IS the garden from outside, so outside senders cannot pick
+a member — except the roster human's own Address, whose doorbell reply lands
+in the seat path as the human speaking. A separate drain loop picks a runnable
 member with a non-empty queue and runs ONE turn that drains the WHOLE queue:
 the prompt renders every queued message at once, so an agent that sees
 "teammates discussed X, then the lead overrode with Y" pivots in one reading
@@ -37,6 +40,7 @@ import re
 import shutil
 import signal
 import subprocess
+import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -97,7 +101,9 @@ def _canonical_recipient(node: str, roster: Roster, to: str) -> str:
     internal form; anything else (external addresses, unknown names) passes
     through untouched. Human members are internal on purpose: their mail parks
     in the node's seat mailbox, and `Address:` is only a doorbell copy when no
-    seat session is attached."""
+    seat session is attached. A human's `Address:` is another name for the
+    human: a tell to it parks in the seat too, and — since doorbell replies
+    enter as the human speaking — closes the human's threads."""
     t = to.strip()
     if ":" in t:
         prefix, _, sub = t.partition(":")
@@ -106,7 +112,7 @@ def _canonical_recipient(node: str, roster: Roster, to: str) -> str:
         name = sub
     else:
         name = t
-    member = roster.find(name)
+    member = roster.find(name) or _human_by_address(roster, name)
     if member is None:
         return t
     return f"{node}:{member.name.lower()}"
@@ -129,6 +135,19 @@ def _human_member(node: str, roster: Roster, addr: str) -> Member | None:
         t = sub
     member = roster.find(t)
     return member if member is not None and member.is_human else None
+
+
+def _human_by_address(roster: Roster, sender: str) -> Member | None:
+    """The roster human whose a8s `Address:` equals `sender` — the doorbell
+    reply path. Their reply is the human speaking, not an outside agent, so
+    ingress re-stamps it to the seat instead of routing it as external mail."""
+    s = (sender or "").strip().lower()
+    if not s:
+        return None
+    for m in roster.members:
+        if m.is_human and m.address and m.address.strip().lower() == s:
+            return m
+    return None
 
 
 def _tell_error(ctx: DispatchContext, recipient: str, text: str) -> None:
@@ -293,8 +312,11 @@ def run_harness(
 ) -> tuple[int, str, float, bool]:
     """Run the rig's argv (pool variant `variant`) with {prompt} substituted
     as a single argv element — never a shell. Returns (exit_code, output,
-    duration_seconds, timed_out)."""
+    duration_seconds, timed_out). When the env carries `R4T_LIVE_LOG`, the
+    harness output is teed there line by line as it arrives, so a gemba attach
+    can tail the turn live; the full output is still returned for staging."""
     argv = rig.argv(prompt, variant)
+    live_log = (env or {}).get("R4T_LIVE_LOG")
     start = time.monotonic()
     try:
         proc = subprocess.Popen(
@@ -309,18 +331,41 @@ def run_harness(
         )
     except OSError as e:
         return 127, f"failed to spawn harness {argv[0]!r}: {e}", 0.0, False
+
+    chunks: list[str] = []
+
+    def _pump() -> None:
+        sink = None
+        if live_log:
+            try:
+                sink = open(live_log, "a", encoding="utf-8")
+            except OSError:
+                sink = None
+        try:
+            for line in proc.stdout:
+                chunks.append(line)
+                if sink is not None:
+                    sink.write(line)
+                    sink.flush()
+        finally:
+            if sink is not None:
+                sink.close()
+
+    reader = threading.Thread(target=_pump, daemon=True)
+    reader.start()
     timed_out = False
     try:
-        output, _ = proc.communicate(timeout=rig.timeout_seconds)
+        proc.wait(timeout=rig.timeout_seconds)
     except subprocess.TimeoutExpired:
         timed_out = True
         try:
             os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
         except OSError:
             proc.kill()
-        output, _ = proc.communicate()
+        proc.wait()
+    reader.join()
     duration = time.monotonic() - start
-    return proc.returncode, output or "", duration, timed_out
+    return proc.returncode, "".join(chunks), duration, timed_out
 
 
 def _throttle_block(ctx: DispatchContext, config: RigConfig) -> str | None:
@@ -359,13 +404,29 @@ def _ingest(
 ) -> str:
     """Resolve the recipient and enqueue. Humans park in the seat; undeliverable
     mail dead-letters with an audit record; a deliverable message to an AI
-    member enqueues unconditionally (duplicate-collapsed) and returns QUEUED."""
-    _, sub = split_recipient(to)
+    member enqueues unconditionally (duplicate-collapsed) and returns QUEUED.
 
+    Ingress routing turns on trust. Intra-team and seat traffic
+    (`trusted_header`) honors `node:member` addressing — that is how the tree
+    delivers between members and how the human seat reaches anyone. External
+    mail does NOT: the topmost leader IS the garden from outside, so every
+    outside message enters at the top regardless of any sub-address. The lone
+    exception is the roster human's own `Address:` — their doorbell reply is the
+    human speaking, re-stamped to the seat so it routes and closes threads
+    exactly like a chat/seat send."""
     if roster is None:
         roster = _load_roster(ctx, sender)
     if roster is None:
         return SKIPPED
+
+    if trusted_header:
+        _, sub = split_recipient(to)
+    else:
+        human = _human_by_address(roster, sender)
+        if human is not None:
+            sender = f"{ctx.node}:{human.name.lower()}"
+        to = ctx.node
+        sub = ""
 
     if sub:
         member = roster.find(sub)
@@ -451,10 +512,11 @@ def _ingest(
         },
     )
     state.update_meta(ctx.node, member.name, last_inbound_at=state.utc_now())
+    preview = " ".join(body.split())[:80]
     state.append_log(
         ctx.node,
         f"r4t: QUEUED {sender} -> {member.name.lower()} thread={thread_id} "
-        f"hop={hop} (depth {state.queue_depth(ctx.node, member.name)})",
+        f'hop={hop} "{preview}" (depth {state.queue_depth(ctx.node, member.name)})',
     )
     return QUEUED
 
@@ -733,6 +795,7 @@ def _run_turn(
 
     env = dict(os.environ)
     env["TELL_OUTBOX_DIR"] = str(staging)
+    env["R4T_LIVE_LOG"] = str(state.reset_live_log(ctx.node, member.name))
     state.append_log(
         ctx.node,
         f"## {state.utc_now()} dispatch {len(batch)} message(s) -> {member.name} "

--- a/apps/r4t/docs/tutorial.md
+++ b/apps/r4t/docs/tutorial.md
@@ -55,7 +55,6 @@ a8s namespace myrepo myrepo-node
 a8s start myrepo-node
 tell myrepo-node "hello"       # bare agent name -> roster leader
 tell myrepo "hello"            # bare namespace prefix -> roster leader
-tell myrepo:dev "hello"        # namespace prefix:member -> specific member
 ```
 
 Run those commands (adjust paths and names) before expecting live traffic.
@@ -179,9 +178,11 @@ r4t rig add junior-dev opencode
 
 ## How a message flows
 
-1. `tell myrepo:dev "..."` routes through a8s to the team node; the node's
-   definition invokes `r4t dispatch`.
-2. r4t loads the roster, resolves Dev's rig, checks governance
+1. `tell myrepo "..."` routes through a8s to the team node; the node's
+   definition invokes `r4t dispatch`. External messages always enter at the
+   roster leader — the topmost leader IS the garden from outside; only the
+   team itself (and the human seat) addresses individual members.
+2. r4t loads the roster, resolves the leader's rig, checks governance
    gates, and runs the rig's CLI with a prompt (persona, history, incoming
    message).
 3. The harness's `$TELL_OUTBOX_DIR` points at a per-turn staging dir. The
@@ -214,7 +215,7 @@ r4t roster check
 a8s add acme-node ~/repos/acme ~/bin/apps/r4t/example-definition.json
 a8s namespace acme acme-node
 a8s start acme-node
-tell acme:gerry "Ship the refactor; report when reviewed."
+tell acme "Ship the refactor; report when reviewed."
 ```
 
 Watch: `a8s logs acme-node -f`, `r4t status --node acme`, and dead letters

--- a/apps/r4t/example-definition.json
+++ b/apps/r4t/example-definition.json
@@ -1,5 +1,5 @@
 {
-  "description": "r4t — Roster For Teams. Namespace node: bind a prefix with `a8s namespace <prefix> <node>` and tell <prefix> or <prefix>:<member>. Roster in <root>/ROSTER.md; rig config out-of-repo at ~/.config/r4t/rigs.json (append --roster / --harness-config to override). The idle invoke resolves the sole ~/.config/r4t team; with multiple teams, copy this file per node and append \"--node\", \"<prefix>\" to the IDLE invoke only (dispatch derives the node from --to and rejects --node).",
+  "description": "r4t \u2014 Roster For Teams. Namespace node: bind a prefix with `a8s namespace <prefix> <node>` and tell <prefix> \u2014 external mail always enters at the roster leader. Roster in <root>/ROSTER.md; rig config out-of-repo at ~/.config/r4t/rigs.json (append --roster / --harness-config to override). The idle invoke resolves the sole ~/.config/r4t team; with multiple teams, copy this file per node and append \"--node\", \"<prefix>\" to the IDLE invoke only (dispatch derives the node from --to and rejects --node).",
   "invoke": [
     "python3",
     "$A8S_DIR/../r4t/r4t.py",

--- a/apps/r4t/plans/CELL-SPEC.md
+++ b/apps/r4t/plans/CELL-SPEC.md
@@ -133,8 +133,16 @@ JSON edit.
 - TUI composer gains command parity with the line UI; unknown commands
   say so instead of vanishing. `/tasks` renamed `/threads`.
 - Chat message headers carry the rig slug: `d5n:vela (specialist)`.
-- Later ("gemba mode"): scope a chat session to one cell — see that
-  cell's traffic, message its members directly, then step back out.
+- Gemba mode (decided 2026-07-13, issue #176): `r4t chat` is the control
+  plane. A member status panel (active/resting/broken, queue depths) plus
+  ATTACH — click a member or `/attach <name>` for a read-only live view:
+  every message it receives as it is enqueued, and its turn output
+  streaming as it comes out (dispatch tees harness output to
+  `agents/<member>/live.log`, truncated at turn start). Observation only;
+  `/detach` steps back out. This replaced the old scope-to-a-cell idea,
+  and direct outside-world connection to a member was rejected outright —
+  observing creates no channel that later needs locking down. Messaging
+  an attached member is future gemba work.
 
 ## Phase 3 — mission/milestone doc
 

--- a/apps/r4t/r4t.py
+++ b/apps/r4t/r4t.py
@@ -649,6 +649,7 @@ def cmd_chat(args: argparse.Namespace) -> int:
         return 2
     ctx = _context(args, node)
     _ensure_tell_outbox(ctx)
+    attach = getattr(args, "attach", None)
     if not args.plain and sys.stdout.isatty():
         try:
             from chat_tui import run_chat_tui
@@ -659,10 +660,10 @@ def cmd_chat(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
         else:
-            return run_chat_tui(ctx)
+            return run_chat_tui(ctx, attach=attach)
     from chat import run_chat
 
-    return run_chat(ctx)
+    return run_chat(ctx, attach=attach)
 
 
 def _seat_human(roster: Roster) -> Member | None:
@@ -1108,6 +1109,10 @@ def build_parser() -> argparse.ArgumentParser:
     chat_p.add_argument(
         "--plain", action="store_true",
         help="Line UI instead of the full-screen TUI.",
+    )
+    chat_p.add_argument(
+        "--attach", metavar="MEMBER",
+        help="Open watching a member read-only (messages in and turn output live).",
     )
     chat_p.set_defaults(func=cmd_chat)
 

--- a/apps/r4t/state.py
+++ b/apps/r4t/state.py
@@ -12,6 +12,8 @@ honors A8S_HOME).
     ├── agents/<name>/meta.json    last inbound / last completed turn bookkeeping
     ├── agents/<name>/staging/     per-turn $TELL_OUTBOX_DIR — envelopes the agent
     │                              sent this turn, released by dispatch afterwards
+    ├── agents/<name>/live.log     the running turn's harness output, teed live
+    │                              (truncated at turn start; a gemba attach tails it)
     ├── tasks/<id>.json            thread ledger (see tasks.py)
     ├── dead-letter/               undeliverable mail (unknown recipient, malformed)
     ├── buckets.json               per-member + team spend budgets (turns, not tokens)
@@ -577,6 +579,39 @@ def staged_envelopes(node: str, name: str) -> list[Path]:
     if not d.is_dir():
         return []
     return sorted(f for f in d.iterdir() if f.is_file() and f.name.endswith(".json"))
+
+
+# ---------- live turn output (a gemba attach tails this) ----------
+
+def live_log_path(node: str, name: str) -> Path:
+    return agent_dir(node, name) / "live.log"
+
+
+def reset_live_log(node: str, name: str) -> Path:
+    """Truncate the member's live turn log and return its path. Dispatch tees
+    the turn's harness output here as it streams, so an attached read-only view
+    can tail the turn AS IT COMES OUT instead of waiting for the turn to end."""
+    path = live_log_path(node, name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _atomic_write_text(path, "")
+    return path
+
+
+def read_live_log_tail(node: str, name: str, offset: int) -> tuple[str, int]:
+    """Return (new text since `offset`, new offset). A shrunk file means the
+    next turn truncated it, so reading restarts from the top."""
+    path = live_log_path(node, name)
+    if not path.is_file():
+        return "", 0
+    try:
+        if path.stat().st_size < offset:
+            offset = 0
+        with path.open("r", encoding="utf-8") as f:
+            f.seek(offset)
+            chunk = f.read()
+            return chunk, f.tell()
+    except OSError:
+        return "", offset
 
 
 # ---------- dead letters ----------

--- a/apps/r4t/tests/test_chat.py
+++ b/apps/r4t/tests/test_chat.py
@@ -172,3 +172,66 @@ def test_run_chat_requires_human(ctx, repo, r4t_home):
         encoding="utf-8",
     )
     assert run_chat(ctx) == 2
+
+
+def test_handle_command_attach_and_detach(roster, human):
+    attached = handle_command(roster, NODE, human, "/attach phil")
+    assert attached.attach == "phil" and attached.detach is False
+    assert "attached to phil" in attached.lines[0]
+    miss = handle_command(roster, NODE, human, "/attach nobody")
+    assert miss.attach is None and "no AI member" in miss.lines[0]
+    human_miss = handle_command(roster, NODE, human, "/attach neil")
+    assert human_miss.attach is None  # the human is not a dispatchable member
+    detached = handle_command(roster, NODE, human, "/detach")
+    assert detached.detach is True
+
+
+def test_help_lists_attach_and_detach(session, capsys):
+    session.handle_line("/help")
+    out = capsys.readouterr().out
+    assert "/attach" in out and "/detach" in out
+
+
+def test_member_log_event_filters_by_member():
+    from chat import member_log_event
+
+    line = 'r4t: QUEUED gerry -> vela thread=T hop=0 "hi" (depth 1)'
+    assert member_log_event(line, "vela") == line
+    assert member_log_event(line, "cass") is None
+    assert member_log_event("### Prompt", "vela") is None
+
+
+def test_member_watch_streams_recv_and_output(r4t_home):
+    from chat import MemberWatch
+
+    watch = MemberWatch(NODE, "phil")
+    watch.poll()  # first poll syncs the log offset to the end (skips history)
+    state.append_log(NODE, 'r4t: QUEUED gerry -> phil thread=T hop=0 "do it" (depth 1)')
+    state.reset_live_log(NODE, "phil")
+    with state.live_log_path(NODE, "phil").open("a", encoding="utf-8") as f:
+        f.write("thinking out loud\n")
+    events = watch.poll()
+    kinds = [k for k, _ in events]
+    assert "recv" in kinds and "out" in kinds
+    recv = next(text for kind, text in events if kind == "recv")
+    assert "phil" in recv and "do it" in recv
+    out = next(text for kind, text in events if kind == "out")
+    assert "thinking out loud" in out
+
+
+def test_member_statuses_reports_active_resting_and_queue(ctx, roster, r4t_home):
+    from chat import member_statuses
+    from rig import load_rig_config
+
+    config = load_rig_config(ctx.config_path)
+    state.enqueue(NODE, "phil", {"from": "acme:gerry", "body": "x"})
+    rows = {r.name: r for r in member_statuses(NODE, roster, config)}
+    assert rows["Phil"].queue == 1
+    assert "Neil" not in rows and "Broken" not in rows  # human + errored excluded
+    lock = state.AgentLock(NODE, "gerry")
+    assert lock.acquire("leader")
+    try:
+        active = {r.name: r for r in member_statuses(NODE, roster, config)}
+        assert active["Gerry"].state == "active"
+    finally:
+        lock.release()

--- a/apps/r4t/tests/test_chat_tui.py
+++ b/apps/r4t/tests/test_chat_tui.py
@@ -166,3 +166,56 @@ def test_tui_header_surfaces_trouble(seat):
             assert "pair-repeat" in header
 
     asyncio.run(scenario())
+
+
+def test_tui_attach_and_detach_toggles_panes(seat):
+    ctx, roster, human = seat
+
+    async def scenario():
+        from textual.widgets import Input, RichLog
+
+        app = ChatApp(ctx, roster, human)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            composer = app.query_one("#composer", Input)
+            composer.value = "/attach phil"
+            await pilot.press("enter")
+            await pilot.pause()
+            assert app.attached == "phil"
+            assert app.query_one("#attach", RichLog).display is True
+            assert app.query_one("#activity", RichLog).display is False
+
+            composer.value = "/detach"
+            await pilot.press("enter")
+            await pilot.pause()
+            assert app.attached is None
+            assert app.query_one("#attach", RichLog).display is False
+            assert app.query_one("#activity", RichLog).display is True
+
+    asyncio.run(scenario())
+
+
+def test_tui_click_member_attaches(seat):
+    ctx, roster, human = seat
+
+    async def scenario():
+        app = ChatApp(ctx, roster, human)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.click("#member-phil")
+            await pilot.pause()
+            assert app.attached == "phil"
+
+    asyncio.run(scenario())
+
+
+def test_tui_attach_flag_opens_attached(seat):
+    ctx, roster, human = seat
+
+    async def scenario():
+        app = ChatApp(ctx, roster, human, attach="phil")
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app.attached == "phil"
+
+    asyncio.run(scenario())

--- a/apps/r4t/tests/test_dispatch.py
+++ b/apps/r4t/tests/test_dispatch.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import errno
 import json
+import os
 import sys
 import textwrap
 import time
@@ -155,7 +156,7 @@ class TestIngressAndTurn:
         assert len(harness_calls(fake_harness)) == 1
 
     def test_prompt_batches_messages_without_headers(self, ctx, fake_harness):
-        handle_message(ctx, "gerry", "acme:phil", "hi")
+        handle_message(ctx, "acme:gerry", "acme:phil", "hi")
         prompt = read_prompt(harness_calls(fake_harness)[0])
         assert "You are Phil" in prompt
         assert "## Messages since your last turn" in prompt
@@ -199,30 +200,30 @@ class TestIngressAndTurn:
         assert "You are Gerry" in prompt
 
     def test_history_holds_inbound(self, ctx, fake_harness):
-        handle_message(ctx, "gerry", "acme:phil", "first job")
+        handle_message(ctx, "acme:gerry", "acme:phil", "first job")
         assert "first job" in state.read_history(NODE, "phil")
 
     def test_conversation_history_fed_back(self, ctx, fake_harness):
-        handle_message(ctx, "gerry", "acme:phil", "first job")
-        handle_message(ctx, "marcus", "acme:phil", "second job")
+        handle_message(ctx, "acme:gerry", "acme:phil", "first job")
+        handle_message(ctx, "acme:marcus", "acme:phil", "second job")
         prompt = read_prompt(harness_calls(fake_harness)[-1])
         assert "first job" in prompt  # earlier turn is now in the history block
 
     def test_velocity_recorded(self, ctx, fake_harness):
-        handle_message(ctx, "gerry", "acme:phil", "job")
+        handle_message(ctx, "acme:gerry", "acme:phil", "job")
         rows = (state.team_dir(NODE) / "velocity.csv").read_text().splitlines()
         assert len(rows) == 2  # header + one turn
 
     def test_transcript_logged(self, ctx, fake_harness):
-        handle_message(ctx, "gerry", "acme:phil", "job")
+        handle_message(ctx, "acme:gerry", "acme:phil", "job")
         log = read_log()
         assert "### Prompt" in log
         assert "### Output (Phil" in log
 
     def test_two_messages_drain_in_one_batch_turn(self, ctx, fake_harness):
         # Both arrive before any turn runs: ONE turn drains the whole queue.
-        handle_message(ctx, "gerry", "acme:phil", "job one", drain_after=False)
-        handle_message(ctx, "marcus", "acme:phil", "job two", drain_after=False)
+        handle_message(ctx, "acme:gerry", "acme:phil", "job one", drain_after=False)
+        handle_message(ctx, "acme:marcus", "acme:phil", "job two", drain_after=False)
         assert state.queue_depth(NODE, "phil") == 2
         assert drain(ctx) == 1
         calls = harness_calls(fake_harness)
@@ -231,8 +232,8 @@ class TestIngressAndTurn:
         assert "job one" in prompt and "job two" in prompt
 
     def test_duplicate_collapse_notes_repeats(self, ctx, fake_harness):
-        handle_message(ctx, "gerry", "acme:phil", "same ping", drain_after=False)
-        handle_message(ctx, "gerry", "acme:phil", "same ping", drain_after=False)
+        handle_message(ctx, "acme:gerry", "acme:phil", "same ping", drain_after=False)
+        handle_message(ctx, "acme:gerry", "acme:phil", "same ping", drain_after=False)
         assert state.queue_depth(NODE, "phil") == 1
         assert drain(ctx) == 1
         prompt = read_prompt(harness_calls(fake_harness)[0])
@@ -244,7 +245,7 @@ class TestIngressAndTurn:
             state.enqueue(NODE, "phil", {"from": "late", "body": "arrived mid-turn", "task": new_ulid(), "hop": 0})
             return run_harness(rig, prompt, cwd, env=env, variant=variant)
 
-        handle_message(ctx, "gerry", "acme:phil", "first", drain_after=False)
+        handle_message(ctx, "acme:gerry", "acme:phil", "first", drain_after=False)
         assert drain(ctx, run_fn=enqueue_midturn) == 1
         assert "arrived mid-turn" not in read_prompt(harness_calls(fake_harness)[0])
         assert state.queue_depth(NODE, "phil") == 1  # it waits for the next turn
@@ -253,15 +254,15 @@ class TestIngressAndTurn:
 class TestRejections:
     def test_unknown_member_dead_letters_and_tells(self, ctx, tells, fake_harness):
         sent, _ = tells
-        handle_message(ctx, "gerry", "acme:nobody", "hi")
+        handle_message(ctx, "acme:gerry", "acme:nobody", "hi")
         assert not harness_calls(fake_harness)
         assert any("no team member named" in b for _, b in sent)
         assert "unknown-recipient" in dead_reasons()
 
     def test_human_message_parks_in_seat(self, ctx, tells, fake_harness):
-        handle_message(ctx, "gerry", "acme:neil", "hi")
+        handle_message(ctx, "acme:gerry", "acme:neil", "hi")
         assert not harness_calls(fake_harness)
-        assert [m["from"] for m in seat_messages()] == ["gerry"]
+        assert [m["from"] for m in seat_messages()] == ["acme:gerry"]
 
     def test_doorbell_copy_is_headerless_egress(self, ctx, tells, fake_harness):
         sent, _ = tells
@@ -272,12 +273,12 @@ class TestRejections:
     def test_human_doorbell_skipped_when_attached(self, ctx, tells, fake_harness):
         sent, _ = tells
         state.touch_seat_presence(NODE, "Neil")
-        handle_message(ctx, "gerry", "acme:neil", "hi")
+        handle_message(ctx, "acme:gerry", "acme:neil", "hi")
         assert not sent
 
     def test_disabled_member_dead_letters(self, ctx, tells, fake_harness):
         sent, _ = tells
-        handle_message(ctx, "gerry", "acme:broken", "hi")
+        handle_message(ctx, "acme:gerry", "acme:broken", "hi")
         assert any("disabled" in b for _, b in sent)
         assert "member-disabled" in dead_reasons()
 
@@ -294,7 +295,7 @@ class TestRejections:
     def test_missing_roster(self, ctx, repo, tells, fake_harness):
         (repo / "ROSTER.md").unlink()
         sent, _ = tells
-        handle_message(ctx, "gerry", "acme:phil", "hi")
+        handle_message(ctx, "acme:gerry", "acme:phil", "hi")
         assert any("cannot dispatch" in b for _, b in sent)
 
     def test_no_leader_for_bare_node(self, ctx, repo, tells, fake_harness):
@@ -320,7 +321,7 @@ class TestStagingRelease:
     ):
         monkeypatch.setenv("CHATTY_TO", "outsider")
         monkeypatch.setenv("CHATTY_BODY", "the fix is deployed")
-        assert run_one(chatty_ctx, "gerry", "acme:phil", "deploy the fix") == 1
+        assert run_one(chatty_ctx, "acme:gerry", "acme:phil", "deploy the fix") == 1
         envelopes = outbox_envelopes(repo)
         assert len(envelopes) == 1
         envelope = envelopes[0]
@@ -333,7 +334,7 @@ class TestStagingRelease:
     def test_outbound_attributed_to_history(self, chatty_ctx, chatty_harness, monkeypatch):
         monkeypatch.setenv("CHATTY_TO", "neil")
         monkeypatch.setenv("CHATTY_BODY", "status: done")
-        run_one(chatty_ctx, "gerry", "acme:phil", "report status")
+        run_one(chatty_ctx, "acme:gerry", "acme:phil", "report status")
         history = state.read_history(NODE, "phil")
         assert "to neil" in history
         assert "status: done" in history
@@ -341,7 +342,7 @@ class TestStagingRelease:
     def test_quota_overflow_dead_letters(self, chatty_ctx, repo, chatty_harness, monkeypatch):
         monkeypatch.setenv("CHATTY_TO", "outsider")
         monkeypatch.setenv("CHATTY_SENDS", "4")  # max_sends_per_turn is 2
-        run_one(chatty_ctx, "gerry", "acme:phil", "fan out")
+        run_one(chatty_ctx, "acme:gerry", "acme:phil", "fan out")
         assert len(outbox_envelopes(repo)) == 2
         assert dead_reasons() == ["quota", "quota"]
 
@@ -350,7 +351,7 @@ class TestStagingRelease:
     ):
         monkeypatch.setenv("CHATTY_TO", "acme:gerry")
         monkeypatch.setenv("CHATTY_BODY", "please review my patch")
-        assert run_one(chatty_ctx, "neil", "acme:phil", "do the work") == 1
+        assert run_one(chatty_ctx, "acme:gerry", "acme:phil", "do the work") == 1
         assert state.queue_depth(NODE, "gerry") == 1  # delegation queued for gerry
         monkeypatch.setenv("CHATTY_SENDS", "0")
         assert drain_until_quiet(chatty_ctx) == 1
@@ -367,7 +368,7 @@ class TestStagingRelease:
     ):
         monkeypatch.setenv("CHATTY_TO", "Gerry")
         monkeypatch.setenv("CHATTY_BODY", "please review my patch")
-        assert run_one(chatty_ctx, "neil", "acme:phil", "do the work") == 1
+        assert run_one(chatty_ctx, "acme:gerry", "acme:phil", "do the work") == 1
         assert outbox_envelopes(repo) == []
         assert state.queue_depth(NODE, "gerry") == 1
 
@@ -376,7 +377,7 @@ class TestStagingRelease:
     ):
         monkeypatch.setenv("CHATTY_TO", "acme:neil")
         monkeypatch.setenv("CHATTY_BODY", "shipped")
-        assert run_one(chatty_ctx, "gerry", "acme:phil", "ship it") == 1
+        assert run_one(chatty_ctx, "acme:gerry", "acme:phil", "ship it") == 1
         assert outbox_envelopes(repo) == []
         parked = seat_messages()
         assert [m["from"] for m in parked] == ["acme:phil"]
@@ -387,7 +388,7 @@ class TestStagingRelease:
     ):
         monkeypatch.setenv("CHATTY_TO", "chatroom")
         monkeypatch.setenv("CHATTY_BODY", "#dev hello")
-        assert run_one(chatty_ctx, "neil", "acme:phil", "post an update") == 1
+        assert run_one(chatty_ctx, "acme:gerry", "acme:phil", "post an update") == 1
         assert [e["to"] for e in outbox_envelopes(repo)] == ["chatroom"]
 
     def test_reply_to_human_creator_closes_thread(
@@ -418,7 +419,7 @@ class TestStagingRelease:
         monkeypatch.setenv("CHATTY_TO", "neil,gerry")
         monkeypatch.setenv("CHATTY_SENDS", "2")
         monkeypatch.setenv("CHATTY_BODY", "P0 logged, dispatching ({i})")
-        assert run_one(chatty_ctx, "neil", "acme:phil", "movement is broken") == 1
+        assert run_one(chatty_ctx, "acme:gerry", "acme:phil", "movement is broken") == 1
         assert state.queue_depth(NODE, "gerry") == 1
         monkeypatch.setenv("CHATTY_SENDS", "0")
         assert drain_until_quiet(chatty_ctx) == 1
@@ -429,7 +430,7 @@ class TestStagingRelease:
     ):
         monkeypatch.setenv("CHATTY_TO", "chatroom")
         monkeypatch.setenv("CHATTY_BODY", "#dev progress update")
-        assert run_one(chatty_ctx, "neil", "acme:phil", "post an update") == 1
+        assert run_one(chatty_ctx, "acme:gerry", "acme:phil", "post an update") == 1
         assert tasks.list_tasks(NODE)[0]["status"] == tasks.STATUS_OPEN
 
     def test_released_envelope_claims_namespaced_sender(
@@ -437,7 +438,7 @@ class TestStagingRelease:
     ):
         monkeypatch.setenv("CHATTY_TO", "outsider")
         monkeypatch.setenv("CHATTY_BODY", "status: done")
-        run_one(chatty_ctx, "gerry", "acme:phil", "report status")
+        run_one(chatty_ctx, "acme:gerry", "acme:phil", "report status")
         assert [e["from"] for e in outbox_envelopes(repo)] == ["acme:phil"]
 
     def test_reply_closes_only_the_answered_thread(self, ctx, repo, r4t_home):
@@ -463,7 +464,7 @@ class TestStagingRelease:
 class TestBudgets:
     def test_turn_charges_member_and_team_one_unit(self, ctx, fake_harness):
         config = load_rig_config(ctx.config_path)
-        handle_message(ctx, "gerry", "acme:phil", "job")
+        handle_message(ctx, "acme:gerry", "acme:phil", "job")
         assert member_budget(ctx, "phil") == pytest.approx(99.0, abs=0.3)
         team = state.budget_level(
             NODE, state.CELL_BUDGET_KEY,
@@ -473,7 +474,7 @@ class TestBudgets:
 
     def test_empty_member_budget_rests_and_holds_queue(self, ctx, fake_harness):
         empty_member_budget(ctx, "phil")
-        handle_message(ctx, "gerry", "acme:phil", "job")
+        handle_message(ctx, "acme:gerry", "acme:phil", "job")
         assert not harness_calls(fake_harness)
         assert state.queue_depth(NODE, "phil") == 1
         assert "RESTING phil" in read_log()
@@ -485,7 +486,7 @@ class TestBudgets:
             config.cell_budget_max, config.cell_budget_earn_per_hour,
             config.cell_budget_max + 5,
         )
-        handle_message(ctx, "gerry", "acme:phil", "job")
+        handle_message(ctx, "acme:gerry", "acme:phil", "job")
         assert not harness_calls(fake_harness)
         assert state.queue_depth(NODE, "phil") == 1
 
@@ -497,7 +498,7 @@ class TestBudgets:
             NODE, "phil", rig.budget_max, rig.budget_earn_per_hour,
             rig.budget_max, now=time.time() - 3600,
         )
-        handle_message(ctx, "gerry", "acme:phil", "job")
+        handle_message(ctx, "acme:gerry", "acme:phil", "job")
         assert len(harness_calls(fake_harness)) == 1
 
     def test_seat_send_reports_resting(self, ctx):
@@ -525,20 +526,20 @@ def timeout_run(rig, prompt, cwd, *, env=None, variant=0):
 
 def trip_breaker(ctx, agent="phil", cap=5):
     for i in range(cap):
-        assert run_one(ctx, "neil", f"acme:{agent}", f"attempt {i}", run_fn=fail_run) == 1
+        assert run_one(ctx, "acme:gerry", f"acme:{agent}", f"attempt {i}", run_fn=fail_run) == 1
 
 
 class TestFailureBreaker:
     def test_failures_counted_and_cleared_by_clean_turn(self, ctx):
-        assert run_one(ctx, "neil", "acme:phil", "one", run_fn=fail_run) == 1
-        assert run_one(ctx, "neil", "acme:phil", "two", run_fn=timeout_run) == 1
+        assert run_one(ctx, "acme:gerry", "acme:phil", "one", run_fn=fail_run) == 1
+        assert run_one(ctx, "acme:gerry", "acme:phil", "two", run_fn=timeout_run) == 1
         assert state.read_meta(NODE, "phil")["consecutive_failures"] == 2
-        assert run_one(ctx, "neil", "acme:phil", "three", run_fn=ok_run) == 1
+        assert run_one(ctx, "acme:gerry", "acme:phil", "three", run_fn=ok_run) == 1
         assert state.read_meta(NODE, "phil")["consecutive_failures"] == 0
 
     def test_trips_at_cap_then_holds_queue(self, ctx):
         trip_breaker(ctx)
-        handle_message(ctx, "neil", "acme:phil", "blocked", drain_after=False)
+        handle_message(ctx, "acme:gerry", "acme:phil", "blocked", drain_after=False)
         assert drain(ctx, run_fn=ok_run) == 0  # breaker open: no turn
         assert state.queue_depth(NODE, "phil") >= 1  # messages held, not dropped
         assert "BREAKER phil" in read_log()
@@ -547,14 +548,14 @@ class TestFailureBreaker:
     def test_half_open_probe_success_closes(self, ctx):
         trip_breaker(ctx)
         state.update_meta(NODE, "phil", last_failure_at="2020-01-01T00:00:00Z")
-        assert run_one(ctx, "neil", "acme:phil", "probe", run_fn=ok_run) == 1
+        assert run_one(ctx, "acme:gerry", "acme:phil", "probe", run_fn=ok_run) == 1
         assert state.read_meta(NODE, "phil")["consecutive_failures"] == 0
 
     def test_failed_probe_reopens(self, ctx):
         trip_breaker(ctx)
         state.update_meta(NODE, "phil", last_failure_at="2020-01-01T00:00:00Z")
-        assert run_one(ctx, "neil", "acme:phil", "probe", run_fn=fail_run) == 1
-        handle_message(ctx, "neil", "acme:phil", "again", drain_after=False)
+        assert run_one(ctx, "acme:gerry", "acme:phil", "probe", run_fn=fail_run) == 1
+        handle_message(ctx, "acme:gerry", "acme:phil", "again", drain_after=False)
         assert drain(ctx, run_fn=ok_run) == 0  # reopened for another cooldown
 
 
@@ -714,7 +715,7 @@ class TestTeamThrottle:
                         max_concurrent=1, min_seconds_between_turn_starts=0)
         live = state.AgentLock(NODE, "gerry")
         assert live.acquire("leader")  # one turn already live
-        handle_message(ctx, "neil", "acme:phil", "job", drain_after=False)
+        handle_message(ctx, "acme:gerry", "acme:phil", "job", drain_after=False)
         assert drain(ctx) == 0  # throttle blocks the second start
         assert state.queue_depth(NODE, "phil") == 1
         live.release()
@@ -723,7 +724,7 @@ class TestTeamThrottle:
     def test_cadence_spaces_turn_starts(self, repo, fake_harness, tells, tmp_path, r4t_home):
         ctx = self._ctx(repo, fake_harness, tells, tmp_path,
                         max_concurrent=0, min_seconds_between_turn_starts=30)
-        assert run_one(ctx, "neil", "acme:phil", "one") == 1
+        assert run_one(ctx, "acme:gerry", "acme:phil", "one") == 1
         handle_message(ctx, "neil", "acme:gerry", "two", drain_after=False)
         assert drain(ctx) == 0  # cadence window still shut
         assert state.queue_depth(NODE, "gerry") == 1
@@ -932,7 +933,7 @@ class TestRunHarness:
         config["junior-dev"]["invoke"] = ["/no/such/binary-r4t", "{prompt}"]
         rig_config.write_text(json.dumps(config), encoding="utf-8")
         sent, _ = tells
-        handle_message(ctx, "gerry", f"{NODE}:phil", "hi")
+        handle_message(ctx, "acme:gerry", f"{NODE}:phil", "hi")
         assert any("failed to start" in b for _, b in sent)
 
 
@@ -1039,13 +1040,13 @@ class TestCli:
 
     def test_dispatch_batches_queued_with_live(self, r4t_home, repo, rig_config, fake_harness):
         state.enqueue(
-            NODE, "phil",
-            {"from": "gerry", "to": "acme:phil", "task": new_ulid(), "hop": 0,
+            NODE, "gerry",
+            {"from": "boss", "to": "acme", "task": new_ulid(), "hop": 0,
              "auto": True, "body": "parked earlier"},
         )
         self.run(
-            "dispatch", "--root", str(repo), "--from", "gerry",
-            "--to", "acme:phil", "--message", "live one",
+            "dispatch", "--root", str(repo), "--from", "boss",
+            "--to", "acme", "--message", "live one",
             "--rig-config", str(rig_config), "--no-notify",
         )
         calls = harness_calls(fake_harness)
@@ -1321,3 +1322,78 @@ class TestInit:
         assert "left unchanged" in out
         assert (root / "ROSTER.md").read_text(encoding="utf-8") == roster_before
         assert (r4t_home / "rigs.json").read_text(encoding="utf-8") == config_before
+
+
+class TestExternalIngressEntersAtTheTop:
+    def test_external_member_address_routes_to_leader(self, ctx, fake_harness):
+        # An outside agent cannot reach a member by namespace: the topmost
+        # leader IS the garden from outside, so a sub-address is ignored.
+        handle_message(ctx, "boss", "acme:phil", "do this")
+        assert state.queue_depth(NODE, "phil") == 0
+        prompt = read_prompt(harness_calls(fake_harness)[0])
+        assert "You are Gerry" in prompt
+        assert tasks.list_tasks(NODE)[0]["creator"] == "boss"  # sender unchanged
+
+    def test_external_bare_node_reaches_leader(self, ctx, fake_harness):
+        handle_message(ctx, "boss", "acme", "status?")
+        assert "You are Gerry" in read_prompt(harness_calls(fake_harness)[0])
+
+    def test_internal_sender_still_reaches_named_member(self, ctx, fake_harness):
+        handle_message(ctx, "acme:gerry", "acme:phil", "do this")
+        assert "You are Phil" in read_prompt(harness_calls(fake_harness)[0])
+
+    def test_doorbell_reply_lands_in_seat_path_and_routes_to_leader(self, ctx, fake_harness):
+        # "neil" is the roster human's Address: a reply from it is the human
+        # speaking, re-stamped to the seat and routed to the leader.
+        handle_message(ctx, "neil", "acme:phil", "please do X")
+        assert state.queue_depth(NODE, "phil") == 0
+        assert "You are Gerry" in read_prompt(harness_calls(fake_harness)[0])
+        assert tasks.list_tasks(NODE)[0]["creator"] == "acme:neil"
+
+    def test_doorbell_reply_thread_closes_on_answer(
+        self, chatty_ctx, chatty_harness, monkeypatch
+    ):
+        monkeypatch.setenv("CHATTY_TO", "neil")
+        monkeypatch.setenv("CHATTY_BODY", "done: shipped and verified")
+        assert run_one(chatty_ctx, "neil", "acme:gerry", "please ship") == 1
+        task = tasks.list_tasks(NODE)[0]
+        assert task["creator"] == "acme:neil"
+        assert task["status"] == tasks.STATUS_CLOSED
+
+    def test_reply_to_human_address_parks_in_seat_and_closes(
+        self, chatty_ctx, repo, chatty_harness, tells, monkeypatch
+    ):
+        # Gerry answers the doorbell reply by its a8s Address ("neil"), the
+        # human's other name: it parks in the seat, rings the doorbell, and
+        # closes the human's thread — no envelope leaves the garden.
+        sent, _ = tells
+        monkeypatch.setenv("CHATTY_TO", "neil")
+        monkeypatch.setenv("CHATTY_BODY", "done: shipped and verified")
+        assert run_one(chatty_ctx, "neil", "acme", "please ship") == 1
+        assert outbox_envelopes(repo) == []
+        assert [m["from"] for m in seat_messages()] == ["acme:gerry"]
+        assert ("neil", "done: shipped and verified") in sent
+        task = tasks.list_tasks(NODE)[0]
+        assert task["creator"] == "acme:neil"
+        assert task["status"] == tasks.STATUS_CLOSED
+
+
+class TestLiveLogTee:
+    def test_run_harness_tees_output_to_live_log(self, tmp_path):
+        script = tmp_path / "chatter.py"
+        script.write_text("print('line one')\nprint('line two')\n", encoding="utf-8")
+        rig = Rig(
+            name="t", invoke=[sys.executable, str(script), "{prompt}"], timeout_seconds=10
+        )
+        live = tmp_path / "live.log"
+        env = {**os.environ, "R4T_LIVE_LOG": str(live)}
+        code, out, _dur, timed = run_harness(rig, "x", tmp_path, env=env)
+        assert code == 0 and not timed
+        streamed = live.read_text(encoding="utf-8")
+        assert "line one" in streamed and "line two" in streamed
+        assert "line one" in out  # still returned in full for staging
+
+    def test_turn_streams_to_member_live_log(self, ctx, fake_harness):
+        handle_message(ctx, "acme:gerry", "acme:phil", "hi")
+        text = state.live_log_path(NODE, "phil").read_text(encoding="utf-8")
+        assert "fake harness ran" in text

--- a/apps/r4t/tests/test_seat.py
+++ b/apps/r4t/tests/test_seat.py
@@ -83,7 +83,7 @@ def test_seat_send_rejects_unknown_member(repo, rig_config, r4t_home, capsys):
 def test_live_lock_holds_queue_for_next_drain(ctx, r4t_home, fake_harness):
     # The agent lock is the only claim: a member with a live turn cannot be
     # run by a concurrent drainer, and its queued mail simply waits.
-    handle_message(ctx, "boss", "acme:phil", "go", drain_after=False)
+    handle_message(ctx, "acme:gerry", "acme:phil", "go", drain_after=False)
     lock = state.AgentLock(NODE, "phil")
     assert lock.acquire("junior-dev")
     assert drain(ctx) == 0
@@ -95,7 +95,7 @@ def test_live_lock_holds_queue_for_next_drain(ctx, r4t_home, fake_harness):
 
 
 def test_stale_lock_does_not_block_drain(ctx, r4t_home, fake_harness):
-    handle_message(ctx, "boss", "acme:phil", "go", drain_after=False)
+    handle_message(ctx, "acme:gerry", "acme:phil", "go", drain_after=False)
     dead = state.agent_dir(NODE, "phil") / ".lock"
     dead.parent.mkdir(parents=True, exist_ok=True)
     dead.write_text(json.dumps({"pid": 999999999, "rig": "junior-dev"}), encoding="utf-8")

--- a/apps/r4t/tests/test_state.py
+++ b/apps/r4t/tests/test_state.py
@@ -284,3 +284,16 @@ class TestStaging:
         (d / "001").mkdir()
         names = [p.name for p in staged_envelopes(NODE, "phil")]
         assert names == ["001.json", "002.json"]
+
+
+def test_live_log_reset_and_tail(r4t_home):
+    path = state.reset_live_log(NODE, "phil")
+    assert path.read_text(encoding="utf-8") == ""
+    with path.open("a", encoding="utf-8") as f:
+        f.write("hello\n")
+    chunk, offset = state.read_live_log_tail(NODE, "phil", 0)
+    assert chunk == "hello\n" and offset == 6
+    assert state.read_live_log_tail(NODE, "phil", offset) == ("", 6)
+    # a new turn truncates the file; a stale offset restarts from the top
+    state.reset_live_log(NODE, "phil")
+    assert state.read_live_log_tail(NODE, "phil", offset) == ("", 0)


### PR DESCRIPTION
Implements the two coupled decisions from #176.

## One way in, one way out

Egress already enforced that a member's words leave the garden only through the release path. Ingress was asymmetric: any outside a8s sender could address `node:member` and land directly on a member's queue — a second door that a whole class of lockdown machinery existed to guard. This PR closes the door instead of guarding it:

- **External mail always enters at the top.** The topmost leader IS the garden from outside (existing doctrine, now mechanical). A sub-address from an outside sender is ignored; the leader decides what to relay inward. One ingress point means one thing to reason about — the same abstraction argument that already simplified egress.
- **The doorbell reply path lands in the seat.** A message from the roster human's `Address:` is the human speaking, not an outside agent: the sender is re-stamped to `node:human`, so it routes and closes threads exactly as if typed in `r4t chat` / `r4t seat send`. Symmetrically, the Address is canonicalized as another name for the human on release, so answering the human by either name parks in the seat, rings the doorbell, and closes the thread.
- **Inside the wall, nothing changes.** The tree, the seat, and intra-team member addressing are untouched; a8s core (namespace feature included) is untouched.

Deleted: nothing beyond the direct-member routing branch itself — the TTL guards / tell-loophole handling that once guarded direct member ingress had already been scorched by the #174 re-founding; this PR removes the last reason they could ever come back.

## Gemba: observation beats connection

Neil's walk-the-floor ruling: direct outside-world connection to a member was rejected — observing creates no channel that later needs locking down. `r4t chat` (doorbell feature untouched) becomes the control plane:

- **Status panel** — every member with live state (active / resting / broken, queue depth, ready-in estimate), fed by the same `state.py` signals as `r4t status`. Clickable.
- **Attach** — click a member, `/attach vela`, or `r4t chat --attach vela` for a read-only live view: every message the member receives as it is enqueued (team event log; `QUEUED` lines now carry a body preview) and the member's turn output streaming AS IT RUNS. `/detach` steps back out.
- **Streaming mechanics** — dispatch tees harness stdout/stderr line-by-line to `agents/<member>/live.log` (truncated at turn start); the TUI tails it. No second event channel invented.
- **Read-only by construction** — attach has no send path; the composer keeps talking to the seat's usual counterparties. Messaging an attached member is future gemba work.
- **Degrades without textual** — `--plain --attach` tail-prints the same feed.

## Tests

- r4t: 308 passed (baseline 291; rewrote external-ingress tests for top-only routing, added tests for leader routing, doorbell seat-path ingress + closure, live.log teeing, `/attach`//`/detach` CommandResult handling, TUI click/flag attach, MemberWatch streaming, member statuses).
- a8s + PII: 646 passed (no cross-breakage).
- Docs: README ingress/egress + seat/chat sections, tutorial, CELL-SPEC Phase 2 gemba bullet updated to the decided design.

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)