### PR TITLE
feat(r4t): the verification round — check sweep + doorbell gate (#202)

### DIFF
--- a/apps/r4t/README.md
+++ b/apps/r4t/README.md
@@ -323,6 +323,21 @@ config without a `repo` key is an in-repo org that just wants settings.
 | `comms` | `open` | `open` delivers a tell to any valid member (learned addresses); `closed` reroutes non-adjacent tells through the sender's lead |
 | `leader_sees_lateral` | `false` | when `true`, a lateral (peer) delivery lands a read-only copy in the lead's history — no turn burned |
 | `egress` | `true` | only the topmost leader may message outside the garden; a non-top member's external tell redirects up to it. `false` keeps the org silent outward |
+| `doorbell_check` | *absent* | a shell command that gates every ring of an absent human's doorbell (see below); absent or empty means no gate |
+
+## The verification round
+
+An agent cannot be the judge of its own deliverable, so the judge is machinery it cannot see into.
+
+`r4t check <node>` sweeps the tracked files in the node's workplace for forbidden patterns and prints exactly `check passed` or `check failed: N finding(s)` — nothing else.
+
+The findings (which file, which line, which pattern) go to stderr, the surface only the human reads; the agent gets an opaque verdict it cannot game.
+
+Patterns are one Python regex per line in `~/.config/r4t/checklists/default.txt` (every node) and `~/.config/r4t/checklists/<node>.txt` (per-node additions); `#` comments and blank lines are ignored, and no checklist at all is a pass.
+
+These files live outside every repo, uncommitted, because they may carry private strings like a codename (e.g. `secret-codename`) or a name.
+
+Set `doorbell_check` in `r4t-org.json` to run any command — the sweep or a test suite — before the org may ring an absent human, and a failing check parks the message without ringing rather than losing it.
 
 ## Governance knobs
 

--- a/apps/r4t/check.py
+++ b/apps/r4t/check.py
@@ -1,0 +1,117 @@
+"""Forbidden-pattern sweep — the 'bones' of the verification round.
+
+Playtest verification (eyes) and a pattern sweep (bones) catch disjoint
+failure classes: eyes confirm behavior, bones catch literal escapes and
+self-certification phrases the eyes glide past. This module is the bones.
+
+Patterns live OUTSIDE every repo (machine-global, uncommitted, may carry
+private strings): `default.txt` applies to every node, `<node>.txt` adds
+per-node lines. One Python regex per line; `#` comments and blank lines are
+ignored; case-sensitivity is the author's business via inline `(?i)`.
+
+Information asymmetry is the design: the caller gets an opaque pass/fail on
+stdout, and the detail (which pattern, which file, which line) goes to stderr
+where only the human reads it. An agent cannot game a check whose findings it
+cannot see.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import state
+
+
+class CheckError(Exception):
+    """Operational failure (exit 2): a malformed pattern or an unreadable
+    workplace. Distinct from findings (exit 1) and a clean pass (exit 0)."""
+
+
+def checklists_dir() -> Path:
+    return state.r4t_home() / "checklists"
+
+
+def load_patterns(node: str) -> list[tuple[str, re.Pattern[str]]]:
+    """Compile `default.txt` + `<node>.txt` into (source, compiled) pairs.
+    Raises CheckError naming the file and line on the first malformed regex or
+    unreadable checklist."""
+    base = checklists_dir()
+    compiled: list[tuple[str, re.Pattern[str]]] = []
+    for path in (base / "default.txt", base / f"{node}.txt"):
+        if not path.is_file():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as e:
+            raise CheckError(f"{path}: cannot read checklist: {e}") from e
+        for lineno, raw in enumerate(text.splitlines(), 1):
+            pattern = raw.strip()
+            if not pattern or pattern.startswith("#"):
+                continue
+            try:
+                compiled.append((pattern, re.compile(pattern)))
+            except re.error as e:
+                raise CheckError(f"{path}:{lineno}: bad regex: {e}") from e
+    return compiled
+
+
+def sweep(
+    workplace: Path, patterns: list[tuple[str, re.Pattern[str]]]
+) -> list[tuple[str, int, str]]:
+    """Every pattern against every line of every tracked text file. Returns
+    (path, lineno, pattern) findings. Undecodable files (binaries) are skipped
+    silently. Raises CheckError if `git ls-files` cannot run."""
+    try:
+        listing = subprocess.run(
+            ["git", "ls-files"],
+            cwd=str(workplace),
+            capture_output=True,
+            text=True,
+        )
+    except OSError as e:
+        raise CheckError(f"cannot list files in {workplace}: {e}") from e
+    if listing.returncode != 0:
+        raise CheckError(
+            f"git ls-files failed in {workplace}: {listing.stderr.strip()}"
+        )
+    findings: list[tuple[str, int, str]] = []
+    for rel in listing.stdout.splitlines():
+        if not rel:
+            continue
+        try:
+            text = (workplace / rel).read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for lineno, line in enumerate(text.splitlines(), 1):
+            for source, pattern in patterns:
+                if pattern.search(line):
+                    findings.append((rel, lineno, source))
+    return findings
+
+
+def run(node: str, workplace: Path, *, out=sys.stdout, err=sys.stderr) -> int:
+    """The `r4t check` body. stdout carries exactly the opaque verdict; stderr
+    carries the findings and operational notes. Returns the exit code."""
+    try:
+        patterns = load_patterns(node)
+    except CheckError as e:
+        print(str(e), file=err)
+        return 2
+    if not patterns:
+        print("no checklists configured", file=err)
+        print("check passed", file=out)
+        return 0
+    try:
+        findings = sweep(workplace, patterns)
+    except CheckError as e:
+        print(str(e), file=err)
+        return 2
+    if not findings:
+        print("check passed", file=out)
+        return 0
+    for rel, lineno, source in findings:
+        print(f"{rel}:{lineno}: {source}", file=err)
+    print(f"check failed: {len(findings)} finding(s)", file=out)
+    return 1

--- a/apps/r4t/dispatch.py
+++ b/apps/r4t/dispatch.py
@@ -150,6 +150,7 @@ class DispatchContext:
     comms: str = "open"
     leader_sees_lateral: bool = False
     egress: bool = True
+    doorbell_check: str | None = None
     definition_path: Path | None = None
 
     def __post_init__(self) -> None:
@@ -291,18 +292,87 @@ def _tell_error(
     ctx.tell_fn(recipient, f"[r4t {ctx.node}] {text}")
 
 
-def _park_seat(ctx: DispatchContext, member: Member, sender: str, body: str) -> None:
+DOORBELL_CHECK_TIMEOUT = 120
+
+
+def _run_doorbell_check(ctx: DispatchContext, command: str) -> tuple[bool, str, list[str]]:
+    """Run the org's `doorbell_check` before a ring. Returns
+    (ring_ok, sender_reason, log_lines). A nonzero exit reports the check's
+    first stdout line to the sender and its stderr to the node log; a timeout or
+    exec failure fails CLOSED — a broken gate must never become a silently
+    broken doorbell."""
+    env = dict(os.environ, R4T_NODE=ctx.node)
+    try:
+        proc = subprocess.run(
+            command,
+            shell=True,
+            cwd=str(ctx.workplace),
+            capture_output=True,
+            text=True,
+            timeout=DOORBELL_CHECK_TIMEOUT,
+            env=env,
+        )
+    except subprocess.TimeoutExpired:
+        return False, "check did not complete", [
+            f"check timed out after {DOORBELL_CHECK_TIMEOUT}s: {command}"
+        ]
+    except OSError as e:
+        return False, "check did not complete", [f"check failed to run: {e}"]
+    if proc.returncode == 0:
+        return True, "", []
+    stdout_lines = proc.stdout.strip().splitlines()
+    reason = stdout_lines[0] if stdout_lines else "check failed"
+    return False, reason, [l for l in proc.stderr.splitlines() if l.strip()]
+
+
+def _park_seat(
+    ctx: DispatchContext,
+    member: Member,
+    sender: str,
+    body: str,
+    *,
+    thread: str | None = None,
+    roster: Roster | None = None,
+) -> None:
     """Deliver a message to a roster human: park it in the node's seat
     mailbox, and ring the `Address:` doorbell (a forwarded copy over a8s)
-    only when no seat session is attached to read it live."""
+    only when no seat session is attached to read it live. When the org sets a
+    `doorbell_check`, that command gates the ring — the message is always parked
+    first (seat mail is never lost), and a failing gate suppresses only the
+    ring and replies to the sender with an error."""
     state.park_seat_message(ctx.node, member.name, sender, body)
-    bell = ""
-    if member.address and not state.seat_attached(ctx.node, member.name):
-        ctx.tell_fn(member.address, body)
-        bell = f", doorbell -> {member.address}"
+    if not (member.address and not state.seat_attached(ctx.node, member.name)):
+        state.append_log(
+            ctx.node, f"r4t: SEAT {member.name.lower()} <- {sender} (parked)"
+        )
+        return
+    command = (ctx.doorbell_check or "").strip()
+    if command:
+        ring_ok, reason, log_lines = _run_doorbell_check(ctx, command)
+        if not ring_ok:
+            for line in log_lines:
+                state.append_log(ctx.node, f"r4t: GATE {ctx.node} {line}")
+            state.append_log(
+                ctx.node,
+                f"r4t: GATE {ctx.node} doorbell BLOCKED for "
+                f"{member.name.lower()}: {reason}",
+            )
+            _tell_error(
+                ctx, sender, f"seat unreachable: {reason}",
+                thread=thread, roster=roster,
+            )
+            state.append_log(
+                ctx.node,
+                f"r4t: SEAT {member.name.lower()} <- {sender} "
+                "(parked, doorbell blocked by gate)",
+            )
+            return
+        state.append_log(ctx.node, f"r4t: GATE {ctx.node} passed")
+    ctx.tell_fn(member.address, body)
     state.append_log(
         ctx.node,
-        f"r4t: SEAT {member.name.lower()} <- {sender} (parked{bell})",
+        f"r4t: SEAT {member.name.lower()} <- {sender} "
+        f"(parked, doorbell -> {member.address})",
     )
 
 
@@ -605,7 +675,7 @@ def _ingest(
             return DEAD
 
     if member.is_human:
-        _park_seat(ctx, member, sender, body)
+        _park_seat(ctx, member, sender, body, thread=thread, roster=roster)
         return SKIPPED
 
     if member.errors:

--- a/apps/r4t/org.py
+++ b/apps/r4t/org.py
@@ -32,6 +32,10 @@ home — this file is the org-level home):
 - `egress` (bool, default `true`): when on, the topmost leader alone may
   originate external mail; when off, no member may, and external `to`s redirect
   to the top leader (the garden's single voice).
+- `doorbell_check` (string, default absent): a shell command run before the org
+  may ring an absent human's doorbell. Exit 0 lets the ring through; nonzero
+  parks the message without ringing (the gate protects attention, not the
+  mailbox). Absent or empty is today's behavior — no gate.
 
 Graduation is trivial: copy ROSTER.md + MISSION.md into the repo and drop the
 `repo` key (or the whole file, if it carries no settings). Resolution falls
@@ -61,6 +65,7 @@ class Org:
     comms: str = COMMS_OPEN
     leader_sees_lateral: bool = False
     egress: bool = True
+    doorbell_check: str | None = None
 
     @property
     def is_portable(self) -> bool:
@@ -102,6 +107,14 @@ def _parse_bool(raw: object, default: bool, key: str) -> tuple[bool, str | None]
     return raw, None
 
 
+def _parse_str(raw: object, key: str) -> tuple[str | None, str | None]:
+    if raw is None:
+        return None, None
+    if not isinstance(raw, str):
+        return None, f'org config "{key}" must be a string (got {raw!r})'
+    return raw, None
+
+
 def _parse_settings(data: dict) -> tuple[dict, list[str]]:
     errors: list[str] = []
     comms = data.get("comms", COMMS_OPEN)
@@ -114,7 +127,15 @@ def _parse_settings(data: dict) -> tuple[dict, list[str]]:
     egress, err = _parse_bool(data.get("egress"), True, "egress")
     if err:
         errors.append(err)
-    return {"comms": comms, "leader_sees_lateral": lsl, "egress": egress}, errors
+    doorbell_check, err = _parse_str(data.get("doorbell_check"), "doorbell_check")
+    if err:
+        errors.append(err)
+    return {
+        "comms": comms,
+        "leader_sees_lateral": lsl,
+        "egress": egress,
+        "doorbell_check": doorbell_check,
+    }, errors
 
 
 def load_org(root: Path) -> Org:

--- a/apps/r4t/plans/VERIFY-SPEC.md
+++ b/apps/r4t/plans/VERIFY-SPEC.md
@@ -1,0 +1,149 @@
+# The verification round — implementation spec
+
+*2026-07-14. Follows the d5n M4 experiment (experiments/d5n-m4/) and Neil's
+ruling after the bless: structural verification and pattern sweeps catch
+disjoint failure classes. The runner's real-key playtest PASSED M4 while two
+lines of regex would have caught the literal `\n\n` the milestone shipped
+with. One issue, one implementation PR, spec first (this doc). Style follows
+[COMMS-SPEC.md](COMMS-SPEC.md); every open question is resolved inline
+(marked DECIDED).*
+
+*Scope: `apps/r4t/` only. Pre-v1 scorch-the-earth — no migration code; an
+org without the new setting behaves exactly as today.*
+
+---
+
+## 1. Background and the through-line
+
+Three findings from the d5n run drive this:
+
+- **Bones vs eyes.** Independent playtest verification (eyes) confirmed M4's
+  navigation worked; it did not notice literal `\n\n` rendering in the text.
+  A forbidden-pattern sweep (bones) would have. Neither replaces the other;
+  the round needs both, and the bones are cheap enough to run on every
+  human-bound escalation.
+- **Self-certification.** The org described a 0.29-second smoke test as
+  "perfectly validated." Agents cannot be the judge of their own
+  deliverables; the judge must be machinery the org cannot see into.
+- **Information asymmetry is the design.** Agents get an opaque pass/fail on
+  stdout; the detail (which pattern, which file) goes to stderr and lands
+  only in surfaces the human reads. Agents cannot game tests they cannot
+  see, and the human can spot a broken test from the detail.
+
+Two features deliver the round: a forbidden-pattern sweep CLI (`r4t check`)
+and a doorbell gate that runs a configured check command before the org can
+ring the human. The sweep is the first such command; the gate accepts any
+CLI, so future checks (test suites, linters, form validators) slot in
+without touching dispatch again.
+
+## 2. Feature A — `r4t check <node>`: the forbidden-pattern sweep
+
+### Pattern files
+
+Patterns live OUTSIDE every repo, in the machine-global config dir:
+
+- `~/.config/r4t/checklists/default.txt` — applies to every node
+- `~/.config/r4t/checklists/<node>.txt` — per-node additions (optional)
+
+Both are applied when present. Format: one Python regex per line, `#`
+comments and blank lines ignored. Case-sensitivity is the author's business
+via inline `(?i)`. DECIDED: no name/tab/severity columns — a line is a
+regex, nothing else. A malformed regex is an operational error (exit 2,
+message on stderr naming the file and line), not a silent skip.
+
+The files are intentionally uncommitted and may contain private strings
+(the human's name, project codewords). A sync mechanism from a GitHub
+secret (pii-check style) is a follow-up, NOT in this PR. This PR documents
+the file location and format only; docs use placeholder patterns, never
+real private strings.
+
+DECIDED: no pattern files at all → the sweep passes with a note on stderr
+(`no checklists configured`). The gate is opt-in by configuration presence.
+
+### Sweep target
+
+Tracked files in the node's org workplace repo: `git ls-files` run in
+`org.workplace` (resolve the node the same way other node-scoped commands
+do). Each file is read as UTF-8 text; files that fail to decode are skipped
+silently (binaries). Every pattern is tested against every line.
+
+### Output contract
+
+- **stdout** (the agent-visible surface): exactly one line —
+  `check passed` or `check failed: N finding(s)`. Nothing else, ever.
+- **stderr** (the human-visible surface): one line per finding —
+  `<path>:<line>: <pattern>` — plus operational notes.
+- **exit**: 0 pass, 1 findings, 2 operational error (unknown node,
+  unreadable workplace, malformed regex).
+
+### Seed patterns (documented for Neil to install locally, not shipped)
+
+- `\\n` — literal backslash-n in committed text (the M4 escape bug)
+- the human's name in produced docs/code
+- self-certification phrases (`(?i)blessed by`, `(?i)perfectly validated`)
+
+## 3. Feature B — the doorbell gate
+
+### Setting
+
+`r4t-org.json` gains one org setting alongside `comms` / `egress` /
+`leader_sees_lateral`:
+
+- `doorbell_check` (string, default absent): a shell command. Absent or
+  empty → no gate; today's behavior exactly.
+
+Parsed in `org._parse_settings` (must be a string; anything else is a
+config error that degrades to absent, same pattern as the booleans).
+For d5n the value will be `r4t check d5n` — the setting is verbatim; no
+magic node substitution. The command runs with `cwd=org.workplace` and
+`R4T_NODE=<node>` in the environment for commands that want it.
+
+### Gate semantics (in `dispatch._park_seat`)
+
+The gate wraps the RING only. Today `_park_seat` parks the message and
+rings `Address:` when no seat session is attached. With a `doorbell_check`
+configured, before ringing:
+
+1. Run the command (shell, `cwd=org.workplace`, timeout 120s).
+2. **Exit 0** → ring as today. Log `r4t: GATE <node> passed` to the node log.
+3. **Nonzero exit** → do NOT ring. The message still PARKS — seat mail is
+   never lost; the gate protects the human's attention, not the mailbox.
+   The sender receives an error-class reply (same channel as `_tell_error`
+   structured errors): `seat unreachable: <first line of check stdout>`.
+   The check's stderr is appended to the node log, line-prefixed
+   `r4t: GATE <node>`, so `r4t logs` shows the human the detail.
+4. **Timeout or exec failure** → fail closed: no ring, park, sender gets
+   `seat unreachable: check did not complete`, loud log line. DECIDED:
+   a broken gate must not become a broken doorbell silently — the log
+   line is the human's signal to fix the check.
+
+DECIDED: when a seat session IS attached, no ring happens today and the
+gate does not run — the human is present and reads parked mail live. The
+gate governs escalation to an absent human only.
+
+DECIDED: the gate applies to every doorbell ring (all human-bound
+escalations), not just milestone/bless requests — dispatch cannot classify
+intent and must not try. Cheap checks make this affordable.
+
+## 4. Non-goals (round two and later)
+
+- Doorbell FORMS (structured escalation with per-project presets).
+- Checklist sync from a GitHub secret.
+- MISSION.md machine-checkable acceptance sections — a doc convention the
+  human starts writing by hand for M5; tooling that parses it comes after
+  the convention proves out.
+
+## 5. Tests and docs
+
+- `tests/test_check.py` (new): pattern-file parsing (comments, blanks,
+  malformed regex → exit 2), sweep over a tmp git repo (findings,
+  binary skip, clean pass), no-checklist pass, stdout opacity (assert
+  stdout carries no path/pattern text).
+- `tests/test_dispatch.py`: gate pass rings; gate fail parks without ring,
+  sender gets the error reply, node log carries stderr detail; timeout
+  fails closed; no setting → today's behavior byte-for-byte.
+- `tests/test_org.py` (or wherever settings parse is tested):
+  `doorbell_check` string accepted, non-string degrades with error.
+- README: short section on the verification round — the two surfaces
+  (stdout/stderr), the gate setting, the checklist location. One-sentence
+  user-facing style; detail stays here and in docstrings.

--- a/apps/r4t/r4t.py
+++ b/apps/r4t/r4t.py
@@ -156,6 +156,7 @@ def _context(args: argparse.Namespace, node: str) -> DispatchContext:
         comms=org.comms,
         leader_sees_lateral=org.leader_sees_lateral,
         egress=org.egress,
+        doorbell_check=org.doorbell_check,
         definition_path=(
             Path(defn).expanduser() if (defn := getattr(args, "definition", None)) else None
         ),
@@ -734,6 +735,28 @@ def cmd_logs(args: argparse.Namespace) -> int:
             time.sleep(0.5)
     except KeyboardInterrupt:
         return 0
+
+
+def cmd_check(args: argparse.Namespace) -> int:
+    node = _resolve_node(args.node)
+    if node is None:
+        return 2
+    root = _resolve_root(args.root)
+    if not getattr(args, "root", None):
+        stamped = state.read_root(node)
+        if stamped is not None and stamped.is_dir():
+            root = stamped
+    org = load_org(root)
+    if not org.workplace.is_dir():
+        print(
+            f"check: workplace {org.workplace} does not exist "
+            f"(try: r4t roster check --node {node})",
+            file=sys.stderr,
+        )
+        return 2
+    from check import run as run_check
+
+    return run_check(node, org.workplace)
 
 
 def _ensure_tell_outbox(ctx: DispatchContext) -> None:
@@ -1384,6 +1407,18 @@ def build_parser() -> argparse.ArgumentParser:
         help="Only one member's activity; with --full, their captured turns.",
     )
     logs_p.set_defaults(func=cmd_logs)
+
+    check_p = sub.add_parser(
+        "check",
+        help="Forbidden-pattern sweep: opaque pass/fail on stdout, findings on "
+        "stderr. Patterns live in ~/.config/r4t/checklists/.",
+    )
+    _add_common(check_p)
+    check_p.add_argument(
+        "node", nargs="?",
+        help="Team node name (default: sole ~/.config/r4t team).",
+    )
+    check_p.set_defaults(func=cmd_check)
 
     chat_p = sub.add_parser(
         "chat", help="Interactive human seat: messages and team activity in one window."

--- a/apps/r4t/tests/test_check.py
+++ b/apps/r4t/tests/test_check.py
@@ -1,0 +1,134 @@
+"""Forbidden-pattern sweep — parsing, sweep, and the stdout/stderr contract."""
+from __future__ import annotations
+
+import io
+import subprocess
+
+import pytest
+
+import check
+
+
+def _git_repo(root):
+    root.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    return root
+
+
+def _track(root, rel, content, *, binary=False):
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if binary:
+        path.write_bytes(content)
+    else:
+        path.write_text(content, encoding="utf-8")
+    subprocess.run(["git", "add", rel], cwd=root, check=True)
+
+
+def _checklist(home, name, text):
+    d = home / "checklists"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / name).write_text(text, encoding="utf-8")
+
+
+def _run(node, workplace):
+    out, err = io.StringIO(), io.StringIO()
+    code = check.run(node, workplace, out=out, err=err)
+    return code, out.getvalue(), err.getvalue()
+
+
+# ---------- pattern-file parsing ----------
+
+def test_comments_and_blanks_ignored(r4t_home):
+    _checklist(r4t_home, "default.txt", "# a comment\n\n   \nfoo\n")
+    patterns = check.load_patterns("acme")
+    assert [src for src, _ in patterns] == ["foo"]
+
+
+def test_per_node_file_adds_to_default(r4t_home):
+    _checklist(r4t_home, "default.txt", "foo\n")
+    _checklist(r4t_home, "acme.txt", "bar\n")
+    assert [src for src, _ in check.load_patterns("acme")] == ["foo", "bar"]
+
+
+def test_malformed_regex_is_operational_error(r4t_home, tmp_path):
+    _checklist(r4t_home, "default.txt", "good\n[unclosed\n")
+    repo = _git_repo(tmp_path / "repo")
+    code, out, err = _run("acme", repo)
+    assert code == 2
+    assert "default.txt:2" in err
+    assert out == ""
+
+
+# ---------- sweep ----------
+
+def test_findings_reported_on_stderr_only(r4t_home, tmp_path):
+    _checklist(r4t_home, "default.txt", r"\\n")
+    repo = _git_repo(tmp_path / "repo")
+    _track(repo, "doc.md", "clean line\nhas a \\n escape here\n")
+    code, out, err = _run("acme", repo)
+    assert code == 1
+    assert out == "check failed: 1 finding(s)\n"
+    assert "doc.md:2" in err
+
+
+def test_clean_repo_passes(r4t_home, tmp_path):
+    _checklist(r4t_home, "default.txt", "forbidden\n")
+    repo = _git_repo(tmp_path / "repo")
+    _track(repo, "doc.md", "nothing here\n")
+    code, out, err = _run("acme", repo)
+    assert code == 0
+    assert out == "check passed\n"
+
+
+def test_binary_files_skipped_silently(r4t_home, tmp_path):
+    _checklist(r4t_home, "default.txt", "match\n")
+    repo = _git_repo(tmp_path / "repo")
+    _track(repo, "blob.bin", b"\xff\xfe match \x00\x01", binary=True)
+    code, out, err = _run("acme", repo)
+    assert code == 0
+    assert out == "check passed\n"
+
+
+def test_untracked_files_are_not_swept(r4t_home, tmp_path):
+    _checklist(r4t_home, "default.txt", "forbidden\n")
+    repo = _git_repo(tmp_path / "repo")
+    (repo / "loose.md").write_text("forbidden here\n", encoding="utf-8")
+    code, out, err = _run("acme", repo)
+    assert code == 0
+    assert out == "check passed\n"
+
+
+def test_inline_case_flag_honored(r4t_home, tmp_path):
+    _checklist(r4t_home, "default.txt", "(?i)perfectly validated\n")
+    repo = _git_repo(tmp_path / "repo")
+    _track(repo, "report.md", "the org said it was Perfectly Validated\n")
+    code, out, err = _run("acme", repo)
+    assert code == 1
+    assert "report.md:1" in err
+
+
+# ---------- no checklists ----------
+
+def test_no_checklists_passes_with_note(r4t_home, tmp_path):
+    repo = _git_repo(tmp_path / "repo")
+    _track(repo, "doc.md", "anything\n")
+    code, out, err = _run("acme", repo)
+    assert code == 0
+    assert out == "check passed\n"
+    assert "no checklists configured" in err
+
+
+# ---------- stdout opacity ----------
+
+def test_stdout_never_leaks_path_or_pattern(r4t_home, tmp_path):
+    _checklist(r4t_home, "default.txt", "secret-codename\n")
+    repo = _git_repo(tmp_path / "repo")
+    _track(repo, "notes.md", "the plan is secret-codename go\n")
+    code, out, err = _run("acme", repo)
+    assert code == 1
+    assert "secret-codename" not in out
+    assert "notes.md" not in out
+    assert out == "check failed: 1 finding(s)\n"
+    # the detail lands only on the human surface
+    assert "secret-codename" in err and "notes.md:1" in err

--- a/apps/r4t/tests/test_dispatch.py
+++ b/apps/r4t/tests/test_dispatch.py
@@ -6,6 +6,7 @@ import os
 import sys
 import textwrap
 import time
+from dataclasses import replace
 
 import pytest
 

--- a/apps/r4t/tests/test_dispatch.py
+++ b/apps/r4t/tests/test_dispatch.py
@@ -1821,3 +1821,48 @@ class TestLiveLogTee:
         handle_message(ctx, "acme:gerry", "acme:phil", "hi")
         text = state.live_log_path(NODE, "phil").read_text(encoding="utf-8")
         assert "fake harness ran" in text
+
+
+class TestDoorbellGate:
+    def test_no_setting_rings_as_today(self, ctx, tells, fake_harness):
+        sent, _ = tells
+        handle_message(ctx, "acme:gerry", "acme:neil", "hi")
+        assert ("neil", "hi") in sent
+        assert "GATE" not in read_log()
+
+    def test_gate_pass_rings(self, ctx, tells, fake_harness):
+        sent, _ = tells
+        gated = replace(ctx, doorbell_check="exit 0")
+        handle_message(gated, "acme:gerry", "acme:neil", "hi")
+        assert ("neil", "hi") in sent
+        assert "GATE acme passed" in read_log()
+
+    def test_gate_fail_parks_without_ring(self, ctx, tells, fake_harness):
+        sent, _ = tells
+        cmd = "echo 'check failed: 2 finding(s)'; echo 'doc.md:2: bad' 1>&2; exit 1"
+        gated = replace(ctx, doorbell_check=cmd)
+        handle_message(gated, "acme:gerry", "acme:neil", "hi")
+        assert ("neil", "hi") not in sent
+        assert [m["from"] for m in seat_messages()] == ["acme:gerry"]
+        assert any("seat unreachable: check failed: 2 finding(s)" in b for _, b in sent)
+        log = read_log()
+        assert "r4t: GATE acme doc.md:2: bad" in log
+        assert "doorbell BLOCKED" in log
+
+    def test_gate_timeout_fails_closed(self, ctx, tells, fake_harness, monkeypatch):
+        sent, _ = tells
+        monkeypatch.setattr(dispatch, "DOORBELL_CHECK_TIMEOUT", 0.3)
+        gated = replace(ctx, doorbell_check="sleep 5")
+        handle_message(gated, "acme:gerry", "acme:neil", "hi")
+        assert ("neil", "hi") not in sent
+        assert [m["from"] for m in seat_messages()] == ["acme:gerry"]
+        assert any("seat unreachable: check did not complete" in b for _, b in sent)
+        assert "timed out" in read_log()
+
+    def test_gate_skipped_when_seat_attached(self, ctx, tells, fake_harness):
+        sent, _ = tells
+        state.touch_seat_presence(NODE, "Neil")
+        gated = replace(ctx, doorbell_check="exit 1")
+        handle_message(gated, "acme:gerry", "acme:neil", "hi")
+        assert not sent
+        assert "GATE" not in read_log()

--- a/apps/r4t/tests/test_org.py
+++ b/apps/r4t/tests/test_org.py
@@ -128,6 +128,26 @@ def test_check_flags_bad_setting_values(tmp_path):
     assert org.comms == "open" and org.leader_sees_lateral is False
 
 
+def test_doorbell_check_string_accepted(tmp_path):
+    (tmp_path / ORG_CONFIG_NAME).write_text(
+        json.dumps({"doorbell_check": "r4t check acme"}), encoding="utf-8"
+    )
+    assert load_org(tmp_path).doorbell_check == "r4t check acme"
+    assert check_org(tmp_path) == []
+
+
+def test_doorbell_check_absent_by_default(tmp_path):
+    assert load_org(tmp_path).doorbell_check is None
+
+
+def test_doorbell_check_non_string_degrades_with_error(tmp_path):
+    (tmp_path / ORG_CONFIG_NAME).write_text(
+        json.dumps({"doorbell_check": ["r4t", "check"]}), encoding="utf-8"
+    )
+    assert any('"doorbell_check" must be a string' in m for m in check_org(tmp_path))
+    assert load_org(tmp_path).doorbell_check is None
+
+
 # ---------- integration: turns resolve org dir vs workplace ----------
 
 def _portable_org(tmp_path, mission="Ship the thing and stop."):


### PR DESCRIPTION
## Summary

The d5n M4 run exposed two disjoint failure classes: independent playtest verification (eyes) confirmed navigation worked but glided past the literal `\n\n` the milestone shipped with; a two-line regex sweep (bones) would have caught it. This PR adds the bones and a gate that runs them before the org may ring an absent human.

- **`r4t check <node>`** — a forbidden-pattern sweep over the tracked files in the node's workplace, driven by checklists in `~/.config/r4t/checklists/` (`default.txt` for every node, `<node>.txt` for per-node additions; one Python regex per line).
- **Doorbell gate** — a new org setting `doorbell_check` (a shell command) runs before `dispatch._park_seat` rings an absent human. The message is always parked first — the gate protects attention, not the mailbox. Fail-closed on timeout/exec failure so a broken gate never becomes a silently broken doorbell.

## Design: information asymmetry

An agent cannot be the judge of its own deliverable, so the judge is machinery it cannot see into. The output contract enforces that:

| Surface | Content |
|---|---|
| **stdout** (agent-visible) | exactly one line — `check passed` or `check failed: N finding(s)`. Never a path or pattern. |
| **stderr** (human-visible) | one line per finding — `<path>:<line>: <pattern>` — plus operational notes. |
| **exit** | `0` pass · `1` findings · `2` operational error (unknown node, unreadable workplace, malformed regex) |

No checklists at all is a pass with a `no checklists configured` note. The checklist files live outside every repo, uncommitted, because they may carry private strings.

## Gate semantics

| Check result | Ring? | Sender reply | Node log |
|---|---|---|---|
| exit 0 | rings as today | — | `r4t: GATE <node> passed` |
| nonzero exit | no ring, message stays parked | `seat unreachable: <first line of check stdout>` | check stderr, line-prefixed `r4t: GATE <node>`, + a loud BLOCKED line |
| timeout / exec failure | no ring, message stays parked (fail closed) | `seat unreachable: check did not complete` | loud line |
| setting absent/empty | today's behavior byte-for-byte | — | — |

## Tests

- `tests/test_check.py` (new, 10 tests): parsing (comments/blanks/malformed→exit 2), sweep (findings, binary skip, untracked skip, inline `(?i)`, clean pass), no-checklist pass, and **stdout opacity** (asserts no path/pattern leaks to stdout).
- `tests/test_dispatch.py` (+5, `TestDoorbellGate`): gate pass rings + logs; gate fail parks without ring, sender gets the opaque error reply, stderr detail lands in the node log; timeout fails closed; attached-seat skips the gate; no setting → today's behavior byte-for-byte. (These landed in a follow-up commit — the first push carried the implementation but the test block was lost in an editing step.)
- `tests/test_org.py` (+3): `doorbell_check` string accepted, absent by default, non-string degrades with a config error.

Suites green: **r4t 482 passed** (464 pre-PR + 10 check + 3 org + 5 gate), **a8s 648 passed**.

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)