### PR TITLE
fix(a8s): expose remote delivery boundaries

### DIFF
--- a/apps/a8s/network.py
+++ b/apps/a8s/network.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import json
 import os
 import threading
+import time
 from pathlib import Path
 from typing import Callable
 
@@ -50,6 +51,32 @@ from ulid import is_ulid
 # threads (one per remote) call seen_id_append concurrently; the append
 # itself is atomic per POSIX, but the truncate-after-rotate is not.
 _SEEN_IDS_LOCK = threading.Lock()
+_REMOTE_DIAGNOSTIC_LOCK = threading.Lock()
+_REMOTE_DIAGNOSTIC_LAST: dict[tuple[str, str], float] = {}
+_REMOTE_DIAGNOSTIC_INTERVAL_S = 300.0
+_REMOTE_DIAGNOSTIC_MAX_KEYS = 256
+
+
+def _remote_drop_diagnostic(msg_id: str, recipient: str, reason: str) -> None:
+    """Rate-limited shared-topic miss diagnostic; never includes content."""
+    key = (reason, recipient.lower())
+    now = time.monotonic()
+    with _REMOTE_DIAGNOSTIC_LOCK:
+        last = _REMOTE_DIAGNOSTIC_LAST.get(key)
+        if last is not None and now - last < _REMOTE_DIAGNOSTIC_INTERVAL_S:
+            return
+        _REMOTE_DIAGNOSTIC_LAST[key] = now
+        if len(_REMOTE_DIAGNOSTIC_LAST) > _REMOTE_DIAGNOSTIC_MAX_KEYS:
+            oldest = min(_REMOTE_DIAGNOSTIC_LAST, key=_REMOTE_DIAGNOSTIC_LAST.get)
+            del _REMOTE_DIAGNOSTIC_LAST[oldest]
+    out(f"REMOTE_DROP id={msg_id} to={recipient!r} reason={reason}")
+    txlog.log(
+        "DROPPED",
+        msg_id=msg_id,
+        recipient=recipient,
+        remote="remote",
+        detail=reason,
+    )
 
 
 # ---------- network.json ----------
@@ -308,8 +335,8 @@ def receive_envelope(
 ) -> None:
     """Decode an incoming envelope, dedupe, filter against the local
     registry, and atomically write into each matched local recipient's
-    inbox. Drops silently if the recipient isn't ours, the envelope is
-    malformed, or the ULID has been seen before — nothing should crash the
+    inbox. Unknown local destinations emit bounded, rate-limited diagnostics;
+    malformed or duplicate envelopes drop silently. Nothing should crash the
     subscriber thread.
 
     `services`: configured storage services (#90). When set and the
@@ -337,9 +364,7 @@ def receive_envelope(
     try:
         kind, member_names = resolve_name(recipient_name)
     except (KeyError, ValueError):
-        # Recipient name unknown locally — receive-side filter says "not
-        # for me." Drop silently; logging every miss would be noisy on a
-        # busy network.
+        _remote_drop_diagnostic(msg_id, recipient_name, "not in local registry")
         return
     recipients: list[Participant] = []
     for m in member_names:
@@ -350,7 +375,8 @@ def receive_envelope(
             # is the dual-name foot-gun. Per the design, deliver locally.
             recipients.append(rp)
     if not recipients:
-        return  # alias resolved to nothing locally
+        _remote_drop_diagnostic(msg_id, recipient_name, f"{kind} resolved to zero local recipients")
+        return
     # File payloads (#90): when storage services are configured, download
     # each file's bytes into the recipient's `.files/` and rewrite the
     # envelope entry to local-path shape. Without storage services
@@ -380,6 +406,14 @@ def receive_envelope(
         inbox_tmp_dir(recipient.name).mkdir(parents=True, exist_ok=True)
         final = inbox_dir(recipient.name) / f"{msg_id}.json"
         if final.is_file():
+            txlog.log(
+                "RECEIVED_REMOTE",
+                msg_id=msg_id,
+                sender=msg.get("from") or "?",
+                recipient=recipient.name,
+                remote="remote",
+                detail="inbox already contained envelope",
+            )
             delivered_names.append(recipient.name)
             continue
         staging = inbox_tmp_dir(recipient.name) / f"{msg_id}.json"
@@ -392,7 +426,15 @@ def receive_envelope(
             continue
         out_agent(recipient.name, f"received from {sender_label} (via remote): {preview}")
         file_names = [e.get("filename", "") for e in (msg_for_recipient.get("files") or []) if e.get("filename")]
-        txlog.log("RECEIVED_REMOTE", msg_id=msg_id, sender=sender_label, recipient=recipient.name, files=file_names or None, remote="remote", detail=preview)
+        txlog.log(
+            "RECEIVED_REMOTE",
+            msg_id=msg_id,
+            sender=sender_label,
+            recipient=recipient.name,
+            files=file_names or None,
+            remote="remote",
+            detail="inbox write complete",
+        )
         delivered_names.append(recipient.name)
     if delivered_names:
         import convo
@@ -453,5 +495,3 @@ def stop_remotes(remotes: list[Transport]) -> None:
             r.stop()
         except Exception as e:
             out(f"WARN: remote {r.id} stop raised: {e}")
-
-

--- a/apps/a8s/tests/test_network.py
+++ b/apps/a8s/tests/test_network.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Callable
 
 import pytest
+import network
 
 from core import (
     MAX_SEEN_IDS,
@@ -237,16 +238,76 @@ class TestReceiveEnvelope:
         assert body["from"] == "REMOTE_X"
         assert body["content"] == "hello via remote"
 
-    def test_unknown_recipient_dropped_silently(self, two_local_agents):
+    def test_unknown_recipient_records_rate_limited_diagnostic(
+        self, two_local_agents, monkeypatch,
+    ):
+        diagnostics = []
+        tx_events = []
+        network._REMOTE_DIAGNOSTIC_LAST.clear()
+        monkeypatch.setattr(network, "out", diagnostics.append)
+        monkeypatch.setattr(network.txlog, "log", lambda event, **fields: tx_events.append((event, fields)))
+        msg_id = new_ulid()
         envelope = json.dumps({
-            "id": new_ulid(), "from": "X", "to": "GHOST",
+            "id": msg_id, "from": "X", "to": "GHOST",
             "content": "ignored", "files": [],
         }).encode()
         receive_envelope(envelope, two_local_agents)
+        receive_envelope(json.dumps({
+            "id": new_ulid(), "from": "X", "to": "GHOST",
+            "content": "different secret", "files": [],
+        }).encode(), two_local_agents)
+        assert diagnostics == [f"REMOTE_DROP id={msg_id} to='GHOST' reason=not in local registry"]
+        assert tx_events[0] == (
+            "DROPPED",
+            {
+                "msg_id": msg_id,
+                "recipient": "GHOST",
+                "remote": "remote",
+                "detail": "not in local registry",
+            },
+        )
+        assert "ignored" not in diagnostics[0]
         # No inbox writes anywhere — the dirs may not even exist.
         for n in ("A", "B"):
             d = inbox_dir(n)
             assert not d.exists() or list(d.iterdir()) == []
+
+    def test_alias_with_no_local_participants_records_diagnostic(
+        self, fake_home, tmp_path, monkeypatch,
+    ):
+        root = tmp_path / "A"
+        root.mkdir()
+        save_registry({"A": {"root": str(root)}, "B": {"root": str(tmp_path / "B")}})
+        save_aliases({"team": ["B"]})
+        diagnostics = []
+        network._REMOTE_DIAGNOSTIC_LAST.clear()
+        monkeypatch.setattr(network, "out", diagnostics.append)
+        receive_envelope(json.dumps({
+            "id": new_ulid(), "from": "X", "to": "team", "content": "secret", "files": [],
+        }).encode(), [Participant("A", root)])
+        assert len(diagnostics) == 1
+        assert "alias resolved to zero local recipients" in diagnostics[0]
+        assert "secret" not in diagnostics[0]
+
+    def test_valid_delivery_txlog_marks_inbox_write_without_content(
+        self, two_local_agents, monkeypatch,
+    ):
+        events = []
+        monkeypatch.setattr(network.txlog, "log", lambda event, **fields: events.append((event, fields)))
+        msg_id = new_ulid()
+        receive_envelope(json.dumps({
+            "id": msg_id, "from": "X", "to": "B", "content": "private text", "files": [],
+        }).encode(), two_local_agents)
+        received = [fields for event, fields in events if event == "RECEIVED_REMOTE"]
+        assert received == [{
+            "msg_id": msg_id,
+            "sender": "X",
+            "recipient": "B",
+            "files": None,
+            "remote": "remote",
+            "detail": "inbox write complete",
+        }]
+        assert "private text" not in repr(received)
 
     def test_dedup_by_ulid(self, two_local_agents):
         msg_id = new_ulid()


### PR DESCRIPTION
## Summary

- record bounded, rate-limited remote-drop diagnostics with envelope ULID and destination but no content
- distinguish names absent from the local registry from aliases resolving to zero local participants
- record the inbox-write boundary without copying message content into the transaction detail
- keep duplicate behavior idempotent and shared-topic diagnostics bounded to 256 keys with a five-minute interval

## Verification

- env -u TELL_OUTBOX_DIR venv/bin/python -m pytest apps/a8s/tests/ (653 passed)

Addresses #225. The optional cross-cluster delivery-receipt wire protocol remains intentionally deferred pending protocol approval.