### PR TITLE
fix(r4t): agy preset needs --dangerously-skip-permissions on 1.1.3

### DIFF
--- a/apps/r4t/docs/harness-agy.md
+++ b/apps/r4t/docs/harness-agy.md
@@ -72,6 +72,29 @@ Two things make it work:
    requires dispatch to inject the per-turn staging path into the argv, since
    the path is per-node/per-member. Not currently wired.
 
+## Update: headless command permissions (2026-07-16, agy 1.1.3)
+
+agy 1.1.3 introduced a new permission model, `toolPermission=request-review`.
+In headless `--print` runs any tool needing the **"command"** permission is
+**auto-denied** — headless mode has no way to surface the review prompt, so the
+turn produces only the denial text (`a tool required the "command" permission
+that headless mode cannot prompt for, so it was auto-denied`). Crucially,
+`--mode accept-edits` covers *file edits* but **not commands**: a member that
+runs `tell` or `git` now stalls even though it never touches `--sandbox`.
+
+The r4t `agy` preset therefore now passes **`--dangerously-skip-permissions`**,
+matching what `apps/a8s/definitions/agy.json` already does. This is consistent
+with r4t doctrine (ISOLATE-SPEC): the security line is the **OS isolation
+boundary**, not the harness's own sandbox/permission layer, which r4t already
+trusts for its peers.
+
+The narrow alternative is per-target allow rules —
+`command(<target>)` entries under `permissions.allow` in
+`~/.gemini/antigravity-cli/settings.json`. That works for a rig that only ever
+runs a fixed, known command set, but it is impractical for roster members that
+need broad shell access (arbitrary `git`, `tell`, build tooling), so r4t skips
+permissions wholesale instead.
+
 ## Recommended invocations per role
 
 - **A rig that must `tell`** (any r4t member): no `--sandbox`. Keep

--- a/apps/r4t/rig.py
+++ b/apps/r4t/rig.py
@@ -240,13 +240,19 @@ HARNESS_PRESETS: dict[str, dict] = {
         "text_tier": "big",
         "description": (
             "Antigravity 1.1+ — --print for headless turns; --mode accept-edits "
-            "so edits skip the review prompt. No --sandbox: it confines child "
-            "writes to CWD, blocking tell's staging outbox (see docs/harness-agy.md)"
+            "so edits skip the review prompt. --dangerously-skip-permissions "
+            "because 1.1.3+ auto-denies command tools in headless --print runs "
+            "(toolPermission=request-review can't prompt), which accept-edits no "
+            "longer covers — roster members must run tell and git. OS isolation, "
+            "not the harness permission layer, is the security boundary. "
+            "No --sandbox: it confines child writes to CWD, blocking tell's "
+            "staging outbox (see docs/harness-agy.md)"
         ),
         "a8s_definition": "agy.json",
         "headless": "--print",
         "invoke": [
             "agy",
+            "--dangerously-skip-permissions",
             "--mode",
             "accept-edits",
             "--print",

--- a/apps/r4t/tests/test_rig.py
+++ b/apps/r4t/tests/test_rig.py
@@ -470,15 +470,21 @@ class TestHarnessPresets:
         raw = json.loads(path.read_text(encoding="utf-8"))
         assert "qwen2.5-coder:7b" in raw["worker"]["_notes"]
 
-    def test_opencode_and_agy_presets_avoid_skip_permissions(self):
+    def test_opencode_avoids_skip_permissions(self):
         opencode = " ".join(HARNESS_PRESETS["opencode"]["invoke"])
-        agy = " ".join(HARNESS_PRESETS["agy"]["invoke"])
         assert "dangerously-skip-permissions" not in opencode
-        assert "dangerously-skip-permissions" not in agy
         assert "--auto" in opencode
+        assert "-i" not in opencode
+
+    def test_agy_preset_carries_skip_permissions(self):
+        # agy 1.1.3+ auto-denies command tools in headless --print runs
+        # (toolPermission=request-review can't prompt); accept-edits no longer
+        # covers commands, so roster members that must run tell/git need the
+        # skip. OS isolation is the security boundary, not this flag.
+        agy = " ".join(HARNESS_PRESETS["agy"]["invoke"])
+        assert "--dangerously-skip-permissions" in agy
         assert "--mode" in agy and "accept-edits" in agy
         assert "--print" in agy
-        assert "-i" not in opencode
 
     def test_build_preset_invoke_opencode(self):
         argv = build_preset_invoke("opencode")


### PR DESCRIPTION
agy auto-updated 1.1.2 → 1.1.3 overnight, adding a `toolPermission=request-review` model that auto-denies "command" tools in headless `--print` runs — `--mode accept-edits` covers file edits but not shell commands, so live r4t members that run `tell`/`git` stalled mid-turn with only the denial text. This adds `--dangerously-skip-permissions` to the agy preset invoke (matching `apps/a8s/definitions/agy.json`), since per ISOLATE-SPEC the security boundary is OS isolation, not the harness permission layer r4t already trusts for peers. Includes the updated preset description, test, and a dated note in `docs/harness-agy.md`; full r4t suite is green (520 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)