### PR TITLE
feat(a8s): add rm command alias

### DIFF
--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -109,7 +109,7 @@ That's the full loop. Members don't know they're "in a8s" — they just see a `t
 |                                |                                                                                                                                                                |
 | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `a8s add <name> <dir> [<def>]` | Register an agent. Auto-detects definition from `<dir>`'s marker file unless `<def>` is given.                                                                 |
-| `a8s remove <name>`            | Unregister an agent. Wipes `~/.a8s/agents/<NAME>/` and prunes the agent from any alias's member list (deletes empty aliases). Refuses if a handler is running. |
+| `a8s remove <name>` / `a8s rm <name>` | Unregister an agent. Wipes `~/.a8s/agents/<NAME>/` and prunes the agent from any alias's member list (deletes empty aliases). Refuses if a handler is running. |
 | `a8s define <name> [<path>]`   | Show or set the agent's definition file.                                                                                                                       |
 | `a8s discover <path>`          | Walk a path for marker files; print suggested `add`+`define` commands. Read-only.                                                                              |
 | `a8s ls [-q]`                  | List every registered node, running or not: NAME, STATUS (`running (pid N)` / `stopped`), KIND, ROOT, and bound namespaces. `-q` prints just names.             |

--- a/apps/a8s/cli.py
+++ b/apps/a8s/cli.py
@@ -43,6 +43,7 @@ from commands import (
 COMMANDS: list[tuple[str, str, str]] = [
     ("add",      "<name> <dir> [<def>]",      "Register a node."),
     ("remove",   "<name>",                    "Unregister a node and delete its mailbox."),
+    ("rm",       "<name>",                    "Alias for remove."),
     ("ls",       "[-q]",                      "List all registered nodes, running or not."),
     ("discover", "<path>",                    "Scan a path for nodes and suggest `add` commands."),
     ("define",   "<name> [<path>]",           "Show or set an agent's command definition."),
@@ -92,7 +93,7 @@ CLI_EPILOG = "Commands:\n" + _format_commands(COMMANDS)
 def dispatch(cmd: str, args: list[str], interval: float) -> int:
     if cmd == "add":
         return cmd_add(args)
-    if cmd == "remove":
+    if cmd in ("remove", "rm"):
         return cmd_remove(args)
     if cmd == "ls":
         return cmd_ls(args)

--- a/apps/a8s/tests/test_cli.py
+++ b/apps/a8s/tests/test_cli.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import cli
+
+
+def test_rm_is_a_known_command():
+    assert "rm" in cli.KNOWN_COMMANDS
+    assert "rm <name>" in cli.CLI_EPILOG
+
+
+def test_rm_dispatches_to_remove(monkeypatch):
+    calls = []
+    monkeypatch.setattr(cli, "cmd_remove", lambda args: calls.append(args) or 7)
+
+    assert cli.dispatch("rm", ["alice"], interval=1.0) == 7
+    assert calls == [["alice"]]
+
+
+def test_remove_still_dispatches_to_same_handler(monkeypatch):
+    calls = []
+    monkeypatch.setattr(cli, "cmd_remove", lambda args: calls.append(args) or 0)
+
+    assert cli.dispatch("remove", ["alice"], interval=1.0) == 0
+    assert calls == [["alice"]]


### PR DESCRIPTION
## Summary

- accept a8s rm <name> as an alias for a8s remove <name>
- route both spellings through the same cmd_remove implementation
- expose the alias in CLI help and current documentation

## Verification

- env -u TELL_OUTBOX_DIR venv/bin/python -m pytest apps/a8s/tests/ (656 passed)
- tests cover known-command registration and dispatch equivalence for rm and remove