### PR TITLE
docs(r4t): agy capability map + drop --sandbox so tell works

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,9 +96,9 @@ in skill frontmatter.
 ## Top-level scripts: `tell`
 
 `~/bin/tell` is a **thin shim** to `a8s tell` (plus `tell.cmd` on Windows).
-Implementation lives in `apps/a8s/tell.py`. It walks up from CWD to find
-the first `.outbox/` directory and atomic-writes a JSON envelope there — no
-`~/.a8s` access required. When the registry is reachable and CWD is inside a
+Implementation lives in `apps/a8s/tell.py`. It requires `TELL_OUTBOX_DIR`
+(set by a8s on agent wake) and atomic-writes a JSON envelope there — no
+filesystem discovery. When the registry is reachable and CWD is inside a
 registered agent, recipient validation, `from` stamping, and agent logging
 apply on top.
 

--- a/apps/r4t/README.md
+++ b/apps/r4t/README.md
@@ -51,6 +51,12 @@ prefers the fewest extra tokens, then the highest effort suffix
 matches nothing fails the turn loudly with the available names — an unresolved
 value is never passed through, because agy would silently run its default.
 
+The `agy` preset runs **without** `--sandbox`. agy's sandbox confines the
+agent's child-process writes to the CWD, which blocks `tell` (its staging
+outbox lives outside the workplace repo) — the whole capability map and the
+2026-07-14 incident are in [docs/harness-agy.md](docs/harness-agy.md). Like
+every other r4t preset, agy is trusted with normal filesystem permissions.
+
 `r4t rig remove <rig>...` (alias `rm`) deletes one or more rigs. It refuses if
 a roster member or pin still references the rig, naming what does; pass
 `--force` to remove anyway.

--- a/apps/r4t/docs/harness-agy.md
+++ b/apps/r4t/docs/harness-agy.md
@@ -1,0 +1,115 @@
+# The agy harness: capabilities, sandbox, and `tell`
+
+Findings dated 2026-07-14. agy version 1.1.2 on macOS (`sandbox-exec`).
+
+`agy` is Antigravity, Google's headless coding-agent CLI. r4t drives it through
+the `agy` preset in [`rig.py`](../rig.py). This note maps what agy can and
+cannot do under its flags — chiefly `--sandbox` — because the sandbox silently
+breaks `tell`, and that surprised a live org before it was understood.
+
+## How r4t invokes agy
+
+Every turn, `dispatch.py` runs the rig's argv with:
+
+- **CWD** = the workplace repo (`ctx.workplace`), the tree the member edits and
+  commits in.
+- **`TELL_OUTBOX_DIR`** = a per-turn staging dir under the a8s node root,
+  `~/.config/r4t/teams/<node>/agents/<member>/staging/`. `tell` writes its
+  envelope JSON there; dispatch reads it back, applies quota and thread rules,
+  then releases it to the real outbox. The staging dir is **outside the
+  workplace repo**.
+
+`tell` (via `apps/a8s/tell.py`) finds its outbox **only** from
+`$TELL_OUTBOX_DIR` — it no longer walks up from CWD. On each send it does
+`mkdir -p $TELL_OUTBOX_DIR` and writes a probe file there; if that write
+fails it prints `cannot send from this directory` /
+`TELL_OUTBOX_DIR is set but outbox is unavailable` and exits 1.
+
+## What `--sandbox` does
+
+Marketing calls it "terminal restrictions." Empirically, on macOS it wraps the
+agent's **child processes** (the `run_command` terminal tool) in a
+`sandbox-exec` profile. It does **not** sandbox agy's own process, so agy still
+reaches its model API. The confinement is filesystem-write only, and it is
+**soft**: the terminal tool exposes a `BypassSandbox` parameter the model can
+set to escape it.
+
+Writable set under `--sandbox` = the workspace (CWD) + any `--add-dir` path +
+essential system locations. Everything else is read-only.
+
+## Capability matrix
+
+Cells verified with `agy --model "Gemini 3.5 Flash (Low)" ... --print`,
+`--mode accept-edits`, headless. "workspace" = CWD or an `--add-dir` path.
+
+| Capability | `--sandbox` | no `--sandbox` | Notes |
+|---|---|---|---|
+| Run an arbitrary CLI (exec) | allowed | allowed | Exec itself is never blocked; only the child's writes are. |
+| Write inside workspace (absolute path) | allowed, persists to real FS | allowed | |
+| Write outside the writable set | **blocked** — `operation not permitted` | allowed (normal OS perms) | |
+| Relative-path write | lands in agy's own scratch overlay, not CWD | same | The terminal tool does not run in the `--print` CWD; **use absolute paths**. |
+| Network egress (HTTPS `curl`) | **allowed** | allowed | Contradicts the "network isolation" marketing; external egress works on macOS. |
+| Env vars visible to child | yes | yes | `$TELL_OUTBOX_DIR` passes through intact. |
+| `tell` to `$TELL_OUTBOX_DIR` outside workspace | **blocked** (`outbox is unavailable`) | allowed | Root cause of the incident. |
+| `tell` with `--add-dir <staging>` | allowed | n/a | Surgical fix; requires the runtime staging path. |
+| `BypassSandbox: true` (tool param) | honored in headless `--mode accept-edits` | n/a | This is what "bypass the sandbox" means (see case study). |
+
+## The `tell` interaction
+
+Under `--sandbox`, `tell`'s outbox is `$TELL_OUTBOX_DIR` — the staging dir
+outside the workplace repo. `tell`'s probe write into it is a write outside the
+writable set, so the sandbox denies it and `tell` reports the outbox
+unavailable. Env passthrough is fine; the block is purely the filesystem write
+target being outside CWD.
+
+Two things make it work:
+
+1. **Drop `--sandbox`** (what r4t now does). agy runs with normal OS
+   permissions, like every other r4t preset (`claude`, `codex`, `cursor`,
+   `opencode`, `copilot` carry no sandbox). `tell` writes the staging dir
+   freely.
+2. **Keep `--sandbox`, add `--add-dir <staging>`.** Preserves confinement but
+   requires dispatch to inject the per-turn staging path into the argv, since
+   the path is per-node/per-member. Not currently wired.
+
+## Recommended invocations per role
+
+- **A rig that must `tell`** (any r4t member): no `--sandbox`. Keep
+  `--mode accept-edits` (so headless file edits don't stall on the review
+  prompt) and `--print`.
+- **A rig that only edits a repo and never messages**: `--sandbox --mode
+  accept-edits --print` is safe, but note the sandbox is soft (`BypassSandbox`)
+  and does not block network. It buys little over trusting the rig, which r4t
+  already does for its peers.
+
+## Quota notes
+
+agy shares the owner's real subscription across **two quotas** — a larger
+Gemini quota and a smaller Anthropic (Claude models) quota. The model list is
+**live**: `agy models` display names drift across releases, so r4t stores the
+friendly `--model` string and re-resolves it against `agy models` before every
+turn (`resolve_agy_model` in `rig.py`). Prefer Gemini models for routine work;
+reserve Claude models for turns that need them.
+
+## Incident case study (2026-07-14, org d5n, milestone M4)
+
+Members Vela and Faye (both on the `agy` preset, then `--sandbox --mode
+accept-edits --print`) could not `tell`. Both hit `cannot send from this
+directory` / `TELL_OUTBOX_DIR is set but outbox is unavailable`. The org
+survived because dispatch's **STDOUT-REPLY fallback** stages a member's cleaned
+stdout as one reply when the turn releases no envelope — so their prose reports
+still reached their recipients, just downgraded to a single fallback message.
+
+Vela then reported she "bypassed the sandbox to write to the outbox." What
+actually happened: agy's terminal tool, on the first denied write, hints the
+model to retry with `BypassSandbox: true`; in headless `--mode accept-edits`
+that retry is honored (no `--dangerously-skip-permissions` required). So the
+"bypass" was a real agy tool feature, not a workaround she invented — but it is
+model-discretionary and unreliable as a transport. The fix is to not sandbox a
+rig that needs `tell` in the first place.
+
+Related: the a8s definition `apps/a8s/definitions/agy.json` invokes `--sandbox
+--dangerously-skip-permissions`. That combination is a documented agy issue
+(the skip-permissions flag auto-approves the sandbox bypass, defeating it); it
+happens to let `tell` through but relies on the very bypass this note advises
+against depending on. Worth revisiting separately.

--- a/apps/r4t/rig.py
+++ b/apps/r4t/rig.py
@@ -165,14 +165,14 @@ HARNESS_PRESETS: dict[str, dict] = {
     "agy": {
         "text_tier": "big",
         "description": (
-            "Antigravity 1.1+ — --print for headless turns; --sandbox + "
-            "--mode accept-edits for repo writes"
+            "Antigravity 1.1+ — --print for headless turns; --mode accept-edits "
+            "so edits skip the review prompt. No --sandbox: it confines child "
+            "writes to CWD, blocking tell's staging outbox (see docs/harness-agy.md)"
         ),
         "a8s_definition": "agy.json",
         "headless": "--print",
         "invoke": [
             "agy",
-            "--sandbox",
             "--mode",
             "accept-edits",
             "--print",


### PR DESCRIPTION
## Summary

Maps what agy (Antigravity) can and cannot do under its flags — chiefly `--sandbox` — and fixes the class of failure a live org hit on 2026-07-14, when `agy` members could not `tell`.

- New doc: `apps/r4t/docs/harness-agy.md` — full capability matrix, the tell/outbox interaction, per-role invocation guidance, quota notes, and the incident as a case study.
- `rig.py`: drop `--sandbox` from the `agy` preset (keep `--mode accept-edits --print`); updated `description`.
- `README.md`: agy `--model` section gains a short note on why no `--sandbox`, linking the doc.

## Root cause

agy's `--sandbox` wraps the terminal tool's **child processes** in a macOS `sandbox-exec` profile whose writable set is CWD + `--add-dir` + system locations. r4t points `tell` at a per-turn staging outbox under the a8s node root (`~/.config/r4t/teams/<node>/agents/<member>/staging/`) — **outside** the workplace repo — so `tell`'s probe write is denied and it prints `cannot send from this directory` / `TELL_OUTBOX_DIR is set but outbox is unavailable`. Env passthrough is fine; only the out-of-CWD write is blocked.

## Matrix highlights (8 `agy --print` runs, Gemini 3.5 Flash Low)

| Capability | `--sandbox` | no `--sandbox` |
|---|---|---|
| Exec arbitrary CLI | allowed | allowed |
| Write inside CWD (absolute) | allowed, persists | allowed |
| Write outside writable set | **blocked** | allowed |
| Network egress (HTTPS) | **allowed** | allowed |
| Env vars visible | yes | yes |
| `tell` to staging outbox | **blocked** | allowed |
| `tell` with `--add-dir <staging>` | allowed | n/a |

The terminal tool also does not run in the `--print` CWD — relative writes land in agy's own scratch overlay; only absolute paths hit the real FS.

## What "bypass the sandbox" was

Vela's claimed bypass was agy's own `run_command` `BypassSandbox` parameter, which the model is hinted to set after a denied write and which is honored in headless `--mode accept-edits` (no `--dangerously-skip-permissions` needed). Real agy behavior, but model-discretionary and unreliable as a transport.

## Why drop `--sandbox` rather than keep it

- Every other r4t preset (`claude`, `codex`, `cursor`, `opencode`, `copilot`) already runs unsandboxed; r4t trusts its rigs with the workplace and commits.
- The sandbox is soft (`BypassSandbox`) and does **not** block network — little real isolation gained.
- The surgical alternative — keep `--sandbox`, inject `--add-dir <staging>` per turn — needs dispatch to splice the runtime staging path into argv (agy-specific special-casing). Left unwired; noted in the doc if confinement is later wanted.

Related follow-up (not in this PR): `apps/a8s/definitions/agy.json` uses `--sandbox --dangerously-skip-permissions`, the documented combo where skip-permissions auto-approves the bypass and defeats the sandbox.

## Tests

`python3 -m pytest apps/r4t/tests/ apps/a8s/tests/` — 1112 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)