### PR TITLE
docs(r4t): the 2026-07-14 overview for external review

### DIFF
--- a/apps/r4t/docs/OVERVIEW-2026-07-14.md
+++ b/apps/r4t/docs/OVERVIEW-2026-07-14.md
@@ -319,8 +319,11 @@ what makes multi-agent viable on consumer subscriptions at all.
   r4t's inter-member transport is files, not a protocol).
 - **A2A** (Linux Foundation, 150+ orgs) — agent-to-agent identity and
   routing via cryptographically signed agent cards. The sharpest identity
-  contrast: r4t's sender identity is unforgeable filesystem ownership — no
-  keys, no cards, no network — which is elegant and strictly single-host.
+  contrast: within one machine, r4t's sender identity is unforgeable
+  filesystem ownership — no keys, no cards. Across machines, a8s remotes
+  (MQTT transport plus a file service for attachments) already carry mail
+  between one operator's devices; trust on that hop rests on the operator's
+  shared broker credentials rather than per-agent signed identity.
 - **ACP (Agent Client Protocol)** — standardizes the editor↔agent control
   channel (Devin Desktop, Jun 2026). r4t achieves harness interchangeability
   one level down: any CLI that takes a prompt, no protocol required of it.
@@ -350,8 +353,12 @@ what makes multi-agent viable on consumer subscriptions at all.
 ### 6.4 What the landscape has that r4t lacks
 
 Our own suspected gaps, offered to reviewers as a starting point: no
-cross-machine federation or interop protocol (identity is single-host by
-construction); no automated verification layer (MAST's third category —
+cross-OWNER federation — a8s remotes give cross-machine reach within one
+operator's network, but there is no story for exchanging mail with agents
+someone else owns, where neither filesystem ownership nor a shared broker
+can vouch for the sender (contrast A2A's signed cards, AMQ's peering,
+Gastown's Wasteland), and it is an open choice whether that is a gap or a
+deliberate boundary; no automated verification layer (MAST's third category —
 today the human seat is the QA); no crash/restart supervision for a member
 that dies mid-turn; no run-state checkpoint/replay for debugging an org run;
 thin per-turn tracing and cost analytics relative to budget *enforcement*;

--- a/apps/r4t/docs/OVERVIEW-2026-07-14.md
+++ b/apps/r4t/docs/OVERVIEW-2026-07-14.md
@@ -1,0 +1,396 @@
+# R4T — Roster For Teams
+
+*2026-07-14. A single document covering the current design, the intent behind
+it, what we have learned running it, and how it sits against the wider
+landscape. Written to be handed to outside reviewers (human or AI) with no
+other context; everything referenced lives in this repo under `apps/r4t/`
+(design specs in `plans/`, experiment records in `experiments/`) and
+`apps/a8s/`.*
+
+---
+
+## 1. What r4t is
+
+r4t runs a **team of AI agents as an organization**: a roster of members with
+names and roles, arranged in a reporting structure, working a prose mission
+against a git repository, with a human as a first-class member who blesses
+milestones. It is not an agent framework in the SDK sense — members are
+**unmodified third-party CLI harnesses** (Claude Code, Codex CLI, Cursor,
+OpenCode, Antigravity, or a bare `ollama run` of a 0.6B local model), each
+invoked one turn at a time with a prompt and expected to reply, message a
+teammate, commit work, or stay silent.
+
+Underneath sits **a8s**, a filesystem-based message router: agents exchange
+JSON envelopes through directories, a router process delivers them, and the
+`tell` command is the only verb an agent needs. r4t builds the organization
+layer on top — durable per-member queues, budgets, org shape, missions,
+observability — and treats the filesystem as the machine: no server, no
+database, no SDK linked into any agent. State is files; identity is directory
+ownership; everything is inspectable with `ls` and `cat`.
+
+The one-sentence intent: **make a heterogeneous pile of AI subscriptions and
+idle hardware behave like a staffed, budgeted, observable organization that
+ships — without the human being its liveness mechanism.**
+
+## 2. Design pillars
+
+### 2.1 The filesystem is the machine
+
+Every member has an on-disk queue of structured messages
+(`teams/<node>/agents/<member>/queue/*.json`), written atomically, delivered
+durably: a message to a broke or sleeping agent waits; **nothing is ever
+dropped for economic reasons**. Sender identity is *stamped, never claimed* —
+a message's `from` is derived from which member's staging directory it was
+written into, the same way the a8s router force-overwrites `from` based on
+which agent's root a message left. Agents cannot spoof each other; there is
+no credential to leak because there is no credential.
+
+### 2.2 Harness-agnostic members ("rigs")
+
+A **rig** is a named way of running a CLI: preset + model + capability knobs.
+Presets exist for the major CLI agents and for local models; `--model` is
+resolved per-preset (for Antigravity, by fuzzy-matching the operator's string
+against the live model list before every turn, because its accepted names
+drift with releases). Members that cannot use tools at all — tiny local
+models — still participate through a **stdout fallback**: a turn that stages
+no messages but prints non-trivial output has that output delivered back to
+its sender as a reply. Proven live: a 0.6B model held up its end of a
+delegation loop purely through stdout. A rig does not even have to be an
+LLM — a scripted program posing as "the creative one" is a legitimate roster
+member, and teammates cannot tell.
+
+### 2.3 The walled garden, and one node to the outside world
+
+Inside an org ("the garden"), r4t owns the message format end-to-end — a
+structured record (`id, from, to, thread, hop, class, body`) with no text
+headers to parse. Conversion to/from a8s envelopes happens **only at the
+wall**: external mail enters at the topmost leader; outbound mail leaves
+stamped as the org's single node name. An r4t org presents to the rest of an
+a8s network as **one agent**; outside nodes cannot tell it is "deep." How the
+org answers — one mind, one mouth — is up to its leader's prompt, not up to
+machinery.
+
+### 2.4 Org shape is configuration, not code
+
+The same roster can run as a depth-2 **tree** (leads over cells, prompts
+listing only tree-adjacent names) or a **flat newsroom** (everyone reports to
+the desk). Comms doctrine is an org-level setting: `open` (the civilian
+model — addresses aren't handed out, but a learned address delivers directly)
+or `closed` (military-style: off-tree messages reroute through the lead).
+Leader visibility into lateral traffic, and whether the top leader may
+message outside the org, are likewise settings. The standing meta-rule:
+**every this-or-that design question becomes a setting with a sane default**,
+so running a differently-shaped org never requires touching the codebase.
+Experiments pick the defaults.
+
+### 2.5 The human seat
+
+The roster human is a member, not an operator console: messages to them park
+in a seat inbox; a **doorbell** (a copy forwarded to their phone) rings only
+when no live session is attached. The human is terminal in closure logic —
+answering the human answers the task. Two hard doctrines came out of running
+real orgs: **only the human blesses milestones** (a team once cheerfully
+self-certified its own blessing), and the seat must never become the org's
+liveness mechanism (see §4, n5a). The human can also "walk the factory
+floor": gemba attach is a read-only live view of any member's inbound
+messages and turn output — observation deliberately built as a one-way glass
+rather than a channel that would then need locking down.
+
+### 2.6 Missions and milestones stay prose
+
+A mission is a markdown file that "outranks every other document," injected
+into leads' prompts (and, after both experimental orgs independently wrote
+their own shadow copies to disk, soon materialized into the workplace repo
+as well — convergent behavior we chose to adopt rather than fight). Milestones
+are prose the human interprets; r4t never mechanizes task state. Where the
+machine needs a judgment ("is the mission met?"), it hands the question to
+the leader in a prompt rather than growing a tracker. Doctrine lines earned
+from live failures ride every prompt: *your message body is all the recipient
+sees*; *work is not done until it is committed*.
+
+### 2.7 Economics are first-class
+
+Three token buckets must all have balance for a member to take a turn: the
+**member's**, the **cell's**, and the **rig's** — the last one machine-global
+and shared across every org on the box, because it protects a real consumer
+subscription (e.g. ~20 prompts/hour on a personal plan). A broke agent simply
+doesn't run; its mail queues. **Batch invoke** delivers everything queued in
+a single wake — a storm damper and a quota saver. Throttling controls money;
+concurrency controls CPU; the two are never conflated. A blank response is
+treated as the one reliable cross-vendor out-of-quota signal. The product
+story underneath: most people's AI subscriptions sit idle most of the day —
+r4t exists so *nothing goes to waste*, safely.
+
+### 2.8 Liveness without a babysitter
+
+An org must burn on its own. The a8s idle tick (cadence set per node
+definition) drains queues and nudges quiet-but-open threads; the current
+design round adds the missing piece found in the field: when an org is
+*structurally stalled* — every queue empty, every thread closed, no work in
+flight — the topmost leader gets a budget-gated **mission-review turn**:
+mission injected, "judge whether it is met, decide the next move," with
+backoff, dormancy after repeated silent reviews, and an explicit line that no
+communication to the human needs to happen. If the leader has no budget, the
+nudge is skipped — liveness never overrides economics.
+
+### 2.9 Observability quartet
+
+`r4t status` (snapshot with plain-English verdicts: waiting-on-YOU, runaway,
+stalled member, out-of-hops), `r4t logs` (the team's own event stream),
+`r4t chat` (a TUI: conversation pane plus fly-on-the-wall activity, budget
+bars), and `r4t seat` (the scriptable human seat, usable by an orchestrating
+agent as a proxy). Every message, turn, and reroute is on disk and greppable;
+the experiment record for a run is written from artifacts, not memory.
+
+## 3. What is being built right now
+
+The **comms re-founding** (in implementation as this document is written;
+spec: `plans/COMMS-SPEC.md`): the structured internal message protocol
+replacing header-parsing end-to-end; `open|closed` comms doctrine,
+lateral-visibility, and top-leader egress as org settings; per-key prompt
+overrides in the node definition (prompt engineering is ranked equal in
+importance to mechanics); history/context size as rig-level capability knobs;
+and the mission-review idle turn. Six tracked issues, one PR, four phases.
+
+## 4. What we have learned (brief history)
+
+**Tic-tac-toe and the first real team (2026-07-early).** Tiny local models
+can be real members (stdout fallback); weak teams naturally form a star
+through their leader, so hop limits are an economic knob, not a formality.
+
+**d5n — a dungeon crawler built by a 13-member, 3-cell tree.** Three
+milestones (design, skeleton, one honest playable run) delivered in a day,
+almost entirely on free/local rigs. The verification lesson stuck: an
+**independent playtest by an agent outside the team** found a real focus bug
+the builder's own harness could not. Also settled: a design doc is a plan,
+not a debt — the mission file outranks it.
+
+**n5a — the org-shape A/B (2026-07-13, one day, shut down same night).** Two
+orgs, identical ten-member rosters, identical mission ("a 15–20k-word novella
+in one sitting"), one variable: tree vs flat newsroom. Neither converged a
+publishable story, but they failed on **opposite axes**, which is the actual
+result: the flat org was blisteringly fast and constraint-blind (16 chapters
+in a day, 2.4× the word cap, self-certified a milestone blessing); the tree
+was gate-clean and produced nothing (a politeness coma — all threads closed,
+mission unmet, no mechanism to reopen; plus a measured "tree tax" of every
+cross-cell reply rerouting through the lead). **Speed-vs-gates looks like the
+real axis org shape trades on.** Full record: `experiments/n5a/RETRO.md`.
+
+Findings that changed the design: both orgs independently materialized their
+own mission files (→ materialize it for them); self-blessing (→ only the
+human blesses); the idle-tick liveness gap (→ §2.8); the tree tax (→ `open`
+comms default); a universal stall pattern — members consuming messages and
+ending turns without replying *or* committing — visible in both shapes (→
+doctrine lines, and the leader rather than the human as re-engager).
+
+Process learnings, written in blood rather than code: **experiments get a
+wall-clock time box declared before launch** (n5a had none and ran an
+evening past useful); start small and ladder up — a novella was a good idea
+and a bad *first* experiment; interventions during a run come from a
+pre-written decision table, not improvisation; and the whole experiment must
+be documented well enough that a cheaper model — or a different harness
+entirely — can run it (`experiments/PROTOCOL.md`).
+
+## 5. Where this is going
+
+- **The experiment ladder**: small, time-boxed, cheap-rig missions (local
+  models and the larger of the two Antigravity quotas paired with OpenCode)
+  to tune prompts, rosters, and comms defaults before optimizing mechanics.
+- **Portable orgs, A/B on one repo**: mission and roster designatable outside
+  the workplace repo, so two differently-shaped orgs can work the *same*
+  codebase — the concrete target is a production single-page app rebuild run
+  by a slow-furnace "parity org" alongside an agile "feature org."
+- **One node outward**: an entire org behind a single a8s address, composable
+  — gardens as members of bigger gardens.
+- **Gopher intelligence**: many tiny-model members generating discardable
+  branches with a few smart members at the combine/discard points — good
+  enough for maintenance work (log triage, CVE watching, ticket grooming).
+- **A personal-assistant org**: one node at the top with a cohesive voice,
+  roster members as life-area specialists underneath.
+
+The operating philosophy throughout: *we strive to ship, not to complete
+everything* — and the machine idles warm rather than hot.
+
+## 6. The landscape
+
+Where r4t sits, verified against the July 2026 state of each project. The
+two closest kin found: **AMQ**, an independently-built maildir-style
+file-based agent bus that deliberately stops at messaging (r4t is the org
+and economics layer AMQ explicitly declines to be), and **AWS CAO**, the
+nearest mainstream team framework (harness-agnostic CLI orchestration —
+but server-based, and without budgets or durability guarantees). Two data
+points validate the economics-first thesis from opposite directions:
+Anthropic's own multi-agent research system reports ~15× the token use of
+single-agent chat, and Gastown famously runs ~$100/hour with no cost
+governor. r4t's bet is that the budget layer is not an accessory — it is
+what makes multi-agent viable on consumer subscriptions at all.
+
+### 6.1 Agent-team frameworks
+
+- **AutoGen / AG2 / Microsoft Agent Framework** — AutoGen is in maintenance;
+  AG2 (community fork) and Microsoft Agent Framework 1.0 (Apr 2026, unifying
+  AutoGen + Semantic Kernel) carry it forward. Similar: agents as
+  conversational participants with roles and handoffs. Different: members are
+  SDK-instantiated objects in one Python process — not unmodified third-party
+  CLIs on a shared git repo; no budget economics, no org-shape experiments.
+  (github.com/ag2ai/ag2)
+- **CrewAI** — role-playing agent crews with task flows and three-layer
+  memory (~46k stars). Similar: role-based division of labor. Different:
+  in-process SDK constructs with a mechanized task graph; r4t's missions stay
+  human-blessed prose and cost is a budget, not an accounting report.
+  (github.com/crewaiinc/crewai)
+- **LangGraph** — the most-adopted orchestrator; explicit directed graphs
+  with typed state, checkpointing, time-travel replay. Similar: durable state
+  and human-in-the-loop gates. Different: you author the graph; r4t has no
+  graph — coordination emerges from queues plus org doctrine.
+  (langchain.com/langgraph)
+- **OpenAI Agents SDK** (ex-Swarm) — handoffs, guardrails, tracing, sandbox
+  execution. Similar: the delegation primitive. Different: handoffs are
+  function calls inside one runtime; r4t delegation is a JSON message in
+  another member's on-disk queue. (github.com/openai/openai-agents-python)
+- **MetaGPT / MGX** — the "AI software company" with SOP-driven roles and a
+  shared message pool. Closest *conceptual* sibling on running a company
+  against a software mission. Different: a hard-coded waterfall SOP and role
+  set; r4t treats org shape and comms doctrine as the experiment variable.
+  (github.com/FoundationAgents/MetaGPT)
+- **ChatDev 2.0 "DevAll"** — zero-code orchestration over a designer-authored
+  agent DAG (MacNet). Different on the same axis as LangGraph: authored
+  workflow vs emergent coordination; simulated company vs real external CLIs
+  on a live checkout. (github.com/openbmb/ChatDev)
+- **CAMEL-AI** — research on agent *societies* and scaling laws (OASIS
+  simulates millions). Shares the "structure is the research object" stance;
+  differs in being simulation-scale research, where r4t is small-N production
+  work capped by span-of-control. (github.com/camel-ai/camel)
+- **Anthropic multi-agent research system; Claude Code subagents / Agent
+  Teams** — orchestrator-worker with parallel subagents, each with its own
+  context window; productized as Agent Teams (Feb 2026). Similar: the
+  lead-plus-workers hierarchy, and the finding that multi-agent costs ~15×
+  tokens — r4t's economic thesis stated by the vendor. Different: ephemeral,
+  homogeneous, single-vendor instances; r4t members are durable,
+  cross-vendor, and survive being broke.
+  (anthropic.com/engineering/multi-agent-research-system)
+- **Letta** (ex-MemGPT) — the memory OS for stateful single agents (tiered
+  memory, git-versioned context). Complementary rather than competing: r4t is
+  agnostic about member internals — a Letta-style member would slot in as a
+  rig. (github.com/letta-ai/letta)
+- **smolagents** — minimalist, tiny/local-model-friendly, agents that think
+  in code. Shares the local-model embrace; no queues, no org, no budgets.
+  (github.com/huggingface/smolagents)
+- **OpenHands** (ex-OpenDevin) — SWE-agent platform with runtime delegation
+  to specialist micro-agents and parallel conflict-free codebase work
+  (~70k stars). Similar goals on a real codebase; a heavyweight server
+  runtime with its own agent, where r4t is serverless plumbing over
+  unmodified CLIs. (github.com/OpenHands/OpenHands)
+- **Gastown** (Steve Yegge) — "Kubernetes for agents": a mayor agent over
+  20–30 parallel Claude Code workers in tmux, git-based work tracking
+  (Beads), a cross-town trust network (Wasteland). Closest in *spirit* —
+  role hierarchy of real CLIs on a git repo, human-supervised. Sharpest
+  contrast: no cost governor (~$100/hr; famously burned through accounts at
+  launch); r4t's entire pitch is the token-bucket opposite.
+  (github.com/steveyegge/gastown)
+- **Ruflo** (ex-Claude Flow) — queen-and-swarm meta-harness over Claude Code
+  (~31k stars, 250k+ LOC, 87 MCP tools). Similar supervisor/worker shape;
+  the philosophical opposite on footprint vs r4t's dependency-light
+  filesystem core. (github.com/ruvnet/ruflo)
+- **AWS CLI Agent Orchestrator (CAO)** — supervisor + specialist workers
+  across 9+ CLI harnesses (Claude Code, Codex, Cursor, Antigravity,
+  OpenCode…), each in a tmux session, coordinated via a local MCP HTTP
+  server, with role-based tool restrictions and cron flows. The nearest
+  mainstream twin on harness-agnostic CLI orchestration with async inbox
+  messaging. Different: server-based, no budgets, no documented queue
+  durability. (github.com/awslabs/cli-agent-orchestrator)
+- **AMQ (agent-message-queue)** — an independently built, maildir-style,
+  serverless file bus for heterogeneous CLI agents: atomic tmp→new→cur
+  writes, sender handles, threading, cross-project federation. The closest
+  architectural sibling that exists — and it deliberately scopes itself to
+  messaging only, deferring org and scheduling "to higher-level
+  orchestrators." r4t is that higher level: the tree, budgets, seat, and
+  experiments on top of the same file-queue instinct.
+  (github.com/avivsinai/agent-message-queue)
+- **Cursor / Devin parallel agents; Project Sid** — context points: closed
+  products running homogeneous first-party agents in parallel on one repo
+  (Cursor Composer, Devin 2.0), and Altera's Project Sid simulating
+  1,000-agent societies with emergent roles and culture. r4t sits between:
+  directed production work, open plumbing, the user's own subscriptions.
+
+### 6.2 Protocols and standards
+
+- **MCP** — agent-to-tool; complementary (members may use it internally;
+  r4t's inter-member transport is files, not a protocol).
+- **A2A** (Linux Foundation, 150+ orgs) — agent-to-agent identity and
+  routing via cryptographically signed agent cards. The sharpest identity
+  contrast: r4t's sender identity is unforgeable filesystem ownership — no
+  keys, no cards, no network — which is elegant and strictly single-host.
+- **ACP (Agent Client Protocol)** — standardizes the editor↔agent control
+  channel (Devin Desktop, Jun 2026). r4t achieves harness interchangeability
+  one level down: any CLI that takes a prompt, no protocol required of it.
+
+### 6.3 Research anchors
+
+- **MAST — "Why Do Multi-Agent LLM Systems Fail?"** (arXiv:2503.13657):
+  14 failure modes in 3 categories (specification, inter-agent misalignment,
+  task verification) from 1,600+ annotated traces. Maps directly onto r4t's
+  choices — comms doctrine and info hiding target misalignment; human-blessed
+  milestones are the verification gate — and is the natural rubric for
+  scoring r4t's org A/Bs.
+- **Topology and coordination-overhead findings (2025–26)** — coordination
+  overhead grows superlinearly; practical flat team size lands around 3–4
+  agents before fragmentation, with hierarchical decomposition the
+  recommended mitigation (e.g. arXiv:2605.03310). Empirical backing for
+  depth-2 trees and the span-of-control caps — and r4t's tree-vs-newsroom
+  A/B is a direct test of exactly the question this literature is arguing.
+- **Non-LLM lineage** — Erlang/OTP supervision trees and actor mailboxes
+  (r4t's queues are single-reader mailboxes; its cells are a supervision
+  tree that escalates to a human instead of auto-restarting); **maildir**
+  (the atomic-rename file-queue pattern r4t and AMQ both inherit); and
+  span-of-control research (~3–7 reports for novel work — r4t's soft-cap 6 /
+  hard-cap 10 imports organizational-behavior priors rather than inventing
+  limits).
+
+### 6.4 What the landscape has that r4t lacks
+
+Our own suspected gaps, offered to reviewers as a starting point: no
+cross-machine federation or interop protocol (identity is single-host by
+construction); no automated verification layer (MAST's third category —
+today the human seat is the QA); no crash/restart supervision for a member
+that dies mid-turn; no run-state checkpoint/replay for debugging an org run;
+thin per-turn tracing and cost analytics relative to budget *enforcement*;
+no way to author a genuinely deterministic pipeline when the work is one;
+the span-of-control assumption (that human org limits transfer to LLM
+members) is unmeasured; and member memory is left entirely to the harness.
+
+## 7. What we want outside reviewers to challenge
+
+1. **Liveness vs economics.** Is a budget-gated, backoff-widened
+   mission-review turn the right self-liveness mechanism, or does the
+   landscape have a better pattern for "an org that re-engages itself
+   without burning quota"?
+2. **Constraint adherence without gates everywhere.** Fast flat orgs sail
+   through written constraints (word caps, blessing rules). Short of a human
+   gate at every step, what actually makes prose constraints binding —
+   mechanized lint, adversarial reviewer members, something else?
+3. **The prose boundary.** We deliberately keep missions/milestones as prose
+   the human or leader interprets, and mechanize only structure (queues,
+   budgets, threads). Is that boundary drawn in the right place?
+4. **Evaluating org experiments at n=1.** Each A/B run is one sample with
+   confounds (one org here was handicapped by an operator bug and got a
+   fairness ledger). What would a defensible methodology for org-shape
+   science at hobby scale look like?
+5. **Identity and info hiding.** Filesystem-stamped identity plus
+   prompt-level info hiding (names not advertised, contact not blocked) —
+   is that sufficient, or naive, as orgs get bigger and mail crosses walls?
+6. **Failure taxonomy coverage.** Which known multi-agent failure modes
+   (per the published taxonomies) has r4t not yet hit only because it is
+   small?
+7. **What are we missing entirely?** §6.4 is our own suspected-gaps list —
+   confirm, refute, and extend it; the extensions are the most valuable
+   output of this review.
+
+---
+
+*Repo: `github.com/neilobremski/bin` — `apps/r4t/` (this layer),
+`apps/a8s/` (the router). Key documents: `plans/COMMS-SPEC.md` (current
+design round), `plans/SYNTHESIS.md` (the re-founding rationale),
+`experiments/n5a/RETRO.md` (the org-shape A/B), `experiments/PROTOCOL.md`
+(how experiments are run), `plans/research/ORG-LESSONS.md` (span-of-control
+research feeding the tree lint).*


### PR DESCRIPTION
A single dated document (`apps/r4t/docs/OVERVIEW-2026-07-14.md`) covering current design + intent, past learnings with brief historical references, and the verified July-2026 landscape (frameworks, protocols, research anchors, non-LLM lineage) — written to be shipped to external AI/deep-research tools for outside perspective. Ends with our own suspected-gaps list and seven challenge questions for reviewers.

No code changes. Independent of the comms re-founding branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)