### PR TITLE
feat(r4t): OS-level rig isolation — run_as user and container (#210)

### DIFF
--- a/apps/r4t/README.md
+++ b/apps/r4t/README.md
@@ -86,6 +86,7 @@ in production too. Full flow: [docs/message-flow.md](docs/message-flow.md).
 - [Verification](docs/verification.md) — `r4t check`, checklists, doorbell gate, the post-hoc judge
 - [Governance](docs/governance.md) — why each layer exists, with prior art
 - [Security model](docs/security.md) — what a repo edit can never change
+- [Isolation](docs/isolation.md) — run a rig behind a Unix user or a container
 - [Development](docs/development.md) — sandbox testing, module layout
 - Harness notes: [agy](docs/harness-agy.md) ·
   [ollama launch](docs/harness-ollama-launch.md)

--- a/apps/r4t/dispatch.py
+++ b/apps/r4t/dispatch.py
@@ -47,6 +47,7 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
+import isolate
 import state
 import tasks
 from rig import RigConfig, RigError, Rig, load_rig_config, resolve_agy_model
@@ -513,7 +514,12 @@ def run_harness(
     as a single argv element — never a shell. Returns (exit_code, output,
     duration_seconds, timed_out). When the env carries `R4T_LIVE_LOG`, the
     harness output is teed there line by line as it arrives, so a gemba attach
-    can tail the turn live; the full output is still returned for staging."""
+    can tail the turn live; the full output is still returned for staging.
+
+    When the rig sets `run_as` or `container` (rig.py; plans/ISOLATE-SPEC.md)
+    the argv is wrapped in the OS-level boundary. An isolation prereq that fails
+    closed returns a nonzero exit like any other failed turn — the batch stays
+    queued and the breaker counts it."""
     argv = rig.argv(prompt, variant)
     if rig.model_resolver == "agy-live":
         # Resolve the friendly --model against the live `agy models` list before
@@ -525,6 +531,30 @@ def run_harness(
         except RigError as e:
             return 127, f"agy --model {rig.model!r} did not resolve: {e}", 0.0, False
         argv = [resolved if a == "{model}" else a for a in argv]
+
+    staging = (env or {}).get("TELL_OUTBOX_DIR", "")
+    kill_container_name: str | None = None
+    if rig.run_as:
+        probe_error = isolate.probe_run_as(rig.run_as, cwd)
+        if probe_error:
+            return 126, f"run_as {rig.run_as!r} isolation failed: {probe_error}", 0.0, False
+        if staging:
+            isolate.assert_writable_shared_dir(staging, isolate.agent_gid(rig.run_as))
+        argv = isolate.wrap_run_as(argv, rig.run_as, staging, cwd)
+    elif rig.container:
+        kill_container_name = isolate.container_name(
+            (env or {}).get("R4T_NODE", ""), (env or {}).get("R4T_MEMBER", "")
+        )
+        argv = isolate.build_container_argv(
+            argv,
+            rig.container,
+            name=kill_container_name,
+            staging_dir=staging,
+            workplace=cwd,
+            tell_outbox=staging,
+            container_args=rig.container_args,
+        )
+
     live_log = (env or {}).get("R4T_LIVE_LOG")
     start = time.monotonic()
     try:
@@ -567,6 +597,11 @@ def run_harness(
         proc.wait(timeout=rig.timeout_seconds)
     except subprocess.TimeoutExpired:
         timed_out = True
+        # A container runs detached from the `docker run` client's process
+        # group, so killpg alone leaks it — kill it by its deterministic name,
+        # then `--rm` reaps it.
+        if kill_container_name:
+            isolate.kill_container(kill_container_name)
         try:
             os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
         except OSError:
@@ -1131,6 +1166,10 @@ def _run_turn(
     env = dict(os.environ)
     env["TELL_OUTBOX_DIR"] = str(staging)
     env["R4T_LIVE_LOG"] = str(state.reset_live_log(ctx.node, member.name))
+    # Carried so run_harness can name a container rig's container deterministically
+    # (r4t-<node>-<member>-<ts>) without widening the run_fn contract.
+    env["R4T_NODE"] = ctx.node
+    env["R4T_MEMBER"] = member.name
     state.append_log(
         ctx.node,
         f"## {state.utc_now()} dispatch {len(batch)} message(s) -> {member.name} "

--- a/apps/r4t/docs/isolation.md
+++ b/apps/r4t/docs/isolation.md
@@ -1,0 +1,163 @@
+# Isolation — a real OS boundary per rig
+
+Harness sandbox flags are not a security boundary: a CLI's `--sandbox` is
+model-discretionary and drifts between versions. The boundary that holds is the
+one the operating system already enforces — a Unix user with no sudo, or a
+container. r4t makes either a per-rig property. Inside the boundary the agent
+runs fully permissive; the OS, not a flag, is what contains it.
+
+Two mutually exclusive rig keys (both set is a config error and the rig fails
+closed):
+
+- `run_as: "<username>"` — wrap the turn in `sudo -u <username>`.
+- `container: "<image>"` — run the turn under `docker run --rm`.
+
+r4t **verifies** the prerequisites before every turn and fails closed with an
+action-first error; it never creates users, sudoers grants, workplace
+permissions, or images. Provisioning is the operator's, once, below. A failed
+check is an ordinary failed turn: the batch stays queued, the breaker counts
+it, and `r4t status` shows the member unhealthy with the real error.
+
+Set the boundary on an existing rig by editing `~/.config/r4t/rigs.json`:
+
+```json
+{
+  "leader": {
+    "preset": "claude",
+    "invoke": ["claude", "--permission-mode", "dontAsk", "...", "-p", "{prompt}"],
+    "run_as": "r4t-leader"
+  }
+}
+```
+
+`r4t rig list` and `r4t status` then tag the rig `[user:r4t-leader]` /
+`[container:<image>]` so the boundary is visible at a glance.
+
+## Posture: most-permissive preset behind the boundary
+
+Isolation composes with any harness preset and does not touch its flags. The
+intended posture is the inverse of the flag-juggling it replaces: **behind
+`run_as`/`container`, choose the preset's most-permissive flags.** The point of
+the OS boundary is that the harness no longer has to police itself — a
+half-trusted `--sandbox` inside an untrusted user buys nothing but breakage
+(it was `--sandbox` that silently broke message staging for a whole org). Let
+the agent be free inside the cell; let the cell be the wall.
+
+## `run_as` — prerequisites (operator-provisioned, once)
+
+1. **Create the agent user** — no sudo group, no sudoers entry of its own:
+
+   ```bash
+   sudo useradd -m -s /bin/bash r4t-leader
+   ```
+
+2. **Grant the router passwordless sudo to that user.** The scoped shape below
+   limits the grant to the exact wake command; a blanket `NOPASSWD: ALL` for
+   the target user also works but grants more than needed. Replace `router`
+   with the user the r4t daemon runs as, and edit with `sudo visudo`:
+
+   ```sudoers
+   # /etc/sudoers.d/r4t-leader  (chmod 0440)
+   Cmnd_Alias R4T_LEADER = /usr/bin/bash --login -c *
+   router ALL=(r4t-leader) NOPASSWD: R4T_LEADER
+   ```
+
+   Verify the grant the same way r4t probes it:
+
+   ```bash
+   sudo -n -u r4t-leader true && echo "grant OK"
+   ```
+
+3. **Make the org workplace writable by the agent user.** r4t members work in
+   the shared repo (cwd = the workplace), so the agent user needs write there.
+   A shared group is the least-surprising arrangement:
+
+   ```bash
+   sudo groupadd r4t-work
+   sudo usermod -aG r4t-work router
+   sudo usermod -aG r4t-work r4t-leader
+   sudo chgrp -R r4t-work /path/to/workplace
+   sudo chmod -R g+ws /path/to/workplace     # g+s so new files stay group-owned
+   ```
+
+r4t re-probes 2 and 3 before every turn (`sudo -n -u <user> true`, then a touch
+in the workplace as the agent user) and fails the turn if either regresses.
+
+### What r4t does own
+
+The message channel — the per-member staging dir that `TELL_OUTBOX_DIR` points
+at — is r4t's own state, not the operator's repo. r4t re-asserts it to
+`router:<agent-group>`, mode `2770` setgid, before every turn, so the agent
+writes envelopes into it and everything the agent creates stays group-owned and
+reachable by the router. Turn transcripts live under the router-owned team
+directory and are written from the subprocess pipe, so the agent user cannot
+read, alter, or erase the audit trail.
+
+### The wrapper
+
+```
+sudo -u <user> bash --login -c \
+  'export TELL_OUTBOX_DIR="$1"; cd "$2"; shift 2; exec "$@"' \
+  _ <staging-dir> <workplace> <argv...>
+```
+
+`bash --login` so the agent user's own profile resolves its per-user tool
+installs. The environment cannot survive sudoers `env_reset`, so
+`TELL_OUTBOX_DIR` and the workplace ride as positional arguments; `exec "$@"`
+hands the harness argv through untouched, so quoting bugs are impossible. The
+rig's wall-clock timeout wraps the whole `sudo`.
+
+## `container` — prerequisites and contract
+
+The image contract is minimal: **the harness CLI must be on the image's PATH.**
+r4t never builds, pulls, or inspects the image — a missing image is an ordinary
+turn failure with docker's own error on the human surface. The turn runs:
+
+```
+docker run --rm --name r4t-<node>-<member>-<ts> \
+  -v <workplace>:<workplace> -w <workplace> \
+  -v <staging>:<staging> -e TELL_OUTBOX_DIR=<staging> \
+  -v <a8s-client>:<a8s-client>:ro -e PATH=<a8s-client>:<standard-path> \
+  <container_args...> <image> <argv...>
+```
+
+- The workplace is bind-mounted read-write at the same absolute path and used
+  as the workdir.
+- The staging dir is bind-mounted read-write with `TELL_OUTBOX_DIR` injected
+  via `-e` (no `env_reset` inside a container).
+- The a8s client dir is mounted read-only with a PATH shim so the unmodified
+  `tell` resolves inside the container.
+- Network stays on (agents talk to model APIs). Turn it off in `container_args`
+  if you want it off.
+
+### `container_args` — credentials and everything else
+
+A per-rig `container_args` list is appended to `docker run` verbatim (the
+option-passthrough principle). Cloud-CLI credentials ride here as
+operator-chosen read-only mounts:
+
+```json
+{
+  "cloud-rig": {
+    "preset": "claude",
+    "invoke": ["claude", "--permission-mode", "dontAsk", "...", "-p", "{prompt}"],
+    "container": "r4t/claude:latest",
+    "container_args": [
+      "-v", "/home/router/.config/anthropic:/root/.config/anthropic:ro",
+      "--network", "host"
+    ]
+  }
+}
+```
+
+Interactive and browser-based auth flows are an explicit non-goal: a harness
+that cannot authenticate headlessly from mounted files does not belong in a
+container rig. On rig-timeout expiry r4t kills the container by its
+deterministic name and lets `--rm` reap it.
+
+## Not automated (by design)
+
+Auto-provisioning users, sudoers, or workplace group bits; a forbidden-paths
+sweep of the agent user's home; GUI/desktop OAuth flows; supervising the router
+daemon itself. See [the security model](security.md) for what a repo edit can
+never change, and `plans/ISOLATE-SPEC.md` for the ratified design record.

--- a/apps/r4t/docs/security.md
+++ b/apps/r4t/docs/security.md
@@ -20,4 +20,6 @@ What keeps a repo edit, or a lying message, from changing what runs.
 Related: external ingress is untrusted by design — see
 [message-flow.md](message-flow.md#no-wire-header-inside-the-walls). The
 verification round keeps its findings on a surface agents cannot read — see
-[verification.md](verification.md).
+[verification.md](verification.md). A rig can also run behind a real OS
+boundary — a Unix user or a container — so the harness sandbox stops being
+load-bearing; see [isolation.md](isolation.md).

--- a/apps/r4t/example-rigs.json
+++ b/apps/r4t/example-rigs.json
@@ -48,6 +48,14 @@
     "rig_budget_earn_per_hour": 20
   },
 
+  "walled": {
+    "_notes": "Isolated rig — the security boundary is the OS, not a harness flag. `run_as` wraps the turn in `sudo -u <user>` (a Unix user with no sudo); `container` runs it under `docker run --rm` with `container_args` appended verbatim (e.g. read-only credential mounts). The two are mutually exclusive. Prereqs are operator-provisioned and probed per turn — see docs/isolation.md. Behind the wall, choose the most-permissive preset.",
+    "invoke": ["claude", "--permission-mode", "dontAsk", "-p", "{prompt}"],
+    "run_as": "r4t-worker",
+    "_container_example": "img/claude:latest",
+    "_container_args_example": ["-v", "/home/router/.config/anthropic:/root/.config/anthropic:ro"]
+  },
+
   "pins": {
     "_notes": "agent name -> rig. A pinned agent's rig comes from HERE, silently overriding the roster's Rig line — an in-repo roster edit can't upgrade a pinned agent.",
     "gerry": "leader"

--- a/apps/r4t/isolate.py
+++ b/apps/r4t/isolate.py
@@ -1,0 +1,199 @@
+"""OS-level isolation for rig invocation — run-as-user and container variants.
+
+The through-line (see plans/ISOLATE-SPEC.md): harness sandbox flags are not a
+security boundary; the operating system is. A rig may name `run_as` (a Unix
+user with no sudo) or `container` (an image) and the agent runs fully
+permissive INSIDE that boundary. r4t never provisions the boundary — it
+verifies operator-provisioned prerequisites and fails closed with an
+action-first error — except for the shared message dirs, which are r4t's own
+state and are re-asserted to the correct owner-group/mode before every turn.
+
+Both wrappers are pure argv builders so the exact shape is unit-testable
+against fake `sudo`/`docker` binaries; nothing here shells out except the
+prereq probes and the container kill, which run the real tool by name.
+"""
+from __future__ import annotations
+
+import os
+import pwd
+import re
+import subprocess
+import time
+from pathlib import Path
+
+PROBE_TIMEOUT_SECONDS = 10
+
+# The bash the wrapped `sudo` runs: env cannot survive sudoers env_reset, so
+# TELL_OUTBOX_DIR rides as $1 and the workplace as $2; `exec "$@"` hands the
+# remaining positionals to the harness verbatim — no quoted command string, so
+# quoting bugs are structurally impossible.
+_RUN_AS_BOOTSTRAP = 'export TELL_OUTBOX_DIR="$1"; cd "$2"; shift 2; exec "$@"'
+
+# A standard system PATH the container shim prepends the a8s client dir to, so
+# an unmodified `tell` resolves inside the image. Operators can override with a
+# later `-e PATH=...` in container_args (docker keeps the last value).
+_CONTAINER_BASE_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+
+class IsolationError(Exception):
+    pass
+
+
+def a8s_client_dir() -> Path:
+    """The repo bin root that holds the `tell` client shim — mounted read-only
+    into a container so `tell` resolves on PATH. isolate.py lives at
+    apps/r4t/, so two parents up is the bin root."""
+    return Path(__file__).resolve().parents[2]
+
+
+# ---------- run_as ----------
+
+def wrap_run_as(
+    argv: list[str], user: str, staging_dir: str | Path, workplace: str | Path
+) -> list[str]:
+    return [
+        "sudo", "-u", user, "bash", "--login", "-c",
+        _RUN_AS_BOOTSTRAP, "_", str(staging_dir), str(workplace), *argv,
+    ]
+
+
+def _run_probe(argv: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        argv, capture_output=True, text=True, timeout=PROBE_TIMEOUT_SECONDS
+    )
+
+
+def probe_run_as(user: str, workplace: str | Path) -> str | None:
+    """Verify the two operator-provisioned prerequisites for `run_as`: a
+    passwordless sudo grant to `user`, and a workplace writable by `user`.
+    Returns None when both pass, else an action-first error carrying the fix.
+    Never provisions anything."""
+    try:
+        grant = _run_probe(["sudo", "-n", "-u", user, "true"])
+    except (OSError, subprocess.TimeoutExpired) as e:
+        return (
+            f"cannot probe sudo to {user!r}: {e} "
+            f"(try: install sudo and grant the router NOPASSWD — see "
+            f"apps/r4t/docs/isolation.md)"
+        )
+    if grant.returncode != 0:
+        detail = (grant.stderr or grant.stdout or "").strip()
+        return (
+            f"no passwordless sudo to user {user!r}"
+            + (f": {detail}" if detail else "")
+            + " (try: add a NOPASSWD sudoers grant for the wake command — see "
+            "apps/r4t/docs/isolation.md)"
+        )
+    probe = f".r4t-write-probe.{os.getpid()}.{time.time_ns()}"
+    try:
+        write = _run_probe([
+            "sudo", "-n", "-u", user, "bash", "--login", "-c",
+            'f="$1/$2"; touch "$f" && rm -f "$f"', "_", str(workplace), probe,
+        ])
+    except (OSError, subprocess.TimeoutExpired) as e:
+        return f"cannot probe workplace write as {user!r}: {e}"
+    if write.returncode != 0:
+        detail = (write.stderr or write.stdout or "").strip()
+        return (
+            f"workplace {workplace} not writable by user {user!r}"
+            + (f": {detail}" if detail else "")
+            + " (try: give the agent user's group g+ws on the workplace — see "
+            "apps/r4t/docs/isolation.md)"
+        )
+    return None
+
+
+def agent_gid(user: str) -> int | None:
+    """The agent user's primary gid, for group-owning the shared dirs. None if
+    the user is unknown (the sudo probe reports that failure first)."""
+    try:
+        return pwd.getpwnam(user).pw_gid
+    except KeyError:
+        return None
+
+
+def assert_writable_shared_dir(path: str | Path, gid: int | None) -> None:
+    """Re-assert r4t's writable message channel: owned by the router, group set
+    to the agent's group, mode 2770 setgid so the agent writes envelopes and
+    everything the agent creates stays group-owned. Idempotent; called before
+    every turn, not just at setup — re-assertion is what made the precedent
+    robust against drift."""
+    p = Path(path)
+    p.mkdir(parents=True, exist_ok=True)
+    if gid is not None:
+        os.chown(p, -1, gid)
+    os.chmod(p, 0o2770)
+
+
+def assert_readonly_shared_dir(path: str | Path, gid: int | None) -> None:
+    """Re-assert a dir the agent may only READ (delivered files): router-owned,
+    agent's group, mode 2750 setgid, no group write bit."""
+    p = Path(path)
+    p.mkdir(parents=True, exist_ok=True)
+    if gid is not None:
+        os.chown(p, -1, gid)
+    os.chmod(p, 0o2750)
+
+
+# ---------- container ----------
+
+_SLUG_RE = re.compile(r"[^a-zA-Z0-9_.-]+")
+
+
+def _slug(text: str) -> str:
+    return _SLUG_RE.sub("-", (text or "").strip()) or "x"
+
+
+def container_name(node: str, member: str, ts: int | None = None) -> str:
+    """Deterministic per-turn container name so a timeout can kill by name."""
+    stamp = ts if ts is not None else time.time_ns()
+    return f"r4t-{_slug(node)}-{_slug(member)}-{stamp}"
+
+
+def build_container_argv(
+    argv: list[str],
+    image: str,
+    *,
+    name: str,
+    staging_dir: str | Path,
+    workplace: str | Path,
+    tell_outbox: str | Path,
+    container_args: list[str] | None = None,
+    delivered_dir: str | Path | None = None,
+    client_dir: str | Path | None = None,
+) -> list[str]:
+    """`docker run --rm` with the workplace bind-mounted rw at the same path and
+    used as workdir, the staging dir rw at the same path with TELL_OUTBOX_DIR
+    injected (no env_reset inside a container), the a8s client ro with a PATH
+    shim, an optional delivered-files dir ro, then per-rig container_args
+    verbatim, then the image and the harness argv. r4t never builds, pulls, or
+    inspects the image — a missing image is an ordinary turn failure."""
+    client = Path(client_dir) if client_dir is not None else a8s_client_dir()
+    cmd = [
+        "docker", "run", "--rm", "--name", name,
+        "-v", f"{workplace}:{workplace}",
+        "-w", str(workplace),
+        "-v", f"{staging_dir}:{staging_dir}",
+        "-e", f"TELL_OUTBOX_DIR={tell_outbox}",
+        "-v", f"{client}:{client}:ro",
+        "-e", f"PATH={client}:{_CONTAINER_BASE_PATH}",
+    ]
+    if delivered_dir is not None:
+        cmd += ["-v", f"{delivered_dir}:{delivered_dir}:ro"]
+    cmd += list(container_args or [])
+    cmd += [image, *argv]
+    return cmd
+
+
+def kill_container(name: str) -> None:
+    """Best-effort kill a container by name after a rig timeout; `--rm` reaps
+    it. Never raises — the turn already failed."""
+    try:
+        subprocess.run(
+            ["docker", "kill", name],
+            capture_output=True,
+            text=True,
+            timeout=PROBE_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        pass

--- a/apps/r4t/plans/ISOLATE-SPEC.md
+++ b/apps/r4t/plans/ISOLATE-SPEC.md
@@ -1,0 +1,181 @@
+# The isolation phase — implementation spec
+
+*2026-07-15. Follows the verification round (VERIFY-SPEC.md) and Neil's
+ruling that morning: run-as-user and run-via-container become first-class
+r4t features, buildable in parallel with the verification work. One issue,
+one implementation PR, spec first (this doc). Every open question is
+resolved inline (marked DECIDED).*
+
+*Scope: `apps/r4t/` only. Pre-v1 scorch-the-earth — no migration code; a
+rig without the new keys behaves byte-for-byte as today.*
+
+*Ratified by Neil 2026-07-16: workplace access is probe-only (r4t never
+fixes operator repo perms), presets stay untouched under isolation
+(posture lives in docs), both variants ship in one PR.*
+
+---
+
+## 1. Background and the through-line
+
+Two findings drive this:
+
+- **Harness sandbox flags are not a security boundary.** The d5n M4 run
+  proved it: one CLI's sandbox is model-discretionary (the harness *hints*
+  the model to retry denied operations with a bypass parameter, and
+  auto-approval honors it), and the same sandbox silently broke message
+  staging for a whole org. Rationalizing per-harness flags is a losing
+  game; the capability map that came out of it (docs/harness-agy.md)
+  exists because nobody could say from memory what the flag actually did.
+- **The OS already has a boundary that works.** A private production
+  deployment has run an agent for weeks behind a plain Unix user boundary:
+  the agent user has no sudo and cannot read the router user's home; the
+  only channel between them is a setgid shared directory the agent writes
+  message envelopes into. Verified live by inspection (2026-07-15): no
+  ACLs, no namespaces, no container — `sudo -u`, `chmod 2770`, and POSIX
+  ownership do all the work.
+
+The posture this feature ships: **the security boundary is the operating
+system — a Unix user or a container — and inside that boundary the agent
+runs fully permissive.** Harness sandbox flags stop being load-bearing.
+
+## 2. Where the knobs live
+
+DECIDED: per-rig keys in `rigs.json`, named `run_as` and `container`.
+
+- Rigs are already the member-capability layer and already live outside
+  the repo in machine-global config — and an OS username or local image
+  tag is a machine-local fact. Rosters stay portable; the same roster runs
+  isolated on one machine and bare on another.
+- `container` names the concept, not the implementation (the
+  protocol-not-library rule). Docker is today's backend; the key does not
+  say so.
+- DECIDED: `run_as` and `container` are mutually exclusive. Both set is a
+  config error and the rig fails closed (member does not run), same
+  posture as a rig missing from config.
+
+## 3. Feature A — `run_as: "<username>"`
+
+### Prerequisites (operator-provisioned, documented, never automated)
+
+- The target user exists (`useradd -m -s /bin/bash <user>`), is NOT in
+  the sudo group, and has no sudoers entry of its own.
+- The router user can `sudo -u <user>` without a password. The docs show
+  the scoped shape (a `Cmnd_Alias` limited to the wake command) as the
+  recommended grant; a blanket NOPASSWD grant also works.
+- The org workplace is writable by the agent user (shared group +
+  `g+ws`, or any arrangement the operator prefers).
+
+DECIDED: r4t verifies prerequisites and fails closed with action-first
+errors carrying the exact fix command — it never provisions users,
+sudoers entries, or workplace permissions itself. Verification at invoke
+time: `sudo -n -u <user> true` (grant probe) and a write probe in the
+workplace as the agent user. A failed probe fails the turn like any other
+turn failure (breaker counts it; the message stays queued, never lost).
+
+### Invoke wrapping
+
+When `run_as` is set, the rig's resolved argv is wrapped:
+
+```
+sudo -u <user> bash --login -c \
+  'export TELL_OUTBOX_DIR="$1"; cd "$2"; shift 2; exec "$@"' \
+  _ <staging-dir> <workplace> <argv...>
+```
+
+- `bash --login` so the agent user's own profile/PATH resolves its own
+  CLI installs (per-user tool installs are the norm).
+- Env must ride as positional arguments baked through the `-c` string:
+  sudoers `env_reset` (the default) strips the caller's environment, so
+  exported vars from dispatch never survive the boundary. DECIDED: the
+  `exec "$@"` form, not a quoted command string — argv passes through
+  untouched and quoting bugs are structurally impossible.
+- cwd is the org workplace (r4t members work in the shared repo; this
+  deliberately differs from the production precedent, whose agent works
+  in its own home).
+- The existing rig wall-clock timeout applies to the whole `sudo`
+  wrapper unchanged.
+
+### Shared directories
+
+The message channel is the same pattern the production deployment uses:
+
+- Any per-member directory the agent must WRITE (the staging dir that
+  `TELL_OUTBOX_DIR` points at) is owned `<router>:<agent-group>`, mode
+  `2770` (setgid).
+- Any directory the agent must only READ (delivered files/attachments)
+  is group-readable to the agent's group, no write bit.
+- DECIDED: r4t re-asserts ownership and mode on these dirs before every
+  turn, not just at setup — the boundary is procedural, and re-assertion
+  is what made the precedent robust in practice. This is the one place
+  r4t DOES fix permissions itself: these dirs are r4t's own state, unlike
+  the operator's workplace.
+
+Turn transcripts (`agents/<member>/turns/`) already live under the
+router-owned team dir and are written by dispatch from the subprocess
+pipe — the agent user cannot reach, alter, or erase the audit trail. No
+change needed; stated here as a required property.
+
+## 4. Feature B — `container: "<image>"`
+
+- Invoke becomes `docker run --rm` with:
+  - the workplace bind-mounted read-write at the same absolute path, and
+    used as the container workdir;
+  - the member staging dir bind-mounted read-write at the same path,
+    `TELL_OUTBOX_DIR` injected via `-e` (no env_reset inside a container
+    — env passes directly);
+  - the delivered-files dir bind-mounted read-only;
+  - the a8s client bind-mounted read-only with a PATH shim so `tell`
+    resolves inside the container.
+- DECIDED: the image contract is minimal — the harness CLI must be on
+  the image's PATH. r4t never builds, pulls, or inspects images; a
+  missing image is a turn failure with the docker error on the human
+  surface.
+- DECIDED: a per-rig `container_args` list is appended verbatim to
+  `docker run` (the option-passthrough principle). Credentials for cloud
+  CLIs ride this way as operator-chosen read-only mounts. Interactive
+  and browser-based auth flows are an explicit non-goal of the container
+  variant — if a harness cannot auth headlessly from mounted files, it
+  does not belong in a container rig.
+- Timeout: the container gets a deterministic name
+  (`r4t-<node>-<member>-<ts>`); on rig-timeout expiry r4t kills the
+  container by name, then reaps. `--rm` handles the normal path.
+- Network stays on (agents talk to model APIs). Operators who want it
+  off say so in `container_args`.
+
+## 5. Shared semantics
+
+- Fail closed everywhere; every isolation failure is an ordinary failed
+  turn — breaker counts it, messages stay queued, `r4t status` shows the
+  member unhealthy with the real error and a `(try: ...)` hint.
+- `r4t status` rig rows show the isolation mode (`user:<name>` /
+  `container:<image>`) so the operator sees the boundary at a glance.
+- Harness presets are untouched: isolation composes with any preset.
+  Docs state the intended posture — behind `run_as`/`container`, choose
+  the preset's most-permissive flags; the OS is the boundary.
+
+## 6. Non-goals (round two and later)
+
+- Auto-provisioning (users, sudoers, workplace group bits) — documented
+  prerequisites only.
+- A configurable forbidden-paths sweep of the agent user's home (the
+  precedent self-heals rogue router-state paths before every wake;
+  generalizing that is its own feature).
+- GUI/desktop OAuth flows for either variant.
+- Supervising the router daemon itself (systemd unit / reboot survival)
+  — real, but orthogonal to per-turn isolation.
+- Remote-machine execution; per-member overrides of a rig's isolation.
+
+## 7. Tests and docs
+
+- `tests/test_isolate.py` (new): argv wrapping shape for both variants
+  (assert exact wrapper argv, no real sudo/docker — fake binaries on
+  PATH); mutual-exclusion config error fails closed; failed sudo probe →
+  turn fails, message still queued, breaker incremented; shared-dir
+  assertion sets owner-group/mode on tmp dirs and re-asserts after
+  tampering; container timeout kills by name (fake docker records the
+  kill).
+- `r4t status` row rendering for isolated rigs.
+- Docs: one user-facing sentence in the README; `docs/isolation.md`
+  operator page with the full prerequisite incantations (useradd,
+  scoped sudoers example, workplace group setup, container auth-mount
+  example). Detail stays there and in docstrings.

--- a/apps/r4t/r4t.py
+++ b/apps/r4t/r4t.py
@@ -192,7 +192,8 @@ def _print_rig_summary(config_path: Path, roster_path: Path | None = None) -> No
                 f" rig-budget={rig.rig_budget_max:g}/"
                 f"+{rig.rig_budget_earn_per_hour:g}per-h"
             )
-        print(f"  {name}: {argv}  ({limits})")
+        iso = _isolation_tag(rig)
+        print(f"  {name}: {argv}  ({limits})" + (f"  {iso}" if iso else ""))
     if config.pins:
         print("  pins:")
         for agent in sorted(config.pins):
@@ -479,6 +480,15 @@ def _roster_rows(
     return rows
 
 
+def _isolation_tag(rig) -> str:
+    """The rig's OS-level boundary at a glance, or "" for a bare rig."""
+    if rig.run_as:
+        return f"[user:{rig.run_as}]"
+    if rig.container:
+        return f"[container:{rig.container}]"
+    return ""
+
+
 def _rig_rows(
     ctx: DispatchContext, config
 ) -> list[tuple[bool | None, str, str, str | None]]:
@@ -508,7 +518,9 @@ def _rig_rows(
                 f" rig-budget={rig.rig_budget_max:g}/"
                 f"+{rig.rig_budget_earn_per_hour:g}per-h"
             )
-        rows.append((True, name, f"{argv}  ({limits})", None))
+        iso = _isolation_tag(rig)
+        detail = f"{argv}  ({limits})" + (f"  {iso}" if iso else "")
+        rows.append((True, name, detail, None))
     for agent in sorted(config.pins):
         rows.append((None, "pin", f"{agent} -> {config.pins[agent]}", None))
     rows.append((

--- a/apps/r4t/rig.py
+++ b/apps/r4t/rig.py
@@ -35,6 +35,13 @@ record it). It defaults the text knobs (`history_max_bytes` /
 `history_body_max` / `prompt_body_max`) by the preset's text tier (TEXT_TIERS);
 explicit values always win, and a rig with no preset gets the small tier.
 
+`run_as` / `container` — OS-level isolation (mutually exclusive; both set is a
+config error and the rig fails closed). `run_as: "<username>"` wraps the invoke
+in `sudo -u <user>`; `container: "<image>"` runs it under `docker run --rm`,
+with `container_args` appended verbatim. Prerequisites are operator-provisioned
+and probed per turn — r4t never creates users, sudoers grants, or images. See
+apps/r4t/docs/isolation.md.
+
 Keys starting with `_` anywhere are ignored so shipped examples can carry
 notes.
 """
@@ -336,6 +343,9 @@ class Rig:
     prompt_body_max: int = DEFAULT_PROMPT_BODY_MAX
     model: str | None = None
     model_resolver: str | None = None
+    run_as: str | None = None
+    container: str | None = None
+    container_args: list = field(default_factory=list)
     error: str | None = None
 
     def pool(self) -> list[list[str]]:
@@ -959,6 +969,35 @@ def _parse_rig(name: str, raw: object) -> Rig:
                 problems.append(f"rig_budget_earn_per_hour: {err}")
     elif raw_rig_earn is not None:
         problems.append("rig_budget_earn_per_hour set but rig_budget_max missing")
+
+    # OS-level isolation (plans/ISOLATE-SPEC.md). run_as and container are
+    # mutually exclusive — both set is a config error and the rig fails closed,
+    # same posture as a rig missing from config.
+    run_as = raw.get("run_as")
+    container = raw.get("container")
+    if run_as is not None and container is not None:
+        problems.append("run_as and container are mutually exclusive; set only one")
+    else:
+        if run_as is not None:
+            if not isinstance(run_as, str) or not run_as.strip():
+                problems.append("run_as must be a non-empty username string")
+            else:
+                rig.run_as = run_as.strip()
+        if container is not None:
+            if not isinstance(container, str) or not container.strip():
+                problems.append("container must be a non-empty image string")
+            else:
+                rig.container = container.strip()
+    container_args = raw.get("container_args")
+    if container_args is not None:
+        if not isinstance(container_args, list) or not all(
+            isinstance(a, str) for a in container_args
+        ):
+            problems.append("container_args must be a list of strings")
+        elif container is None:
+            problems.append("container_args set but container is not")
+        else:
+            rig.container_args = list(container_args)
 
     if problems:
         rig.error = "; ".join(problems)

--- a/apps/r4t/tests/test_isolate.py
+++ b/apps/r4t/tests/test_isolate.py
@@ -1,0 +1,306 @@
+"""OS-level isolation — run_as and container variants (plans/ISOLATE-SPEC.md §7).
+
+Wrapper argv is asserted EXACTLY; the prereq probe and the container kill run
+against fake `sudo`/`docker` binaries put on PATH — no real sudo, docker, or
+LLM. State stays under the tmp R4T_HOME the shared fixtures set; the live
+~/.config/r4t is never touched.
+"""
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+import textwrap
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import isolate
+import state
+from dispatch import DispatchContext, drain, handle_message, run_harness
+from rig import Rig, RigConfig, Throttle, load_rig_config
+from roster import Member
+
+NODE = "acme"
+
+
+def _fake_bin(directory: Path, name: str, body: str) -> Path:
+    """Write an executable Python stub named `name` into `directory`."""
+    path = directory / name
+    path.write_text(f"#!{sys.executable}\n" + textwrap.dedent(body), encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return path
+
+
+@pytest.fixture
+def fakebin(tmp_path, monkeypatch):
+    d = tmp_path / "fakebin"
+    d.mkdir()
+    monkeypatch.setenv("PATH", str(d) + os.pathsep + os.environ.get("PATH", ""))
+    return d
+
+
+class TestWrapRunAs:
+    def test_exact_argv(self):
+        argv = isolate.wrap_run_as(
+            ["claude", "-p", "{hi}"], "agent-x", "/stg/dir", "/work/place"
+        )
+        assert argv == [
+            "sudo", "-u", "agent-x", "bash", "--login", "-c",
+            'export TELL_OUTBOX_DIR="$1"; cd "$2"; shift 2; exec "$@"',
+            "_", "/stg/dir", "/work/place", "claude", "-p", "{hi}",
+        ]
+
+    def test_env_rides_as_positionals_not_a_command_string(self):
+        argv = isolate.wrap_run_as(["h", "a b"], "u", "/s", "/w")
+        # The bootstrap is a single -c argument; the harness argv follows as
+        # discrete positionals, so a space in an arg can never re-split.
+        assert argv[6] == 'export TELL_OUTBOX_DIR="$1"; cd "$2"; shift 2; exec "$@"'
+        assert argv[-2:] == ["h", "a b"]
+
+
+class TestBuildContainer:
+    def test_exact_argv(self):
+        argv = isolate.build_container_argv(
+            ["claude", "-p", "{hi}"],
+            "myimg:latest",
+            name="r4t-acme-phil-42",
+            staging_dir="/stg",
+            workplace="/work",
+            tell_outbox="/stg",
+            client_dir="/opt/bin",
+        )
+        assert argv == [
+            "docker", "run", "--rm", "--name", "r4t-acme-phil-42",
+            "-v", "/work:/work",
+            "-w", "/work",
+            "-v", "/stg:/stg",
+            "-e", "TELL_OUTBOX_DIR=/stg",
+            "-v", "/opt/bin:/opt/bin:ro",
+            "-e", "PATH=/opt/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "myimg:latest", "claude", "-p", "{hi}",
+        ]
+
+    def test_container_args_appended_verbatim_before_image(self):
+        argv = isolate.build_container_argv(
+            ["h", "{p}"], "img", name="n",
+            staging_dir="/s", workplace="/w", tell_outbox="/s",
+            container_args=["--gpus", "all", "-v", "/creds:/creds:ro"],
+            client_dir="/c",
+        )
+        i = argv.index("img")
+        assert argv[i - 4:i] == ["--gpus", "all", "-v", "/creds:/creds:ro"]
+        assert argv[i:] == ["img", "h", "{p}"]
+
+    def test_delivered_dir_mounts_read_only(self):
+        argv = isolate.build_container_argv(
+            ["h", "{p}"], "img", name="n",
+            staging_dir="/s", workplace="/w", tell_outbox="/s",
+            delivered_dir="/deliver", client_dir="/c",
+        )
+        assert "-v" in argv and "/deliver:/deliver:ro" in argv
+
+    def test_container_name_deterministic_with_ts_and_slugs_bad_chars(self):
+        assert isolate.container_name("ac me", "Phil/1", ts=7) == "r4t-ac-me-Phil-1-7"
+
+
+class TestMutualExclusion:
+    def _load(self, tmp_path, entry: dict) -> RigConfig:
+        path = tmp_path / "rigs.json"
+        path.write_text(json.dumps({"iso": {"invoke": ["h", "{prompt}"], **entry}}))
+        return load_rig_config(path)
+
+    def test_both_set_is_config_error(self, tmp_path):
+        config = self._load(tmp_path, {"run_as": "u", "container": "img"})
+        assert "mutually exclusive" in (config.rigs["iso"].error or "")
+
+    def test_both_set_fails_closed_no_run(self, tmp_path):
+        config = self._load(tmp_path, {"run_as": "u", "container": "img"})
+        member = Member(name="Bob", rig="iso")
+        rig, error, _pinned = config.rig_for(member)
+        assert rig is None and "invalid" in (error or "")
+
+    def test_container_args_without_container_errors(self, tmp_path):
+        config = self._load(tmp_path, {"container_args": ["--gpus", "all"]})
+        assert "container_args set but container is not" in (config.rigs["iso"].error or "")
+
+    def test_blank_run_as_errors(self, tmp_path):
+        config = self._load(tmp_path, {"run_as": "   "})
+        assert "non-empty username" in (config.rigs["iso"].error or "")
+
+    def test_valid_run_as_parses(self, tmp_path):
+        config = self._load(tmp_path, {"run_as": "agent-x"})
+        assert config.rigs["iso"].error is None
+        assert config.rigs["iso"].run_as == "agent-x"
+
+    def test_valid_container_parses_with_args(self, tmp_path):
+        config = self._load(tmp_path, {"container": "img", "container_args": ["-v", "/c:/c:ro"]})
+        rig = config.rigs["iso"]
+        assert rig.error is None
+        assert rig.container == "img" and rig.container_args == ["-v", "/c:/c:ro"]
+
+
+class TestSharedDirAssertion:
+    def _mode(self, path: Path) -> int:
+        return stat.S_IMODE(path.stat().st_mode)
+
+    def test_writable_dir_gets_2770_setgid(self, tmp_path):
+        d = tmp_path / "staging"
+        isolate.assert_writable_shared_dir(d, os.getgid())
+        assert self._mode(d) == 0o2770
+        assert d.stat().st_gid == os.getgid()
+
+    def test_readonly_dir_gets_2750_setgid(self, tmp_path):
+        d = tmp_path / "delivered"
+        isolate.assert_readonly_shared_dir(d, os.getgid())
+        assert self._mode(d) == 0o2750
+
+    def test_reasserts_after_tampering(self, tmp_path):
+        d = tmp_path / "staging"
+        isolate.assert_writable_shared_dir(d, os.getgid())
+        d.chmod(0o700)  # an agent (or drift) narrows it
+        assert self._mode(d) != 0o2770
+        isolate.assert_writable_shared_dir(d, os.getgid())  # re-assert before the next turn
+        assert self._mode(d) == 0o2770
+
+    def test_unknown_group_still_sets_mode(self, tmp_path):
+        d = tmp_path / "staging"
+        isolate.assert_writable_shared_dir(d, None)  # gid None: skip chown, keep mode
+        assert self._mode(d) == 0o2770
+
+
+# ---------- dispatch-level: fail closed, breaker, kill-by-name ----------
+
+
+ROSTER = textwrap.dedent(
+    """\
+    # Team
+
+    ### Gerry
+    - **Status:** AI
+    - **Rig:** leader
+    - **Leader:** yes
+
+    ### Phil
+    - **Status:** AI
+    - **Rig:** junior-dev
+    """
+)
+
+
+def _iso_config(tmp_path, fake_harness, junior_extra: dict) -> Path:
+    script, _out = fake_harness
+    invoke = [sys.executable, str(script), "{prompt}"]
+    payload = {
+        "throttle": {"max_concurrent": 0, "min_seconds_between_turn_starts": 0},
+        "cell_budget_max": 200,
+        "cell_budget_earn_per_hour": 100,
+        "leader": {"invoke": invoke, "timeout_seconds": 30, "budget_max": 100, "budget_earn_per_hour": 50},
+        "junior-dev": {
+            "invoke": invoke, "timeout_seconds": 30, "budget_max": 100,
+            "budget_earn_per_hour": 50, **junior_extra,
+        },
+        "pins": {"gerry": "leader"},
+    }
+    path = tmp_path / "iso-rigs.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def iso_ctx_factory(r4t_home, tmp_path, fake_harness, tells):
+    def make(junior_extra: dict) -> DispatchContext:
+        root = tmp_path / "iso-repo"
+        root.mkdir(exist_ok=True)
+        (root / "ROSTER.md").write_text(ROSTER, encoding="utf-8")
+        _sent, capture = tells
+        return DispatchContext(
+            root=root,
+            node=NODE,
+            roster_path=root / "ROSTER.md",
+            config_path=_iso_config(tmp_path, fake_harness, junior_extra),
+            tell_fn=capture,
+        )
+
+    return make
+
+
+class TestRunAsProbeFailsClosed:
+    def test_failed_grant_probe_fails_turn_and_requeues_and_trips_breaker(
+        self, iso_ctx_factory, fakebin
+    ):
+        _fake_bin(fakebin, "sudo", "import sys\nsys.exit(1)\n")  # no NOPASSWD grant
+        ctx = iso_ctx_factory({"run_as": "agent-x"})
+
+        handle_message(ctx, "acme:gerry", "acme:phil", "do work", drain_after=False)
+        ran = drain(ctx, run_fn=run_harness)
+
+        assert ran == 1  # the turn ran and failed closed (not skipped)
+        assert state.queue_depth(NODE, "phil") >= 1  # message returned to the queue
+        assert state.read_meta(NODE, "phil")["consecutive_failures"] == 1  # breaker counts it
+
+    def test_probe_error_surfaces_the_fix(self, iso_ctx_factory, fakebin):
+        _fake_bin(fakebin, "sudo", "import sys\nsys.exit(1)\n")
+        rig = Rig(name="junior-dev", invoke=["true", "{prompt}"], run_as="agent-x")
+        code, out, _dur, timed = run_harness(
+            rig, "p", Path("/tmp"), env={"TELL_OUTBOX_DIR": "/tmp/s"}
+        )
+        assert code == 126 and not timed
+        assert "no passwordless sudo" in out and "docs/isolation.md" in out
+
+
+class TestContainerTimeoutKill:
+    def test_timeout_kills_container_by_name(self, tmp_path, fakebin, monkeypatch):
+        record = tmp_path / "docker-kills.txt"
+        _fake_bin(
+            fakebin, "docker",
+            f"""
+            import os, sys, time
+            args = sys.argv[1:]
+            if args and args[0] == "run":
+                time.sleep(30)
+            elif args and args[0] == "kill":
+                open({str(record)!r}, "a").write(args[1] + "\\n")
+            """,
+        )
+        rig = Rig(
+            name="c", invoke=["harness", "{prompt}"], container="img",
+            timeout_seconds=0.5,
+        )
+        env = dict(os.environ)
+        env["TELL_OUTBOX_DIR"] = str(tmp_path / "stg")
+        env["R4T_NODE"] = "acme"
+        env["R4T_MEMBER"] = "phil"
+
+        _code, _out, _dur, timed_out = run_harness(rig, "p", tmp_path, env=env)
+
+        assert timed_out
+        killed = record.read_text(encoding="utf-8").split()
+        assert len(killed) == 1
+        assert killed[0].startswith("r4t-acme-phil-")
+
+
+class TestStatusRowRendering:
+    def test_isolation_tag(self):
+        from r4t import _isolation_tag
+
+        assert _isolation_tag(Rig(name="a", run_as="agent-x")) == "[user:agent-x]"
+        assert _isolation_tag(Rig(name="b", container="img:1")) == "[container:img:1]"
+        assert _isolation_tag(Rig(name="c")) == ""
+
+    def test_rig_row_shows_boundary(self):
+        from r4t import _rig_rows
+
+        config = RigConfig(
+            path=Path("/x/rigs.json"),
+            rigs={
+                "iso": Rig(name="iso", invoke=["claude", "-p", "{prompt}"], run_as="agent-x"),
+            },
+            throttle=Throttle(),
+        )
+        ctx = SimpleNamespace(node=NODE, config_path=config.path)
+        rows = _rig_rows(ctx, config)
+        iso_row = next(r for r in rows if r[1] == "iso")
+        assert "[user:agent-x]" in iso_row[2]


### PR DESCRIPTION
Closes #210 — the isolation phase. Implements plans/ISOLATE-SPEC.md (ratified by Neil 2026-07-16), which lands with the code.

## What

Harness sandbox flags are not a security boundary — one CLI's `--sandbox` is model-discretionary and silently broke message staging for a whole org during the d5n M4 run. The boundary that holds is the OS. This makes it a per-rig property:

- **`run_as: "<username>"`** wraps the turn in `sudo -u <user>` (a Unix user with no sudo). Env cannot survive sudoers `env_reset`, so `TELL_OUTBOX_DIR` and the workplace ride as positional args through `exec "$@"` — quoting bugs are structurally impossible.
- **`container: "<image>"`** runs the turn under `docker run --rm` — workplace bind-mounted rw at the same path + workdir, staging rw with `TELL_OUTBOX_DIR` via `-e`, a8s client ro with a PATH shim so `tell` resolves, per-rig `container_args` appended verbatim (credentials ride as operator read-only mounts). Timeout kills by the deterministic name `r4t-<node>-<member>-<ts>`, then `--rm` reaps.
- The two are **mutually exclusive**; both set is a config error and the rig fails closed.

r4t **verifies** operator-provisioned prerequisites before every turn (`sudo -n -u <user> true` grant probe + workplace write probe as the agent user) and fails closed with an action-first `(try: ...)` error — it never provisions users, sudoers, or images. The one thing it owns — the writable staging channel — is re-asserted to `router:<agent-group>` mode `2770` setgid before every turn.

Every isolation failure is an ordinary failed turn: the batch stays queued, the breaker counts it. `r4t status` / `rig list` tag the rig `[user:<name>]` / `[container:<image>]`.

## Files

- `isolate.py` (new) — pure argv builders + prereq probes + kill-by-name
- `rig.py` — parse `run_as`/`container`/`container_args`, mutual-exclusion fail-closed
- `dispatch.py` — wrap argv + probe + shared-dir assertion in `run_harness`; container timeout kill-by-name
- `r4t.py` — `_isolation_tag` on `rig list` and status rows
- `tests/test_isolate.py` (new, 21 tests) — exact wrapper argv both variants, mutual exclusion, probe fail-closed → queued + breaker, shared-dir assert + re-assert after tampering, container timeout kill-by-name, status rendering
- `docs/isolation.md` (new) — operator prerequisites (useradd, scoped sudoers, workplace group, container credential mounts); linked from README + security.md
- `example-rigs.json`, `README.md`, `docs/security.md`, `plans/ISOLATE-SPEC.md`

## Tests

Full suite green: **518 passed** (497 baseline + 21 new isolation tests). Fake sudo/docker binaries on PATH; no real sudo, docker, or LLM; live `~/.config/r4t/` never touched.

## Merge timing

**Do not merge until the running d5n org concludes its milestone** — dispatch runs off the live working tree, and this touches `dispatch.py`/`rig.py` on the invoke path. Freeze changes during the live experiment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)