### PR TITLE
feat(r4t): ollama-launch rig presets (#203)

### DIFF
--- a/apps/r4t/README.md
+++ b/apps/r4t/README.md
@@ -36,8 +36,10 @@ fail closed — see the [tutorial](docs/tutorial.md#missing-rig-no-default--fail
 (`claude`, `codex`, `cursor`, `opencode`) it is spliced into the invoke at add
 time — `--model <alias>` for claude, `-m <id>` after `exec` for codex, after
 `run` for opencode — and omitting it lets the CLI's own default apply. The
-`ollama` and `opencode-ollama` presets have no default, so their `--model` is
-required and names a local model tag.
+`ollama` preset and the `ollama launch`-wrapped presets (`opencode-ollama`,
+`claude-ollama`, `codex-ollama`, `copilot-ollama` — see
+[docs/harness-ollama-launch.md](docs/harness-ollama-launch.md)) have no
+default, so their `--model` is required and names a local model tag.
 
 `agy` is different: its `--model` takes an exact display name from `agy models`
 (short aliases are silently ignored), and those names carry version numbers

--- a/apps/r4t/docs/harness-ollama-launch.md
+++ b/apps/r4t/docs/harness-ollama-launch.md
@@ -1,0 +1,94 @@
+# `ollama launch` harnesses: local models under the big-name CLIs
+
+Findings dated 2026-07-14. ollama 0.32.0 on macOS; validated against
+qwen3.6:latest (23 GB) unless noted.
+
+`ollama launch <integration>` starts a coding-agent CLI pointed at the local
+ollama server instead of its cloud backend — no env vars or config files to
+hand-edit. r4t wraps it in the `claude-ollama`, `codex-ollama`, and
+`copilot-ollama` presets in [`rig.py`](../rig.py), alongside the older
+`opencode-ollama`. Local models mean no cloud quota, which is what makes
+whole-org experiments affordable.
+
+## How the launcher works
+
+```
+ollama launch <integration> --model <tag> -y -- <the harness's own headless argv>
+```
+
+- `--model` takes an ollama tag verbatim (`qwen3.6:latest`); the launcher
+  owns model selection for the child.
+- Everything after `--` is passed through to the integration untouched. Each
+  r4t preset's passthrough is the parent preset's headless argv, verbatim —
+  all three parents' argv worked under the launcher with no flag changes.
+- `-y` auto-answers the launcher's own confirmation prompts. Required for
+  unattended dispatch: a first-run or install confirmation would otherwise
+  hang the turn.
+
+## What the launcher persists, per integration
+
+Verified by checksumming every config surface before and after each launch.
+
+| Integration | Mechanism | Persisted to the real config |
+|---|---|---|
+| claude | env injection (`ANTHROPIC_BASE_URL`, `ANTHROPIC_API_KEY`, `ANTHROPIC_DEFAULT_*_MODEL` on the child) | **Nothing.** `~/.claude/settings.json` and `settings.local.json` byte-identical; `~/.claude.json` shows only Claude Code's ordinary startup churn |
+| codex | overlay file: `~/.codex/ollama-launch.config.toml` (`model_provider = ollama-launch`, `base_url = http://127.0.0.1:11434/v1/`, `wire_api = responses`) plus a `~/.codex/model.json` catalog | **Real `~/.codex/config.toml` untouched.** Trust entries codex adds under `[projects]` are codex's own `--full-auto` behavior, identical to an unwrapped `codex exec` |
+| copilot | env injection (`COPILOT_MODEL` et al.) | **Nothing.** `~/.copilot/config.json` byte-identical |
+
+`--restore` exists for integrations whose real profile the launcher rewrites —
+chiefly `codex-app` (the desktop app), which gets its config regenerated and a
+`~/.codex/ollama-codex-app-restore.json` restore-state saved. The three CLI
+integrations above persist nothing, so there is nothing to restore
+(`ollama launch <x> --restore` reports unsupported where no state exists).
+Safe to run against a working install.
+
+## Validated presets
+
+Both turns run in a scratch git repo: a one-shot reply
+("Reply with exactly the word: pong") and a tool-use turn (create `proof.txt`
+with a given word, verified on disk).
+
+| Preset | One-shot | Tool-use | Wall time per turn |
+|---|---|---|---|
+| `claude-ollama` | pass | pass | 92–100 s |
+| `codex-ollama` | pass | pass | 10–24 s |
+| `copilot-ollama` | pass | pass | 18–25 s (qwen3:1.7b) |
+
+Oddities worth knowing:
+
+- **codex: never pass `-m`/`--model` after the `--`.** The launcher manages
+  the model and rejects the conflict
+  (`conflicting extra argument: ollama launch codex manages --model`). Same
+  for kimi. The preset takes `--model` on the launcher side only.
+- **Claude Code is the slow one.** Its system prompt is enormous relative to a
+  local model's throughput, so ~90–100 s/turn where codex takes 10–24 s on the
+  same model. Budget rig timeouts accordingly.
+- **Model quality is the real gate, not the plumbing.** qwen3:1.7b under
+  codex emitted junk tool calls instead of "pong"; under Claude Code,
+  qwen3.6 once hallucinated a mangled absolute path for `Write` (the tool ran
+  fine — at the wrong path). Pick a qwen3.6-class model and keep prompts
+  small: all three presets sit in the `small` text tier.
+- ollama recommends raising the server context length to at least 64k tokens
+  for coding tools.
+
+## Not-installed integrations (future candidates)
+
+From `ollama launch --help` plus web docs only — none installed, none tested.
+
+| Integration | Headless story | Notes |
+|---|---|---|
+| qwen | `--prompt` non-interactive mode, stdin piping | gemini-cli lineage; closest analog to the validated three |
+| kimi | `-p/--prompt`, `--print`, `--quiet` | launcher manages `--model` and `--config` (same conflict rule as codex) |
+| droid | `droid exec` one-shot with tiered autonomy flags | default is read-only; needs an autonomy flag for edits |
+| pool | `pool exec` non-interactive | Poolside's agent; ships its own sandbox |
+| cline | `-y` yolo mode, stdin/stdout piping, `--json` | CLI 2.0 |
+| pi | print mode reads stdin; RPC mode (JSON over stdio) | minimal agent by Mario Zechner |
+| omp | pi derivative ("oh-my-pi"), same print/RPC surface | batteries-included pi fork |
+| hermes | gateway/daemon architecture, not a one-shot CLI | Nous Research; poor fit for r4t's turn model |
+| openclaw | daemon + chat-platform gateway, not a one-shot CLI | same fit problem as hermes |
+
+`codex-app`, `hermes-desktop`, and `vscode` are GUI targets — not rig
+material. The daemon-shaped ones (hermes, openclaw) would need an adapter to
+fit r4t's spawn-per-turn dispatch; the exec-shaped ones (qwen, kimi, droid,
+pool, cline, pi, omp) look preset-sized once installed and validated the same
+way as the three above.

--- a/apps/r4t/rig.py
+++ b/apps/r4t/rig.py
@@ -148,6 +148,73 @@ HARNESS_PRESETS: dict[str, dict] = {
             "{prompt}",
         ],
     },
+    "claude-ollama": {
+        "text_tier": "small",
+        "description": (
+            "Claude Code via `ollama launch` — local models, no cloud quota; "
+            "requires --model"
+        ),
+        "a8s_definition": "claude.json",
+        "headless": "ollama launch claude --model MODEL -y -- --permission-mode dontAsk -p",
+        "invoke": [
+            "ollama",
+            "launch",
+            "claude",
+            "--model",
+            "{model}",
+            "-y",
+            "--",
+            "--permission-mode",
+            "dontAsk",
+            "--allowedTools",
+            "Bash(tell:*) Read Edit Write Glob Grep WebFetch WebSearch TodoWrite",
+            "-p",
+            "{prompt}",
+        ],
+    },
+    "codex-ollama": {
+        "text_tier": "small",
+        "description": (
+            "Codex via `ollama launch` — local models, no cloud quota; "
+            "requires --model (the launcher owns -m)"
+        ),
+        "a8s_definition": "codex.json",
+        "headless": "ollama launch codex --model MODEL -y -- exec --full-auto",
+        "invoke": [
+            "ollama",
+            "launch",
+            "codex",
+            "--model",
+            "{model}",
+            "-y",
+            "--",
+            "exec",
+            "--full-auto",
+            "--skip-git-repo-check",
+            "{prompt}",
+        ],
+    },
+    "copilot-ollama": {
+        "text_tier": "small",
+        "description": (
+            "Copilot CLI via `ollama launch` — local models, no cloud quota; "
+            "requires --model"
+        ),
+        "a8s_definition": "copilot.json",
+        "headless": "ollama launch copilot --model MODEL -y -- --allow-all-tools -p",
+        "invoke": [
+            "ollama",
+            "launch",
+            "copilot",
+            "--model",
+            "{model}",
+            "-y",
+            "--",
+            "--allow-all-tools",
+            "-p",
+            "{prompt}",
+        ],
+    },
     "ollama": {
         "text_tier": "small",
         "description": (

--- a/apps/r4t/tests/test_rig.py
+++ b/apps/r4t/tests/test_rig.py
@@ -279,8 +279,8 @@ class TestDefaultPayload:
 class TestHarnessPresets:
     def test_preset_names_match_a8s_kinds(self):
         assert preset_names() == [
-            "agy", "claude", "codex", "copilot", "cursor", "ollama", "opencode",
-            "opencode-ollama",
+            "agy", "claude", "claude-ollama", "codex", "codex-ollama", "copilot",
+            "copilot-ollama", "cursor", "ollama", "opencode", "opencode-ollama",
         ]
 
     def test_every_preset_declares_a_known_text_tier(self):
@@ -292,6 +292,8 @@ class TestHarnessPresets:
             "agy": "big", "claude": "big", "codex": "big",
             "copilot": "moderate", "cursor": "moderate", "opencode": "moderate",
             "ollama": "small", "opencode-ollama": "small",
+            "claude-ollama": "small", "codex-ollama": "small",
+            "copilot-ollama": "small",
         }
 
     def test_text_tier_anchors(self):
@@ -491,6 +493,27 @@ class TestHarnessPresets:
         assert argv[4] == "qwen2.5-coder:7b"
         assert argv[5:8] == ["--", "run", "--auto"]
         assert "{prompt}" in argv
+
+    def test_build_preset_invoke_launch_wrapped_presets_require_model(self):
+        for name in ("claude-ollama", "codex-ollama", "copilot-ollama"):
+            with pytest.raises(RigError, match="requires --model"):
+                build_preset_invoke(name)
+
+    def test_build_preset_invoke_launch_wrapped_presets(self):
+        parent_headless = {
+            "claude-ollama": HARNESS_PRESETS["claude"]["invoke"][:-1],
+            "codex-ollama": HARNESS_PRESETS["codex"]["invoke"][:-1],
+            "copilot-ollama": HARNESS_PRESETS["copilot"]["invoke"][:-1],
+        }
+        for name, tail in parent_headless.items():
+            argv = build_preset_invoke(name, model="qwen3.6:latest")
+            parent = name.removesuffix("-ollama")
+            assert argv[:7] == [
+                "ollama", "launch", parent, "--model", "qwen3.6:latest", "-y", "--",
+            ]
+            assert argv[7:-1] == tail[1:]
+            assert argv[-1] == "{prompt}"
+            assert "-m" not in argv[7:]
 
     def test_build_preset_invoke_unknown(self):
         with pytest.raises(RigError, match="unknown preset"):


### PR DESCRIPTION
Three new rig presets run the big-name harnesses against local ollama models via `ollama launch`: `claude-ollama`, `codex-ollama`, `copilot-ollama` — modeled on `opencode-ollama` (text_tier small, `--model` required, parent's a8s definition, parent's headless argv passed through after `--`).

## Validated matrix (qwen3.6:latest, scratch git repo)

| Preset | One-shot ("pong") | Tool-use (proof.txt on disk) | Wall/turn |
|---|---|---|---|
| claude-ollama | pass | pass | 92–100 s |
| codex-ollama | pass | pass | 10–24 s |
| copilot-ollama | pass | pass | 18–25 s (qwen3:1.7b) |

## Persistence findings (checksummed before/after every launch)

- **claude**: pure env-var injection (`ANTHROPIC_BASE_URL`, `ANTHROPIC_API_KEY`, `ANTHROPIC_DEFAULT_*_MODEL`). `~/.claude/settings.json` and `settings.local.json` byte-identical; `~/.claude.json` only ordinary Claude Code startup churn. Nothing to restore — safe against a working install.
- **codex**: real `~/.codex/config.toml` untouched; the launcher writes a separate overlay `~/.codex/ollama-launch.config.toml` (provider `ollama-launch` → `http://127.0.0.1:11434/v1/`) plus a `model.json` catalog. The launcher owns `--model` and rejects `-m` in the passthrough. `[projects]` trust entries are codex's own `--full-auto` behavior, same as unwrapped.
- **copilot**: env injection (`COPILOT_MODEL`); `~/.copilot/config.json` byte-identical.
- `--restore` is for integrations whose real profile gets rewritten — chiefly `codex-app` (desktop), which saves `ollama-codex-app-restore.json`. None of the three CLI presets need it.

`-y` is baked into the invokes so launcher confirmation prompts can't hang unattended turns. Docs one-pager (`apps/r4t/docs/harness-ollama-launch.md`) covers the mechanism, timings, oddities, and a survey of the not-installed integrations (qwen, kimi, droid, pool, cline, pi, omp, hermes, openclaw) as future candidates.

## Tests

- r4t: 466 passed (preset-name/tier enumeration extended; new model-required and invoke-resolution tests for the three presets)
- a8s: 648 passed

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)