### PR TITLE
fix(r4t): teach judge the stdout-fallback delivery semantics

### DIFF
--- a/apps/r4t/judge.py
+++ b/apps/r4t/judge.py
@@ -120,6 +120,28 @@ names):
 """
 
 
+FALLBACK_NOTE = """\
+Delivery semantics you must apply before grading "printed instead of sending":
+this team has a stdout fallback. A turn that ends without staging any message
+but prints a non-trivial prose answer does NOT lose that answer — the cleaned
+stdout is delivered as ONE reply to the sender of the message the turn was
+answering. Prose-only output is therefore a normal, delivered reply, not a
+dropped one. Do not raise FM-1.1, FM-2.5, or FM-2.6 merely because a member
+answered in prose without an explicit send.
+
+Prose-only output IS a genuine failure only when one of these holds:
+- the output narrates messages to recipients other than (or in addition to)
+  the one inbound sender — the fallback reaches the inbound sender alone, so
+  "I told Rook and Faye and Neil" as prose reaches only whoever last wrote in;
+  the other named recipients never receive it;
+- the turn is genuinely silent or chrome-only — no answer worth relaying, so
+  nothing is delivered at all; or
+- a required non-message action (writing a file, running a command) is
+  narrated as done but was not actually performed in the turn.
+Grade those normally. A plain prose answer to the inbound sender is delivered
+and is not a finding on its own."""
+
+
 @dataclass
 class Unit:
     member: str
@@ -250,6 +272,8 @@ r4t extension):
 {_taxonomy_block()}
 
 {EXAMPLES}
+
+{FALLBACK_NOTE}
 
 Rules:
 - Report a finding only when the transcript text in front of you shows it.

--- a/apps/r4t/tests/test_judge.py
+++ b/apps/r4t/tests/test_judge.py
@@ -173,6 +173,20 @@ def test_prompt_carries_taxonomy_captures_and_context(
     assert "budget" in prompt
 
 
+def test_prompt_teaches_stdout_fallback_semantics(
+    r4t_home, judge_config, judge_harness
+):
+    _script, calls = judge_harness
+    _seed_capture()
+    code, _out, _err = _run(judge_config)
+    assert code == 0
+    prompt = (calls / "call-000.txt").read_text(encoding="utf-8")
+    assert "stdout fallback" in prompt
+    assert "ONE reply to the sender" in prompt
+    assert "recipients other than" in prompt
+    assert "genuinely silent or chrome-only" in prompt
+
+
 def test_chunking_invokes_per_chunk_and_aggregates(
     r4t_home, judge_config, judge_harness, monkeypatch
 ):


### PR DESCRIPTION
Fixes #216.

## Why

`r4t judge` grades transcripts for "printed instead of sending" (FM-1.1, FM-2.5, FM-2.6) with no knowledge of r4t's **stdout fallback** (message-flow.md §5): a turn that exits 0, stages no envelope, and prints a non-trivial answer has that cleaned stdout delivered as ONE reply to the inbound sender (log event `STDOUT-REPLY`; all-chrome output logs `SILENT`). Prose-only output is therefore usually a delivered reply, not a lost one.

A calibration run of `r4t judge d5n` produced **90 findings, 71** of them in those three "sent nothing" classes; the d5n node log showed **61 `STDOUT-REPLY` vs 11 `SILENT`**, so most were by-design deliveries the judge overcounted as failures.

## What

- Add a fallback-semantics paragraph (`FALLBACK_NOTE`) to the judge rubric. Prose-only output is now a finding only when it (a) narrates messages to recipients other than the inbound sender (the fallback reaches the inbound sender alone), (b) is genuinely silent/chrome-only, or (c) narrates a required non-message action (file write, command) that was not executed. Original prompt text — no MAST repo text copied.
- One test asserting the prompt carries the fallback paragraph.

## Mechanical `[fallback-delivered]` annotation — investigated, skipped

Not reliably derivable from existing recorded data. The `STDOUT-REPLY` log line (dispatch.py) carries no per-turn timestamp, thread id, or capture filename, and `append_log` writes no inline timestamp (day-file granularity only). The finding's `turn` is a microsecond capture stem, so there is no shared key to join a graded turn to a specific fallback event; ordering-based zipping is unreliable (captures cover all turns and are pruned to 50, log has only fallback turns interleaved with SILENT/QUOTA-SUSPECT). Per the brief, no new capture plumbing was built for it, so docs/verification.md is left unchanged (the annotation sentence was conditioned on adding the annotation).

## Tests

Full r4t suite: baseline **497 passed**, with this change **498 passed**.

## Merge timing

Do not merge until the running d5n org concludes — this touches the live dispatch working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)