### PR TITLE
feat(n0b): speak teachings layer and sticky default voice

### DIFF
--- a/apps/n0b/cli.py
+++ b/apps/n0b/cli.py
@@ -92,13 +92,47 @@ def build_parser() -> argparse.ArgumentParser:
         help="Output audio file: .wav, or .m4a via afconvert (default: <input>.wav)",
     )
     ai_speak.add_argument(
-        "--voice", default="af_heart", help="Kokoro voice (default: af_heart)"
+        "--voice",
+        help=(
+            "Kokoro voice id or path to a .pt pack; default reads "
+            "~/.config/n0b/speak-voice.txt, else af_heart"
+        ),
     )
     ai_speak.add_argument(
         "--speed", type=float, default=1.0, help="Speech speed multiplier"
     )
     ai_speak.add_argument(
         "--raw", action="store_true", help="Skip markdown-to-prose cleanup"
+    )
+    ai_speak.add_argument(
+        "--replace",
+        action="append",
+        default=[],
+        dest="replaces",
+        metavar="'TEXT => SPOKEN'",
+        help=(
+            "Regex + spoken form applied before synthesis. Merged with "
+            "~/.config/n0b/speak-replacements.txt"
+        ),
+    )
+    ai_speak.add_argument(
+        "--pronounce",
+        action="append",
+        default=[],
+        dest="pronounces",
+        metavar="'WORD => IPA'",
+        help=(
+            "Regex + misaki IPA phonemes; matches become [word](/ipa/). "
+            "Merged with ~/.config/n0b/speak-pronunciations.txt"
+        ),
+    )
+    ai_speak.add_argument(
+        "--save",
+        action="store_true",
+        help=(
+            "Append --replace/--pronounce to their global files and/or "
+            "persist --voice as the system default"
+        ),
     )
     ai_transcribe = ai_sub.add_parser(
         "transcribe", help="Transcribe an audio file locally with Whisper"
@@ -225,7 +259,14 @@ def dispatch(args: argparse.Namespace) -> int:
             return cmd_research(args.prompt)
         if args.ai_kind == "speak":
             return cmd_speak(
-                args.text, args.out, args.voice, args.speed, raw=args.raw
+                args.text,
+                args.out,
+                args.voice,
+                args.speed,
+                raw=args.raw,
+                replaces=args.replaces,
+                pronounces=args.pronounces,
+                save=args.save,
             )
         if args.ai_kind == "transcribe":
             return cmd_transcribe(

--- a/apps/n0b/commands/ai_cmd.py
+++ b/apps/n0b/commands/ai_cmd.py
@@ -56,6 +56,10 @@ def cmd_research(args: list[str]) -> int:
 WHISPER_VENV = Path.home() / ".cache" / "n0b" / "whisper-venv"
 HINTS_FILE = Path.home() / ".config" / "n0b" / "transcribe-hints.txt"
 REPLACEMENTS_FILE = Path.home() / ".config" / "n0b" / "transcribe-replacements.txt"
+SPEAK_REPLACEMENTS_FILE = Path.home() / ".config" / "n0b" / "speak-replacements.txt"
+SPEAK_PRONUNCIATIONS_FILE = Path.home() / ".config" / "n0b" / "speak-pronunciations.txt"
+SPEAK_VOICE_FILE = Path.home() / ".config" / "n0b" / "speak-voice.txt"
+DEFAULT_SPEAK_VOICE = "af_heart"
 
 _WHISPER_SNIPPET = """\
 import sys
@@ -97,13 +101,14 @@ if not chunks:
 sf.write(out_path, np.concatenate(chunks), 24000)
 """
 
-_MD_LINK_RE = re.compile(r"\[([^\]]+)\]\([^)]*\)")
+_MD_URL_LINK_RE = re.compile(r"\[([^\]]+)\]\((?!/)[^)]*\)")
 _MD_NOISE_RE = re.compile(r"[*_`#>|]+")
 
 
 def speakable(markdown: str) -> str:
     """Reduce markdown to prose worth hearing: drop code fences and table
-    rows, unwrap links, strip emphasis markers."""
+    rows, unwrap URL links, strip emphasis markers. Keeps misaki phoneme
+    overrides like [word](/ipa/)."""
     out: list[str] = []
     fenced = False
     for line in markdown.splitlines():
@@ -113,7 +118,7 @@ def speakable(markdown: str) -> str:
             continue
         if fenced or s.startswith("|"):
             continue
-        line = _MD_LINK_RE.sub(r"\1", line)
+        line = _MD_URL_LINK_RE.sub(r"\1", line)
         line = _MD_NOISE_RE.sub("", line)
         out.append(line)
     return "\n".join(out)
@@ -162,13 +167,172 @@ def _kokoro_python() -> Path:
     return python
 
 
+def read_sticky_voice(voice_file: Path | None = None) -> str | None:
+    path = SPEAK_VOICE_FILE if voice_file is None else voice_file
+    if not path.is_file():
+        return None
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if line and not line.startswith("#"):
+            return line
+    return None
+
+
+def save_sticky_voice(voice: str, voice_file: Path | None = None) -> int:
+    path = SPEAK_VOICE_FILE if voice_file is None else voice_file
+    voice = voice.strip()
+    if not voice:
+        return 2
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"{voice}\n")
+    print(f"saved default voice to {path}", file=sys.stderr)
+    return 0
+
+
+def resolve_speak_voice(cli_voice: str | None) -> tuple[str, str]:
+    if cli_voice is not None:
+        return cli_voice, "cli"
+    sticky = read_sticky_voice()
+    if sticky:
+        return sticky, str(SPEAK_VOICE_FILE)
+    return DEFAULT_SPEAK_VOICE, "built-in default"
+
+
+def read_pair_file(
+    pair_file: Path, label: str = "n0b"
+) -> list[tuple[str, str]]:
+    pairs: list[tuple[str, str]] = []
+    if not pair_file.is_file():
+        return pairs
+    for line in pair_file.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        pair = parse_replacement(line)
+        if pair is None:
+            print(
+                f"{label}: skipping bad line (want 'left => right'): {line!r}",
+                file=sys.stderr,
+            )
+            continue
+        pairs.append(pair)
+    return pairs
+
+
+def parse_cli_pairs(cli_values: list[str], label: str) -> list[tuple[str, str]]:
+    pairs: list[tuple[str, str]] = []
+    for raw in cli_values:
+        pair = parse_replacement(raw)
+        if pair is None:
+            print(
+                f"{label}: bad value (want 'left => right'): {raw!r}",
+                file=sys.stderr,
+            )
+            continue
+        pairs.append(pair)
+    return pairs
+
+
+def apply_speak_replacements(
+    text: str, pairs: list[tuple[str, str]]
+) -> tuple[str, list[str]]:
+    applied: list[str] = []
+    for pattern, spoken in pairs:
+        try:
+            text, count = re.subn(pattern, spoken, text)
+        except re.error as exc:
+            print(
+                f"n0b ai speak: bad replacement regex {pattern!r}: {exc}",
+                file=sys.stderr,
+            )
+            continue
+        if count:
+            applied.append(f"{pattern} => {spoken} (x{count})")
+    return text, applied
+
+
+def apply_pronunciations(
+    text: str, pairs: list[tuple[str, str]]
+) -> tuple[str, list[str]]:
+    applied: list[str] = []
+    for pattern, ipa in pairs:
+        def wrap(m: re.Match[str]) -> str:
+            word = m.group(0)
+            return f"[{word}](/{ipa}/)"
+
+        try:
+            text, count = re.subn(pattern, wrap, text)
+        except re.error as exc:
+            print(
+                f"n0b ai speak: bad pronunciation regex {pattern!r}: {exc}",
+                file=sys.stderr,
+            )
+            continue
+        if count:
+            applied.append(f"{pattern} => /{ipa}/ (x{count})")
+    return text, applied
+
+
+def save_pair_file(
+    cli_values: list[str],
+    pair_file: Path,
+    label: str,
+) -> int:
+    new = parse_cli_pairs(cli_values, label)
+    if not new:
+        return 2
+    known = {pattern for pattern, _ in read_pair_file(pair_file, label)}
+    added = [(p, r) for p, r in new if p not in known]
+    if added:
+        pair_file.parent.mkdir(parents=True, exist_ok=True)
+        lead = ""
+        if pair_file.is_file():
+            text = pair_file.read_text()
+            if text and not text.endswith("\n"):
+                lead = "\n"
+        with pair_file.open("a") as f:
+            f.write(lead + "".join(f"{p} => {r}\n" for p, r in added))
+    print(
+        f"saved {len(added)} entry(ies) to {pair_file}"
+        + (f" ({len(new) - len(added)} already there)" if len(added) < len(new) else ""),
+        file=sys.stderr,
+    )
+    return 0
+
+
 def cmd_speak(
     source: str | None,
     out: str | None,
-    voice: str,
+    voice: str | None,
     speed: float,
     raw: bool = False,
+    replaces: list[str] | None = None,
+    pronounces: list[str] | None = None,
+    save: bool = False,
 ) -> int:
+    replaces = replaces or []
+    pronounces = pronounces or []
+    if save:
+        saved = False
+        if parse_cli_pairs(replaces, "n0b ai speak"):
+            save_pair_file(replaces, SPEAK_REPLACEMENTS_FILE, "n0b ai speak")
+            saved = True
+        if parse_cli_pairs(pronounces, "n0b ai speak"):
+            save_pair_file(pronounces, SPEAK_PRONUNCIATIONS_FILE, "n0b ai speak")
+            saved = True
+        if voice is not None:
+            save_sticky_voice(voice)
+            saved = True
+        if not saved:
+            print(
+                "n0b ai speak: --save needs --voice, --replace, and/or --pronounce",
+                file=sys.stderr,
+            )
+            return 2
+        if source is None:
+            return 0
+    voice, voice_src = resolve_speak_voice(voice)
+    print(f"voice: {voice} ({voice_src})", file=sys.stderr)
     if source is None or source == "-":
         text = sys.stdin.read()
         stem = "speech"
@@ -181,6 +345,32 @@ def cmd_speak(
         stem = path.stem
     if not raw:
         text = speakable(text)
+    file_replaces = read_pair_file(SPEAK_REPLACEMENTS_FILE, "n0b ai speak")
+    cli_replaces = parse_cli_pairs(replaces, "n0b ai speak")
+    replace_pairs = file_replaces + cli_replaces
+    file_pronounces = read_pair_file(SPEAK_PRONUNCIATIONS_FILE, "n0b ai speak")
+    cli_pronounces = parse_cli_pairs(pronounces, "n0b ai speak")
+    pronounce_pairs = file_pronounces + cli_pronounces
+    if pronounce_pairs:
+        print(
+            f"pronunciations: {len(pronounce_pairs)} pattern(s) loaded "
+            f"({len(file_pronounces)} from {SPEAK_PRONUNCIATIONS_FILE}, "
+            f"{len(cli_pronounces)} from --pronounce)",
+            file=sys.stderr,
+        )
+        text, applied = apply_pronunciations(text, pronounce_pairs)
+        note = "; ".join(applied) if applied else "none matched"
+        print(f"pronunciations applied: {note}", file=sys.stderr)
+    if replace_pairs:
+        print(
+            f"replacements: {len(replace_pairs)} pattern(s) loaded "
+            f"({len(file_replaces)} from {SPEAK_REPLACEMENTS_FILE}, "
+            f"{len(cli_replaces)} from --replace)",
+            file=sys.stderr,
+        )
+        text, applied = apply_speak_replacements(text, replace_pairs)
+        note = "; ".join(applied) if applied else "none matched"
+        print(f"replacements applied: {note}", file=sys.stderr)
     if not text.strip():
         print("n0b ai speak: nothing to say after cleanup", file=sys.stderr)
         return 2
@@ -259,38 +449,11 @@ def parse_replacement(line: str) -> tuple[str, str] | None:
 
 
 def read_replacements(replacements_file: Path) -> list[tuple[str, str]]:
-    pairs: list[tuple[str, str]] = []
-    if not replacements_file.is_file():
-        return pairs
-    for line in replacements_file.read_text().splitlines():
-        line = line.strip()
-        if not line or line.startswith("#"):
-            continue
-        pair = parse_replacement(line)
-        if pair is None:
-            print(
-                f"n0b ai transcribe: skipping bad replacement line "
-                f"(want 'wrong => right'): {line!r}",
-                file=sys.stderr,
-            )
-            continue
-        pairs.append(pair)
-    return pairs
+    return read_pair_file(replacements_file, "n0b ai transcribe")
 
 
 def parse_cli_replacements(cli_replaces: list[str]) -> list[tuple[str, str]]:
-    pairs: list[tuple[str, str]] = []
-    for raw in cli_replaces:
-        pair = parse_replacement(raw)
-        if pair is None:
-            print(
-                f"n0b ai transcribe: bad --replace value "
-                f"(want 'wrong => right'): {raw!r}",
-                file=sys.stderr,
-            )
-            continue
-        pairs.append(pair)
-    return pairs
+    return parse_cli_pairs(cli_replaces, "n0b ai transcribe")
 
 
 def apply_replacements(
@@ -315,26 +478,7 @@ def apply_replacements(
 
 
 def save_replacements(cli_replaces: list[str], replacements_file: Path) -> int:
-    new = parse_cli_replacements(cli_replaces)
-    if not new:
-        return 2
-    known = {pattern for pattern, _ in read_replacements(replacements_file)}
-    added = [(p, c) for p, c in new if p not in known]
-    if added:
-        replacements_file.parent.mkdir(parents=True, exist_ok=True)
-        lead = ""
-        if replacements_file.is_file():
-            text = replacements_file.read_text()
-            if text and not text.endswith("\n"):
-                lead = "\n"
-        with replacements_file.open("a") as f:
-            f.write(lead + "".join(f"{p} => {c}\n" for p, c in added))
-    print(
-        f"saved {len(added)} replacement(s) to {replacements_file}"
-        + (f" ({len(new) - len(added)} already there)" if len(added) < len(new) else ""),
-        file=sys.stderr,
-    )
-    return 0
+    return save_pair_file(cli_replaces, replacements_file, "n0b ai transcribe")
 
 
 def save_hints(cli_hints: list[str], hints_file: Path) -> int:

--- a/apps/n0b/docs/ai-speak.md
+++ b/apps/n0b/docs/ai-speak.md
@@ -13,18 +13,49 @@ setup; no API keys.
 ```bash
 n0b ai speak notes.md -o notes.m4a          # markdown -> spoken m4a
 echo "ship it" | n0b ai speak - -o say.wav  # stdin -> wav
-n0b ai speak brief.txt --voice am_adam --speed 1.1
+n0b ai speak brief.txt --voice af_nicole --speed 1.1
+
+n0b ai speak --voice af_nicole --save       # sticky default voice
+n0b ai speak notes.md --replace '\ba8s\b => A eight S'
+n0b ai speak notes.md --pronounce 'Pay-i => pˈeɪ ˈaɪ'
+n0b ai speak --replace 'Pay-i => Pay eye' --save   # add to global file
 ```
 
 - **Input** is cleaned for listening by default: code fences and table
-  rows are dropped, links unwrapped, emphasis markers stripped. Pass
-  `--raw` to synthesize the text exactly as given.
+  rows are dropped, URL links unwrapped, emphasis markers stripped.
+  Misaki phoneme overrides like `[word](/ipa/)` are kept. Pass `--raw` to
+  synthesize the text exactly as given.
 - **Output** format follows the extension: `.wav` (native, 24 kHz) or
   `.m4a`/`.aac` (converted with macOS `afconvert`). Default is
   `<input>.wav`.
-- **Voices**: any Kokoro voice id (default `af_heart`; e.g. `am_adam`,
-  `bf_emma` — the leading letter picks the language/accent pipeline).
+- **Voices**: any Kokoro voice id (e.g. `af_bella`, `af_nicole`, `am_adam`;
+  comma-separated names are averaged). Set a sticky default with
+  `--voice NAME --save`; stored in `~/.config/n0b/speak-voice.txt`.
 - `--speed` is a multiplier (1.0 = normal).
+
+## Replacements
+
+Spoken-form rewrites run **before** synthesis — the right-hand side is
+what Kokoro hears:
+
+- `~/.config/n0b/speak-replacements.txt` — one `pattern => spoken` per
+  line, `#` comments allowed; left side is a Python regex.
+- `--replace` — repeatable; `--save` appends to the global file (deduped
+  by pattern).
+
+Use for acronyms and jargon where IPA is overkill: `\bAPI\b => A P I`.
+
+## Pronunciations
+
+IPA overrides wrap matches as misaki markup `[word](/ipa/)` before
+synthesis:
+
+- `~/.config/n0b/speak-pronunciations.txt` — one `pattern => ipa` per
+  line, `#` comments allowed.
+- `--pronounce` — repeatable; `--save` appends to the global file.
+
+Pronunciations run before replacements. IPA reference:
+[misaki EN_PHONES.md](https://github.com/hexgrad/misaki/blob/main/EN_PHONES.md).
 
 ## Setup (automatic, one-time)
 

--- a/apps/n0b/tests/test_cli.py
+++ b/apps/n0b/tests/test_cli.py
@@ -13,13 +13,19 @@ N0B_PY = Path(__file__).resolve().parents[1] / "n0b.py"
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from commands.ai_cmd import (  # noqa: E402
+    apply_pronunciations,
     apply_replacements,
+    apply_speak_replacements,
     cmd_ai,
+    cmd_speak,
     cmd_transcribe,
     merged_hints,
     read_replacements,
+    resolve_speak_voice,
     save_hints,
     save_replacements,
+    save_sticky_voice,
+    speakable,
 )
 from commands.secrets_cmd import cmd_set, resolve  # noqa: E402
 
@@ -291,3 +297,105 @@ def test_transcribe_help():
     assert proc.returncode == 0
     assert "--hint" in proc.stdout
     assert "--language" in proc.stdout
+
+
+def test_speakable_keeps_phoneme_overrides():
+    md = "See [Pay-i](/pˈeɪ ˈaɪ/) and [docs](https://example.com/x)."
+    assert speakable(md) == "See [Pay-i](/pˈeɪ ˈaɪ/) and docs."
+
+
+def test_speakable_drops_fences_and_tables():
+    md = "# Title\n\n| a | b |\n|---|---|\n\nHello\n\n```py\nx=1\n```\n"
+    assert speakable(md) == " Title\n\n\nHello\n"
+
+
+def test_apply_speak_replacements_substitutes():
+    text, applied = apply_speak_replacements(
+        "a8s ships via tell.", [("\\ba8s\\b", "A eight S")]
+    )
+    assert text == "A eight S ships via tell."
+    assert applied == ["\\ba8s\\b => A eight S (x1)"]
+
+
+def test_apply_pronunciations_wraps_ipa():
+    text, applied = apply_pronunciations(
+        "Pay-i uses k7e.", [("Pay-i", "pˈeɪ ˈaɪ")]
+    )
+    assert text == "[Pay-i](/pˈeɪ ˈaɪ/) uses k7e."
+    assert applied == ["Pay-i => /pˈeɪ ˈaɪ/ (x1)"]
+
+
+def test_resolve_speak_voice_sticky(tmp_path, monkeypatch):
+    voice_file = tmp_path / "speak-voice.txt"
+    voice_file.write_text("af_nicole\n")
+    with patch("commands.ai_cmd.SPEAK_VOICE_FILE", voice_file):
+        assert resolve_speak_voice(None) == ("af_nicole", str(voice_file))
+        assert resolve_speak_voice("af_bella") == ("af_bella", "cli")
+
+
+def test_resolve_speak_voice_builtin_default(tmp_path):
+    missing = tmp_path / "missing.txt"
+    with patch("commands.ai_cmd.SPEAK_VOICE_FILE", missing):
+        assert resolve_speak_voice(None) == ("af_heart", "built-in default")
+
+
+def test_save_sticky_voice(tmp_path):
+    voice_file = tmp_path / "speak-voice.txt"
+    with patch("commands.ai_cmd.SPEAK_VOICE_FILE", voice_file):
+        assert save_sticky_voice("af_bella", voice_file) == 0
+    assert voice_file.read_text() == "af_bella\n"
+
+
+def test_speak_save_voice_only(tmp_path):
+    voice_file = tmp_path / "speak-voice.txt"
+    with patch("commands.ai_cmd.SPEAK_VOICE_FILE", voice_file):
+        rc = cmd_speak(None, None, "af_nicole", 1.0, save=True)
+    assert rc == 0
+    assert voice_file.read_text() == "af_nicole\n"
+
+
+def test_speak_save_replacements_only(tmp_path):
+    repl = tmp_path / "speak-replacements.txt"
+    with (
+        patch("commands.ai_cmd.SPEAK_REPLACEMENTS_FILE", repl),
+        patch("commands.ai_cmd.SPEAK_PRONUNCIATIONS_FILE", tmp_path / "p.txt"),
+    ):
+        rc = cmd_speak(
+            None, None, None, 1.0, save=True, replaces=["\\ba8s\\b => A eight S"]
+        )
+    assert rc == 0
+    assert repl.read_text() == "\\ba8s\\b => A eight S\n"
+
+
+def test_speak_applies_teachings_before_kokoro(tmp_path, capsys):
+    src = tmp_path / "note.txt"
+    src.write_text("a8s ready")
+    repl = tmp_path / "speak-replacements.txt"
+    repl.write_text("\\ba8s\\b => A eight S\n")
+    fake_python = tmp_path / "venv" / "bin" / "python3"
+    captured: dict[str, str] = {}
+    with (
+        patch("commands.ai_cmd._kokoro_python", return_value=fake_python),
+        patch("commands.ai_cmd.SPEAK_REPLACEMENTS_FILE", repl),
+        patch("commands.ai_cmd.SPEAK_PRONUNCIATIONS_FILE", tmp_path / "missing.txt"),
+        patch("commands.ai_cmd.SPEAK_VOICE_FILE", tmp_path / "missing-voice.txt"),
+        patch("commands.ai_cmd.subprocess.run") as run,
+    ):
+        def capture_run(cmd, **kwargs):
+            captured["text"] = Path(cmd[3]).read_text(encoding="utf-8")
+            run.return_value.returncode = 0
+            return run.return_value
+
+        run.side_effect = capture_run
+        rc = cmd_speak(str(src), str(tmp_path / "out.wav"), None, 1.0)
+    assert rc == 0
+    assert captured["text"] == "A eight S ready"
+    err = capsys.readouterr().err
+    assert "replacements applied" in err
+
+
+def test_speak_help():
+    proc = run_n0b("ai", "speak", "--help")
+    assert proc.returncode == 0
+    assert "--pronounce" in proc.stdout
+    assert "--save" in proc.stdout


### PR DESCRIPTION
## Summary
- Add transcribe-style global config for `n0b ai speak`: spoken-form `--replace` rules, IPA `--pronounce` rules, and `--save` to persist them under `~/.config/n0b/`.
- Add sticky default voice via `~/.config/n0b/speak-voice.txt` (`n0b ai speak --voice af_nicole --save`).
- Fix markdown cleanup to preserve misaki phoneme overrides `[word](/ipa/)` while still unwrapping URL links.

## Test plan
- [x] `venv/bin/python3 -m pytest apps/n0b/tests/test_cli.py` (42 passed)
- [ ] `n0b ai speak --voice af_nicole --save` then `n0b ai speak hello.txt` uses Nicole without `--voice`
- [ ] `n0b ai speak --replace '\ba8s\b => A eight S' --save` then verify `~/.config/n0b/speak-replacements.txt`
- [ ] `n0b ai speak --pronounce 'Pay-i => pˈeɪ ˈaɪ' --save` improves name pronunciation on a sample doc


Made with [Cursor](https://cursor.com)