### PR TITLE
feat(r4t): rig --model across presets; agy resolves via live fuzzy match

### DIFF
--- a/apps/r4t/README.md
+++ b/apps/r4t/README.md
@@ -19,7 +19,9 @@ Why each governance layer exists, with prior art:
 cd /path/to/your/repo
 r4t init                              # ROSTER.md + ~/.config/r4t/rigs.json
 r4t rig add worker opencode       # when roster members need extra rigs
+r4t rig add brain agy --model sonnet   # pick a model for the preset
 r4t rig swap worker agy           # switch a rig's preset, keep its settings
+r4t rig remove worker             # drop a rig (alias: rm)
 r4t roster check                      # lint roster ↔ harness mappings
 # register with a8s (exact commands printed by r4t init)
 ```
@@ -27,6 +29,31 @@ r4t roster check                      # lint roster ↔ harness mappings
 The roster (`ROSTER.md`) names members and symbolic rigs; the harness
 config (`~/.config/r4t/rigs.json`) maps those rigs to CLIs. Unknown rigs
 fail closed — see the [tutorial](docs/tutorial.md#missing-rig-no-default--fail-closed).
+
+### Picking a model (`--model`)
+
+`r4t rig add` and `r4t rig swap` take an optional `--model`. For most presets
+(`claude`, `codex`, `cursor`, `opencode`) it is spliced into the invoke at add
+time — `--model <alias>` for claude, `-m <id>` after `exec` for codex, after
+`run` for opencode — and omitting it lets the CLI's own default apply. The
+`ollama` and `opencode-ollama` presets have no default, so their `--model` is
+required and names a local model tag.
+
+`agy` is different: its `--model` takes an exact display name from `agy models`
+(short aliases are silently ignored), and those names carry version numbers
+that change as agy ships releases. So r4t stores the friendly string you give
+(`--model sonnet`) and resolves it against the live `agy models` list before
+**every** turn — never a pinned table that could go stale. Matching is
+case-insensitive with dashes and spaces interchangeable (`gemini-3.5-flash`
+matches "Gemini 3.5 Flash (Medium)"); when several names match, the tie-break
+prefers the fewest extra tokens, then the highest effort suffix
+(thinking > high > medium > low), then alphabetical order. A string that
+matches nothing fails the turn loudly with the available names — an unresolved
+value is never passed through, because agy would silently run its default.
+
+`r4t rig remove <rig>...` (alias `rm`) deletes one or more rigs. It refuses if
+a roster member or pin still references the rig, naming what does; pass
+`--force` to remove anyway.
 
 ### How a message flows
 

--- a/apps/r4t/dispatch.py
+++ b/apps/r4t/dispatch.py
@@ -47,7 +47,7 @@ from pathlib import Path
 
 import state
 import tasks
-from rig import RigConfig, RigError, Rig, load_rig_config
+from rig import RigConfig, RigError, Rig, load_rig_config, resolve_agy_model
 from notify import TellFn
 from roster import Member, Roster, RosterError, load_roster
 
@@ -325,6 +325,16 @@ def run_harness(
     harness output is teed there line by line as it arrives, so a gemba attach
     can tail the turn live; the full output is still returned for staging."""
     argv = rig.argv(prompt, variant)
+    if rig.model_resolver == "agy-live":
+        # Resolve the friendly --model against the live `agy models` list before
+        # every turn — the display names drift as agy ships versions, and agy
+        # silently ignores an unrecognized string, so a stale/bad value must
+        # fail the turn loudly rather than run the account default.
+        try:
+            resolved = resolve_agy_model(rig.model or "")
+        except RigError as e:
+            return 127, f"agy --model {rig.model!r} did not resolve: {e}", 0.0, False
+        argv = [resolved if a == "{model}" else a for a in argv]
     live_log = (env or {}).get("R4T_LIVE_LOG")
     start = time.monotonic()
     try:

--- a/apps/r4t/r4t.py
+++ b/apps/r4t/r4t.py
@@ -37,6 +37,7 @@ from rig import (
     format_preset_invoke,
     load_rig_config,
     preset_names,
+    remove_rig,
     resolve_config_path,
     swap_preset_rig,
 )
@@ -53,6 +54,7 @@ COMMAND_HELP = [
     ("rig list", "Rig invoke lines, limits, and roster rig resolution"),
     ("rig presets", "Named CLI presets aligned with a8s definitions"),
     ("rig add <rig> <preset>", "Add a rig to ~/.config/r4t/rigs.json from a preset"),
+    ("rig remove <rig>", "Remove a rig from the config (alias: rm)"),
     ("roster check", "Lint ROSTER.md against the rig config"),
     ("task list", "List conversation threads for a team"),
     ("task show <id>", "Show one task ledger record as JSON"),
@@ -797,6 +799,7 @@ RIG_COMMAND_HELP = [
     ("rig presets", "Named CLI presets aligned with a8s definitions"),
     ("rig add <rig> <preset>", "Add a rig (creates the config if needed; --model M, --force)"),
     ("rig swap <rig> <preset>", "Switch an existing rig to a preset, keeping its settings"),
+    ("rig remove <rig>...", "Remove one or more rigs from the config (alias: rm)"),
 ]
 
 
@@ -868,6 +871,7 @@ def cmd_rig_add(args: argparse.Namespace) -> int:
         return 1
     print(f"added rig {rig_key!r} ({args.preset}) to {config_path}")
     print(f"  invoke: {' '.join(invoke)}")
+    _print_model_note(preset_key, args.model)
     print(f"Reference it from ROSTER.md: `- **Rig:** {rig_key}`")
     return 0
 
@@ -888,7 +892,69 @@ def cmd_rig_swap(args: argparse.Namespace) -> int:
         return 1
     print(f"swapped rig {rig_key!r} to {args.preset} in {config_path}")
     print(f"  invoke: {' '.join(invoke)}")
+    _print_model_note(preset_key, args.model)
     return 0
+
+
+def _print_model_note(preset_key: str, model: str | None) -> None:
+    if model and HARNESS_PRESETS.get(preset_key, {}).get("model_resolver") == "agy-live":
+        print(
+            f"  model: {model.strip()!r} — resolved live against `agy models` "
+            f"before every turn"
+        )
+
+
+def _rig_usage(config, roster, rig_key: str) -> list[str]:
+    """Members and pins still pointing at rig_key — used to refuse a remove that
+    would strand a live team."""
+    users: list[str] = []
+    for agent, pinned in config.pins.items():
+        if pinned == rig_key:
+            users.append(f"{agent} (pinned)")
+    if roster is not None:
+        for m in roster.members:
+            if (m.rig or "").strip().lower() == rig_key:
+                users.append(m.name)
+    return users
+
+
+def cmd_rig_remove(args: argparse.Namespace) -> int:
+    config_path = resolve_config_path(args.rig_config)
+    try:
+        config = load_rig_config(config_path)
+    except RigError as e:
+        print(str(e), file=sys.stderr)
+        return 1
+    roster = None
+    if not args.force:
+        roster_path = resolve_roster_path(
+            _resolve_root(getattr(args, "root", None)), getattr(args, "roster", None)
+        )
+        if roster_path.is_file():
+            try:
+                roster = load_roster(roster_path)
+            except RosterError:
+                roster = None
+    rc = 0
+    for name in args.rigs:
+        rig_key = name.strip().lower()
+        users = [] if args.force else _rig_usage(config, roster, rig_key)
+        if users:
+            print(
+                f"rig {rig_key!r} still used by {', '.join(users)}; not removed "
+                f"(try: repoint them, or r4t rig remove {rig_key} --force)",
+                file=sys.stderr,
+            )
+            rc = 1
+            continue
+        try:
+            remove_rig(config_path, name)
+        except RigError as e:
+            print(str(e), file=sys.stderr)
+            rc = 1
+            continue
+        print(f"removed rig {rig_key!r} from {config_path}")
+    return rc
 
 
 def cmd_task(args: argparse.Namespace) -> int:
@@ -1226,7 +1292,7 @@ def build_parser() -> argparse.ArgumentParser:
     rig_add_p.add_argument(
         "--model",
         metavar="MODEL",
-        help="Model name for presets that need it (e.g. opencode-ollama).",
+        help="Optional model for the preset (required for ollama; agy resolves it live).",
     )
     rig_add_p.add_argument(
         "--rig-config",
@@ -1257,6 +1323,27 @@ def build_parser() -> argparse.ArgumentParser:
         help="Harness config path (default: ~/.config/r4t/rigs.json).",
     )
     rig_swap_p.set_defaults(func=cmd_rig_swap)
+
+    rig_remove_p = rig_sub.add_parser(
+        "remove",
+        aliases=["rm"],
+        help="Remove one or more rigs from the rig config.",
+    )
+    rig_remove_p.add_argument(
+        "rigs",
+        nargs="+",
+        help="Symbolic rig name(s) to remove.",
+    )
+    rig_remove_p.add_argument(
+        "--force",
+        action="store_true",
+        help="Remove even if a roster member or pin still references the rig.",
+    )
+    rig_remove_p.add_argument(
+        "--rig-config",
+        help="Harness config path (default: ~/.config/r4t/rigs.json).",
+    )
+    rig_remove_p.set_defaults(func=cmd_rig_remove)
 
     task_p = sub.add_parser("task", help="Task ledger commands.")
     task_p.add_argument("action", choices=["list", "show"])

--- a/apps/r4t/rig.py
+++ b/apps/r4t/rig.py
@@ -36,6 +36,8 @@ notes.
 from __future__ import annotations
 
 import json
+import re
+import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -68,6 +70,7 @@ HARNESS_PRESETS: dict[str, dict] = {
             "-p",
             "{prompt}",
         ],
+        "model_argv": ["--model", "{model}"],
     },
     "codex": {
         "description": "OpenAI Codex CLI — matches apps/a8s/definitions/codex.json",
@@ -80,6 +83,8 @@ HARNESS_PRESETS: dict[str, dict] = {
             "--skip-git-repo-check",
             "{prompt}",
         ],
+        "model_argv": ["-m", "{model}"],
+        "model_anchor": "exec",
     },
     "cursor": {
         "description": "Cursor Agent CLI (`agent`) — matches apps/a8s/definitions/cursor.json",
@@ -93,6 +98,7 @@ HARNESS_PRESETS: dict[str, dict] = {
             "--approve-mcps",
             "{prompt}",
         ],
+        "model_argv": ["--model", "{model}"],
     },
     "opencode": {
         "description": (
@@ -108,6 +114,8 @@ HARNESS_PRESETS: dict[str, dict] = {
             ".",
             "{prompt}",
         ],
+        "model_argv": ["-m", "{model}"],
+        "model_anchor": "run",
     },
     "opencode-ollama": {
         "description": (
@@ -158,6 +166,8 @@ HARNESS_PRESETS: dict[str, dict] = {
             "--print",
             "{prompt}",
         ],
+        "model_argv": ["--model", "{model}"],
+        "model_resolver": "agy-live",
     },
     "copilot": {
         "description": "GitHub Copilot CLI — matches apps/a8s/definitions/copilot.json",
@@ -211,6 +221,8 @@ class Rig:
     budget_earn_per_hour: float = DEFAULT_BUDGET_EARN_PER_HOUR
     rig_budget_max: float | None = None
     rig_budget_earn_per_hour: float | None = None
+    model: str | None = None
+    model_resolver: str | None = None
     error: str | None = None
 
     def pool(self) -> list[list[str]]:
@@ -286,22 +298,131 @@ def format_preset_invoke(preset: str) -> str:
 
 
 def build_preset_invoke(preset: str, *, model: str | None = None) -> list[str]:
-    """Materialize a preset argv, substituting {model} when the preset needs it."""
+    """Materialize a preset argv for a given --model.
+
+    Three shapes, keyed off the preset's metadata:
+
+    - Inline `{model}` presets (ollama, opencode-ollama): --model is REQUIRED
+      and substituted straight into the placeholder — the CLI has no default.
+    - `model_argv` presets with a live resolver (agy): splice the flag pair but
+      keep the `{model}` placeholder so dispatch re-resolves the friendly string
+      against `agy models` before every turn (the display names drift as agy
+      ships new versions, so a value baked in at add-time would go stale).
+    - `model_argv` presets without a resolver (claude/codex/cursor/opencode):
+      splice the flag pair with the resolved value now. --model is OPTIONAL —
+      absent, the base argv is returned and the CLI's own default applies.
+    """
     preset_key = preset.strip().lower()
     if preset_key not in HARNESS_PRESETS:
         known = ", ".join(preset_names())
         raise RigError(f"unknown preset {preset!r}; choose one of: {known}")
-    needs_model = any("{model}" in arg for arg in HARNESS_PRESETS[preset_key]["invoke"])
-    if needs_model and not (model or "").strip():
-        raise RigError(f"preset {preset_key!r} requires --model")
+    entry = HARNESS_PRESETS[preset_key]
     model_value = (model or "").strip()
-    argv: list[str] = []
-    for arg in HARNESS_PRESETS[preset_key]["invoke"]:
-        if arg == "{model}":
-            argv.append(model_value)
-        else:
-            argv.append(arg)
+
+    if any("{model}" in arg for arg in entry["invoke"]):
+        if not model_value:
+            raise RigError(f"preset {preset_key!r} requires --model")
+        return [model_value if arg == "{model}" else arg for arg in entry["invoke"]]
+
+    argv = list(entry["invoke"])
+    if not model_value:
+        return argv
+
+    model_argv = entry.get("model_argv")
+    if not model_argv:
+        raise RigError(f"preset {preset_key!r} does not support --model")
+    spliced = "{model}" if entry.get("model_resolver") else model_value
+    flag_pair = [spliced if arg == "{model}" else arg for arg in model_argv]
+    anchor = entry.get("model_anchor")
+    insert_at = argv.index(anchor) + 1 if anchor else 1
+    argv[insert_at:insert_at] = flag_pair
     return argv
+
+
+AGY_MODELS_TIMEOUT_SECONDS = 10
+
+# Effort/thinking suffix ranking used to break ties when a friendly string
+# matches several display names (e.g. `flash` hits Flash Low/Medium/High).
+_EFFORT_RANK = {"thinking": 4, "high": 3, "medium": 2, "low": 1}
+
+
+def _model_tokens(text: str) -> list[str]:
+    """Lowercase and split on runs of dashes/whitespace, dropping any wrapping
+    parens so `-` and ` ` are interchangeable: `gemini-3.5-flash` and
+    `Gemini 3.5 Flash` tokenize identically."""
+    return [t.strip("()") for t in re.split(r"[-\s]+", text.strip().lower()) if t.strip("()")]
+
+
+def _effort_rank(tokens: list[str]) -> int:
+    return max((_EFFORT_RANK.get(t, 0) for t in tokens), default=0)
+
+
+def fuzzy_match_model(query: str, names: list[str]) -> str:
+    """Resolve a friendly --model string to one exact display name.
+
+    A name matches when every query token is a substring of some name token,
+    after both sides are normalized by `_model_tokens` (case-insensitive, dashes
+    and spaces treated as the same separator, parens stripped). So `sonnet`,
+    `claude-sonnet`, and the exact `Claude Sonnet 4.6 (Thinking)` all resolve;
+    `gpt-oss-120b` matches `GPT-OSS 120B (Medium)`.
+
+    Tie-break when several names match, in order: fewest extra tokens (tightest
+    match) → highest effort/thinking suffix (thinking > high > medium > low) →
+    alphabetical. A miss raises RigError listing the available names — agy
+    silently ignores unknown --model strings, so an unresolved value must never
+    be passed through.
+    """
+    q = _model_tokens(query)
+    if not q:
+        raise RigError("empty --model value; nothing to match")
+    scored: list[tuple[int, int, str]] = []
+    for name in names:
+        name_tokens = _model_tokens(name)
+        if all(any(tok in cand for cand in name_tokens) for tok in q):
+            scored.append((len(name_tokens) - len(q), -_effort_rank(name_tokens), name))
+    if not scored:
+        listing = "\n".join(f"  {n}" for n in names)
+        raise RigError(
+            f"--model {query!r} matched no agy model. Available:\n{listing}\n"
+            f"(try: r4t rig swap <rig> agy --model <one of the above>)"
+        )
+    scored.sort()
+    return scored[0][2]
+
+
+def agy_model_names(timeout: float = AGY_MODELS_TIMEOUT_SECONDS) -> list[str]:
+    """The current `agy models` display names, one per line. Errors loudly —
+    never returns a partial or fabricated list."""
+    try:
+        proc = subprocess.run(
+            ["agy", "models"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError as e:
+        raise RigError(f"could not run `agy models` to resolve --model: {e}") from e
+    except subprocess.TimeoutExpired as e:
+        raise RigError(
+            f"`agy models` timed out after {timeout:g}s while resolving --model"
+        ) from e
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "").strip()
+        raise RigError(f"`agy models` failed (exit {proc.returncode}): {detail}")
+    names = [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+    if not names:
+        raise RigError("`agy models` returned no models to match against")
+    return names
+
+
+def resolve_agy_model(
+    query: str, *, timeout: float = AGY_MODELS_TIMEOUT_SECONDS, names: list[str] | None = None
+) -> str:
+    """Fuzzy-match `query` against the live `agy models` list. Nothing is cached:
+    the list is re-fetched per call so it stays current as agy ships versions."""
+    if names is None:
+        names = agy_model_names(timeout)
+    return fuzzy_match_model(query, names)
 
 
 def _validate_rig_name(name: str) -> str:
@@ -361,10 +482,14 @@ def add_preset_rig(
     )
     if model:
         note += f" model={model.strip()}."
-    payload[rig_key] = {
+    rig_entry: dict = {
         "_notes": note,
         "invoke": invoke,
     }
+    if model and entry.get("model_resolver"):
+        rig_entry["model"] = model.strip()
+        rig_entry["model_resolver"] = entry["model_resolver"]
+    payload[rig_key] = rig_entry
     atomic_write_json(path, payload)
     return rig_key
 
@@ -390,12 +515,37 @@ def swap_preset_rig(
             f"no rig {rig_key!r} to swap in {path} "
             f"(try: r4t rig add {rig_key} {preset_key})"
         )
+    entry = HARNESS_PRESETS[preset_key]
     invoke = build_preset_invoke(preset_key, model=model)
     note = f"Swapped to preset {preset_key!r} by `r4t rig swap`."
     if model:
         note += f" model={model.strip()}."
     existing["_notes"] = note
     existing["invoke"] = invoke
+    # A swap replaces the harness wholesale, so stale model resolution from the
+    # previous preset must not linger.
+    existing.pop("model", None)
+    existing.pop("model_resolver", None)
+    if model and entry.get("model_resolver"):
+        existing["model"] = model.strip()
+        existing["model_resolver"] = entry["model_resolver"]
+    atomic_write_json(path, payload)
+    return rig_key
+
+
+def remove_rig(path: Path, rig_name: str) -> str:
+    """Delete a symbolic rig from the config. Returns the removed key.
+
+    Fails loudly if the rig is absent — the same shape `swap` uses for an
+    unknown rig. Usage checks (roster/pin references) live in the CLI layer,
+    which can reach the roster."""
+    rig_key = _validate_rig_name(rig_name)
+    payload = _load_config_payload(path)
+    if rig_key not in payload or rig_key.startswith("_"):
+        raise RigError(
+            f"no rig {rig_key!r} to remove in {path} (try: r4t rig list)"
+        )
+    del payload[rig_key]
     atomic_write_json(path, payload)
     return rig_key
 
@@ -447,6 +597,11 @@ def _parse_rig(name: str, raw: object) -> Rig:
         rig.error = err
         return rig
     rig.invoke = invoke
+
+    resolver = raw.get("model_resolver")
+    if resolver is not None:
+        rig.model_resolver = str(resolver)
+        rig.model = str(raw.get("model") or "").strip() or None
 
     problems: list[str] = []
     rig.timeout_seconds, err = _positive_number(

--- a/apps/r4t/tests/test_dispatch.py
+++ b/apps/r4t/tests/test_dispatch.py
@@ -22,7 +22,7 @@ from dispatch import (
     run_idle,
     split_recipient,
 )
-from rig import Rig, load_rig_config
+from rig import Rig, RigError, load_rig_config
 from roster import load_roster
 from r4t import main as r4t_main
 from ulid import new as new_ulid
@@ -1020,6 +1020,45 @@ class TestRunHarness:
         assert code == 127
         assert "failed to spawn" in out
         assert not timed_out
+
+    def test_agy_model_resolved_live_before_turn(self, tmp_path, monkeypatch):
+        # The stored argv carries a {model} placeholder; run_harness resolves it
+        # against the live list right before spawning.
+        seen = {}
+
+        def fake_resolve(query, **_):
+            seen["query"] = query
+            return "Claude Sonnet 4.6 (Thinking)"
+
+        monkeypatch.setattr(dispatch, "resolve_agy_model", fake_resolve)
+        rig = Rig(
+            name="brain",
+            invoke=["printf", "%s\\n", "--model", "{model}", "{prompt}"],
+            model="sonnet",
+            model_resolver="agy-live",
+        )
+        code, out, _dur, timed_out = run_harness(rig, "hello", tmp_path)
+        assert code == 0
+        assert not timed_out
+        assert seen["query"] == "sonnet"
+        assert "Claude Sonnet 4.6 (Thinking)" in out
+        assert "{model}" not in out
+
+    def test_agy_resolution_failure_fails_turn_loudly(self, tmp_path, monkeypatch):
+        def boom(query, **_):
+            raise RigError("--model 'banana' matched no agy model")
+
+        monkeypatch.setattr(dispatch, "resolve_agy_model", boom)
+        rig = Rig(
+            name="brain",
+            invoke=["echo", "--model", "{model}", "{prompt}"],
+            model="banana",
+            model_resolver="agy-live",
+        )
+        code, out, _dur, _timed = run_harness(rig, "x", tmp_path)
+        assert code == 127
+        assert "did not resolve" in out
+        assert "banana" in out
 
     def test_spawn_failure_tells_sender(self, ctx, repo, tells, fake_harness, rig_config):
         config = json.loads(rig_config.read_text(encoding="utf-8"))

--- a/apps/r4t/tests/test_rig.py
+++ b/apps/r4t/tests/test_rig.py
@@ -21,11 +21,15 @@ from rig import (
     build_preset_invoke,
     default_config_payload,
     format_preset_invoke,
+    fuzzy_match_model,
     load_rig_config,
     preset_names,
+    remove_rig,
+    resolve_agy_model,
     swap_preset_rig,
 )
 from roster import Member
+from r4t import main as r4t_main
 
 
 def write_config(tmp_path: Path, data: dict) -> Path:
@@ -404,3 +408,193 @@ class TestHarnessPresets:
     def test_build_preset_invoke_unknown(self):
         with pytest.raises(RigError, match="unknown preset"):
             build_preset_invoke("gemini")
+
+
+AGY_MODEL_LIST = [
+    "Gemini 3.5 Flash (Medium)",
+    "Gemini 3.5 Flash (High)",
+    "Gemini 3.5 Flash (Low)",
+    "Gemini 3.1 Pro (Low)",
+    "Gemini 3.1 Pro (High)",
+    "Claude Sonnet 4.6 (Thinking)",
+    "Claude Opus 4.6 (Thinking)",
+    "GPT-OSS 120B (Medium)",
+]
+
+
+class TestModelSplice:
+    """--model splices at the right position for each preset (see the ruling on
+    issue #186: static presets splice now, agy keeps a placeholder for live
+    resolution)."""
+
+    def test_optional_when_absent_returns_base(self):
+        for preset in ("claude", "codex", "cursor", "opencode", "agy"):
+            assert build_preset_invoke(preset) == HARNESS_PRESETS[preset]["invoke"]
+
+    def test_claude_splices_after_executable(self):
+        argv = build_preset_invoke("claude", model="sonnet")
+        assert argv[:3] == ["claude", "--model", "sonnet"]
+        assert argv[-2:] == ["-p", "{prompt}"]
+
+    def test_codex_splices_after_exec(self):
+        argv = build_preset_invoke("codex", model="gpt-5.6-sol")
+        assert argv[:4] == ["codex", "exec", "-m", "gpt-5.6-sol"]
+        assert argv[-1] == "{prompt}"
+
+    def test_cursor_splices_after_executable(self):
+        argv = build_preset_invoke("cursor", model="sonnet-4-thinking")
+        assert argv[:3] == ["agent", "--model", "sonnet-4-thinking"]
+
+    def test_opencode_splices_after_run(self):
+        argv = build_preset_invoke("opencode", model="anthropic/claude-sonnet-4-5")
+        assert argv[:4] == ["opencode", "run", "-m", "anthropic/claude-sonnet-4-5"]
+        assert "--auto" in argv
+
+    def test_agy_keeps_placeholder_for_live_resolution(self):
+        argv = build_preset_invoke("agy", model="sonnet")
+        assert argv[:3] == ["agy", "--model", "{model}"]
+        assert "sonnet" not in argv
+
+    def test_ollama_requires_model_and_substitutes(self):
+        with pytest.raises(RigError, match="requires --model"):
+            build_preset_invoke("ollama")
+        argv = build_preset_invoke("ollama", model="qwen2.5-coder:7b")
+        assert argv == ["ollama", "run", "qwen2.5-coder:7b", "{prompt}"]
+
+    def test_preset_without_model_support_refuses_model(self):
+        with pytest.raises(RigError, match="does not support --model"):
+            build_preset_invoke("copilot", model="opus")
+
+    def test_agy_add_persists_model_and_resolver(self, tmp_path):
+        path = tmp_path / "rigs.json"
+        add_preset_rig(path, "brain", "agy", model="sonnet")
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        assert raw["brain"]["model"] == "sonnet"
+        assert raw["brain"]["model_resolver"] == "agy-live"
+        config = load_rig_config(path)
+        assert config.rigs["brain"].model == "sonnet"
+        assert config.rigs["brain"].model_resolver == "agy-live"
+
+    def test_static_add_does_not_persist_resolver(self, tmp_path):
+        path = tmp_path / "rigs.json"
+        add_preset_rig(path, "coder", "claude", model="opus")
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        assert "model_resolver" not in raw["coder"]
+        assert raw["coder"]["invoke"][:3] == ["claude", "--model", "opus"]
+
+    def test_swap_off_agy_drops_stale_resolver(self, tmp_path):
+        path = write_config(tmp_path, {"worker": {"invoke": ["x", "{prompt}"]}})
+        swap_preset_rig(path, "worker", "agy", model="sonnet")
+        assert load_rig_config(path).rigs["worker"].model_resolver == "agy-live"
+        swap_preset_rig(path, "worker", "claude", model="opus")
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        assert "model_resolver" not in raw["worker"]
+        assert "model" not in raw["worker"]
+
+
+class TestFuzzyMatchModel:
+    @pytest.mark.parametrize("query,expected", [
+        ("sonnet", "Claude Sonnet 4.6 (Thinking)"),
+        ("opus", "Claude Opus 4.6 (Thinking)"),
+        ("gpt-oss", "GPT-OSS 120B (Medium)"),
+        ("gpt-oss-120b", "GPT-OSS 120B (Medium)"),
+        ("claude-sonnet", "Claude Sonnet 4.6 (Thinking)"),
+        ("gemini-3.5-flash", "Gemini 3.5 Flash (High)"),
+        ("Claude Sonnet 4.6 (Thinking)", "Claude Sonnet 4.6 (Thinking)"),
+    ])
+    def test_resolves(self, query, expected):
+        assert fuzzy_match_model(query, AGY_MODEL_LIST) == expected
+
+    def test_dashes_and_spaces_interchangeable(self):
+        assert fuzzy_match_model("gemini 3.5 flash", AGY_MODEL_LIST) == fuzzy_match_model(
+            "gemini-3.5-flash", AGY_MODEL_LIST
+        )
+
+    def test_tiebreak_prefers_highest_effort(self):
+        # flash hits Low/Medium/High; the effort tie-break picks High.
+        assert fuzzy_match_model("flash", AGY_MODEL_LIST) == "Gemini 3.5 Flash (High)"
+
+    def test_ambiguous_family_tiebreak_is_deterministic(self):
+        # gemini hits every Gemini line; extra-token count ties, effort favors
+        # the High variants, alphabetical breaks Pro vs Flash -> Pro.
+        assert fuzzy_match_model("gemini", AGY_MODEL_LIST) == "Gemini 3.1 Pro (High)"
+        assert fuzzy_match_model("pro", AGY_MODEL_LIST) == "Gemini 3.1 Pro (High)"
+
+    def test_garbage_errors_loudly_with_listing(self):
+        with pytest.raises(RigError) as exc:
+            fuzzy_match_model("banana", AGY_MODEL_LIST)
+        msg = str(exc.value)
+        assert "matched no agy model" in msg
+        assert "Claude Sonnet 4.6 (Thinking)" in msg
+
+    def test_resolve_agy_model_uses_injected_names(self):
+        assert resolve_agy_model("opus", names=AGY_MODEL_LIST) == "Claude Opus 4.6 (Thinking)"
+
+
+class TestRemoveRig:
+    def test_remove_deletes_entry(self, tmp_path):
+        path = write_config(tmp_path, {
+            "worker": {"invoke": ["x", "{prompt}"]},
+            "spare": {"invoke": ["y", "{prompt}"]},
+        })
+        assert remove_rig(path, "worker") == "worker"
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        assert "worker" not in raw
+        assert "spare" in raw
+
+    def test_remove_unknown_errors(self, tmp_path):
+        path = write_config(tmp_path, {"worker": {"invoke": ["x", "{prompt}"]}})
+        with pytest.raises(RigError, match="no rig 'ghost' to remove"):
+            remove_rig(path, "ghost")
+
+    def test_remove_missing_config_errors(self, tmp_path):
+        with pytest.raises(RigError, match="no rig"):
+            remove_rig(tmp_path / "rigs.json", "worker")
+
+
+class TestRemoveCLI:
+    def test_remove_via_cli(self, tmp_path):
+        path = write_config(tmp_path, {
+            "a": {"invoke": ["x", "{prompt}"]},
+            "b": {"invoke": ["y", "{prompt}"]},
+        })
+        assert r4t_main(["rig", "remove", "a", "--rig-config", str(path)]) == 0
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        assert "a" not in raw and "b" in raw
+
+    def test_rm_alias(self, tmp_path):
+        path = write_config(tmp_path, {"a": {"invoke": ["x", "{prompt}"]}})
+        assert r4t_main(["rig", "rm", "a", "--rig-config", str(path)]) == 0
+        assert "a" not in json.loads(path.read_text(encoding="utf-8"))
+
+    def test_remove_multiple(self, tmp_path):
+        path = write_config(tmp_path, {
+            "a": {"invoke": ["x", "{prompt}"]},
+            "b": {"invoke": ["y", "{prompt}"]},
+            "c": {"invoke": ["z", "{prompt}"]},
+        })
+        assert r4t_main(["rig", "remove", "a", "b", "--rig-config", str(path)]) == 0
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        assert "a" not in raw and "b" not in raw and "c" in raw
+
+    def test_remove_unknown_returns_1(self, tmp_path):
+        path = write_config(tmp_path, {"a": {"invoke": ["x", "{prompt}"]}})
+        assert r4t_main(["rig", "remove", "ghost", "--rig-config", str(path)]) == 1
+
+    def test_remove_refuses_pinned_rig(self, tmp_path):
+        path = write_config(tmp_path, {
+            "a": {"invoke": ["x", "{prompt}"]},
+            "pins": {"phil": "a"},
+        })
+        assert r4t_main(["rig", "remove", "a", "--rig-config", str(path)]) == 1
+        assert "a" in json.loads(path.read_text(encoding="utf-8"))
+
+    def test_remove_force_ignores_pin(self, tmp_path):
+        path = write_config(tmp_path, {
+            "a": {"invoke": ["x", "{prompt}"]},
+            "pins": {"phil": "a"},
+        })
+        assert r4t_main(
+            ["rig", "remove", "a", "--force", "--rig-config", str(path)]
+        ) == 0
+        assert "a" not in json.loads(path.read_text(encoding="utf-8"))


### PR DESCRIPTION
Closes #186.

## What

`--model` on `r4t rig add`/`swap` now works across every preset, and adds `r4t rig remove` (alias `rm`).

### Static presets (splice at add time; `--model` OPTIONAL)
- **claude** → `--model <alias>` (native `opus`/`sonnet`/`haiku` pass through)
- **codex** → `-m <id>` after the `exec` token (codex-cli 0.144.4, verified)
- **cursor** (`agent`) → `--model <id>`
- **opencode** → `-m <provider/model>` after `run`
- Absent `--model` → the CLI's own default applies.
- **ollama** / **opencode-ollama** keep `{model}` REQUIRED (no CLI default).

### agy — resolved live, per prompt (the ruling)
`agy --model` accepts only an exact display name from `agy models`, and those
names carry version numbers that drift as agy ships releases — so **no pinned
alias table**. The rig stores the friendly string (`--model sonnet`) plus a
`model_resolver: agy-live` marker; dispatch re-runs `agy models` and
fuzzy-matches **before every turn** so the choice tracks the current list.

- Case-insensitive; dashes and spaces interchangeable (`gemini-3.5-flash`
  matches "Gemini 3.5 Flash (Medium)").
- Tie-break: fewest extra tokens → highest effort suffix
  (thinking > high > medium > low) → alphabetical.
- A miss **fails the turn loudly** with the available names. agy silently
  ignores an unknown string and would run its default, so an unresolved value
  is never passed through. `agy models` itself failing/timing out (10s) also
  errors loudly — no fallback to the raw string.

### `r4t rig remove` / `rm`
Removes one or more rigs. Refuses (p0o-style action-first error) any rig still
referenced by a roster member or pin, unless `--force`.

## Tests
Full r4t suite green (399 passed). New coverage: splice positions per preset,
required-vs-optional behavior, the fuzzy matcher (incl. dash/space
normalization, tie-breaks, exact string, garbage → loud error), the dispatch
live-resolution hook (success + loud failure), and rig remove (function + CLI,
`rm` alias, multi-name, unknown, pin refusal, `--force`). Verified against the
real `agy models` output (no prompts run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)