### PR TITLE
fix(a8s): compose batch prompt in daemon instead of re-parsing envelopes

### DIFF
--- a/apps/a8s/daemon.py
+++ b/apps/a8s/daemon.py
@@ -53,6 +53,7 @@ from core import (
     unique_path,
 )
 from definitions import (
+    BatchEntry,
     batch_limit,
     build_batch_command,
     build_command,
@@ -386,13 +387,16 @@ def wake_batch(
 
     trashed: list[Path] = []
     previews: list[str] = []
+    entries: list[BatchEntry] = []
     for msg_path in msg_paths:
         try:
             with msg_path.open("r", encoding="utf-8") as f:
                 msg = json.load(f)
             previews.append(_preview(msg.get("content", "")))
-        except (OSError, json.JSONDecodeError):
+            entries.append(BatchEntry(msg, msg_path.name))
+        except (OSError, json.JSONDecodeError) as e:
             previews.append(msg_path.name)
+            entries.append(BatchEntry(None, msg_path.name, str(e)))
         dest = unique_path(trash_dir(p.name) / msg_path.name)
         msg_path.rename(dest)
         trashed.append(dest)
@@ -405,7 +409,7 @@ def wake_batch(
         f"[{p.name}] batch waking ({len(trashed)}): {summary}",
     )
     p.files_path().mkdir(parents=True, exist_ok=True)
-    cmd = build_batch_command(definition, p.name, trashed, resolve_definition_path(p.name))
+    cmd = build_batch_command(definition, p.name, entries, resolve_definition_path(p.name))
     out_agent(p.name, f"[{p.name}] batch exec: {shlex.join(cmd)}")
     max_sec = max_wake_seconds(definition)
     if async_wake:

--- a/apps/a8s/definitions.py
+++ b/apps/a8s/definitions.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import json
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import NamedTuple
 
 from core import (
     DEFINITIONS_DIR,
@@ -323,11 +324,69 @@ def batch_limit(definition: dict) -> int:
     return max(1, v)
 
 
+class BatchEntry(NamedTuple):
+    """One inbox envelope handed to `build_batch_command`. `msg` is the
+    parsed envelope dict; it is None if the file failed to parse, in which
+    case `name`/`error` are used to render a visible placeholder instead of
+    silently dropping the message (a batch wake must account for every file
+    it trashed)."""
+    msg: dict | None
+    name: str
+    error: str | None = None
+
+
+def format_batch_message(msg: dict) -> str:
+    """Render one envelope as a '----' block, in the same voice
+    `build_command` uses for a single message: sender, human age (falling
+    back to the raw ISO date, then 'unknown time'), and content."""
+    sender = (msg.get("from") or "").strip() or "unknown"
+    date_str = (msg.get("date") or "").strip()
+    age = _format_age(date_str) or date_str or "unknown time"
+    content = msg.get("content", "")
+    return f"----\n{sender} sent ({age}): {content}"
+
+
+def format_batch_placeholder(name: str, error: str) -> str:
+    """Visible stand-in for an envelope file that failed to parse — batch
+    delivery must never silently drop a message."""
+    return f"---- [unreadable message file {name}: {error}]"
+
+
+def build_batch_prompt(recipient: str, entries: list[BatchEntry]) -> str:
+    """Compose the single prompt string passed to `batch.invoke`: the same
+    header `build_command` implies via the single-message CLI convention,
+    followed by one '----' block per entry (or a placeholder for one that
+    failed to parse).
+
+    This replaces the old contract of handing the invoked command N raw
+    envelope file paths and trusting it to re-parse them — that second,
+    schema-divergent parser (in the external `bulk-invoke` helper) is what
+    silently broke batch delivery. Composing the prompt here means there is
+    only one place in the pipeline that understands the envelope schema."""
+    header = (
+        f"You are receiving messages as '{recipient}'. Use bash CLI "
+        "`tell [--attach /path/to/file] <recipient> <message>` to send asynchronously."
+    )
+    blocks = [header]
+    for entry in entries:
+        if entry.msg is None:
+            blocks.append(
+                format_batch_placeholder(entry.name, entry.error or "unknown error")
+            )
+        else:
+            blocks.append(format_batch_message(entry.msg))
+    return "\n".join(blocks)
+
+
 def build_batch_command(
-    definition: dict, agent_name: str, msg_paths: list[Path], definition_path: str = ""
+    definition: dict,
+    agent_name: str,
+    entries: list[BatchEntry],
+    definition_path: str = "",
 ) -> list[str]:
-    """Expand `batch.invoke` like idle (no incoming message) and append each
-    message file path as a trailing argv element."""
+    """Expand `batch.invoke` like idle (no incoming message) and append ONE
+    composed prompt string (see `build_batch_prompt`) as the trailing argv
+    element — not raw envelope paths."""
     batch = definition.get("batch")
     if not isinstance(batch, dict):
         raise ValueError("definition missing 'batch'")
@@ -335,7 +394,7 @@ def build_batch_command(
     if not argv:
         raise ValueError("definition missing 'batch.invoke'")
     cmd = _expand_argv(list(argv), "", agent_name, "", "", "", definition_path)
-    cmd.extend(str(p.resolve()) for p in msg_paths)
+    cmd.append(build_batch_prompt(agent_name, entries))
     return cmd
 
 

--- a/apps/a8s/tests/test_daemon.py
+++ b/apps/a8s/tests/test_daemon.py
@@ -820,8 +820,31 @@ class TestBatchWake:
         assert "BATCH|TO:B" in log
         assert log.count("MOCK-CLI: BATCH|TO:B") == 1
         assert log.count("SINGLE|") == 0
+        # The daemon composes one prompt from all 3 envelopes (not raw file
+        # paths) — every message body shows up, plus the shared header.
+        assert "receiving messages as 'B'" in log
         for i in range(3):
-            assert str(trash_dir("B") / f"msg{i}.json") in log or f"msg{i}.json" in log
+            assert f"msg-{i}" in log
+
+    def test_unreadable_envelope_gets_visible_placeholder(self, fake_home, tmp_path, fixtures_dir):
+        # One malformed file among otherwise-good ones must never be silently
+        # dropped — it shows up as a placeholder block in the composed prompt
+        # instead of vanishing (or, pre-fix, poisoning the whole batch).
+        d = tmp_path / "b"
+        d.mkdir()
+        save_registry({
+            "B": {"root": str(d), "definition": str(fixtures_dir / "mock-batch.json")},
+        })
+        ensure_mailboxes(Participant("B", d))
+        self._queue_inbox("B", 2)
+        (inbox_dir("B") / "corrupt.json").write_text("{not json")
+
+        rc = attached_loop(["B"], 0.1, single_pass=True)
+        assert rc == 0
+        log = _read_log("B")
+        assert log.count("batch exec:") == 1
+        assert "msg-0" in log and "msg-1" in log
+        assert "unreadable message file corrupt.json" in log
 
     def test_single_message_uses_normal_invoke(self, fake_home, tmp_path, fixtures_dir):
         d = tmp_path / "b"
@@ -870,10 +893,14 @@ class TestBatchWake:
         attached_loop(["B"], 0.1, single_pass=True)
         log = _read_log("B")
         assert log.count("batch exec:") == 2
-        first_batch = log.split("batch exec:")[1].split("\n")[0]
-        assert first_batch.count(".json") == 5
-        second_batch = log.split("batch exec:")[2].split("\n")[0]
-        assert second_batch.count(".json") == 2
+        # First batch: files are queued/consumed in name order (q0..q6), so
+        # the 5-cap takes q-0..q-4 and the drained remainder is q-5/q-6.
+        first_batch = log.split("batch exec:")[1].split("batch exec:")[0]
+        for i in range(5):
+            assert f"q-{i}" in first_batch
+        second_batch = log.split("batch exec:")[2]
+        for i in (5, 6):
+            assert f"q-{i}" in second_batch
 
 
 class TestPauseBeforeWake:

--- a/apps/a8s/tests/test_definitions.py
+++ b/apps/a8s/tests/test_definitions.py
@@ -483,23 +483,50 @@ class TestBatchInvoke:
         defn = {"invoke": ["x"], "batch": {"invoke": ["y"], "limit": "nope"}}
         assert batch_limit(defn) == 5
 
-    def test_build_batch_command_appends_paths(self, tmp_path):
-        from definitions import build_batch_command
-        p1 = tmp_path / "a.json"
-        p2 = tmp_path / "b.json"
-        p1.write_text("{}")
-        p2.write_text("{}")
+    def test_build_batch_command_appends_one_composed_prompt(self):
+        from definitions import BatchEntry, build_batch_command
+        entries = [
+            BatchEntry({"from": "A", "date": "2026-04-28T14:30:00Z", "content": "hi"}, "a.json"),
+            BatchEntry({"from": "B", "date": "2026-04-28T14:29:00Z", "content": "yo"}, "b.json"),
+        ]
         defn = {"invoke": ["x"], "batch": {"invoke": ["agent", "--batch", "$RECIPIENT"]}}
-        argv = build_batch_command(defn, "neil", [p1, p2])
-        assert argv == ["agent", "--batch", "neil", str(p1.resolve()), str(p2.resolve())]
+        argv = build_batch_command(defn, "neil", entries)
+        assert argv[:3] == ["agent", "--batch", "neil"]
+        assert len(argv) == 4
+        prompt = argv[3]
+        assert "receiving messages as 'neil'" in prompt
+        assert "A sent" in prompt and "hi" in prompt
+        assert "B sent" in prompt and "yo" in prompt
 
-    def test_build_batch_command_empty_message_fields(self):
+    def test_build_batch_command_empty_entries_still_has_header(self):
         from definitions import build_batch_command
         defn = {"invoke": ["x"], "batch": {"invoke": [
             "echo", "S=$SENDER", "M=$MESSAGE", "T=$TIMESTAMP", "A=$AGE",
         ]}}
         argv = build_batch_command(defn, "neil", [])
-        assert argv == ["echo", "S=", "M=", "T=", "A="]
+        assert argv[:-1] == ["echo", "S=", "M=", "T=", "A="]
+        assert "receiving messages as 'neil'" in argv[-1]
+
+    def test_build_batch_command_placeholder_for_unreadable_entry(self):
+        from definitions import BatchEntry, build_batch_command
+        entries = [
+            BatchEntry({"from": "A", "date": "2026-04-28T14:30:00Z", "content": "hi"}, "a.json"),
+            BatchEntry(None, "corrupt.json", "Expecting value: line 1 column 1 (char 0)"),
+        ]
+        defn = {"invoke": ["x"], "batch": {"invoke": ["agent"]}}
+        prompt = build_batch_command(defn, "neil", entries)[-1]
+        assert "A sent" in prompt and "hi" in prompt
+        assert "unreadable message file corrupt.json" in prompt
+        assert "Expecting value" in prompt
+
+    def test_format_batch_message_and_placeholder(self):
+        from definitions import format_batch_message, format_batch_placeholder
+        block = format_batch_message({"from": "A", "date": "2026-04-28T14:30:00Z", "content": "hi"})
+        assert block.startswith("----\n")
+        assert "A sent" in block and "hi" in block
+
+        placeholder = format_batch_placeholder("bad.json", "boom")
+        assert placeholder == "---- [unreadable message file bad.json: boom]"
 
 
 # ---------- build_idle_command + idle_timeout_seconds ----------


### PR DESCRIPTION
Batch delivery (>=2 queued messages) was broken end-to-end: wake_batch trashed the envelope files first, then build_batch_command appended the raw trash-file PATHS as argv to the agent's batch.invoke command, leaving the external ~/agents/bulk-invoke helper to re-parse them. That helper was doubly broken — it read keys recipient/sender/age/message that don't exist on the real envelope schema (to/from/date/content, per mailbox.py's _write_outbox), and its `python3 -c` body formatter had `\"` escapes inside an f-string within bash single-quotes, a compile-time SyntaxError on Python 3.12 that its bare `except Exception: pass` couldn't catch. Net effect: every batched wake delivered "You are receiving messages as 'unknown'." with no message content.

Fix: eliminate the second, schema-divergent parser. definitions.py gains BatchEntry/format_batch_message/format_batch_placeholder/ build_batch_prompt; build_batch_command now composes ONE prompt string (header + a "----" block per envelope, worded like the single-message path, with a visible placeholder for any envelope that fails to parse) and appends it as the sole trailing argv element instead of N file paths. daemon.py's wake_batch collects (msg, name, error) entries while it already has the files open for the log preview, so there's no extra I/O. Single-message delivery (build_command/wake_once) is untouched.

~/agents/bulk-invoke (not version-controlled) becomes a passthrough: exec "$TARGET_COMMAND" "$PROMPT" for the new one-string contract, with a legacy fallback (parses envelope files with the correct keys via a python3 heredoc, not a `python3 -c` one-liner) so an old daemon binary still works during a rolling-upgrade window. Backup of the pre-fix version kept at ~/agents/bulk-invoke.pre-fix.bak.

Updated/added tests in test_definitions.py and test_daemon.py for the new composed-prompt contract, including a malformed-envelope case exercised through a full attached_loop batch wake.

## PR Checklist

### Code Quality
- [x] No `__pycache__` or `.pyc` files in git
- [x] No hardcoded secrets (API keys, passwords, bridge URLs, MQTT creds)
- [x] No PII in committed code or PR description (real emails, phone numbers — use example.com)
- [x] No SQL string interpolation (all queries use `?` parameters)
- [x] No raw `except:` without specific exception types
- [x] No dead imports or unused variables
- [x] Runtime artifacts gitignored (`.db`, `.log`, `.count`, `health.txt`, `stimulus.txt`)

### Testing
- [ ] Integration tests pass (`lifetime.sh`)
- [ ] Unit tests pass (if applicable: `pytest`)
- [x] Manual verification of new features

### Documentation
- [x] Textbook updated if architecture changed
- [x] README updated if organ/CLI interface changed

### Review
- [x] Critic agent reviewed before merge
