### PR TITLE
feat(a8s): add extension-only delivery receipts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,13 @@ The router (`mailbox.py:_process_pending`) force-overwrites `from` based on
 which agent owns the enclosing root — the filesystem is the unforgeable
 identity.
 
+Remote inbox writes emit content-free delivery receipts as normal envelopes
+with an `a8s_control` extension and reserved `to: __a8s_receipt__`. Consume
+control envelopes before participant routing, never place them in an inbox,
+and never generate receipts for them. Older subscribers safely drop the
+reserved destination. `a8s trace <ULID>` reads correlated boundaries from
+`~/.a8s/transactions.tsv`.
+
 Run `a8s install` from an agent root to link bundled skills into
 `.claude/skills/`, `.cursor/skills/`, and `.codex/skills/` there. Use `a8s install --global` for
 user-home install; `source ~/bin/install.sh --skills` for top-level doc skills.

--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -192,6 +192,7 @@ any prefixes pointing at it.
 | `tells [--timeout SEC]` (top-level shim, `[~/bin/tells](/Users/neilo/bin/tells)`) | Receive-side complement of `tell` (`apps/a8s/tells.py`). Resolves the node from `TELL_OUTBOX_DIR`, then blocks up to `--timeout` (default 5s) for new envelopes in `.inbox`, prints each `sender: body`, and exits 0; exit 1 on timeout. Non-destructive; Windows: `tells.cmd`. |
 | `a8s logs <name>... [--tail N] [-f]`                                        | Read per-agent log files; one agent in append order, multiple merge by ISO timestamp. `-f` follows.                                                                                                                                                                                                                       |
 | `a8s convo <name> [--limit N]`                                              | Markdown conversation history for an agent (messages to or from). Default `--limit 10`. Outbound headings use `##`, inbound use `###`. Archive: `~/.a8s/conversations.jsonl` (machine-wide; rotates at `convo_max_limit`, default 1000 — `a8s config`). |
+| `a8s trace <ULID>`                                                          | Show locally observed transaction boundaries for one envelope: routing, remote publication/resolution, inbox write, delivery receipt, and agent wake. |
 | `a8s drain <name>`                                                          | Move pending inbox JSON to trash without waking the agent.                                                                                                                                                                                                                                                                |
 
 
@@ -521,6 +522,38 @@ The most common causes:
 - **Codex without `stdin=DEVNULL`.** Codex CLI hangs reading stdin in headless mode. a8s already passes `stdin=subprocess.DEVNULL` for every wake (`daemon.run_with_prefix`), so this only bites if you're running the underlying CLI manually.
 - **Headless permission denial.** Gemini without `--yolo`, Claude without `--permission-mode dontAsk`, Copilot without `--allow-all-tools`, OpenCode without `--dangerously-skip-permissions`, Cursor without `-p --force` — all silently deny tool calls in non-interactive mode and the wake stalls. The bundled `definitions/<kind>.json` files include the required flag for each kind; only worry if you write a custom definition.
 - **Ollama model still loading.** A cold-start of a 20B model can take 10–30s before any output. `ps aux | grep ollama` should show a `runner` process consuming RAM proportional to the model size.
+
+## Remote delivery receipts
+
+Remote inbox writes produce a best-effort, content-free delivery receipt on
+the same transport. This is an extension of the existing envelope shape:
+
+```json
+{
+  "id": "<receipt ULID>",
+  "date": "<ISO-8601 UTC>",
+  "from": "_a8s",
+  "to": "__a8s_receipt__",
+  "content": "",
+  "files": [],
+  "a8s_control": {
+    "type": "delivery_receipt",
+    "version": 1,
+    "for_id": "<original envelope ULID>",
+    "sender": "alice",
+    "recipients": ["bob"],
+    "stage": "inbox_write"
+  }
+}
+```
+
+The reserved target is not a participant. A8s consumes supported control
+envelopes before normal routing, so they never enter an agent inbox and never
+generate receipts themselves. Subscribers without receipt support treat the
+target as unknown and drop it. Only a cluster with the named original sender
+records the receipt. Receipt publication is best-effort; absence of a receipt
+does not prove non-delivery. Use `a8s trace <original ULID>` to distinguish the
+last locally confirmed boundary.
 
 ## Roadmap
 

--- a/apps/a8s/cli.py
+++ b/apps/a8s/cli.py
@@ -33,6 +33,7 @@ from commands import (
     cmd_storage,
     cmd_tell,
     cmd_tells,
+    cmd_trace,
     cmd_unalias,
     cmd_unnamespace,
     cmd_unremote,
@@ -64,6 +65,7 @@ COMMANDS: list[tuple[str, str, str]] = [
     ("drain",    "<name>",                   "Move local inbox to trash without invoking."),
     ("config",   "[get|set|unset ...]",      "List all knobs or edit ~/.a8s/settings.json."),
     ("convo",    "<name> [--limit N]",       "Show markdown conversation history for an agent."),
+    ("trace",    "<ULID>",                   "Show transaction boundaries for one message."),
     ("logs",     "<name>... [--tail N] [-f]", "Show per-agent logs."),
     ("remote",   "[<name> [<broker> <topic> [--<k> <v> ...]]]", "List, show, or set a cross-machine remote."),
     ("unremote", "<name>",                    "Remove a configured remote."),
@@ -136,6 +138,8 @@ def dispatch(cmd: str, args: list[str], interval: float) -> int:
         return cmd_config(args)
     if cmd == "convo":
         return cmd_convo(args)
+    if cmd == "trace":
+        return cmd_trace(args)
     if cmd == "install":
         return cmd_install(args)
     if cmd == "install-client":

--- a/apps/a8s/commands.py
+++ b/apps/a8s/commands.py
@@ -66,6 +66,8 @@ from registry import (
     save_namespaces,
     save_registry,
 )
+from txlog import read_events
+from ulid import is_ulid
 
 
 # ---------- skill installation helpers ----------
@@ -1394,6 +1396,27 @@ def cmd_convo(args: list[str]) -> int:
     )
     if text:
         print(text)
+    return 0
+
+
+# ---------- trace / logs ----------
+
+def cmd_trace(args: list[str]) -> int:
+    if len(args) != 1 or not is_ulid(args[0]):
+        print("usage: a8s trace <ULID>", file=sys.stderr)
+        return 2
+    msg_id = args[0].upper()
+    events = read_events(msg_id)
+    if not events:
+        print(f"no transaction events for {msg_id}", file=sys.stderr)
+        return 1
+    print(f"trace {msg_id}")
+    for event in events:
+        fields = [event["timestamp"], event["event"]]
+        for key in ("from", "to", "remote", "files", "detail"):
+            if event[key]:
+                fields.append(f"{key}={event[key]}")
+        print("  " + " ".join(fields))
     return 0
 
 

--- a/apps/a8s/delivery_receipt.py
+++ b/apps/a8s/delivery_receipt.py
@@ -1,0 +1,95 @@
+"""Extension-only delivery receipts for remote a8s envelopes.
+
+Receipts retain the normal envelope fields and add ``a8s_control``.  The
+reserved destination is deliberately not a participant: older subscribers
+drop the envelope, while upgraded subscribers consume it before routing.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from ulid import is_ulid, new as new_ulid
+
+
+CONTROL_FIELD = "a8s_control"
+CONTROL_TYPE = "delivery_receipt"
+CONTROL_VERSION = 1
+RECEIPT_TARGET = "__a8s_receipt__"
+
+
+@dataclass(frozen=True)
+class DeliveryReceipt:
+    receipt_id: str
+    for_id: str
+    sender: str
+    recipients: tuple[str, ...]
+    stage: str
+
+
+def is_control_envelope(message: dict) -> bool:
+    return CONTROL_FIELD in message
+
+
+def build_delivery_receipt(original: dict, recipients: list[str]) -> dict | None:
+    """Return a receipt envelope, or None when the original cannot correlate."""
+    original_id = original.get("id")
+    sender = original.get("from")
+    clean_recipients = tuple(dict.fromkeys(name.strip() for name in recipients if name.strip()))
+    if not isinstance(original_id, str) or not is_ulid(original_id):
+        return None
+    if not isinstance(sender, str) or not sender.strip() or not clean_recipients:
+        return None
+    return {
+        "id": new_ulid(),
+        "date": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "from": "_a8s",
+        "to": RECEIPT_TARGET,
+        "content": "",
+        "files": [],
+        CONTROL_FIELD: {
+            "type": CONTROL_TYPE,
+            "version": CONTROL_VERSION,
+            "for_id": original_id,
+            "sender": sender.strip(),
+            "recipients": list(clean_recipients),
+            "stage": "inbox_write",
+        },
+    }
+
+
+def parse_delivery_receipt(message: dict) -> DeliveryReceipt | None:
+    """Parse the supported receipt extension; reject malformed/unknown control."""
+    if message.get("to") != RECEIPT_TARGET or message.get("from") != "_a8s":
+        return None
+    if message.get("content") != "" or message.get("files") != []:
+        return None
+    control = message.get(CONTROL_FIELD)
+    if not isinstance(control, dict):
+        return None
+    if control.get("type") != CONTROL_TYPE or control.get("version") != CONTROL_VERSION:
+        return None
+    receipt_id = message.get("id")
+    for_id = control.get("for_id")
+    sender = control.get("sender")
+    recipients = control.get("recipients")
+    stage = control.get("stage")
+    if not isinstance(receipt_id, str) or not is_ulid(receipt_id):
+        return None
+    if not isinstance(for_id, str) or not is_ulid(for_id):
+        return None
+    if not isinstance(sender, str) or not sender.strip():
+        return None
+    if not isinstance(recipients, list) or not recipients:
+        return None
+    if not all(isinstance(name, str) and name.strip() for name in recipients):
+        return None
+    if stage != "inbox_write":
+        return None
+    return DeliveryReceipt(
+        receipt_id=receipt_id,
+        for_id=for_id,
+        sender=sender.strip(),
+        recipients=tuple(dict.fromkeys(name.strip() for name in recipients)),
+        stage=stage,
+    )

--- a/apps/a8s/network.py
+++ b/apps/a8s/network.py
@@ -40,6 +40,11 @@ from core import (
     out_agent,
     seen_ids_path,
 )
+from delivery_receipt import (
+    build_delivery_receipt,
+    is_control_envelope,
+    parse_delivery_receipt,
+)
 from registry import resolve_name
 from services import StorageService
 from transports import OnMessage, Transport, TransportError
@@ -57,7 +62,12 @@ _REMOTE_DIAGNOSTIC_INTERVAL_S = 300.0
 _REMOTE_DIAGNOSTIC_MAX_KEYS = 256
 
 
-def _remote_drop_diagnostic(msg_id: str, recipient: str, reason: str) -> None:
+def _remote_drop_diagnostic(
+    msg_id: str,
+    recipient: str,
+    reason: str,
+    remote_id: str = "remote",
+) -> None:
     """Rate-limited shared-topic miss diagnostic; never includes content."""
     key = (reason, recipient.lower())
     now = time.monotonic()
@@ -74,7 +84,7 @@ def _remote_drop_diagnostic(msg_id: str, recipient: str, reason: str) -> None:
         "DROPPED",
         msg_id=msg_id,
         recipient=recipient,
-        remote="remote",
+        remote=remote_id,
         detail=reason,
     )
 
@@ -332,6 +342,8 @@ def receive_envelope(
     envelope: bytes,
     all_agents: list[Participant],
     services: list[StorageService] | None = None,
+    publish_control: Callable[[bytes], None] | None = None,
+    remote_id: str = "remote",
 ) -> None:
     """Decode an incoming envelope, dedupe, filter against the local
     registry, and atomically write into each matched local recipient's
@@ -343,7 +355,10 @@ def receive_envelope(
     envelope's `files[i].storage` URLs point at a service we know, the
     helper downloads each file into the recipient's `<root>/.files/` and
     rewrites the entry to local `{filename, path}` shape. None / empty
-    falls back to the v1 limitation (strip files; log warning)."""
+    falls back to the v1 limitation (strip files; log warning).
+
+    `publish_control` is an optional same-transport publisher for internal
+    receipt envelopes. Omitting it preserves receive-only behavior."""
     try:
         msg = json.loads(envelope)
         if not isinstance(msg, dict):
@@ -357,6 +372,10 @@ def receive_envelope(
         return
     if seen_id_contains(msg_id):
         return  # already delivered — silent dedup
+    if is_control_envelope(msg):
+        _receive_control_envelope(msg, all_agents, remote_id)
+        seen_id_append(msg_id)
+        return
     recipient_name = (msg.get("to") or "").strip()
     if not recipient_name:
         return  # malformed; nothing to filter on
@@ -364,7 +383,7 @@ def receive_envelope(
     try:
         kind, member_names = resolve_name(recipient_name)
     except (KeyError, ValueError):
-        _remote_drop_diagnostic(msg_id, recipient_name, "not in local registry")
+        _remote_drop_diagnostic(msg_id, recipient_name, "not in local registry", remote_id)
         return
     recipients: list[Participant] = []
     for m in member_names:
@@ -375,8 +394,21 @@ def receive_envelope(
             # is the dual-name foot-gun. Per the design, deliver locally.
             recipients.append(rp)
     if not recipients:
-        _remote_drop_diagnostic(msg_id, recipient_name, f"{kind} resolved to zero local recipients")
+        _remote_drop_diagnostic(
+            msg_id,
+            recipient_name,
+            f"{kind} resolved to zero local recipients",
+            remote_id,
+        )
         return
+    txlog.log(
+        "RESOLVED_REMOTE",
+        msg_id=msg_id,
+        sender=msg.get("from") or "?",
+        recipient=",".join(recipient.name for recipient in recipients),
+        remote=remote_id,
+        detail=f"{kind} resolved to {len(recipients)} local recipient(s)",
+    )
     # File payloads (#90): when storage services are configured, download
     # each file's bytes into the recipient's `.files/` and rewrite the
     # envelope entry to local-path shape. Without storage services
@@ -411,7 +443,7 @@ def receive_envelope(
                 msg_id=msg_id,
                 sender=msg.get("from") or "?",
                 recipient=recipient.name,
-                remote="remote",
+                remote=remote_id,
                 detail="inbox already contained envelope",
             )
             delivered_names.append(recipient.name)
@@ -432,7 +464,7 @@ def receive_envelope(
             sender=sender_label,
             recipient=recipient.name,
             files=file_names or None,
-            remote="remote",
+            remote=remote_id,
             detail="inbox write complete",
         )
         delivered_names.append(recipient.name)
@@ -441,21 +473,85 @@ def receive_envelope(
 
         convo.record(msg, recipients=delivered_names)
     seen_id_append(msg_id)
+    if delivered_names and publish_control is not None:
+        _publish_delivery_receipt(msg, delivered_names, publish_control, remote_id)
+
+
+def _receive_control_envelope(
+    message: dict,
+    all_agents: list[Participant],
+    remote_id: str,
+) -> None:
+    receipt = parse_delivery_receipt(message)
+    if receipt is None:
+        out(f"WARN: dropped unsupported or malformed a8s control envelope id={message.get('id', '?')}")
+        return
+    local_sender = next(
+        (agent for agent in all_agents if agent.name.lower() == receipt.sender.lower()),
+        None,
+    )
+    if local_sender is None:
+        return
+    recipients = ",".join(receipt.recipients)
+    out_agent(
+        local_sender.name,
+        f"delivery confirmed id={receipt.for_id} -> {recipients} ({receipt.stage})",
+    )
+    txlog.log(
+        "DELIVERY_RECEIPT",
+        msg_id=receipt.for_id,
+        sender=local_sender.name,
+        recipient=recipients,
+        remote=remote_id,
+        detail=f"{receipt.stage}; receipt_id={receipt.receipt_id}",
+    )
+
+
+def _publish_delivery_receipt(
+    original: dict,
+    delivered_names: list[str],
+    publish_control: Callable[[bytes], None],
+    remote_id: str,
+) -> None:
+    receipt = build_delivery_receipt(original, delivered_names)
+    if receipt is None:
+        return
+    try:
+        publish_control(json.dumps(receipt).encode("utf-8"))
+        txlog.log(
+            "RECEIPT_PUBLISHED",
+            msg_id=original["id"],
+            sender=original.get("from") or "?",
+            recipient=",".join(delivered_names),
+            remote=remote_id,
+            detail=f"receipt_id={receipt['id']}",
+        )
+    except Exception as e:
+        out(f"WARN: delivery receipt publish failed id={original.get('id', '?')} remote={remote_id}: {e}")
 
 
 def make_receive_callback(
     get_participants: Callable[[], list[Participant]],
     services: list[StorageService] | None = None,
+    publish_control: Callable[[bytes], None] | None = None,
+    remote_id: str = "remote",
 ) -> OnMessage:
     """Wrap `receive_envelope` so the subscriber thread always passes the
     CURRENT participant list — agents added via `a8s add` after the
     subscriber started are picked up without restarting the loop. Storage
     services (#90) are passed in once at startup; the receive helper uses
-    them to download cross-cluster `FILE:` payloads."""
+    them to download cross-cluster `FILE:` payloads. `publish_control`
+    enables content-free delivery receipts on that same transport."""
 
     def callback(envelope: bytes) -> None:
         try:
-            receive_envelope(envelope, get_participants(), services=services)
+            receive_envelope(
+                envelope,
+                get_participants(),
+                services=services,
+                publish_control=publish_control,
+                remote_id=remote_id,
+            )
         except Exception as e:
             out(f"WARN: receive_envelope raised: {e}")
 
@@ -478,9 +574,14 @@ def start_remotes(
     `.files/` as envelopes arrive. None / empty preserves pre-#90
     behavior (incoming files are stripped + warned)."""
     started: list[Transport] = []
-    cb = make_receive_callback(get_participants, services=services)
     for r in remotes:
         try:
+            cb = make_receive_callback(
+                get_participants,
+                services=services,
+                publish_control=r.publish,
+                remote_id=r.id,
+            )
             r.start(cb)
             started.append(r)
             out(f"remote {r.id}: subscriber started")

--- a/apps/a8s/network.py
+++ b/apps/a8s/network.py
@@ -57,7 +57,7 @@ from ulid import is_ulid
 # itself is atomic per POSIX, but the truncate-after-rotate is not.
 _SEEN_IDS_LOCK = threading.Lock()
 _REMOTE_DIAGNOSTIC_LOCK = threading.Lock()
-_REMOTE_DIAGNOSTIC_LAST: dict[tuple[str, str], float] = {}
+_REMOTE_DIAGNOSTIC_LAST: dict[tuple[str, str, str], float] = {}
 _REMOTE_DIAGNOSTIC_INTERVAL_S = 300.0
 _REMOTE_DIAGNOSTIC_MAX_KEYS = 256
 
@@ -69,7 +69,7 @@ def _remote_drop_diagnostic(
     remote_id: str = "remote",
 ) -> None:
     """Rate-limited shared-topic miss diagnostic; never includes content."""
-    key = (reason, recipient.lower())
+    key = (remote_id, reason, recipient.lower())
     now = time.monotonic()
     with _REMOTE_DIAGNOSTIC_LOCK:
         last = _REMOTE_DIAGNOSTIC_LAST.get(key)
@@ -484,7 +484,12 @@ def _receive_control_envelope(
 ) -> None:
     receipt = parse_delivery_receipt(message)
     if receipt is None:
-        out(f"WARN: dropped unsupported or malformed a8s control envelope id={message.get('id', '?')}")
+        _remote_drop_diagnostic(
+            str(message.get("id", "?")),
+            str(message.get("to", "?")),
+            "unsupported or malformed a8s control envelope",
+            remote_id,
+        )
         return
     local_sender = next(
         (agent for agent in all_agents if agent.name.lower() == receipt.sender.lower()),

--- a/apps/a8s/tests/test_commands.py
+++ b/apps/a8s/tests/test_commands.py
@@ -23,6 +23,7 @@ from commands import (
     cmd_remove,
     cmd_storage,
     cmd_tell,
+    cmd_trace,
     cmd_unalias,
     cmd_unnamespace,
     cmd_unremote,
@@ -1021,4 +1022,38 @@ class TestCmdLogs:
         assert cmd_logs(["claude", "--tail", "2"]) == 0
         assert capsys.readouterr().out.splitlines() == ["line2", "line3"]
 
+
+class TestCmdTrace:
+    def test_prints_correlated_boundaries(self, fake_home, capsys):
+        from txlog import log
+        from ulid import new as new_ulid
+
+        msg_id = new_ulid()
+        log("PUBLISHED", msg_id=msg_id, sender="alice", recipient="bob", remote="mqtt")
+        log(
+            "DELIVERY_RECEIPT",
+            msg_id=msg_id,
+            sender="alice",
+            recipient="bob",
+            remote="mqtt",
+            detail="inbox_write",
+        )
+
+        assert cmd_trace([msg_id.lower()]) == 0
+        output = capsys.readouterr().out
+        assert f"trace {msg_id}" in output
+        assert "PUBLISHED" in output
+        assert "DELIVERY_RECEIPT" in output
+        assert "detail=inbox_write" in output
+
+    def test_rejects_invalid_id(self, fake_home, capsys):
+        assert cmd_trace(["not-a-ulid"]) == 2
+        assert "usage: a8s trace <ULID>" in capsys.readouterr().err
+
+    def test_reports_no_events(self, fake_home, capsys):
+        from ulid import new as new_ulid
+
+        msg_id = new_ulid()
+        assert cmd_trace([msg_id]) == 1
+        assert f"no transaction events for {msg_id}" in capsys.readouterr().err
 

--- a/apps/a8s/tests/test_delivery_receipt.py
+++ b/apps/a8s/tests/test_delivery_receipt.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from delivery_receipt import (
+    CONTROL_FIELD,
+    RECEIPT_TARGET,
+    build_delivery_receipt,
+    is_control_envelope,
+    parse_delivery_receipt,
+)
+from ulid import new as new_ulid
+
+
+def test_build_receipt_is_extension_only_and_contains_no_message_content():
+    original_id = new_ulid()
+    receipt = build_delivery_receipt({
+        "id": original_id,
+        "from": "alice",
+        "to": "bob",
+        "content": "private message",
+        "files": [],
+    }, ["bob"])
+
+    assert receipt is not None
+    assert receipt["to"] == RECEIPT_TARGET
+    assert receipt["content"] == ""
+    assert receipt["files"] == []
+    assert receipt[CONTROL_FIELD] == {
+        "type": "delivery_receipt",
+        "version": 1,
+        "for_id": original_id,
+        "sender": "alice",
+        "recipients": ["bob"],
+        "stage": "inbox_write",
+    }
+    assert "private message" not in repr(receipt)
+
+
+def test_parse_receipt_round_trip_and_deduplicates_recipients():
+    receipt = build_delivery_receipt(
+        {"id": new_ulid(), "from": "alice"},
+        ["bob", "bob", "carol"],
+    )
+    parsed = parse_delivery_receipt(receipt)
+    assert parsed is not None
+    assert parsed.recipients == ("bob", "carol")
+    assert is_control_envelope(receipt)
+
+
+def test_unknown_control_version_is_not_interpreted_as_receipt():
+    receipt = build_delivery_receipt(
+        {"id": new_ulid(), "from": "alice"},
+        ["bob"],
+    )
+    receipt[CONTROL_FIELD]["version"] = 2
+    assert parse_delivery_receipt(receipt) is None
+
+
+def test_missing_sender_or_recipient_does_not_create_receipt():
+    assert build_delivery_receipt({"id": new_ulid(), "from": ""}, ["bob"]) is None
+    assert build_delivery_receipt({"id": new_ulid(), "from": "alice"}, []) is None

--- a/apps/a8s/tests/test_network.py
+++ b/apps/a8s/tests/test_network.py
@@ -371,6 +371,51 @@ class TestReceiveEnvelope:
         )
         assert republished == []
 
+    def test_malformed_control_warning_is_rate_limited_per_remote(
+        self, two_local_agents, monkeypatch,
+    ):
+        diagnostics = []
+        events = []
+        network._REMOTE_DIAGNOSTIC_LAST.clear()
+        monkeypatch.setattr(network, "out", diagnostics.append)
+        monkeypatch.setattr(network.txlog, "log", lambda event, **fields: events.append((event, fields)))
+
+        for remote_id in ("one", "one", "two"):
+            envelope = build_delivery_receipt(
+                {"id": new_ulid(), "from": "A"},
+                ["B"],
+            )
+            envelope["a8s_control"]["version"] = 2
+            receive_envelope(
+                json.dumps(envelope).encode(),
+                two_local_agents,
+                remote_id=remote_id,
+            )
+
+        assert len(diagnostics) == 2
+        assert all("unsupported or malformed a8s control envelope" in line for line in diagnostics)
+        drops = [fields for event, fields in events if event == "DROPPED"]
+        assert [fields["remote"] for fields in drops] == ["one", "two"]
+
+    def test_receipt_publish_failure_does_not_undo_inbox_write(
+        self, two_local_agents, monkeypatch,
+    ):
+        diagnostics = []
+        monkeypatch.setattr(network, "out", diagnostics.append)
+        msg_id = new_ulid()
+
+        def fail_publish(_payload):
+            raise RuntimeError("broker unavailable")
+
+        receive_envelope(json.dumps({
+            "id": msg_id, "from": "A", "to": "B", "content": "private", "files": [],
+        }).encode(), two_local_agents, publish_control=fail_publish, remote_id="mqtt-one")
+
+        assert (inbox_dir("B") / f"{msg_id}.json").is_file()
+        assert len(diagnostics) == 1
+        assert "delivery receipt publish failed" in diagnostics[0]
+        assert "private" not in diagnostics[0]
+
     def test_dedup_by_ulid(self, two_local_agents):
         msg_id = new_ulid()
         envelope = json.dumps({

--- a/apps/a8s/tests/test_network.py
+++ b/apps/a8s/tests/test_network.py
@@ -34,6 +34,7 @@ from network import (
 from registry import save_aliases, save_namespaces, save_registry
 from transports import Transport, TransportError
 from ulid import new as new_ulid
+from delivery_receipt import build_delivery_receipt, parse_delivery_receipt
 
 
 # ---------- StubTransport for tests ----------
@@ -308,6 +309,67 @@ class TestReceiveEnvelope:
             "detail": "inbox write complete",
         }]
         assert "private text" not in repr(received)
+
+    def test_valid_delivery_publishes_correlated_receipt(self, two_local_agents):
+        published = []
+        msg_id = new_ulid()
+        receive_envelope(json.dumps({
+            "id": msg_id, "from": "A", "to": "B", "content": "private", "files": [],
+        }).encode(), two_local_agents, publish_control=published.append, remote_id="mqtt-one")
+
+        assert len(published) == 1
+        receipt = parse_delivery_receipt(json.loads(published[0]))
+        assert receipt is not None
+        assert receipt.for_id == msg_id
+        assert receipt.sender == "A"
+        assert receipt.recipients == ("B",)
+        assert "private" not in published[0].decode()
+
+    def test_receipt_is_internal_idempotent_and_never_receipted(
+        self, two_local_agents, monkeypatch,
+    ):
+        events = []
+        republished = []
+        monkeypatch.setattr(network.txlog, "log", lambda event, **fields: events.append((event, fields)))
+        original_id = new_ulid()
+        envelope = build_delivery_receipt(
+            {"id": original_id, "from": "A"},
+            ["B"],
+        )
+        payload = json.dumps(envelope).encode()
+
+        receive_envelope(
+            payload,
+            two_local_agents,
+            publish_control=republished.append,
+            remote_id="mqtt-one",
+        )
+        receive_envelope(
+            payload,
+            two_local_agents,
+            publish_control=republished.append,
+            remote_id="mqtt-one",
+        )
+
+        receipts = [fields for event, fields in events if event == "DELIVERY_RECEIPT"]
+        assert len(receipts) == 1
+        assert receipts[0]["msg_id"] == original_id
+        assert receipts[0]["recipient"] == "B"
+        assert republished == []
+        assert all(not inbox_dir(name).exists() for name in ("A", "B"))
+
+    def test_receipt_for_nonlocal_sender_is_ignored_without_loop(self, two_local_agents):
+        envelope = build_delivery_receipt(
+            {"id": new_ulid(), "from": "REMOTE_SENDER"},
+            ["B"],
+        )
+        republished = []
+        receive_envelope(
+            json.dumps(envelope).encode(),
+            two_local_agents,
+            publish_control=republished.append,
+        )
+        assert republished == []
 
     def test_dedup_by_ulid(self, two_local_agents):
         msg_id = new_ulid()

--- a/apps/a8s/tests/test_remote_e2e.py
+++ b/apps/a8s/tests/test_remote_e2e.py
@@ -71,7 +71,8 @@ def test_remote_round_trip(tmp_path, mqtt_broker, monkeypatch):
     sender_p = Participant("SENDER", sender_root)
     ensure_mailboxes(sender_p)
     from mailbox import _write_outbox
-    _write_outbox("SENDER", sender_root, "TARGET", "ping from A", [])
+    out_path = _write_outbox("SENDER", sender_root, "TARGET", "ping from A", [])
+    msg_id = out_path.stem
     from daemon import attached_loop
     rc = attached_loop(["SENDER"], 0.2, single_pass=True)
     assert rc == 0
@@ -95,6 +96,32 @@ def test_remote_round_trip(tmp_path, mqtt_broker, monkeypatch):
         assert body["to"] == "TARGET"
     finally:
         stop_remotes(rx_remotes)
+
+    # Step 4: cluster A reconnects its persistent subscriber and consumes
+    # the internal receipt emitted by cluster B after the inbox write.
+    monkeypatch.setenv("HOME", str(cluster_a_home))
+    core.PRINT_LOCK = None
+    receipt_remotes = start_remotes(load_remotes(), lambda: [sender_p])
+    try:
+        from txlog import read_events
+
+        deadline = time.time() + 5.0
+        receipt_events = []
+        while time.time() < deadline:
+            receipt_events = [
+                event for event in read_events(msg_id)
+                if event["event"] == "DELIVERY_RECEIPT"
+            ]
+            if receipt_events:
+                break
+            time.sleep(0.1)
+        assert len(receipt_events) == 1
+        assert receipt_events[0]["from"] == "SENDER"
+        assert receipt_events[0]["to"] == "TARGET"
+        assert "inbox_write" in receipt_events[0]["detail"]
+        assert "ping from A" not in receipt_events[0]["detail"]
+    finally:
+        stop_remotes(receipt_remotes)
 
 
 def test_remote_round_trip_with_file_via_storage(tmp_path, mqtt_broker, monkeypatch):

--- a/apps/a8s/tests/test_txlog.py
+++ b/apps/a8s/tests/test_txlog.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from txlog import HEADER, _sanitize, _ts, _txlog_path, log
+from txlog import HEADER, _sanitize, _ts, _txlog_path, log, read_events
 
 
 class TestTxlogPath:
@@ -120,6 +120,20 @@ class TestLogFieldFormat:
         lines = _txlog_path().read_text().splitlines()
         data_line = lines[1]
         assert data_line.split("\t")[1] == "DROPPED"
+
+
+class TestReadEvents:
+    def test_filters_one_message_and_preserves_order(self, fake_home):
+        log("PUBLISHED", msg_id="01ABC", sender="A", recipient="B")
+        log("DROPPED", msg_id="02DEF", sender="C", recipient="D")
+        log("DELIVERY_RECEIPT", msg_id="01ABC", sender="A", recipient="B")
+
+        events = read_events("01abc")
+        assert [event["event"] for event in events] == ["PUBLISHED", "DELIVERY_RECEIPT"]
+        assert all(event["msg_id"] == "01ABC" for event in events)
+
+    def test_missing_log_returns_empty(self, fake_home):
+        assert read_events("01ABC") == []
 
 
 class TestLogOSError:

--- a/apps/a8s/txlog.py
+++ b/apps/a8s/txlog.py
@@ -14,11 +14,14 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal
 
-__all__ = ["log"]
+__all__ = ["log", "read_events"]
 
 Event = Literal[
     "ROUTED",
     "RECEIVED_REMOTE",
+    "RESOLVED_REMOTE",
+    "RECEIPT_PUBLISHED",
+    "DELIVERY_RECEIPT",
     "FILE_DELIVERED",
     "FILE_UPLOAD_FAILED",
     "PUBLISHED",
@@ -89,3 +92,23 @@ def log(
             f.write(line)
     except OSError:
         pass
+
+
+def read_events(msg_id: str) -> list[dict[str, str]]:
+    """Return transaction events correlated to one message ULID."""
+    path = _txlog_path()
+    if not path.is_file():
+        return []
+    events: list[dict[str, str]] = []
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                values = line.rstrip("\n").split("\t")
+                if values == _COLUMNS or len(values) != len(_COLUMNS):
+                    continue
+                event = dict(zip(_COLUMNS, values))
+                if event["msg_id"].upper() == msg_id.upper():
+                    events.append(event)
+    except OSError:
+        return []
+    return events


### PR DESCRIPTION
## Summary

- add optional content-free delivery receipts correlated to the original envelope ULID
- encode receipts as ordinary envelopes with a versioned `a8s_control` extension and reserved non-participant target
- consume control envelopes before participant routing so they never enter agent inboxes and never generate receipt loops
- record remote resolution, inbox write, receipt publication, receipt observation, and existing agent-wake boundaries in the transaction log
- add `a8s trace <ULID>` for a local correlated timeline

## Compatibility

This is extension-only. Existing message envelopes and routing behavior do not change. Subscribers without receipt support treat the reserved `__a8s_receipt__` destination as unknown and drop it through the existing rate-limited `REMOTE_DROP` diagnostic. a8s-android likewise ignores the non-device, non-phone-agent target. Receipt publication is best-effort, so absence remains inconclusive.

## Verification

- `env -u TELL_OUTBOX_DIR venv/bin/python -m pytest apps/a8s/tests/` (667 passed)
- includes a real two-cluster MQTT persistent-session receipt round trip

Closes #225