### PR TITLE
fix(r4t): observer surfaces resolve portable orgs; attach gains history

### DIFF
--- a/apps/r4t/chat.py
+++ b/apps/r4t/chat.py
@@ -339,6 +339,31 @@ class MemberWatch:
         return [*self._poll_log(), *self._poll_live()]
 
 
+BACKFILL_MAX = 20
+
+
+def member_backfill(
+    node: str, name: str, limit: int = BACKFILL_MAX
+) -> list[tuple[str, str]]:
+    """Recent history for a gemba attach, so a message sent to the member
+    before attach-time is not invisible: its received-message and turn events
+    from the team log (current + previous UTC day), bounded to the last
+    `limit`, then whatever is still waiting in its queue. Read-only; the live
+    stream picks up from here forward."""
+    key = name.strip().lower()
+    events: list[tuple[str, str]] = []
+    for line in state.recent_log_lines(node):
+        event = member_log_event(line, key)
+        if event:
+            events.append(("recv", event))
+    events = events[-limit:]
+    for env in state.read_queue(node, key):
+        sender = str(env.get("from", "?"))
+        first = (str(env.get("body", "")).strip().splitlines() or ["(empty)"])[0]
+        events.append(("recv", f"queued from {sender}: {first}"))
+    return events
+
+
 HELP = """\
 /to <name|team>   set message target (bare team = leader)
 /attach <name>    watch a member read-only (messages in + turn output live)
@@ -457,12 +482,13 @@ class ChatSession:
                 return False
             if result.target is not None:
                 self.target = result.target
-            if result.attach is not None:
-                self.watch = MemberWatch(self.ctx.node, result.attach)
             if result.detach:
                 self.watch = None
             if result.lines:
                 self.emit("sys", "\n".join(result.lines))
+            if result.attach is not None:
+                self.watch = MemberWatch(self.ctx.node, result.attach)
+                self._emit_backfill(result.attach)
             return True
         self.sends.put((self.target, line))
         self.emit("you", f"you -> {self.target}: {line}")
@@ -481,6 +507,15 @@ class ChatSession:
         for kind, text in self.watch.poll():
             self.events.put((kind, f"[{self.watch.name}] {text}"))
 
+    def _emit_backfill(self, name: str) -> None:
+        self.emit("act", "── history ──")
+        events = member_backfill(self.ctx.node, name)
+        if not events:
+            self.emit("act", "(no recent activity)")
+        for kind, text in events:
+            self.emit(kind, f"[{name}] {text}")
+        self.emit("act", "── live ──")
+
     def run(self) -> int:
         self.emit(
             "sys",
@@ -489,6 +524,7 @@ class ChatSession:
         )
         if self.watch is not None:
             self.emit("sys", f"attached to {self.watch.name} — read-only; /detach to stop")
+            self._emit_backfill(self.watch.name)
         state.touch_seat_presence(self.ctx.node, self.human.name)
         self._pump_feed()
         self._pump_watch()

--- a/apps/r4t/chat_tui.py
+++ b/apps/r4t/chat_tui.py
@@ -43,6 +43,7 @@ from chat import (
     SeatFeed,
     handle_command,
     load_seat,
+    member_backfill,
     member_statuses,
     send_as_human,
     sender_label,
@@ -226,8 +227,25 @@ class ChatApp(App):
         attach_log.display = True
         attach_log.clear()
         self._emit("sys", f"── attached to {self.attached} (read-only) ──")
+        self._backfill_attach(attach_log)
         self._pump_watch()
         self._refresh_roster()
+
+    def _backfill_attach(self, attach_log: RichLog) -> None:
+        """Seed the attach pane with the member's recent history so a message
+        sent before attach-time is visible; the live tail continues below."""
+        attach_log.write(Text("── history ──", style="dim"))
+        events = member_backfill(self.ctx.node, self.attached)
+        if not events:
+            attach_log.write(Text("(no recent activity)", style="dim"))
+        for kind, text in events:
+            stamp = datetime.now().strftime("%H:%M:%S")
+            attach_log.write(
+                Text.assemble(
+                    (stamp + " ", "dim"), (text, KIND_STYLE.get(kind, "white"))
+                )
+            )
+        attach_log.write(Text("── live ──", style="dim"))
 
     def _detach(self) -> None:
         if self.attached is None:

--- a/apps/r4t/experiments/n5a/notebook.md
+++ b/apps/r4t/experiments/n5a/notebook.md
@@ -62,7 +62,21 @@ blessings, anything that changed mid-run)*
 
 ## Findings
 
-*(fill in after both M3s land)*
+- **2026-07-13 — shadow MISSION.md in vellum (org B).** In portable-org
+  mode neither workplace repo carries MISSION.md on disk; the mission
+  reaches leads by prompt injection only. Vellum's lead, finding no
+  MISSION.md in the repo, wrote one into the workplace clone
+  (~/repos/vellum) and committed it. Dispatch is unaffected — injection
+  still reads the org dir's copy (~/.config/r4t/orgs/vellum) — but
+  tool-using members reading the repo will now find the lead's shadow
+  copy: two sources of truth. Quill (org A) did not do this. Neil's
+  ruling: leave the shadow in place deliberately and observe the drift —
+  do tool-using members work from the on-disk shadow or the injected
+  text? The drift checkpoint is the M1 blessing: the org-dir copy changes
+  there and the shadow goes stale. Queued design responses (injection
+  declaring itself authoritative; materializing a read-only copy into the
+  workplace) are frozen in `plans/CELL-SPEC.md` under "Queued during the
+  n5a/d5n run" until the run ends.
 
 ## Neil's verdict
 

--- a/apps/r4t/plans/CELL-SPEC.md
+++ b/apps/r4t/plans/CELL-SPEC.md
@@ -211,3 +211,30 @@ per-node. Graduation is trivial — copy the two files into the repo and delete
 `r4t-org.json`; resolution falls back to the in-repo default. `roster check`
 runs against an org dir (tree + 40-line mission lint) and flags a malformed
 config or a missing workplace.
+
+## Queued during the n5a/d5n run (2026-07-13)
+
+Design notes frozen here while the live experiment runs — observe only, no
+agent-facing changes until the run ends.
+
+1. **Mission injection must declare itself authoritative.** The injected
+   prompt text should state explicitly that it IS the mission and that
+   members must never create or edit MISSION.md themselves. Motivated by a
+   live event: one org's lead, seeing no MISSION.md on disk in portable-org
+   mode, wrote one into the workplace repo and committed it. Injection still
+   reads the org dir's copy, so dispatch is unaffected — but tool-using
+   members will read the shadow, giving the team two sources of truth and a
+   standing drift risk. One prompt sentence closes the loophole at the
+   source.
+
+2. **Open question: materialize the mission into the workplace?** In
+   portable-org mode, should dispatch write a read-only MISSION.md copy into
+   the workplace at turn time (so tool-using members find the real one on
+   disk), or stay injection-only (one source of truth, nothing r4t-written
+   in a repo the team also commits to)? Materializing removes the vacuum
+   that invited the shadow copy above, but adds a staleness window between
+   org-dir edits and the next turn. Neil ruled to leave the live shadow in
+   place deliberately (observe-drift experiment: do tool-using members
+   prefer the on-disk shadow over the injected text?); decide after that
+   evidence lands — the drift checkpoint is the M1 blessing, when the org
+   copy changes and the shadow goes stale.

--- a/apps/r4t/r4t.py
+++ b/apps/r4t/r4t.py
@@ -122,13 +122,20 @@ def _resolve_node(raw: str | None) -> str | None:
 
 
 def _context(args: argparse.Namespace, node: str) -> DispatchContext:
-    org = load_org(_resolve_root(args.root))
-    roster_path = resolve_roster_path(org.dir, getattr(args, "roster", None))
-    if not getattr(args, "root", None) and not roster_path.is_file():
+    # The stamped node root IS the org dir — it is what dispatch resolved and
+    # ran against. Observer surfaces (chat/status/seat) must read the roster,
+    # mission and docs from there too, not from wherever the human happens to
+    # stand: in a portable org the workplace repo is not the org dir, and a
+    # member that wrote a shadow ROSTER.md/MISSION.md into the workplace must
+    # not shadow the authoritative copy. So prefer the stamp over cwd whenever
+    # no explicit --root overrides it.
+    root = _resolve_root(args.root)
+    if not getattr(args, "root", None):
         stamped = state.read_root(node)
         if stamped is not None and stamped.is_dir():
-            org = load_org(stamped)
-            roster_path = resolve_roster_path(org.dir, getattr(args, "roster", None))
+            root = stamped
+    org = load_org(root)
+    roster_path = resolve_roster_path(org.dir, getattr(args, "roster", None))
     return DispatchContext(
         root=org.dir,
         node=node,

--- a/apps/r4t/r4t.py
+++ b/apps/r4t/r4t.py
@@ -675,11 +675,24 @@ def _ensure_tell_outbox(ctx: DispatchContext) -> None:
     os.environ.setdefault("TELL_OUTBOX_DIR", str(ctx.root / ".outbox"))
 
 
+def _adopt_root(ctx: DispatchContext) -> None:
+    """A seat session is team ingress just like dispatch — chat/seat sends
+    call handle_message directly and never pass cmd_dispatch, the only place
+    the root stamp was written. A team driven entirely through the seat
+    therefore had no stamp, and every observer command fell back to guessing
+    the root from cwd (the live quill repro). First successful seat
+    resolution writes the stamp; an existing stamp is never overridden here
+    — dispatch owns that."""
+    if state.read_root(ctx.node) is None and ctx.roster_path.is_file():
+        state.stamp_root(ctx.node, ctx.root)
+
+
 def cmd_chat(args: argparse.Namespace) -> int:
     node = _resolve_node(args.node)
     if node is None:
         return 2
     ctx = _context(args, node)
+    _adopt_root(ctx)
     _ensure_tell_outbox(ctx)
     attach = getattr(args, "attach", None)
     if not args.plain and sys.stdout.isatty():
@@ -707,6 +720,7 @@ def cmd_seat(args: argparse.Namespace) -> int:
     if node is None:
         return 2
     ctx = _context(args, node)
+    _adopt_root(ctx)
     _ensure_tell_outbox(ctx)
     try:
         roster = load_roster(ctx.roster_path)

--- a/apps/r4t/state.py
+++ b/apps/r4t/state.py
@@ -107,16 +107,34 @@ def read_root(node: str) -> Path | None:
 
 
 def node_for_root(cwd: Path) -> str | None:
-    """The team whose stamped repo root is cwd or an ancestor of it."""
-    by_root = {}
+    """The team whose stamped org-dir root — or, in a portable org, whose
+    workplace repo — is cwd or an ancestor of it. The org-dir root matches
+    first; the workplace is a fallback so that standing in the repo a portable
+    team works in also infers the node. A workplace shared by two org dirs (the
+    A/B case) is ambiguous and matches neither, so the caller still asks for
+    --node."""
+    from org import load_org
+
+    by_root: dict[Path, str] = {}
+    by_workplace: dict[Path, str | None] = {}
     for node in known_teams():
         root = read_root(node)
-        if root is not None:
-            by_root[root] = node
+        if root is None:
+            continue
+        by_root[root] = node
+        org = load_org(root)
+        if org.is_portable:
+            by_workplace[org.workplace] = (
+                None if org.workplace in by_workplace else node
+            )
     cwd = cwd.resolve()
     for candidate in (cwd, *cwd.parents):
         if candidate in by_root:
             return by_root[candidate]
+    for candidate in (cwd, *cwd.parents):
+        node = by_workplace.get(candidate)
+        if node is not None:
+            return node
     return None
 
 
@@ -495,6 +513,21 @@ def append_log(node: str, text: str) -> None:
     day = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     with (log_dir / f"{day}.md").open("a", encoding="utf-8") as f:
         f.write(text.rstrip() + "\n\n")
+
+
+def recent_log_lines(node: str, *, days: int = 2) -> list[str]:
+    """Raw lines from the last `days` UTC day log files, oldest first — a
+    read-only view for chat/attach backfill. Never writes."""
+    log_dir = team_dir(node) / "log"
+    if not log_dir.is_dir():
+        return []
+    lines: list[str] = []
+    for path in sorted(log_dir.glob("*.md"))[-days:]:
+        try:
+            lines.extend(path.read_text(encoding="utf-8").splitlines())
+        except OSError:
+            continue
+    return lines
 
 
 def _csv_field(value: object) -> str:

--- a/apps/r4t/tests/test_chat.py
+++ b/apps/r4t/tests/test_chat.py
@@ -235,3 +235,67 @@ def test_member_statuses_reports_active_resting_and_queue(ctx, roster, r4t_home)
         assert active["Gerry"].state == "active"
     finally:
         lock.release()
+
+
+# ---------- attach backfill: history before the live stream ----------
+
+def test_member_backfill_reads_log_history_and_queue(r4t_home):
+    from chat import member_backfill
+
+    state.append_log(NODE, 'r4t: QUEUED gerry -> phil thread=T hop=0 "old ask" (depth 1)')
+    state.append_log(NODE, 'r4t: QUEUED gerry -> vela thread=T hop=0 "not his" (depth 1)')
+    state.enqueue(NODE, "phil", {"from": "acme:neil", "body": "waiting for you\nsecond line"})
+    events = member_backfill(NODE, "phil")
+    kinds = {k for k, _ in events}
+    assert kinds == {"recv"}
+    texts = [t for _, t in events]
+    assert any("old ask" in t for t in texts)
+    assert not any("not his" in t for t in texts)
+    assert texts[-1] == "queued from acme:neil: waiting for you"
+
+
+def test_member_backfill_is_bounded(r4t_home):
+    from chat import BACKFILL_MAX, member_backfill
+
+    for i in range(BACKFILL_MAX + 5):
+        state.append_log(
+            NODE, f'r4t: QUEUED gerry -> phil thread=T hop=0 "ask {i}" (depth 1)'
+        )
+    texts = [t for _, t in member_backfill(NODE, "phil")]
+    assert len(texts) == BACKFILL_MAX
+    assert "ask 0" not in "\n".join(texts)          # oldest trimmed
+    assert any(f"ask {BACKFILL_MAX + 4}" in t for t in texts)  # newest kept
+
+
+def test_member_backfill_spans_the_previous_utc_day(r4t_home):
+    from chat import member_backfill
+
+    log_dir = state.team_dir(NODE) / "log"
+    log_dir.mkdir(parents=True)
+    (log_dir / "2020-01-01.md").write_text(
+        'r4t: QUEUED gerry -> phil thread=T hop=0 "from yesterday" (depth 1)\n',
+        encoding="utf-8",
+    )
+    state.append_log(NODE, 'r4t: QUEUED gerry -> phil thread=T hop=0 "from today" (depth 1)')
+    texts = "\n".join(t for _, t in member_backfill(NODE, "phil"))
+    assert "from yesterday" in texts and "from today" in texts
+
+
+def test_attach_command_emits_history_then_live(session, capsys, r4t_home):
+    state.append_log(NODE, 'r4t: QUEUED gerry -> phil thread=T hop=0 "before attach" (depth 1)')
+    session.handle_line("/attach phil")
+    out = capsys.readouterr().out
+    assert "attached to phil" in out
+    history = out.index("── history ──")
+    event = out.index("before attach")
+    live = out.index("── live ──")
+    assert history < event < live
+    # the watch starts AFTER the backfill snapshot: no duplicate live replay
+    assert session.watch is not None
+    assert session.watch.poll() == []
+
+
+def test_attach_backfill_empty_history(session, capsys, r4t_home):
+    session.handle_line("/attach phil")
+    out = capsys.readouterr().out
+    assert "(no recent activity)" in out

--- a/apps/r4t/tests/test_chat_tui.py
+++ b/apps/r4t/tests/test_chat_tui.py
@@ -219,3 +219,32 @@ def test_tui_attach_flag_opens_attached(seat):
             assert app.attached == "phil"
 
     asyncio.run(scenario())
+
+
+def test_tui_attach_backfills_history(seat):
+    ctx, roster, human = seat
+    state.append_log(
+        NODE, 'r4t: QUEUED gerry -> phil thread=T hop=0 "before attach" (depth 1)'
+    )
+    state.enqueue(NODE, "phil", {"from": "acme:neil", "body": "still queued"})
+
+    async def scenario():
+        from textual.widgets import Input, RichLog
+
+        app = ChatApp(ctx, roster, human)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            composer = app.query_one("#composer", Input)
+            composer.value = "/attach phil"
+            await pilot.press("enter")
+            await pilot.pause()
+            text = "\n".join(
+                strip.text for strip in app.query_one("#attach", RichLog).lines
+            )
+            history = text.index("── history ──")
+            event = text.index("before attach")
+            queued = text.index("queued from acme:neil: still queued")
+            live = text.index("── live ──")
+            assert history < event < queued < live
+
+    asyncio.run(scenario())

--- a/apps/r4t/tests/test_node_root.py
+++ b/apps/r4t/tests/test_node_root.py
@@ -74,3 +74,65 @@ def test_bare_node_still_errors_outside_any_root(
     rc = r4t_main(["status"])
     assert rc == 2
     assert "pass --node" in capsys.readouterr().err
+
+
+# ---------- portable orgs: the workplace repo also infers the node ----------
+
+def _portable(tmp_path, node, org_name, workplace):
+    import json
+
+    from org import ORG_CONFIG_NAME
+
+    org_dir = tmp_path / org_name
+    org_dir.mkdir()
+    (org_dir / ORG_CONFIG_NAME).write_text(
+        json.dumps({"repo": str(workplace)}), encoding="utf-8"
+    )
+    state.stamp_root(node, org_dir)
+    return org_dir
+
+
+def test_workplace_cwd_infers_the_node(r4t_home, tmp_path):
+    workplace = tmp_path / "novel-repo"
+    workplace.mkdir()
+    _portable(tmp_path, NODE, "org", workplace)
+    state.stamp_root("other", tmp_path / "elsewhere")
+    sub = workplace / "chapters"
+    sub.mkdir()
+    assert state.node_for_root(workplace) == NODE
+    assert state.node_for_root(sub) == NODE
+
+
+def test_org_dir_cwd_beats_workplace_lookup(r4t_home, tmp_path):
+    workplace = tmp_path / "novel-repo"
+    workplace.mkdir()
+    org_dir = _portable(tmp_path, NODE, "org", workplace)
+    assert state.node_for_root(org_dir) == NODE
+
+
+def test_shared_workplace_stays_ambiguous(r4t_home, tmp_path):
+    # The A/B case: two org dirs, one repo. Standing in the repo cannot pick
+    # a side, so inference declines and the CLI still asks for --node.
+    workplace = tmp_path / "shared-repo"
+    workplace.mkdir()
+    _portable(tmp_path, "org-a-node", "org-a", workplace)
+    _portable(tmp_path, "org-b-node", "org-b", workplace)
+    assert state.node_for_root(workplace) is None
+
+
+def test_bare_status_resolves_from_workplace_cwd(
+    r4t_home, tmp_path, monkeypatch, capsys
+):
+    workplace = tmp_path / "novel-repo"
+    workplace.mkdir()
+    org_dir = _portable(tmp_path, NODE, "org", workplace)
+    (org_dir / "ROSTER.md").write_text(
+        "# Roster\n\n### Gerry\n- **Status:** AI\n- **Rig:** leader\n"
+        "- **Leader:** yes\n",
+        encoding="utf-8",
+    )
+    state.team_dir("other").mkdir(parents=True)  # two teams: ambiguity is real
+    monkeypatch.chdir(workplace)
+    rc = r4t_main(["status"])
+    assert rc == 0
+    assert f"team: {NODE}" in capsys.readouterr().out

--- a/apps/r4t/tests/test_node_root.py
+++ b/apps/r4t/tests/test_node_root.py
@@ -1,6 +1,8 @@
 """node→root stamping — `--node` works from anywhere, CWD finds the node."""
 from __future__ import annotations
 
+import pytest
+
 import state
 from r4t import main as r4t_main
 
@@ -136,3 +138,41 @@ def test_bare_status_resolves_from_workplace_cwd(
     rc = r4t_main(["status"])
     assert rc == 0
     assert f"team: {NODE}" in capsys.readouterr().out
+
+
+# ---------- ambiguity is an error, not a result: every command exits non-zero ----------
+
+AMBIGUOUS_ARGVS = [
+    ["status"],
+    ["seat"],
+    ["seat", "send", "hello"],
+    ["seat", "inbox"],
+    ["chat", "--plain"],
+    ["logs"],
+    ["task", "list"],
+    ["clear"],
+    ["idle"],
+]
+
+
+@pytest.mark.parametrize("argv", AMBIGUOUS_ARGVS, ids=lambda a: " ".join(a))
+def test_ambiguous_team_exits_nonzero(r4t_home, tmp_path, monkeypatch, capsys, argv):
+    # The live hour-long stall: a scripted `r4t seat send` printed the
+    # pass-node hint but the pipeline read exit 0 (the pipe's last command
+    # masked it). r4t's side of the contract is a hard non-zero exit from
+    # EVERY command that resolves a node, so a plain (unpiped) invocation
+    # can never mask a no-op as success.
+    state.team_dir("aaa").mkdir(parents=True)
+    state.team_dir("bbb").mkdir(parents=True)
+    monkeypatch.chdir(tmp_path)  # no stamped root matches cwd
+    rc = r4t_main([*argv, "--simulate-tell"] if argv[0] in ("seat", "chat") else argv)
+    assert rc == 2
+    assert "pass --node" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("argv", AMBIGUOUS_ARGVS, ids=lambda a: " ".join(a))
+def test_no_teams_exits_nonzero(r4t_home, tmp_path, monkeypatch, capsys, argv):
+    monkeypatch.chdir(tmp_path)
+    rc = r4t_main([*argv, "--simulate-tell"] if argv[0] in ("seat", "chat") else argv)
+    assert rc == 2
+    assert "pass --node" in capsys.readouterr().err

--- a/apps/r4t/tests/test_org.py
+++ b/apps/r4t/tests/test_org.py
@@ -196,3 +196,147 @@ def test_two_orgs_one_repo_do_not_collide(r4t_home, tmp_path, fake_harness):
     assert state.team_dir("acme") != state.team_dir("beta")
     assert (state.agent_dir("acme", "gerry")).is_dir()
     assert (state.agent_dir("beta", "gerry")).is_dir()
+
+
+# ---------- observer surfaces resolve the stamped org dir like dispatch ----------
+
+SHADOW_ROSTER = """\
+# Shadow
+
+### Impostor
+- **Status:** AI
+- **Rig:** leader
+- **Leader:** yes
+"""
+
+
+def _stamped_org(r4t_home, tmp_path):
+    org_dir, workplace = _portable_org(tmp_path)
+    state.stamp_root(NODE, org_dir)
+    return org_dir, workplace
+
+
+def test_status_reads_the_org_dir_not_the_cwd(
+    r4t_home, tmp_path, fake_harness, monkeypatch, capsys
+):
+    _org_dir, workplace = _stamped_org(r4t_home, tmp_path)
+    cfg = _rig_config(tmp_path, fake_harness)
+    monkeypatch.chdir(workplace)
+    rc = r4t_main(["status", "--node", NODE, "--rig-config", str(cfg)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "roster not found" not in out
+    assert "Gerry" in out
+
+
+def test_status_ignores_a_shadow_roster_in_the_workplace(
+    r4t_home, tmp_path, fake_harness, monkeypatch, capsys
+):
+    # A member wrote its own ROSTER.md into the workplace (it happened live
+    # with MISSION.md). The stamped org dir stays authoritative.
+    _org_dir, workplace = _stamped_org(r4t_home, tmp_path)
+    (workplace / "ROSTER.md").write_text(SHADOW_ROSTER, encoding="utf-8")
+    cfg = _rig_config(tmp_path, fake_harness)
+    monkeypatch.chdir(workplace)
+    rc = r4t_main(["status", "--node", NODE, "--rig-config", str(cfg)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Gerry" in out
+    assert "Impostor" not in out
+
+
+def test_explicit_root_still_overrides_the_stamp(
+    r4t_home, tmp_path, fake_harness, monkeypatch, capsys
+):
+    _org_dir, workplace = _stamped_org(r4t_home, tmp_path)
+    (workplace / "ROSTER.md").write_text(SHADOW_ROSTER, encoding="utf-8")
+    cfg = _rig_config(tmp_path, fake_harness)
+    rc = r4t_main([
+        "status", "--node", NODE, "--root", str(workplace), "--rig-config", str(cfg),
+    ])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Impostor" in out
+
+
+def test_seat_resolves_the_stamped_org_dir(
+    r4t_home, tmp_path, fake_harness, monkeypatch, capsys
+):
+    _org_dir, workplace = _stamped_org(r4t_home, tmp_path)
+    cfg = _rig_config(tmp_path, fake_harness)
+    monkeypatch.chdir(workplace)
+    rc = r4t_main(["seat", "--node", NODE, "--rig-config", str(cfg), "--simulate-tell"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert f"seat: Neil on {NODE}" in out
+
+
+def test_chat_resolves_the_stamped_org_dir(
+    r4t_home, tmp_path, fake_harness, monkeypatch, capsys
+):
+    import io
+
+    _org_dir, workplace = _stamped_org(r4t_home, tmp_path)
+    cfg = _rig_config(tmp_path, fake_harness)
+    monkeypatch.chdir(workplace)
+    monkeypatch.setattr(sys, "stdin", io.StringIO("/quit\n"))
+    rc = r4t_main([
+        "chat", "--plain", "--node", NODE, "--rig-config", str(cfg), "--simulate-tell",
+    ])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert f"seat: Neil on {NODE}" in out
+
+
+def test_logs_runs_against_an_org_dir_node(
+    r4t_home, tmp_path, fake_harness, monkeypatch, capsys
+):
+    _org_dir, workplace = _stamped_org(r4t_home, tmp_path)
+    state.append_log(NODE, "r4t: QUEUED boss -> gerry thread=T hop=0 \"go\" (depth 1)")
+    monkeypatch.chdir(workplace)
+    rc = r4t_main(["logs", "--node", NODE])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "QUEUED boss -> gerry" in out
+
+
+def test_seat_adopts_the_root_when_no_stamp_exists(
+    r4t_home, tmp_path, fake_harness, monkeypatch, capsys
+):
+    # The live quill sequence: a team driven entirely through the seat never
+    # passes cmd_dispatch, so no stamp exists and observer commands guess
+    # from cwd. One seat run with --root writes the stamp; from then on the
+    # workplace cwd resolves the node and the org dir.
+    org_dir, workplace = _portable_org(tmp_path)
+    cfg = _rig_config(tmp_path, fake_harness)
+    assert state.read_root(NODE) is None
+
+    rc = r4t_main([
+        "seat", "--node", NODE, "--root", str(org_dir),
+        "--rig-config", str(cfg), "--simulate-tell",
+    ])
+    assert rc == 0
+    assert state.read_root(NODE) == org_dir
+
+    state.team_dir("other").mkdir(parents=True)  # ambiguity is real
+    monkeypatch.chdir(workplace)
+    capsys.readouterr()
+    rc = r4t_main(["status", "--rig-config", str(cfg)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert f"team: {NODE}" in out and "Gerry" in out
+
+
+def test_seat_never_overrides_an_existing_stamp(
+    r4t_home, tmp_path, fake_harness, capsys
+):
+    org_dir, workplace = _portable_org(tmp_path)
+    state.stamp_root(NODE, org_dir)
+    (workplace / "ROSTER.md").write_text(SHADOW_ROSTER, encoding="utf-8")
+    cfg = _rig_config(tmp_path, fake_harness)
+    rc = r4t_main([
+        "seat", "--node", NODE, "--root", str(workplace),
+        "--rig-config", str(cfg), "--simulate-tell",
+    ])
+    assert rc == 2  # shadow roster has no human — the seat refuses
+    assert state.read_root(NODE) == org_dir  # and the stamp is untouched


### PR DESCRIPTION
## The resolution bug (live quill repro)

`r4t chat --node quill` from `~/repos/quill` died with `roster not found: /Users/neilo/repos/quill/ROSTER.md`, and bare `r4t chat` could not infer the node. Two stacked causes:

1. **Observer surfaces never learned the root/workplace split.** Dispatch (PR #182) treats the stamped node root as the org dir — ROSTER/MISSION read there, turns run in the workplace. `_context` for chat/status/seat still resolved cwd-first and consulted the stamp only when the cwd roster was *missing*, so a portable org's workplace (or a member-written shadow roster in it) shadowed the authoritative org dir. `_context` now prefers the stamped root whenever no explicit `--root` overrides it.
2. **Only `cmd_dispatch` ever wrote the stamp.** Quill was driven entirely through the seat — chat/seat sends call `handle_message` directly and never pass `cmd_dispatch` — so quill had **no stamp at all** (vellum got one only because a dispatch delivery ran). The seat is team ingress just like dispatch, so `cmd_chat`/`cmd_seat` now adopt the stamp on first successful resolution; an existing stamp is never overridden observer-side. One `r4t seat --node quill --root ~/.config/r4t/orgs/quill` heals the live node.

**CWD inference:** `node_for_root` gains a workplace fallback — the org config knows the repo, the stamp knows the root, so workplace→node is a well-defined reverse lookup. Org-dir roots match first; a workplace shared by two org dirs (the A/B case) stays deliberately ambiguous and still asks for `--node`.

**Symptom addendum — "seat send exited 0" on the pass-node hint (live hour-long stall):** investigated and reproduced. Every observer command that resolves a node (`status`, `seat`, `seat send`, `seat inbox`, `chat`, `logs`, `task list`, `clear`, `idle`) already exits **2** on the ambiguous-team / no-teams path, both invoked directly and through the polyglot wrapper. The observed 0 came from the caller's pipeline: `r4t seat send ... 2>&1 | <cmd>` returns the pipe's last command's status, masking the 2 (demonstrated with `| cat`). r4t's side of the contract — ambiguity is an error, not a result — is now pinned by 18 parametrized exit-code tests so no refactor of `_resolve_node`'s callers can soften it; scripted pipelines should use `set -o pipefail` (or check `${PIPESTATUS[0]}`) on their side.

## Attach backfill

`/attach` (and member click) previously streamed from attach-time forward, so a seat message sent minutes earlier was invisible. `member_backfill` now seeds the view: the member's events from the team log (current + previous UTC day, last 20) plus its still-queued envelopes, between `── history ──` / `── live ──` dividers, in both the line UI and the TUI. The live watch offset syncs *after* the snapshot, so nothing replays twice.

## Freeze-queued docs (no behavior change)

- `plans/CELL-SPEC.md` gains "Queued during the n5a/d5n run (2026-07-13)": mission injection should declare itself authoritative (members must never create/edit MISSION.md — motivated by a live shadow-copy event), and the open materialize-vs-injection-only question.
- `experiments/n5a/notebook.md` records the shadow-MISSION finding and Neil's ruling to leave it in place as an observe-drift experiment (drift checkpoint: the M1 blessing).

## Experiment freeze respected

**No agent-facing behavior changed.** `dispatch.py` is untouched; changes are confined to observer surfaces (`r4t.py` CLI plumbing, `chat.py`, `chat_tui.py`) plus read-only `state.py` helpers (`recent_log_lines`, the `node_for_root` fallback), docs, and tests.

## Tests

- Org-dir resolution for status/seat/chat/logs (fixture: org dir + `r4t-org.json` + separate workplace), shadow-roster guard, explicit `--root` override
- Workplace-cwd node inference, org-dir precedence, shared-workplace ambiguity, seat adopt-stamp healing sequence
- Attach backfill: log+queue history, 20-event bound, previous-UTC-day span, history/live ordering, no double replay, TUI pane backfill
- Exit-code lock: ambiguous-team and no-teams paths exit 2 across all nine node-resolving command forms (parametrized)

Full r4t suite: **365 passed** (329 before this branch; 36 new). PII check: 3 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

