### PR TITLE
feat(r4t): rig-level budgets + portable orgs

### DIFF
--- a/apps/r4t/README.md
+++ b/apps/r4t/README.md
@@ -213,6 +213,28 @@ convention, not machinery: r4t injects the file and lints its length, nothing
 more. `r4t roster check` warns when `MISSION.md` runs past ~40 lines, because
 intent that no longer fits a page has usually gone stale into planning.
 
+## Portable orgs
+
+By default `ROSTER.md` and `MISSION.md` live in the repo — the slow furnace a
+proven structure graduates into. When you want to keep the org OUT of the repo
+(to A/B two casts against the same project, or to iterate on a roster without
+touching the codebase), make an **org directory**: put `ROSTER.md` +
+`MISSION.md` there alongside an `r4t-org.json` naming the workplace repo.
+
+```json
+{ "repo": "/path/to/the/repo" }
+```
+
+Register the a8s node at the org dir; turns run and commit in `repo`, while the
+roster, mission, and mission injection read from the org dir. Org-to-repo is
+many-to-one: two org dirs (same `MISSION.md`, different `ROSTER.md`) can point
+at two clones of one project without their team state colliding — state is
+per-a8s-node, not per-repo. `r4t roster check --root <org-dir>` lints the org,
+including a missing/malformed `r4t-org.json` or a workplace repo that does not
+exist. **Graduation is trivial:** copy the two files into the repo and delete
+`r4t-org.json` — resolution falls back to the in-repo default with no other
+change.
+
 ## Governance knobs
 
 All keys live in the out-of-repo rig config (`~/.config/r4t/rigs.json`).
@@ -220,14 +242,30 @@ Per-rig keys go inside a rig block; the rest are top-level. Rationale and
 prior art per layer: [docs/governance.md](docs/governance.md).
 
 The economics are budgets, not cuts: a member runs while its own spend
-bucket and the shared cell bucket both hold ≥1 unit (a turn costs 1 of
-each). An empty bucket means the member is *resting* — its queue holds and
-it runs again when the bucket refills. Messages are never dropped for lack
-of budget.
+bucket, the shared cell bucket, and (if the rig declares one) the rig's own
+bucket all hold ≥1 unit (a turn costs 1 of each). An empty bucket means the
+member is *resting* — its queue holds and it runs again when the bucket
+refills. Messages are never dropped for lack of budget.
+
+The rig bucket is the quota answer. A rig maps to a real subscription (an
+Antigravity plan good for ~20 prompts an hour, a Claude seat), so its ceiling
+is set **on the rig** and is **machine-global**: it binds every r4t team on
+the machine that shares the rig, so one subscription is safely shared across
+projects. Its bucket lives in `~/.config/r4t/rig-buckets.json` (outside any
+team) and every node charges it atomically. Budget refill IS the retry: an
+exhausted rig rests every member on it, on every team, and the held queues
+catch up when it refills — r4t is the retry system so a8s stays dumb delivery.
+A subscription can run dry mid-plan without any error: agy/claude/opencode all
+exit 0 with a **blank** response when out of quota. So a turn that exits 0,
+releases nothing, and prints not one byte is treated as quota-suspect
+(`QUOTA-SUSPECT` in the log) and drains the rig bucket, resting the whole rig
+until it refills. The rule is deliberately conservative — only a *truly empty*
+transcript triggers it, never chrome-only output from a quiet-but-alive member.
 
 | Key | Default | Governs | Failure mode it stops |
 |---|---|---|---|
 | `budget_max` / `budget_earn_per_hour` (rig) | 8 / 4 | Per-member spend bucket. A turn costs 1 unit regardless of how many queued messages it consumes; empty = resting. Put frontier rigs on a low budget (slow, smart), local rigs on a high one (near-free) | Money burn; a fast rig outrunning its quota |
+| `rig_budget_max` / `rig_budget_earn_per_hour` (rig) | unset (no rig gate) | Machine-global rig spend bucket for the subscription behind the rig. A turn also costs 1 rig unit; when empty, every member on that rig rests on every team. Set both together to bind a shared plan (e.g. 20 / 20 for ~20 prompts an hour) | A shared subscription outrunning its real quota across projects |
 | `max_sends_per_turn` (rig) | 6 | Envelopes released per turn; excess dead-letters | Runaway fan-out width |
 | `timeout_seconds` (rig) | 900 | Harness wall clock; the process group is killed | Hung harnesses |
 | `concurrency` (rig) | 1 | Live turns within one rig | Rig-wide pile-ups |

--- a/apps/r4t/chat.py
+++ b/apps/r4t/chat.py
@@ -234,11 +234,23 @@ def member_statuses(node: str, roster: Roster, config=None) -> list[MemberStatus
                 level = state.budget_level(
                     node, m.name, rig.budget_max, rig.budget_earn_per_hour
                 )
+                rig_level = (
+                    state.rig_budget_level(
+                        rig.name, rig.rig_budget_max, rig.rig_budget_earn_per_hour
+                    )
+                    if rig.rig_budget_max is not None
+                    else None
+                )
                 if depth and level < 1.0:
                     wait = state.budget_seconds_until(
                         node, m.name, rig.budget_max, rig.budget_earn_per_hour
                     )
                     st, detail = RESTING, f"ready ~{wait / 60:.0f}m"
+                elif depth and rig_level is not None and rig_level < 1.0:
+                    wait = state.rig_budget_seconds_until(
+                        rig.name, rig.rig_budget_max, rig.rig_budget_earn_per_hour
+                    )
+                    st, detail = RESTING, f"rig {rig.name} ~{wait / 60:.0f}m"
                 else:
                     st, detail = IDLE, ""
         else:

--- a/apps/r4t/chat_tui.py
+++ b/apps/r4t/chat_tui.py
@@ -262,6 +262,11 @@ class ChatApp(App):
                     self.ctx.node, member.name, rig.budget_max, rig.budget_earn_per_hour
                 )
                 rows.append((member.name, level, rig.budget_max))
+                if rig.rig_budget_max is not None:
+                    rig_level = state.rig_budget_level(
+                        rig.name, rig.rig_budget_max, rig.rig_budget_earn_per_hour
+                    )
+                    rows.append((f"rig {rig.name}", rig_level, rig.rig_budget_max))
         return rows
 
     def _refresh_header(self) -> None:

--- a/apps/r4t/dispatch.py
+++ b/apps/r4t/dispatch.py
@@ -72,6 +72,15 @@ class DispatchContext:
     roster_path: Path
     config_path: Path
     tell_fn: TellFn
+    workplace: Path | None = None
+
+    def __post_init__(self) -> None:
+        # `root` is where the team's documents live (ROSTER.md, MISSION.md, the
+        # a8s node's outbox); `workplace` is the repo where turns run and commits
+        # land. A portable org splits them (see org.py); the in-repo default has
+        # them equal.
+        if self.workplace is None:
+            self.workplace = self.root
 
 
 def split_recipient(to: str) -> tuple[str, str]:
@@ -265,7 +274,7 @@ def build_prompt(
         message_lines.append("")
     parts = [
         f"You are {member.name}, a member of the {ctx.node} team, working in "
-        f"the team repo at {ctx.root.resolve()} (your current directory). "
+        f"the team repo at {ctx.workplace.resolve()} (your current directory). "
         "Write files here with relative paths only.",
         "",
         *_mission_section(ctx, roster, member),
@@ -806,7 +815,7 @@ def _run_turn(
     )
 
     exit_code, output, duration, timed_out = run_fn(
-        rig, prompt, ctx.root, env=env, variant=variant
+        rig, prompt, ctx.workplace, env=env, variant=variant
     )
 
     outcome = f"exit {exit_code} in {duration:.1f}s"
@@ -859,6 +868,27 @@ def _run_turn(
                     f"r4t: STDOUT-REPLY {member.name.lower()} (rig {rig.name}) "
                     f"released nothing; {len(reply)} bytes of cleaned stdout "
                     f"staged as a reply to {newest_sender}",
+                )
+            elif not output.strip():
+                # The blank-response quota signal (Neil's field observation):
+                # an out-of-quota model on agy/claude/opencode exits 0 with a
+                # BLANK — the only reliable cross-harness signal. Conservatively
+                # we treat ONLY a truly empty transcript as quota-suspect, never
+                # chrome-only output (a quiet-but-alive member still prints tool
+                # traces). Draining the rig bucket rests the whole rig; queued
+                # messages catch up once it refills — r4t is deliberately the
+                # retry system, so a8s can stay dumb delivery.
+                note = ""
+                if rig.rig_budget_max is not None:
+                    state.rig_budget_drain(rig.name)
+                    note = (
+                        f"; rig {rig.name} bucket drained to 0 — the rig rests "
+                        "until it refills, then the queue catches up"
+                    )
+                state.append_log(
+                    ctx.node,
+                    f"r4t: QUOTA-SUSPECT {member.name.lower()} (rig {rig.name}) "
+                    f"exit 0 with empty output{note}",
                 )
             elif len(output.strip()) > STDOUT_REPLY_MIN_CHARS:
                 state.append_log(
@@ -941,6 +971,18 @@ def _runnable(
             config.cell_budget_max, config.cell_budget_earn_per_hour,
         )
         return False, f"resting (cell budget {state.fmt_budget(t)}, ready in ~{wait / 60:.0f} min)"
+    if rig.rig_budget_max is not None:
+        r = state.rig_budget_level(
+            rig.name, rig.rig_budget_max, rig.rig_budget_earn_per_hour
+        )
+        if r < 1.0:
+            wait = state.rig_budget_seconds_until(
+                rig.name, rig.rig_budget_max, rig.rig_budget_earn_per_hour
+            )
+            return False, (
+                f"resting — rig {rig.name} exhausted "
+                f"({state.fmt_budget(r)}), ready in ~{wait / 60:.0f} min"
+            )
     return True, ""
 
 
@@ -991,6 +1033,10 @@ def _run_member_turn(
                     ctx.node, state.CELL_BUDGET_KEY,
                     config.cell_budget_max, config.cell_budget_earn_per_hour,
                 )
+                if rig.rig_budget_max is not None:
+                    state.rig_budget_charge(
+                        rig.name, rig.rig_budget_max, rig.rig_budget_earn_per_hour
+                    )
                 state.stamp_last_turn_start(ctx.node)
     finally:
         admission.release()

--- a/apps/r4t/docs/tutorial.md
+++ b/apps/r4t/docs/tutorial.md
@@ -116,6 +116,16 @@ what "done" looks like, the current milestone; never the how. r4t injects it
 into every **lead's** turn prompt (members with reports); leads restate it
 down to their ICs. Keep it under a page — `roster check` warns past ~40 lines.
 
+### 8. (Optional) keep the org outside the repo
+
+`ROSTER.md` and `MISSION.md` default to the repo, but you can put them in an
+**org directory** instead — add an `r4t-org.json` there naming the workplace
+repo (`{ "repo": "/path/to/repo" }`) and register the a8s node at the org dir.
+Turns run in the repo; the roster and mission read from the org dir. Two org
+dirs can point at two clones of one project (same mission, different rosters)
+without their state colliding. See the README's *Portable orgs* section;
+graduate by copying the two files into the repo and deleting `r4t-org.json`.
+
 ## Mental model
 
 ```

--- a/apps/r4t/example-rigs.json
+++ b/apps/r4t/example-rigs.json
@@ -41,9 +41,11 @@
   },
 
   "agy": {
-    "_notes": "Antigravity rig.",
+    "_notes": "Antigravity rig — a real subscription (~20 prompts/hour). rig_budget_max/rig_budget_earn_per_hour bind that plan MACHINE-GLOBALLY: the bucket is shared by every team on this machine that uses `agy`, so one plan is safely shared across projects. Set both together; absent = no rig gate.",
     "invoke": ["agy", "-p", "{prompt}"],
-    "timeout_seconds": 1200
+    "timeout_seconds": 1200,
+    "rig_budget_max": 20,
+    "rig_budget_earn_per_hour": 20
   },
 
   "pins": {

--- a/apps/r4t/org.py
+++ b/apps/r4t/org.py
@@ -1,0 +1,89 @@
+"""Portable org resolution — where the team's documents live vs. where it works.
+
+By default a team lives IN its repo: ROSTER.md and MISSION.md sit at the repo
+root, which is also where turns run and commits land. This is the slow-furnace
+default — a proven structure graduates INTO the repo.
+
+A portable org splits the two: an org directory holds ROSTER.md + MISSION.md +
+a small `r4t-org.json` naming the workplace repo. That lets two org dirs — same
+MISSION, different ROSTERs — point at two clones of one project (the A/B case:
+a novella-writing experiment with identical intent and different casts). Team
+state never collides because it is keyed per a8s node, not per repo.
+
+Precedence, decided once, here:
+
+- If `<root>/r4t-org.json` exists and names a `repo`, `<root>` is the ORG DIR:
+  ROSTER.md and MISSION.md are read from `<root>`, and turns run in `repo`
+  (relative `repo` paths resolve against the org dir).
+- Otherwise `<root>` is both org dir and workplace — the in-repo default.
+
+Graduation is trivial: copy ROSTER.md + MISSION.md into the repo and delete
+r4t-org.json. Resolution falls back to the in-repo default with no other change.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+ORG_CONFIG_NAME = "r4t-org.json"
+
+
+class OrgError(Exception):
+    pass
+
+
+@dataclass
+class Org:
+    dir: Path
+    workplace: Path
+
+    @property
+    def is_portable(self) -> bool:
+        return self.dir != self.workplace
+
+
+def org_config_path(root: Path) -> Path:
+    return root / ORG_CONFIG_NAME
+
+
+def _read_repo(root: Path) -> Path | None:
+    cfg = org_config_path(root)
+    if not cfg.is_file():
+        return None
+    try:
+        data = json.loads(cfg.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        raise OrgError(f"cannot read org config {cfg}: {e}") from e
+    if not isinstance(data, dict):
+        raise OrgError(f"org config {cfg} must be a JSON object")
+    raw = str(data.get("repo", "")).strip()
+    if not raw:
+        raise OrgError(f'org config {cfg} must set "repo" (the workplace repo path)')
+    repo = Path(raw).expanduser()
+    if not repo.is_absolute():
+        repo = (root / repo).resolve()
+    return repo
+
+
+def load_org(root: Path) -> Org:
+    """Resolve `root` to (org dir, workplace) for path building. Never raises —
+    a malformed org config degrades to the in-repo default; `check_org` is the
+    boundary that reports it."""
+    try:
+        repo = _read_repo(root)
+    except OrgError:
+        repo = None
+    return Org(dir=root, workplace=repo or root)
+
+
+def check_org(root: Path) -> list[str]:
+    """Validation for `roster check`: a malformed org config, or a workplace
+    repo that does not exist. Empty when there is no org config (in-repo)."""
+    try:
+        repo = _read_repo(root)
+    except OrgError as e:
+        return [str(e)]
+    if repo is not None and not repo.is_dir():
+        return [f"org workplace {repo} does not exist (create it or fix {ORG_CONFIG_NAME})"]
+    return []

--- a/apps/r4t/plans/CELL-SPEC.md
+++ b/apps/r4t/plans/CELL-SPEC.md
@@ -172,3 +172,42 @@ Decided 2026-07-12 (nested intent, per commander's-intent doctrine):
   (the twice-taught commit lesson).
 - `roster check` warns when MISSION.md exceeds ~40 lines (intent
   docs must stay one page — stale-intent guard).
+
+## Rig-level budgets (decided 2026-07-13, issue #177)
+
+A third token bucket joins member and cell: the **rig** bucket. A rig maps
+to a real subscription (an Antigravity plan good for ~20 prompts/hour), so
+its ceiling is set ON THE RIG (`rig_budget_max` / `rig_budget_earn_per_hour`,
+absent = no gate) and is **machine-global** — one bucket per rig at the
+R4T_HOME root (`rig-buckets.json`), binding every team on the machine that
+shares the rig, so one subscription is safely shared across projects. A turn
+is runnable only when member ≥1 AND cell ≥1 AND rig ≥1, and charges all three.
+Concurrent charges from many nodes are serialized by a machine-global lock;
+the check-then-charge gate is best-effort (clamp-at-zero + queues-hold absorb
+the rare cross-node double-spend). Budget refill is the implicit retry — an
+exhausted rig rests every member on it and the held queues catch up when it
+refills, so a8s stays dumb delivery and r4t remains the retry system.
+
+Blank-response quota signal (Neil, from the field): agy/claude/opencode all
+exit 0 with a BLANK when out of quota — the only reliable cross-harness
+signal. A turn that exits 0, releases nothing, and prints not one byte is
+logged QUOTA-SUSPECT and drains its rig bucket to 0. Conservative on purpose:
+only a TRULY empty transcript triggers it, never chrome-only output (a
+quiet-but-alive member still prints tool traces).
+
+## Portable org (decided 2026-07-13, issue #180)
+
+MISSION.md + ROSTER.md may be designated OUTSIDE the repo, as a choice; in-repo
+stays the default (the slow furnace a proven structure graduates into). An
+**org directory** holds ROSTER.md + MISSION.md + `r4t-org.json` naming the
+workplace repo. Precedence, decided once and documented in org.py: if
+`<root>/r4t-org.json` exists and names a `repo`, `<root>` is the org dir
+(ROSTER/MISSION read here, mission injection reads here) and turns run/commit
+in `repo`; otherwise `<root>` is both. The a8s node is stamped at the org dir;
+`repo` supplies the turn cwd. Org-to-repo is many-to-one — two org dirs (same
+MISSION, different ROSTERs) at two clones of one project is the A/B case (first
+consumer: a novella-writing experiment). Nothing collides: team state is
+per-node. Graduation is trivial — copy the two files into the repo and delete
+`r4t-org.json`; resolution falls back to the in-repo default. `roster check`
+runs against an org dir (tree + 40-line mission lint) and flags a malformed
+config or a missing workplace.

--- a/apps/r4t/r4t.py
+++ b/apps/r4t/r4t.py
@@ -41,6 +41,7 @@ from rig import (
     swap_preset_rig,
 )
 from notify import resolve_tell_fn, simulate_enabled
+from org import check_org, load_org
 from roster import Member, Roster, RosterError, load_roster, resolve_roster_path
 
 DEFAULT_TASK_TTL_SECONDS = 7 * 86400
@@ -121,15 +122,15 @@ def _resolve_node(raw: str | None) -> str | None:
 
 
 def _context(args: argparse.Namespace, node: str) -> DispatchContext:
-    root = _resolve_root(args.root)
-    roster_path = resolve_roster_path(root, getattr(args, "roster", None))
+    org = load_org(_resolve_root(args.root))
+    roster_path = resolve_roster_path(org.dir, getattr(args, "roster", None))
     if not getattr(args, "root", None) and not roster_path.is_file():
         stamped = state.read_root(node)
         if stamped is not None and stamped.is_dir():
-            root = stamped
-            roster_path = resolve_roster_path(root, getattr(args, "roster", None))
+            org = load_org(stamped)
+            roster_path = resolve_roster_path(org.dir, getattr(args, "roster", None))
     return DispatchContext(
-        root=root,
+        root=org.dir,
         node=node,
         roster_path=roster_path,
         config_path=resolve_config_path(getattr(args, "rig_config", None)),
@@ -137,6 +138,7 @@ def _context(args: argparse.Namespace, node: str) -> DispatchContext:
             notify=getattr(args, "notify", True),
             simulate=simulate_enabled(getattr(args, "simulate_tell", False)),
         ),
+        workplace=org.workplace,
     )
 
 
@@ -158,12 +160,17 @@ def _print_rig_summary(config_path: Path, roster_path: Path | None = None) -> No
         argv = " ".join(pool[0])
         if len(pool) > 1:
             argv += f"  [+{len(pool) - 1} pool variant(s)]"
-        print(
-            f"  {name}: {argv}  "
-            f"(timeout={rig.timeout_seconds:g}s "
+        limits = (
+            f"timeout={rig.timeout_seconds:g}s "
             f"budget={rig.budget_max:g}/+{rig.budget_earn_per_hour:g}per-h "
-            f"sends={rig.max_sends_per_turn})"
+            f"sends={rig.max_sends_per_turn}"
         )
+        if rig.rig_budget_max is not None:
+            limits += (
+                f" rig-budget={rig.rig_budget_max:g}/"
+                f"+{rig.rig_budget_earn_per_hour:g}per-h"
+            )
+        print(f"  {name}: {argv}  ({limits})")
     if config.pins:
         print("  pins:")
         for agent in sorted(config.pins):
@@ -413,6 +420,15 @@ def _roster_rows(
             node, m.name, rig.budget_max, rig.budget_earn_per_hour
         )
         detail += f"  budget={state.fmt_budget(level)}/{state.fmt_budget(rig.budget_max)}"
+        rig_level = None
+        if rig.rig_budget_max is not None:
+            rig_level = state.rig_budget_level(
+                rig.name, rig.rig_budget_max, rig.rig_budget_earn_per_hour
+            )
+            detail += (
+                f"  rig={state.fmt_budget(rig_level)}/"
+                f"{state.fmt_budget(rig.rig_budget_max)}"
+            )
         depth = state.queue_depth(node, m.name)
         if depth:
             detail += f"  {depth} queued"
@@ -423,6 +439,11 @@ def _roster_rows(
                 node, m.name, rig.budget_max, rig.budget_earn_per_hour
             )
             detail += f"  RESTING (ready in ~{wait / 60:.0f} min)"
+        elif rig_level is not None and rig_level < 1.0 and depth:
+            wait = state.rig_budget_seconds_until(
+                rig.name, rig.rig_budget_max, rig.rig_budget_earn_per_hour
+            )
+            detail += f"  RESTING (rig {rig.name}, ready in ~{wait / 60:.0f} min)"
         blocked, failures = state.breaker_open(
             node, m.name, config.breaker_cap, config.breaker_cooldown_seconds
         )
@@ -455,13 +476,17 @@ def _rig_rows(
         argv = " ".join(pool[0])
         if len(pool) > 1:
             argv += f"  [+{len(pool) - 1} pool variant(s)]"
-        rows.append((
-            True, name,
-            f"{argv}  (timeout={rig.timeout_seconds:g}s "
+        limits = (
+            f"timeout={rig.timeout_seconds:g}s "
             f"budget={rig.budget_max:g}/+{rig.budget_earn_per_hour:g}per-h "
-            f"sends={rig.max_sends_per_turn})",
-            None,
-        ))
+            f"sends={rig.max_sends_per_turn}"
+        )
+        if rig.rig_budget_max is not None:
+            limits += (
+                f" rig-budget={rig.rig_budget_max:g}/"
+                f"+{rig.rig_budget_earn_per_hour:g}per-h"
+            )
+        rows.append((True, name, f"{argv}  ({limits})", None))
     for agent in sorted(config.pins):
         rows.append((None, "pin", f"{agent} -> {config.pins[agent]}", None))
     rows.append((
@@ -875,7 +900,12 @@ def cmd_task(args: argparse.Namespace) -> int:
 
 
 def cmd_roster_check(args: argparse.Namespace) -> int:
-    root = _resolve_root(args.root)
+    org = load_org(_resolve_root(args.root))
+    root = org.dir
+    problems = 0
+    for message in check_org(root):
+        print(f"org: {message}")
+        problems += 1
     roster_path = resolve_roster_path(root, args.roster)
     try:
         roster = load_roster(roster_path)
@@ -889,7 +919,6 @@ def cmd_roster_check(args: argparse.Namespace) -> int:
         print(f"warning: {e}", file=sys.stderr)
         config = None
 
-    problems = 0
     if not roster.members:
         print(f"{roster_path}: no `### <Name>` member blocks found")
         problems += 1

--- a/apps/r4t/rig.py
+++ b/apps/r4t/rig.py
@@ -23,6 +23,12 @@ optional — every knob has a sane default; see README.md for the table):
 Per-rig keys (defaults for every member on that rig; per-member override
 later): `budget_max` / `budget_earn_per_hour` — the member spend bucket. A
 turn costs 1 member unit; when it is empty the member is resting.
+`rig_budget_max` / `rig_budget_earn_per_hour` — the MACHINE-GLOBAL rig spend
+bucket (absent = no rig gate). A rig maps to a real subscription, so this
+ceiling binds every team on the machine that shares the rig; a turn also costs
+1 rig unit and an empty rig bucket rests every member on it, on every team. If
+`rig_budget_max` is set, `rig_budget_earn_per_hour` must be set too — a real
+plan always declares a refill rate.
 
 Keys starting with `_` anywhere are ignored so shipped examples can carry
 notes.
@@ -203,6 +209,8 @@ class Rig:
     max_sends_per_turn: int = DEFAULT_MAX_SENDS_PER_TURN
     budget_max: float = DEFAULT_BUDGET_MAX
     budget_earn_per_hour: float = DEFAULT_BUDGET_EARN_PER_HOUR
+    rig_budget_max: float | None = None
+    rig_budget_earn_per_hour: float | None = None
     error: str | None = None
 
     def pool(self) -> list[list[str]]:
@@ -464,6 +472,24 @@ def _parse_rig(name: str, raw: object) -> Rig:
     )
     if err:
         problems.append(f"budget_earn_per_hour: {err}")
+
+    # The rig spend bucket is opt-in: absent leaves both None and the rig gate
+    # off. If present, both knobs are required — a real subscription always
+    # declares a refill rate, and a max without one would rest forever.
+    raw_rig_max = raw.get("rig_budget_max")
+    raw_rig_earn = raw.get("rig_budget_earn_per_hour")
+    if raw_rig_max is not None:
+        rig.rig_budget_max, err = _positive_number(raw_rig_max, 0.0)
+        if err:
+            problems.append(f"rig_budget_max: {err}")
+        if raw_rig_earn is None:
+            problems.append("rig_budget_max set but rig_budget_earn_per_hour missing")
+        else:
+            rig.rig_budget_earn_per_hour, err = _positive_number(raw_rig_earn, 0.0)
+            if err:
+                problems.append(f"rig_budget_earn_per_hour: {err}")
+    elif raw_rig_earn is not None:
+        problems.append("rig_budget_earn_per_hour set but rig_budget_max missing")
 
     if problems:
         rig.error = "; ".join(problems)

--- a/apps/r4t/state.py
+++ b/apps/r4t/state.py
@@ -22,17 +22,23 @@ honors A8S_HOME).
     ├── log/<date>.md              full I/O transcript, append-only
     └── velocity.csv               one row per harness turn
 
+One file sits ABOVE the teams, at the R4T_HOME root — rig-buckets.json, the
+machine-global rig spend buckets: a rig maps to a real subscription shared by
+every team on the machine, so its bucket cannot be per-team.
+
 Never inside the repo: the working tree is only touched by the harness
 subprocesses themselves.
 """
 from __future__ import annotations
 
+import fcntl
 import itertools
 import json
 import os
 import re
 import shutil
 import time
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -684,12 +690,7 @@ def fmt_budget(value: float) -> str:
     return f"{rounded:.1f}"
 
 
-def buckets_path(node: str) -> Path:
-    return team_dir(node) / "buckets.json"
-
-
-def read_buckets(node: str) -> dict:
-    path = buckets_path(node)
+def _read_buckets(path: Path) -> dict:
     if not path.is_file():
         return {}
     try:
@@ -699,14 +700,12 @@ def read_buckets(node: str) -> dict:
     return data if isinstance(data, dict) else {}
 
 
-def budget_level(
-    node: str, key: str, budget_max: float, earn_per_hour: float, *, now: float | None = None
+def _bucket_level(
+    entry: object, budget_max: float, earn_per_hour: float, now: float
 ) -> float:
-    """Current balance: the stored level plus whatever has been earned by
-    elapsed wall-clock time since it was last written, capped at `budget_max`.
-    An unseen key starts full."""
-    now = time.time() if now is None else now
-    entry = read_buckets(node).get(key.lower())
+    """Current balance for one stored bucket entry: the stored level plus
+    whatever has been earned by elapsed wall-clock time since it was last
+    written, capped at `budget_max`. An unseen/malformed entry starts full."""
     if not isinstance(entry, dict):
         return float(budget_max)
     try:
@@ -716,6 +715,21 @@ def budget_level(
         return float(budget_max)
     earned = max(0.0, now - at) / 3600.0 * earn_per_hour
     return min(float(budget_max), level + earned)
+
+
+def buckets_path(node: str) -> Path:
+    return team_dir(node) / "buckets.json"
+
+
+def read_buckets(node: str) -> dict:
+    return _read_buckets(buckets_path(node))
+
+
+def budget_level(
+    node: str, key: str, budget_max: float, earn_per_hour: float, *, now: float | None = None
+) -> float:
+    now = time.time() if now is None else now
+    return _bucket_level(read_buckets(node).get(key.lower()), budget_max, earn_per_hour, now)
 
 
 def budget_charge(
@@ -748,6 +762,94 @@ def budget_seconds_until(
     """Seconds until the bucket refills to `target` (0.0 when already there,
     inf when it never will because nothing is earned)."""
     level = budget_level(node, key, budget_max, earn_per_hour, now=now)
+    if level >= target:
+        return 0.0
+    if earn_per_hour <= 0:
+        return float("inf")
+    return (target - level) / earn_per_hour * 3600.0
+
+
+# ---------- rig spend bucket (MACHINE-GLOBAL: one subscription, many teams) ----------
+#
+# A rig maps to a real subscription (an Antigravity plan good for ~20 prompts an
+# hour, a Claude seat). Its ceiling is set ON THE RIG and binds every r4t team
+# on the machine, so one rig is safely shared across projects. This bucket
+# therefore lives at the r4t_home ROOT, not under any one team, and every team
+# node charges it concurrently — so the read-modify-write is serialized by a
+# machine-global lock. The gate itself (check-then-charge) is best-effort across
+# nodes; the charge clamps at zero and the queue holds, so a rare double-spend
+# just runs one extra turn before the rig rests.
+
+def rig_buckets_path() -> Path:
+    return r4t_home() / "rig-buckets.json"
+
+
+@contextmanager
+def _rig_bucket_locked():
+    """Serialize the machine-global rig-bucket read-modify-write across every
+    charging node AND thread. fcntl.flock is the right primitive here: it blocks
+    until the lock is free, works across processes and threads (each open() gets
+    its own file description), and is released automatically if a holder dies —
+    no stale-lock reclaim to race against. POSIX-only, like the rest of r4t."""
+    path = r4t_home() / ".rig-buckets.lock"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(path), os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        os.close(fd)
+
+
+def read_rig_buckets() -> dict:
+    return _read_buckets(rig_buckets_path())
+
+
+def rig_budget_level(
+    rig: str, budget_max: float, earn_per_hour: float, *, now: float | None = None
+) -> float:
+    now = time.time() if now is None else now
+    return _bucket_level(read_rig_buckets().get(rig.lower()), budget_max, earn_per_hour, now)
+
+
+def rig_budget_charge(
+    rig: str,
+    budget_max: float,
+    earn_per_hour: float,
+    amount: float = 1.0,
+    *,
+    now: float | None = None,
+) -> float:
+    now = time.time() if now is None else now
+    with _rig_bucket_locked():
+        data = read_rig_buckets()
+        level = _bucket_level(data.get(rig.lower()), budget_max, earn_per_hour, now)
+        new_level = max(0.0, level - amount)
+        data[rig.lower()] = {"level": round(new_level, 4), "at": now}
+        atomic_write_json(rig_buckets_path(), data)
+        return new_level
+
+
+def rig_budget_drain(rig: str, *, now: float | None = None) -> None:
+    """Empty the rig bucket outright — the whole rig rests until it refills.
+    The blank-response quota signal uses this: an out-of-quota subscription is
+    a rig-wide fact, so one drained bucket rests every member on that rig."""
+    now = time.time() if now is None else now
+    with _rig_bucket_locked():
+        data = read_rig_buckets()
+        data[rig.lower()] = {"level": 0.0, "at": now}
+        atomic_write_json(rig_buckets_path(), data)
+
+
+def rig_budget_seconds_until(
+    rig: str,
+    budget_max: float,
+    earn_per_hour: float,
+    target: float = 1.0,
+    *,
+    now: float | None = None,
+) -> float:
+    level = rig_budget_level(rig, budget_max, earn_per_hour, now=now)
     if level >= target:
         return 0.0
     if earn_per_hour <= 0:

--- a/apps/r4t/tests/conftest.py
+++ b/apps/r4t/tests/conftest.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 import textwrap
 from pathlib import Path
@@ -10,6 +11,20 @@ import pytest
 
 _PKG = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_PKG))
+
+
+@pytest.fixture(autouse=True)
+def _restore_tell_outbox_env():
+    """r4t's seat/chat CLIs set TELL_OUTBOX_DIR in os.environ (so child `tell`
+    processes inherit it). Running a CLI in-process would otherwise leak that
+    into later tests — including the a8s `tell` suite when both run together.
+    Snapshot and restore around every test so nothing escapes the suite."""
+    prior = os.environ.get("TELL_OUTBOX_DIR")
+    yield
+    if prior is None:
+        os.environ.pop("TELL_OUTBOX_DIR", None)
+    else:
+        os.environ["TELL_OUTBOX_DIR"] = prior
 
 
 ROSTER_TEXT = textwrap.dedent(

--- a/apps/r4t/tests/test_dispatch.py
+++ b/apps/r4t/tests/test_dispatch.py
@@ -512,6 +512,101 @@ class TestBudgets:
         assert state.queue_depth(NODE, "phil") == 1  # message safely queued
 
 
+def _local_base_config(script) -> dict:
+    """A minimal rig config built inline — no `from conftest import`, so it
+    resolves the same whether the r4t suite runs alone or alongside a8s, whose
+    tests/conftest.py shares the bare module name `conftest`."""
+    invoke = [sys.executable, str(script), "{prompt}"]
+    return {
+        "throttle": {"max_concurrent": 0, "min_seconds_between_turn_starts": 0},
+        "cell_budget_max": 200,
+        "cell_budget_earn_per_hour": 100,
+        "leader": {"invoke": invoke, "timeout_seconds": 30, "budget_max": 100},
+        "junior-dev": {"invoke": invoke, "timeout_seconds": 30, "budget_max": 100},
+        "pins": {"gerry": "leader"},
+    }
+
+
+def rig_budget_ctx(repo, tmp_path, tells, *, rig_max=2.0, rig_earn=0.001, name="rig-rigs.json"):
+    """A ctx whose junior-dev rig declares a small machine-global rig bucket."""
+    script = tmp_path / "fake-harness.py"  # created by the fake_harness fixture
+    config = _local_base_config(script)
+    config["junior-dev"]["rig_budget_max"] = rig_max
+    config["junior-dev"]["rig_budget_earn_per_hour"] = rig_earn
+    path = tmp_path / name
+    path.write_text(json.dumps(config), encoding="utf-8")
+    _sent, capture = tells
+    return make_ctx(repo, path, capture)
+
+
+class TestRigBudgets:
+    def test_turn_charges_the_rig_bucket(self, repo, fake_harness, tells, tmp_path, r4t_home):
+        ctx = rig_budget_ctx(repo, tmp_path, tells, rig_max=10)
+        assert run_one(ctx, "acme:gerry", "acme:phil", "job") == 1
+        assert state.rig_budget_level("junior-dev", 10, 0.001) == pytest.approx(9.0, abs=0.3)
+
+    def test_empty_rig_bucket_rests_and_holds_queue(self, repo, fake_harness, tells, tmp_path, r4t_home):
+        ctx = rig_budget_ctx(repo, tmp_path, tells)
+        state.rig_budget_charge("junior-dev", 2, 0.001, 5)  # drain it
+        handle_message(ctx, "acme:gerry", "acme:phil", "job")
+        assert not harness_calls(fake_harness)
+        assert state.queue_depth(NODE, "phil") == 1
+        log = read_log()
+        assert "RESTING phil" in log and "rig junior-dev exhausted" in log
+
+    def test_rig_bucket_is_shared_across_two_teams(self, repo, fake_harness, tells, tmp_path, r4t_home):
+        repo2 = tmp_path / "repo2"
+        repo2.mkdir()
+        (repo2 / "ROSTER.md").write_text(
+            (repo / "ROSTER.md").read_text(encoding="utf-8"), encoding="utf-8"
+        )
+        _sent, capture = tells
+        ctx_a = rig_budget_ctx(repo, tmp_path, tells, rig_max=2, name="a.json")
+        cfg_b = tmp_path / "a.json"  # same rig config -> same rig, same bucket
+        ctx_b = dispatch.DispatchContext(
+            root=repo2, node="beta", roster_path=repo2 / "ROSTER.md",
+            config_path=cfg_b, tell_fn=capture,
+        )
+        # Two turns on two DIFFERENT teams spend the ONE shared rig bucket (2 -> 0).
+        assert run_one(ctx_a, "acme:gerry", "acme:phil", "one") == 1
+        assert run_one(ctx_b, "beta:gerry", "beta:phil", "two") == 1
+        assert state.rig_budget_level("junior-dev", 2, 0.001) == pytest.approx(0.0, abs=0.3)
+        # A third turn, on either team, now rests on the exhausted rig.
+        handle_message(ctx_a, "acme:gerry", "acme:phil", "three")
+        assert state.queue_depth("acme", "phil") == 1
+
+    def test_blank_response_drains_the_rig_bucket(self, repo, fake_harness, tells, tmp_path, r4t_home):
+        ctx = rig_budget_ctx(repo, tmp_path, tells, rig_max=10)
+
+        def blank(rig, prompt, cwd, *, env=None, variant=0):
+            return 0, "", 1.0, False  # exit 0, not one byte — the quota signal
+
+        run_one(ctx, "acme:gerry", "acme:phil", "hello?", run_fn=blank)
+        assert state.rig_budget_level("junior-dev", 10, 0.001) == pytest.approx(0.0, abs=0.05)
+        log = read_log()
+        assert "QUOTA-SUSPECT phil" in log and "bucket drained" in log
+
+    def test_chrome_only_does_not_drain_the_rig_bucket(self, repo, fake_harness, tells, tmp_path, r4t_home):
+        ctx = rig_budget_ctx(repo, tmp_path, tells, rig_max=10)
+        chrome = "\x1b[0m\n> build · qwen3:0.6b\n\x1b[0m\n→ Read sample.txt\n"
+
+        def chrome_only(rig, prompt, cwd, *, env=None, variant=0):
+            return 0, chrome, 1.0, False
+
+        run_one(ctx, "acme:gerry", "acme:phil", "hello?", run_fn=chrome_only)
+        # A turn was charged (phil ran) but the rig bucket only lost its 1 unit,
+        # not drained to 0 — chrome is a quiet-but-alive member, not a blank.
+        assert state.rig_budget_level("junior-dev", 10, 0.001) == pytest.approx(9.0, abs=0.3)
+        assert "QUOTA-SUSPECT" not in read_log()
+
+    def test_blank_without_rig_budget_logs_but_does_not_crash(self, ctx, r4t_home):
+        def blank(rig, prompt, cwd, *, env=None, variant=0):
+            return 0, "", 1.0, False
+
+        run_one(ctx, "acme:gerry", "acme:phil", "hello?", run_fn=blank)
+        assert "QUOTA-SUSPECT phil" in read_log()
+
+
 def fail_run(rig, prompt, cwd, *, env=None, variant=0):
     return 1, "boom", 0.05, False
 
@@ -700,10 +795,8 @@ def make_ctx(repo, config_path, tell_fn):
 
 class TestTeamThrottle:
     def _ctx(self, repo, fake_harness, tells, tmp_path, **throttle):
-        from conftest import base_config
-
         script, _out = fake_harness
-        config = base_config(script)
+        config = _local_base_config(script)
         config["throttle"] = throttle
         path = tmp_path / "throttle-rigs.json"
         path.write_text(json.dumps(config), encoding="utf-8")

--- a/apps/r4t/tests/test_org.py
+++ b/apps/r4t/tests/test_org.py
@@ -1,0 +1,198 @@
+"""Portable orgs — ROSTER.md/MISSION.md outside the repo, resolution + graduation."""
+from __future__ import annotations
+
+import json
+import sys
+
+import state
+from org import ORG_CONFIG_NAME, check_org, load_org
+from r4t import main as r4t_main
+
+NODE = "acme"
+
+# Self-contained roster/config (no `from conftest import` — running the a8s and
+# r4t suites together makes the bare `conftest` module ambiguous at collection).
+CLEAN_ROSTER = """\
+# Team Roster
+
+### Neil
+- **Status:** Human
+- **Address:** neil
+- **Role:** Director
+
+### Gerry
+- **Status:** AI
+- **Rig:** leader
+- **Role:** Lead
+- **Leader:** yes
+
+### Phil
+- **Status:** AI
+- **Rig:** junior-dev
+- **Role:** Developer
+"""
+
+ROSTER_TEXT = CLEAN_ROSTER
+
+
+def _prompt_of(fake_harness) -> str:
+    _script, out = fake_harness
+    calls = sorted(out.iterdir())
+    assert calls, "the harness never ran"
+    return calls[-1].read_text(encoding="utf-8")
+
+
+def _rig_config(tmp_path, fake_harness):
+    script, _out = fake_harness
+    invoke = [sys.executable, str(script), "{prompt}"]
+    config = {
+        "throttle": {"max_concurrent": 0, "min_seconds_between_turn_starts": 0},
+        "cell_budget_max": 200,
+        "cell_budget_earn_per_hour": 100,
+        "leader": {"invoke": invoke, "timeout_seconds": 30, "budget_max": 100},
+        "junior-dev": {"invoke": invoke, "timeout_seconds": 30, "budget_max": 100},
+        "pins": {"gerry": "leader"},
+    }
+    path = tmp_path / "rigs.json"
+    path.write_text(json.dumps(config), encoding="utf-8")
+    return path
+
+
+# ---------- unit: resolution + precedence ----------
+
+def test_in_repo_is_the_default(tmp_path):
+    org = load_org(tmp_path)
+    assert org.dir == tmp_path and org.workplace == tmp_path
+    assert not org.is_portable
+
+
+def test_org_config_points_at_a_workplace(tmp_path):
+    org_dir = tmp_path / "org"
+    org_dir.mkdir()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (org_dir / ORG_CONFIG_NAME).write_text(json.dumps({"repo": str(repo)}), encoding="utf-8")
+    org = load_org(org_dir)
+    assert org.dir == org_dir and org.workplace == repo
+    assert org.is_portable
+
+
+def test_relative_repo_resolves_against_the_org_dir(tmp_path):
+    org_dir = tmp_path / "org"
+    (org_dir).mkdir()
+    (tmp_path / "repo").mkdir()
+    (org_dir / ORG_CONFIG_NAME).write_text(json.dumps({"repo": "../repo"}), encoding="utf-8")
+    assert load_org(org_dir).workplace == (tmp_path / "repo").resolve()
+
+
+def test_malformed_config_degrades_but_check_reports(tmp_path):
+    (tmp_path / ORG_CONFIG_NAME).write_text("{ not json", encoding="utf-8")
+    org = load_org(tmp_path)  # never raises — degrades to in-repo
+    assert org.workplace == tmp_path
+    assert any("cannot read org config" in m for m in check_org(tmp_path))
+
+
+def test_check_reports_missing_repo_key_and_absent_workplace(tmp_path):
+    (tmp_path / ORG_CONFIG_NAME).write_text(json.dumps({"note": "oops"}), encoding="utf-8")
+    assert any('must set "repo"' in m for m in check_org(tmp_path))
+    (tmp_path / ORG_CONFIG_NAME).write_text(
+        json.dumps({"repo": str(tmp_path / "nope")}), encoding="utf-8"
+    )
+    assert any("does not exist" in m for m in check_org(tmp_path))
+
+
+# ---------- integration: turns resolve org dir vs workplace ----------
+
+def _portable_org(tmp_path, mission="Ship the thing and stop."):
+    org_dir = tmp_path / "org"
+    org_dir.mkdir()
+    workplace = tmp_path / "workplace"
+    workplace.mkdir()
+    (org_dir / "ROSTER.md").write_text(ROSTER_TEXT, encoding="utf-8")
+    (org_dir / ORG_CONFIG_NAME).write_text(json.dumps({"repo": str(workplace)}), encoding="utf-8")
+    if mission is not None:
+        (org_dir / "MISSION.md").write_text(mission, encoding="utf-8")
+    return org_dir, workplace
+
+
+def test_dispatch_reads_org_docs_but_works_in_the_repo(r4t_home, tmp_path, fake_harness):
+    org_dir, workplace = _portable_org(tmp_path)
+    cfg = _rig_config(tmp_path, fake_harness)
+    rc = r4t_main([
+        "dispatch", "--root", str(org_dir),
+        "--from", "boss", "--to", f"{NODE}:gerry", "--message", "go",
+        "--rig-config", str(cfg), "--no-notify",
+    ])
+    assert rc == 0
+    prompt = _prompt_of(fake_harness)
+    assert f"team repo at {workplace.resolve()}" in prompt   # turns run in the repo
+    assert "Ship the thing and stop." in prompt              # MISSION read from org dir
+    assert state.read_root(NODE) == org_dir                  # node stamped to org dir
+
+
+def test_graduation_falls_back_to_in_repo(r4t_home, tmp_path, fake_harness):
+    # Graduation: copy the docs into the repo and drop the pointer.
+    _org_dir, workplace = _portable_org(tmp_path)
+    (workplace / "ROSTER.md").write_text(ROSTER_TEXT, encoding="utf-8")
+    (workplace / "MISSION.md").write_text("Ship the thing and stop.", encoding="utf-8")
+    cfg = _rig_config(tmp_path, fake_harness)
+    rc = r4t_main([
+        "dispatch", "--root", str(workplace),
+        "--from", "boss", "--to", f"{NODE}:gerry", "--message", "go",
+        "--rig-config", str(cfg), "--no-notify",
+    ])
+    assert rc == 0
+    prompt = _prompt_of(fake_harness)
+    assert f"team repo at {workplace.resolve()}" in prompt
+    assert "Ship the thing and stop." in prompt
+    assert load_org(workplace).workplace == workplace  # no pointer -> in-repo default
+
+
+def test_roster_check_runs_against_an_org_dir(r4t_home, tmp_path, fake_harness, capsys):
+    org_dir, _workplace = _portable_org(tmp_path)
+    (org_dir / "ROSTER.md").write_text(CLEAN_ROSTER, encoding="utf-8")
+    cfg = _rig_config(tmp_path, fake_harness)
+    rc = r4t_main(["roster", "check", "--root", str(org_dir), "--rig-config", str(cfg)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "OK" in out and "leader Gerry" in out
+
+
+def test_roster_check_flags_a_bad_org_config(r4t_home, tmp_path, fake_harness, capsys):
+    org_dir, _workplace = _portable_org(tmp_path)
+    (org_dir / "ROSTER.md").write_text(CLEAN_ROSTER, encoding="utf-8")
+    (org_dir / ORG_CONFIG_NAME).write_text(
+        json.dumps({"repo": str(tmp_path / "gone")}), encoding="utf-8"
+    )
+    cfg = _rig_config(tmp_path, fake_harness)
+    rc = r4t_main(["roster", "check", "--root", str(org_dir), "--rig-config", str(cfg)])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "org:" in out and "does not exist" in out
+
+
+def test_two_orgs_one_repo_do_not_collide(r4t_home, tmp_path, fake_harness):
+    # The A/B case: two org dirs (same repo) run as two a8s nodes; team state is
+    # per-node, so nothing collides.
+    workplace = tmp_path / "shared-repo"
+    workplace.mkdir()
+    cfg = _rig_config(tmp_path, fake_harness)
+    for org_name, node in (("org-a", "acme"), ("org-b", "beta")):
+        org_dir = tmp_path / org_name
+        org_dir.mkdir()
+        (org_dir / "ROSTER.md").write_text(ROSTER_TEXT, encoding="utf-8")
+        (org_dir / ORG_CONFIG_NAME).write_text(
+            json.dumps({"repo": str(workplace)}), encoding="utf-8"
+        )
+        rc = r4t_main([
+            "dispatch", "--root", str(org_dir),
+            "--from", "boss", "--to", f"{node}:gerry", "--message", "go",
+            "--rig-config", str(cfg), "--no-notify",
+        ])
+        assert rc == 0
+
+    assert state.read_root("acme") == tmp_path / "org-a"
+    assert state.read_root("beta") == tmp_path / "org-b"
+    assert state.team_dir("acme") != state.team_dir("beta")
+    assert (state.agent_dir("acme", "gerry")).is_dir()
+    assert (state.agent_dir("beta", "gerry")).is_dir()

--- a/apps/r4t/tests/test_state.py
+++ b/apps/r4t/tests/test_state.py
@@ -260,6 +260,49 @@ class TestBudgets:
         assert budget_level(NODE, "phil", 8.0, 0.0, now=now) == 8.0
 
 
+class TestRigBucket:
+    def test_lives_at_r4t_home_root_not_under_a_team(self, r4t_home):
+        state.rig_budget_charge("agy", 20.0, 0.0, 1.0)
+        assert state.rig_buckets_path() == r4t_home / "rig-buckets.json"
+        assert state.rig_buckets_path().is_file()
+
+    def test_shared_key_charged_from_anywhere(self, r4t_home):
+        now = 1_000_000.0
+        assert state.rig_budget_charge("agy", 20.0, 0.0, 1.0, now=now) == 19.0
+        assert state.rig_budget_charge("agy", 20.0, 0.0, 1.0, now=now) == 18.0
+        assert state.rig_budget_level("agy", 20.0, 0.0, now=now) == 18.0
+
+    def test_drain_empties_the_bucket(self, r4t_home):
+        now = 1_000_000.0
+        state.rig_budget_drain("agy", now=now)
+        assert state.rig_budget_level("agy", 20.0, 0.0, now=now) == 0.0
+
+    def test_refills_over_time(self, r4t_home):
+        start = 1_000_000.0
+        state.rig_budget_drain("agy", now=start)
+        assert state.rig_budget_seconds_until("agy", 20.0, 20.0, now=start) == 180.0
+        assert state.rig_budget_level("agy", 20.0, 20.0, now=start + 3600) == 20.0
+
+    def test_concurrent_charge_is_atomic(self, r4t_home):
+        # Many threads charge the ONE machine-global bucket at once; the
+        # lock-serialized read-modify-write must lose no decrements.
+        import threading
+
+        state.rig_budget_charge("agy", 1000.0, 0.0, 0.0)  # seed at full
+
+        def hit():
+            for _ in range(20):
+                state.rig_budget_charge("agy", 1000.0, 0.0, 1.0)
+
+        threads = [threading.Thread(target=hit) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        # 10 threads * 20 charges = 200 units spent, exactly.
+        assert state.rig_budget_level("agy", 1000.0, 0.0) == 800.0
+
+
 class TestFmtBudget:
     def test_whole_number_drops_decimal(self):
         assert fmt_budget(8.0) == "8"

--- a/apps/r4t/verdict.py
+++ b/apps/r4t/verdict.py
@@ -190,6 +190,25 @@ def team_verdicts(
                     ))
                     flagged += 1
                     continue
+                if rig.rig_budget_max is not None:
+                    rig_level = state.rig_budget_level(
+                        rig.name, rig.rig_budget_max, rig.rig_budget_earn_per_hour,
+                        now=now,
+                    )
+                    if rig_level < 1.0:
+                        wait = state.rig_budget_seconds_until(
+                            rig.name, rig.rig_budget_max, rig.rig_budget_earn_per_hour,
+                            now=now,
+                        )
+                        out.append(Verdict(
+                            WARN,
+                            f"{m.name} resting — rig {rig.name} exhausted, "
+                            f"{depth} queued, ready in ~{wait / 60:.0f} min",
+                            "raise rig_budget_max/rig_budget_earn_per_hour, or "
+                            "the subscription is out of quota",
+                        ))
+                        flagged += 1
+                        continue
             if depth >= QUEUE_DEPTH_WARN:
                 out.append(Verdict(
                     WARN,


### PR DESCRIPTION
Two features on one branch, committed as separate logical series.

## Rig-level budgets (#177)

A rig maps to a real subscription (an Antigravity plan good for ~20
prompts/hour, a Claude seat), not to a member or a team. This adds a **third
token bucket** alongside member and cell: a turn is runnable only when
member ≥1 AND cell ≥1 AND rig ≥1, and charges all three. An empty rig bucket
rests every member on that rig, on **every team** — the queues hold and catch
up on refill.

**Why rig budgets are the quota answer.** Budget refill IS the implicit retry.
r4t is deliberately the retry system so a8s can stay dumb delivery: an
exhausted subscription simply rests and resumes when it earns capacity back,
with nothing lost. No retry counters, no dead-letters, no bounce.

- Knobs mirror the existing pairs: `rig_budget_max` / `rig_budget_earn_per_hour`
  per rig (absent = no rig gate). Both required together — a real plan always
  declares a refill rate; a max without one would rest forever.
- **Machine-global state**: `rig-buckets.json` at the R4T_HOME root, not under
  any team, so one subscription is shared safely across projects. Many nodes
  charge it concurrently, so the read-modify-write is serialized by an
  `fcntl.flock` mutex (blocks, works across processes AND threads,
  auto-released on death — no stale-lock steal to race). The check-then-charge
  *gate* is best-effort across nodes; the charge clamps at zero and queues
  hold, so a rare cross-node double-spend just runs one extra turn before the
  rig rests.
- **Blank-response quota signal** (Neil's field observation): agy/claude/
  opencode all exit 0 with a **blank** when out of quota — the only reliable
  cross-harness signal. A turn that exits 0, releases nothing, and prints not
  one byte is logged `QUOTA-SUSPECT` and drains its rig bucket, resting the
  whole rig until it refills. **Conservative on purpose:** only a *truly empty*
  transcript triggers it, never chrome-only output from a quiet-but-alive
  member (which still prints tool traces) — that stays the existing `SILENT`
  path.

Resting-because-rig reads distinctly ("resting — rig agy exhausted") from
member/cell resting across verdicts, `r4t status`, the chat status panel, and
the TUI header. Governance knob table + `example-rigs.json` updated.

## Portable orgs (#180)

MISSION.md + ROSTER.md can be designated **outside** the repo, as a choice;
in-repo stays the default (the slow furnace a proven structure graduates into).

An **org directory** holds ROSTER.md + MISSION.md + `r4t-org.json` naming the
workplace repo. **Precedence, decided once in `org.py`:** if
`<root>/r4t-org.json` exists and names a `repo`, `<root>` is the org dir
(ROSTER/MISSION and mission injection read here) and turns run/commit in
`repo`; otherwise `<root>` is both — the in-repo default. The a8s node is
stamped at the org dir (its outbox and per-node state resolve there); `repo`
supplies only the turn cwd. `DispatchContext` gains `workplace` for that
split; `root` stays the documents dir.

Org-to-repo is many-to-one and nothing collides: team state is already keyed
per a8s node, so two org dirs pointing at two clones of one project (the A/B
case — first consumer: a novella experiment, same MISSION, different ROSTERs)
each get their own state. `r4t roster check` runs against an org dir (tree +
40-line mission lint) and flags a malformed `r4t-org.json` or a missing
workplace. **Graduation is trivial:** copy the two files into the repo and
delete `r4t-org.json` — resolution falls back to the in-repo default.

## Tests

Full battery green: `pytest apps/r4t/tests/ apps/a8s/tests/ tests/test_pii.py`
→ **978 passed**. New coverage: three-bucket gating, rig bucket shared across
two fake teams, atomic concurrent charge (10 threads), blank-response drain
(and chrome-only NOT draining), resting-because-rig verdict, org-dir
resolution + precedence, graduation, and `roster check` on an org dir.

Also fixed a **pre-existing** test-isolation leak surfaced while running the
combined battery: r4t's seat/chat CLIs set `TELL_OUTBOX_DIR` in `os.environ`,
which leaked into the a8s `tell` suite when both ran together (reproducible on
main with unmodified files). An autouse fixture in the r4t conftest now
snapshots/restores it. (Separately, the r4t test helpers that did
`from conftest import base_config` are now self-contained, so the two suites'
same-named `conftest` modules no longer collide at collection.)

Closes #177
Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)