### PR TITLE
feat(r4t): per-member turn capture + logs --agent (#199)

### DIFF
--- a/apps/r4t/README.md
+++ b/apps/r4t/README.md
@@ -162,7 +162,9 @@ Watch it — one surface per way of looking:
   open threads, and dead letters rolled up by meaning.
 - `r4t logs -f` — the stream. The team's own event log: every governance
   decision and turn boundary, including walled-garden traffic that never
-  reaches a8s. `--full` includes prompts and transcripts.
+  reaches a8s. `--full` includes prompts and transcripts. `--agent <member>`
+  narrows the stream to one member; with `--full` it prints that member's
+  captured turns (each turn's full prompt and raw output, newest last).
 - `r4t chat` — the human, interactively (see the seat section below).
 - `r4t seat` — an orchestrating agent, programmatically.
 
@@ -206,7 +208,10 @@ detach and the doorbell rings again.
 `/attach vela` (`r4t chat --attach vela` to open straight into it) for a live
 view of one member: every message it receives as it is enqueued, and its
 turn output streaming as it comes out (teed to `agents/<member>/live.log`,
-truncated at each turn start). Attaching is observation only — it never sends
+truncated at each turn start). For the record after the fact, every turn is
+also captured whole under `agents/<member>/turns/` — one markdown file per
+turn (prompt + raw output, successes and timeouts alike, most recent 50 kept),
+surfaced by `r4t logs --agent <member> --full`. Attaching is observation only — it never sends
 to that member; the composer keeps talking to the seat's usual
 counterparties. `/detach` steps back out. Training wheels, not a replacement
 for autonomy — everything still flows through normal dispatch and governance.

--- a/apps/r4t/dispatch.py
+++ b/apps/r4t/dispatch.py
@@ -985,6 +985,49 @@ def clean_transcript(output: str) -> str:
     return "\n".join(kept).strip()
 
 
+def _capture_turn(
+    ctx: DispatchContext,
+    member: Member,
+    *,
+    threads: list[str],
+    exit_code: int,
+    duration: float,
+    timed_out: bool,
+    rig_name: str,
+    prompt: str,
+    output: str,
+) -> None:
+    """Persist one turn's full assembled prompt and full raw harness output to
+    agents/<member>/turns/. Wrapped so a write failure only warns — observability
+    must never take down a turn. Captures every dispatched turn, timeouts
+    included: an empty/partial output is exactly the evidence a hang needs."""
+    stamp = state.turn_capture_stamp()
+    meta = "\n".join(
+        [
+            f"- stamp: {stamp}",
+            f"- threads: {', '.join(threads) or '(none)'}",
+            f"- exit: {exit_code}",
+            f"- duration_seconds: {duration:.2f}",
+            f"- timed_out: {str(timed_out).lower()}",
+            f"- rig: {rig_name}",
+        ]
+    )
+    content = (
+        f"# turn {stamp} ({member.name})\n\n{meta}\n\n"
+        f"## Prompt\n\n{prompt}\n\n"
+        f"## Output\n\n{output.strip() or '(no output)'}\n"
+    )
+    try:
+        state.write_turn_capture(
+            ctx.node, member.name, stamp, threads[0] if threads else "batch", content
+        )
+    except OSError as e:
+        state.append_log(
+            ctx.node,
+            f"r4t: WARN turn capture for {member.name.lower()} failed: {e}",
+        )
+
+
 def _run_turn(
     ctx: DispatchContext,
     config: RigConfig,
@@ -1037,6 +1080,18 @@ def _run_turn(
     state.append_log(
         ctx.node,
         f"### Output ({member.name}, {outcome})\n\n{output.strip() or '(no output)'}",
+    )
+
+    _capture_turn(
+        ctx,
+        member,
+        threads=sorted({str(b.get("thread", "")) for b in batch}),
+        exit_code=exit_code,
+        duration=duration,
+        timed_out=timed_out,
+        rig_name=rig.name,
+        prompt=prompt,
+        output=output,
     )
 
     failed = timed_out or exit_code != 0

--- a/apps/r4t/r4t.py
+++ b/apps/r4t/r4t.py
@@ -623,19 +623,74 @@ def cmd_status(args: argparse.Namespace) -> int:
     return 0
 
 
+def _resolve_log_member(args: argparse.Namespace, node: str) -> str | None | bool:
+    """Validate --agent against the roster. Returns the canonical member name,
+    None when no --agent was given, or False on an unknown member (already
+    reported)."""
+    if not args.agent:
+        return None
+    ctx = _context(args, node)
+    try:
+        roster = load_roster(ctx.roster_path)
+    except RosterError as e:
+        print(f"logs --agent: cannot read roster: {e}", file=sys.stderr)
+        return False
+    member = roster.find(args.agent)
+    if member is None:
+        names = ", ".join(roster.names()) or "(none)"
+        print(
+            f"logs --agent: no team member named {args.agent!r} — "
+            f"(try: r4t logs --node {node} --agent <name>; members: {names})",
+            file=sys.stderr,
+        )
+        return False
+    return member.name
+
+
+def _print_member_turns(node: str, member: str) -> int:
+    files = state.list_turn_captures(node, member)
+    if not files:
+        print(
+            f"(no captured turns yet for {member.lower()} under "
+            f"{state.turns_dir(node, member)})",
+            file=sys.stderr,
+        )
+        return 0
+    for path in files:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        print(f"===== {path.name} =====")
+        print(text.rstrip())
+        print()
+    return 0
+
+
 def cmd_logs(args: argparse.Namespace) -> int:
     node = _resolve_node(args.node)
     if node is None:
         return 2
     from chat import filter_log_line
 
+    member = _resolve_log_member(args, node)
+    if member is False:
+        return 2
+    if member and args.full:
+        return _print_member_turns(node, member)
+
+    mention = re.compile(rf"\b{re.escape(member)}\b", re.IGNORECASE) if member else None
     log_dir = state.team_dir(node) / "log"
 
     def rendered(raw: str) -> list[str]:
         if args.full:
             return [raw]
         event = filter_log_line(raw)
-        return [event] if event else []
+        if not event:
+            return []
+        if mention and not mention.search(event):
+            return []
+        return [event]
 
     files = sorted(log_dir.glob("*.md")) if log_dir.is_dir() else []
     collected: list[str] = []
@@ -1323,6 +1378,10 @@ def build_parser() -> argparse.ArgumentParser:
     logs_p.add_argument(
         "--full", action="store_true",
         help="Raw daily log, prompts and transcripts included.",
+    )
+    logs_p.add_argument(
+        "--agent", metavar="MEMBER",
+        help="Only one member's activity; with --full, their captured turns.",
     )
     logs_p.set_defaults(func=cmd_logs)
 

--- a/apps/r4t/state.py
+++ b/apps/r4t/state.py
@@ -14,6 +14,8 @@ honors A8S_HOME).
     │                              sent this turn, released by dispatch afterwards
     ├── agents/<name>/live.log     the running turn's harness output, teed live
     │                              (truncated at turn start; a gemba attach tails it)
+    ├── agents/<name>/turns/       per-turn capture — one markdown file per turn
+    │                              (full prompt + raw output; most recent 50 kept)
     ├── tasks/<id>.json            thread ledger (see tasks.py)
     ├── dead-letter/               undeliverable mail (unknown recipient, malformed)
     ├── buckets.json               per-member + team spend budgets (turns, not tokens)
@@ -671,6 +673,50 @@ def read_live_log_tail(node: str, name: str, offset: int) -> tuple[str, int]:
             return chunk, f.tell()
     except OSError:
         return "", offset
+
+
+# ---------- per-turn capture (prompt + raw output, one file per turn) ----------
+#
+# live.log holds only the LAST turn's raw output and no prompt at all, so a
+# prompting problem cannot be diagnosed after the fact. Turn capture keeps the
+# most recent TURN_RETENTION turns per member as standalone markdown files —
+# the full assembled prompt and the full raw harness output, every turn,
+# successes and timeouts alike. Day logs and #159 own long-term retention.
+
+TURN_RETENTION = 50
+
+
+def turns_dir(node: str, name: str) -> Path:
+    return agent_dir(node, name) / "turns"
+
+
+def turn_capture_stamp() -> str:
+    """Filesystem-safe, time-sortable stamp for a turn-capture filename."""
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+
+
+def list_turn_captures(node: str, name: str) -> list[Path]:
+    d = turns_dir(node, name)
+    if not d.is_dir():
+        return []
+    return sorted(f for f in d.iterdir() if f.is_file() and f.name.endswith(".md"))
+
+
+def write_turn_capture(node: str, name: str, stamp: str, thread: str, content: str) -> Path:
+    """Write one turn-capture file and prune the member's turns/ dir to the
+    most recent TURN_RETENTION. The filename sorts by time; the thread (or
+    'batch' when a turn drained several threads) makes it identifiable."""
+    d = turns_dir(node, name)
+    d.mkdir(parents=True, exist_ok=True)
+    tag = re.sub(r"[^A-Za-z0-9_-]", "", thread) or "batch"
+    path = d / f"{stamp}-{tag}.md"
+    _atomic_write_text(path, content)
+    for stale in list_turn_captures(node, name)[:-TURN_RETENTION]:
+        try:
+            stale.unlink()
+        except OSError:
+            pass
+    return path
 
 
 # ---------- dead letters ----------

--- a/apps/r4t/tests/test_logs.py
+++ b/apps/r4t/tests/test_logs.py
@@ -50,3 +50,70 @@ def test_no_log_yet(r4t_home, capsys):
     assert run_logs() == 0
     err = capsys.readouterr().err
     assert "no log yet" in err
+
+
+def seed_two():
+    state.append_log(NODE, "## 2026-07-11T10:00:00Z dispatch gerry -> Phil (task 01X hop 1, rig junior-dev)")
+    state.append_log(NODE, "### Output (Phil, exit 0 in 2.0s)")
+    state.append_log(NODE, "r4t: RESTING gerry — resting (member budget 0)")
+    state.append_log(NODE, "r4t: RELEASED-internal acme:phil -> acme:gerry thread=01X hop=2")
+
+
+def test_agent_filters_to_one_member(r4t_home, repo, capsys):
+    state.stamp_root(NODE, repo)
+    seed_two()
+    assert run_logs("--agent", "phil") == 0
+    out = capsys.readouterr().out
+    assert "done: Phil, exit 0 in 2.0s" in out
+    assert "acme:phil -> acme:gerry" in out
+    assert "RESTING gerry" not in out
+
+
+def test_agent_excludes_other_members(r4t_home, repo, capsys):
+    state.stamp_root(NODE, repo)
+    seed_two()
+    assert run_logs("--agent", "gerry") == 0
+    out = capsys.readouterr().out
+    assert "RESTING gerry" in out
+    assert "done: Phil" not in out
+
+
+def test_agent_is_case_insensitive(r4t_home, repo, capsys):
+    state.stamp_root(NODE, repo)
+    seed_two()
+    assert run_logs("--agent", "PHIL") == 0
+    assert "done: Phil" in capsys.readouterr().out
+
+
+def test_agent_unknown_member_errors(r4t_home, repo, capsys):
+    state.stamp_root(NODE, repo)
+    seed_two()
+    assert run_logs("--agent", "nobody") == 2
+    err = capsys.readouterr().err
+    assert "no team member named 'nobody'" in err
+    assert "Phil" in err and "Gerry" in err
+    assert "(try:" in err
+
+
+def test_agent_full_prints_captured_turns_newest_last(r4t_home, repo, capsys):
+    state.stamp_root(NODE, repo)
+    state.write_turn_capture(
+        NODE, "phil", "00000000000000000001", "01X",
+        "# turn one\n\n## Prompt\n\nFIRST PROMPT\n\n## Output\n\nFIRST OUTPUT\n",
+    )
+    state.write_turn_capture(
+        NODE, "phil", "00000000000000000002", "02Y",
+        "# turn two\n\n## Prompt\n\nSECOND PROMPT\n\n## Output\n\nSECOND OUTPUT\n",
+    )
+    assert run_logs("--agent", "phil", "--full") == 0
+    out = capsys.readouterr().out
+    assert "FIRST PROMPT" in out and "SECOND OUTPUT" in out
+    assert "=====" in out
+    # Newest last: turn two appears after turn one.
+    assert out.index("FIRST PROMPT") < out.index("SECOND PROMPT")
+
+
+def test_agent_full_no_turns_yet(r4t_home, repo, capsys):
+    state.stamp_root(NODE, repo)
+    assert run_logs("--agent", "phil", "--full") == 0
+    assert "no captured turns yet" in capsys.readouterr().err

--- a/apps/r4t/tests/test_turn_capture.py
+++ b/apps/r4t/tests/test_turn_capture.py
@@ -1,0 +1,71 @@
+"""Per-member turn capture — one markdown file per turn under agents/<m>/turns/."""
+from __future__ import annotations
+
+import state
+from dispatch import drain, handle_message, run_harness
+
+NODE = "acme"
+
+
+def run_one(ctx, sender, to, message, run_fn=run_harness):
+    handle_message(ctx, sender, to, message, run_fn=run_fn, drain_after=False)
+    return drain(ctx, run_fn=run_fn)
+
+
+def timeout_run(rig, prompt, cwd, *, env=None, variant=0):
+    return 0, "partial output before the hang", 0.05, True
+
+
+def captures(name="phil"):
+    return state.list_turn_captures(NODE, name)
+
+
+def test_success_captures_prompt_and_output_verbatim(ctx, fake_harness):
+    handle_message(ctx, "acme:gerry", "acme:phil", "please build the widget")
+    files = captures()
+    assert len(files) == 1
+    text = files[0].read_text(encoding="utf-8")
+    assert "## Prompt" in text
+    assert "## Output" in text
+    # Prompt is captured verbatim: persona and the inbound body both survive.
+    assert "Grumpy, cynical veteran" in text
+    assert "please build the widget" in text
+    # Raw harness stdout is captured pre-cleaning.
+    assert "fake harness ran" in text
+    assert "- exit: 0" in text
+    assert "- timed_out: false" in text
+    assert "- rig: junior-dev" in text
+
+
+def test_timeout_is_captured_with_partial_output(ctx, fake_harness):
+    assert run_one(ctx, "acme:gerry", "acme:phil", "hang please", run_fn=timeout_run) == 1
+    files = captures()
+    assert len(files) == 1
+    text = files[0].read_text(encoding="utf-8")
+    assert "- timed_out: true" in text
+    assert "partial output before the hang" in text
+
+
+def test_retention_prunes_to_fifty(r4t_home):
+    for i in range(state.TURN_RETENTION + 5):
+        state.write_turn_capture(
+            NODE, "phil", f"{i:020d}", "01X", f"# turn {i}\n\n## Prompt\n\np{i}\n"
+        )
+    files = captures()
+    assert len(files) == state.TURN_RETENTION
+    # Newest kept, oldest five pruned.
+    assert files[0].name.startswith(f"{5:020d}")
+    assert files[-1].name.startswith(f"{state.TURN_RETENTION + 4:020d}")
+
+
+def test_capture_failure_only_warns(ctx, fake_harness, monkeypatch):
+    def boom(*a, **k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(state, "write_turn_capture", boom)
+    # The turn must still complete despite the capture write failing.
+    handle_message(ctx, "acme:gerry", "acme:phil", "carry on")
+    log = "".join(
+        f.read_text(encoding="utf-8") for f in (state.team_dir(NODE) / "log").glob("*.md")
+    )
+    assert "WARN turn capture" in log


### PR DESCRIPTION
Closes #199.

## What it does

**Turn capture.** Dispatch now persists every turn — the full assembled prompt and the full raw harness output, successes and timeouts alike — as one markdown file per turn under `agents/<member>/turns/` (stamp, threads, exit, duration, timed_out, rig, then `## Prompt` and `## Output` verbatim). Each member's dir is pruned to the most recent 50 on write; day logs and #159 own long-term retention. The capture write is defensively wrapped: an IOError logs a warning and the turn proceeds — observability must never take down dispatch.

**`r4t logs <node> --agent <member>`** filters the log surface to one member. Default: their compact events from the team day log. `--full`: their captured turns, newest last, each delimited by a filename banner. `-f`: follow, filtered. Member name is case-insensitive and validated against the roster; an unknown name is an action-first error listing the roster with a `(try:)` hint.

Motivation in one line: Rook's agy turn succeeded but he reasoned himself into prose instead of `tell` — only diagnosable because his live.log happened to still hold that turn.

## Example commands

```bash
r4t logs d5n --agent rook            # rook's events from the day log
r4t logs d5n --agent rook --full     # his captured turns: prompt + raw output, newest last
r4t logs d5n --agent rook -f         # follow, filtered to rook
```

## Tests

- Capture on success and on timeout, prompt + output verbatim, retention prune at >50, capture-failure-only-warns
- `logs --agent` filtering (include/exclude/case-insensitive), unknown-member error, `--full` turn rendering, empty-turns notice
- Full suites: r4t 464 passed, a8s 648 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)