### PR TITLE
refactor(r4t): isolation config moves rig -> org

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ jobs:
     outputs:
       l9m: ${{ steps.filter.outputs.l9m }}
       llm: ${{ steps.filter.outputs.llm }}
+      r4t: ${{ steps.filter.outputs.r4t }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -22,6 +23,8 @@ jobs:
               - 'l9m'
               - 'docs/l9m.md'
               - 'apps/q3w/**'
+            r4t:
+              - 'apps/r4t/**'
             llm:
               - 'apps/l9m/**'
               - 'l9m'
@@ -67,6 +70,15 @@ jobs:
           python-version: "3.12"
       - run: pip install pytest
       - run: python -m pytest apps/k7e/tests/ -x -q -m "not llm"
+
+  r4t-isolation:
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.r4t == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Real run_as OS-boundary integration test (Docker)
+        run: apps/r4t/tests/docker/run-as.sh
 
   l9m:
     runs-on: ubuntu-latest

--- a/apps/r4t/README.md
+++ b/apps/r4t/README.md
@@ -89,7 +89,7 @@ in production too. Full flow: [docs/message-flow.md](docs/message-flow.md).
 - [Verification](docs/verification.md) — `r4t check`, checklists, doorbell gate, the post-hoc judge
 - [Governance](docs/governance.md) — why each layer exists, with prior art
 - [Security model](docs/security.md) — what a repo edit can never change
-- [Isolation](docs/isolation.md) — run a rig behind a Unix user or a container
+- [Isolation](docs/isolation.md) — run an org behind a Unix user or a container
 - [Development](docs/development.md) — sandbox testing, module layout
 - Harness notes: [agy](docs/harness-agy.md) ·
   [ollama launch](docs/harness-ollama-launch.md)

--- a/apps/r4t/dispatch.py
+++ b/apps/r4t/dispatch.py
@@ -44,7 +44,7 @@ import signal
 import subprocess
 import threading
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import isolate
@@ -152,6 +152,7 @@ class DispatchContext:
     leader_sees_lateral: bool = False
     egress: bool = True
     doorbell_check: str | None = None
+    isolation: isolate.Isolation = field(default_factory=isolate.Isolation)
     definition_path: Path | None = None
 
     def __post_init__(self) -> None:
@@ -516,10 +517,11 @@ def run_harness(
     harness output is teed there line by line as it arrives, so a gemba attach
     can tail the turn live; the full output is still returned for staging.
 
-    When the rig sets `run_as` or `container` (rig.py; plans/ISOLATE-SPEC.md)
-    the argv is wrapped in the OS-level boundary. An isolation prereq that fails
-    closed returns a nonzero exit like any other failed turn — the batch stays
-    queued and the breaker counts it."""
+    When the org sets `run_as` or `container` (org.py; plans/ISOLATE-SPEC.md)
+    the choice rides in via the turn env and the argv is wrapped in the OS-level
+    boundary — every member turn of that org, whatever rig. An isolation prereq
+    that fails closed returns a nonzero exit like any other failed turn — the
+    batch stays queued and the breaker counts it."""
     argv = rig.argv(prompt, variant)
     if rig.model_resolver == "agy-live":
         # Resolve the friendly --model against the live `agy models` list before
@@ -533,26 +535,27 @@ def run_harness(
         argv = [resolved if a == "{model}" else a for a in argv]
 
     staging = (env or {}).get("TELL_OUTBOX_DIR", "")
+    isolation = isolate.isolation_from_env(env)
     kill_container_name: str | None = None
-    if rig.run_as:
-        probe_error = isolate.probe_run_as(rig.run_as, cwd)
+    if isolation.run_as:
+        probe_error = isolate.probe_run_as(isolation.run_as, cwd)
         if probe_error:
-            return 126, f"run_as {rig.run_as!r} isolation failed: {probe_error}", 0.0, False
+            return 126, f"run_as {isolation.run_as!r} isolation failed: {probe_error}", 0.0, False
         if staging:
-            isolate.assert_writable_shared_dir(staging, isolate.agent_gid(rig.run_as))
-        argv = isolate.wrap_run_as(argv, rig.run_as, staging, cwd)
-    elif rig.container:
+            isolate.assert_writable_shared_dir(staging, isolate.agent_gid(isolation.run_as))
+        argv = isolate.wrap_run_as(argv, isolation.run_as, staging, cwd)
+    elif isolation.container:
         kill_container_name = isolate.container_name(
             (env or {}).get("R4T_NODE", ""), (env or {}).get("R4T_MEMBER", "")
         )
         argv = isolate.build_container_argv(
             argv,
-            rig.container,
+            isolation.container,
             name=kill_container_name,
             staging_dir=staging,
             workplace=cwd,
             tell_outbox=staging,
-            container_args=rig.container_args,
+            container_args=isolation.container_args,
         )
 
     live_log = (env or {}).get("R4T_LIVE_LOG")
@@ -1166,10 +1169,13 @@ def _run_turn(
     env = dict(os.environ)
     env["TELL_OUTBOX_DIR"] = str(staging)
     env["R4T_LIVE_LOG"] = str(state.reset_live_log(ctx.node, member.name))
-    # Carried so run_harness can name a container rig's container deterministically
+    # Carried so run_harness can name a container's container deterministically
     # (r4t-<node>-<member>-<ts>) without widening the run_fn contract.
     env["R4T_NODE"] = ctx.node
     env["R4T_MEMBER"] = member.name
+    # The org's OS-level boundary (org.py) rides in the same way — one setting
+    # wraps every member turn regardless of rig (machinery outside, hands inside).
+    env.update(ctx.isolation.to_env())
     state.append_log(
         ctx.node,
         f"## {state.utc_now()} dispatch {len(batch)} message(s) -> {member.name} "

--- a/apps/r4t/docs/isolation.md
+++ b/apps/r4t/docs/isolation.md
@@ -1,16 +1,33 @@
-# Isolation — a real OS boundary per rig
+# Isolation — a real OS boundary per org
 
 Harness sandbox flags are not a security boundary: a CLI's `--sandbox` is
 model-discretionary and drifts between versions. The boundary that holds is the
 one the operating system already enforces — a Unix user with no sudo, or a
-container. r4t makes either a per-rig property. Inside the boundary the agent
-runs fully permissive; the OS, not a flag, is what contains it.
+container. r4t makes either a per-**org** property. Inside the boundary the
+agent runs fully permissive; the OS, not a flag, is what contains it.
 
-Two mutually exclusive rig keys (both set is a config error and the rig fails
-closed):
+## Why per-org, not per-rig
 
-- `run_as: "<username>"` — wrap the turn in `sudo -u <username>`.
-- `container: "<image>"` — run the turn under `docker run --rm`.
+Isolation is a per-project decision; rigs span the system. A rig maps to a real
+subscription and is machine-global — the same `leader` rig backs every org on
+the box. So the containment choice cannot ride the rig: an org with ten rigs
+must need **one** Unix user (or one image), not ten. A production box runs one
+agent user whose `$HOME` holds the credentials for every CLI, and every rig
+runs as that one user.
+
+The border sits at the turn invoke and nowhere else. r4t and a8s are
+deterministic machinery — routing, staging, budgeting — and run as the
+operator/a8s user; the probabilistic thing, the roster member's harness turn,
+is what gets wrapped. **Machinery outside, hands inside.** One user serves an
+arbitrary roster.
+
+## Setting the boundary
+
+Two mutually exclusive org keys in `r4t-org.json` (both set is a config error,
+reported by `r4t roster check`; the org degrades to no isolation):
+
+- `run_as: "<username>"` — wrap every member turn in `sudo -u <username>`.
+- `container: "<image>"` — run every member turn under `docker run --rm`.
 
 r4t **verifies** the prerequisites before every turn and fails closed with an
 action-first error; it never creates users, sudoers grants, workplace
@@ -18,20 +35,18 @@ permissions, or images. Provisioning is the operator's, once, below. A failed
 check is an ordinary failed turn: the batch stays queued, the breaker counts
 it, and `r4t status` shows the member unhealthy with the real error.
 
-Set the boundary on an existing rig by editing `~/.config/r4t/rigs.json`:
+Set the boundary by editing the org's `r4t-org.json` (the same file that carries
+`comms`, `egress`, and `doorbell_check`):
 
 ```json
 {
-  "leader": {
-    "preset": "claude",
-    "invoke": ["claude", "--permission-mode", "dontAsk", "...", "-p", "{prompt}"],
-    "run_as": "r4t-leader"
-  }
+  "run_as": "r4t-agent"
 }
 ```
 
-`r4t rig list` and `r4t status` then tag the rig `[user:r4t-leader]` /
-`[container:<image>]` so the boundary is visible at a glance.
+`r4t status` then prints one org-level line — `isolation: [user:r4t-agent]` /
+`[container:<image>]` — so the boundary that covers the whole roster is visible
+at a glance.
 
 ## Posture: most-permissive preset behind the boundary
 
@@ -132,21 +147,17 @@ docker run --rm --name r4t-<node>-<member>-<ts> \
 
 ### `container_args` — credentials and everything else
 
-A per-rig `container_args` list is appended to `docker run` verbatim (the
+An org-level `container_args` list is appended to `docker run` verbatim (the
 option-passthrough principle). Cloud-CLI credentials ride here as
 operator-chosen read-only mounts:
 
 ```json
 {
-  "cloud-rig": {
-    "preset": "claude",
-    "invoke": ["claude", "--permission-mode", "dontAsk", "...", "-p", "{prompt}"],
-    "container": "r4t/claude:latest",
-    "container_args": [
-      "-v", "/home/router/.config/anthropic:/root/.config/anthropic:ro",
-      "--network", "host"
-    ]
-  }
+  "container": "r4t/claude:latest",
+  "container_args": [
+    "-v", "/home/router/.config/anthropic:/root/.config/anthropic:ro",
+    "--network", "host"
+  ]
 }
 ```
 
@@ -166,6 +177,28 @@ everything that runs inside the boundary for as long as it is mounted
 candidates for a later isolation round; today, mount only credentials the
 rig's job actually needs, and treat "isolated" as meaning *it cannot
 change what runs* — not *it cannot phone out*.
+
+## Whole-node containment (a deployment choice, not a feature)
+
+The org boundary wraps each member's turn. Because r4t anchors a team on a
+directory and runs as ordinary machinery, an operator who wants a coarser wall
+can simply run the **entire node** — the r4t daemon, a8s, everything — under one
+Unix user or inside one container, as a deployment choice. Nothing in r4t needs
+to know: it is just `sudo -u node-user r4t ...` or a node-wide container image.
+Per-org `run_as`/`container` and whole-node containment compose; pick the grain
+your threat model wants.
+
+## Testing the real boundary
+
+`tests/docker/run-as.sh` is the reference provisioning sequence: it builds an
+`ubuntu:24.04` container and, as root inside it, creates a sudo-less agent user,
+a shared work group, a scoped `visudo`-validated sudoers drop-in, and setgid
+`2770` staging/workplace dirs — then runs a real org-level `run_as` dispatch turn
+and asserts the boundary holds from inside (the turn's effective user is the
+agent user, `TELL_OUTBOX_DIR` survived `env_reset`, staging writes are
+group-writable, the agent cannot sudo, and it cannot read the router's home).
+Run it directly (`apps/r4t/tests/docker/run-as.sh`); CI runs it on r4t changes.
+It doubles as a copy-pasteable provisioning checklist for a real deployment.
 
 ## Not automated (by design)
 

--- a/apps/r4t/docs/org.md
+++ b/apps/r4t/docs/org.md
@@ -119,3 +119,6 @@ config without a `repo` key is an in-repo org that just wants settings.
 | `leader_sees_lateral` | `false` | when `true`, a lateral (peer) delivery lands a read-only copy in the lead's history — no turn burned |
 | `egress` | `true` | only the topmost leader may message outside the garden; a non-top member's external tell redirects up to it. `false` keeps the org silent outward |
 | `doorbell_check` | *absent* | a shell command that gates every ring of an absent human's doorbell (see [verification.md](verification.md)); absent or empty means no gate |
+| `run_as` | *absent* | OS-level isolation: wrap every member turn in `sudo -u <username>`. One user serves the whole roster (see [isolation.md](isolation.md)) |
+| `container` | *absent* | OS-level isolation: run every member turn under `docker run --rm <image>`; mutually exclusive with `run_as` (see [isolation.md](isolation.md)) |
+| `container_args` | *absent* | extra `docker run` args appended verbatim (credential mounts, `--network`); needs `container` |

--- a/apps/r4t/example-rigs.json
+++ b/apps/r4t/example-rigs.json
@@ -48,13 +48,7 @@
     "rig_budget_earn_per_hour": 20
   },
 
-  "walled": {
-    "_notes": "Isolated rig — the security boundary is the OS, not a harness flag. `run_as` wraps the turn in `sudo -u <user>` (a Unix user with no sudo); `container` runs it under `docker run --rm` with `container_args` appended verbatim (e.g. read-only credential mounts). The two are mutually exclusive. Prereqs are operator-provisioned and probed per turn — see docs/isolation.md. Behind the wall, choose the most-permissive preset.",
-    "invoke": ["claude", "--permission-mode", "dontAsk", "-p", "{prompt}"],
-    "run_as": "r4t-worker",
-    "_container_example": "img/claude:latest",
-    "_container_args_example": ["-v", "/home/router/.config/anthropic:/root/.config/anthropic:ro"]
-  },
+  "_isolation_note": "OS-level isolation (run_as / container) is NOT a rig key — it is a per-ORG setting in r4t-org.json (one Unix user or image serves an org's whole roster, whatever rig runs a member). Behind the wall, choose the most-permissive preset. See docs/isolation.md.",
 
   "pins": {
     "_notes": "agent name -> rig. A pinned agent's rig comes from HERE, silently overriding the roster's Rig line — an in-repo roster edit can't upgrade a pinned agent.",

--- a/apps/r4t/isolate.py
+++ b/apps/r4t/isolate.py
@@ -1,12 +1,16 @@
-"""OS-level isolation for rig invocation — run-as-user and container variants.
+"""OS-level isolation for turn invocation — run-as-user and container variants.
 
 The through-line (see plans/ISOLATE-SPEC.md): harness sandbox flags are not a
-security boundary; the operating system is. A rig may name `run_as` (a Unix
-user with no sudo) or `container` (an image) and the agent runs fully
-permissive INSIDE that boundary. r4t never provisions the boundary — it
-verifies operator-provisioned prerequisites and fails closed with an
-action-first error — except for the shared message dirs, which are r4t's own
-state and are re-asserted to the correct owner-group/mode before every turn.
+security boundary; the operating system is. An ORG may name `run_as` (a Unix
+user with no sudo) or `container` (an image) and every member turn runs fully
+permissive INSIDE that boundary regardless of rig — isolation is a per-project
+decision, so it lives with the org (org.py), not the machine-global rig.
+Machinery outside, hands inside: r4t/a8s code runs as the operator, and the
+boundary applies at the moment a member's turn invoke runs. r4t never provisions
+the boundary — it verifies operator-provisioned prerequisites and fails closed
+with an action-first error — except for the shared message dirs, which are
+r4t's own state and are re-asserted to the correct owner-group/mode before
+every turn.
 
 Both wrappers are pure argv builders so the exact shape is unit-testable
 against fake `sudo`/`docker` binaries; nothing here shells out except the
@@ -14,14 +18,23 @@ prereq probes and the container kill, which run the real tool by name.
 """
 from __future__ import annotations
 
+import json
 import os
 import pwd
 import re
 import subprocess
 import time
+from dataclasses import dataclass, field
 from pathlib import Path
 
 PROBE_TIMEOUT_SECONDS = 10
+
+# The org's isolation choice rides to run_harness through the turn env (like
+# R4T_NODE/R4T_MEMBER), so the run_fn contract stays (rig, prompt, cwd, env,
+# variant) — dispatch never has to widen it or thread a new positional.
+ENV_RUN_AS = "R4T_RUN_AS"
+ENV_CONTAINER = "R4T_CONTAINER"
+ENV_CONTAINER_ARGS = "R4T_CONTAINER_ARGS"
 
 # The bash the wrapped `sudo` runs: env cannot survive sudoers env_reset, so
 # TELL_OUTBOX_DIR rides as $1 and the workplace as $2; `exec "$@"` hands the
@@ -37,6 +50,57 @@ _CONTAINER_BASE_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:
 
 class IsolationError(Exception):
     pass
+
+
+@dataclass
+class Isolation:
+    """The org's OS-level boundary (plans/ISOLATE-SPEC.md). Applies to EVERY
+    member turn of the org, whatever rig runs it — one Unix user or one image
+    per org. `run_as` and `container` are mutually exclusive; the parse in
+    org.py rejects both-set, so a live Isolation carries at most one."""
+
+    run_as: str | None = None
+    container: str | None = None
+    container_args: list = field(default_factory=list)
+
+    @property
+    def active(self) -> bool:
+        return bool(self.run_as or self.container)
+
+    def to_env(self) -> dict[str, str]:
+        """The env keys run_harness reads to wrap a turn. Empty when isolation
+        is off, so a bare org adds nothing to the turn environment."""
+        env: dict[str, str] = {}
+        if self.run_as:
+            env[ENV_RUN_AS] = self.run_as
+        elif self.container:
+            env[ENV_CONTAINER] = self.container
+            if self.container_args:
+                env[ENV_CONTAINER_ARGS] = json.dumps(self.container_args)
+        return env
+
+
+def isolation_from_env(env: dict | None) -> Isolation:
+    """Reconstruct the org's Isolation from the turn env. Trusted internal
+    round-trip of `Isolation.to_env`; a malformed container_args degrades to
+    none rather than raising inside a turn."""
+    env = env or {}
+    run_as = (env.get(ENV_RUN_AS) or "").strip() or None
+    if run_as:
+        return Isolation(run_as=run_as)
+    container = (env.get(ENV_CONTAINER) or "").strip() or None
+    if not container:
+        return Isolation()
+    args: list = []
+    raw = env.get(ENV_CONTAINER_ARGS) or ""
+    if raw:
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            parsed = None
+        if isinstance(parsed, list):
+            args = [str(a) for a in parsed]
+    return Isolation(container=container, container_args=args)
 
 
 def a8s_client_dir() -> Path:
@@ -165,7 +229,7 @@ def build_container_argv(
     """`docker run --rm` with the workplace bind-mounted rw at the same path and
     used as workdir, the staging dir rw at the same path with TELL_OUTBOX_DIR
     injected (no env_reset inside a container), the a8s client ro with a PATH
-    shim, an optional delivered-files dir ro, then per-rig container_args
+    shim, an optional delivered-files dir ro, then the org's container_args
     verbatim, then the image and the harness argv. r4t never builds, pulls, or
     inspects the image — a missing image is an ordinary turn failure."""
     client = Path(client_dir) if client_dir is not None else a8s_client_dir()

--- a/apps/r4t/org.py
+++ b/apps/r4t/org.py
@@ -36,6 +36,12 @@ home — this file is the org-level home):
   may ring an absent human's doorbell. Exit 0 lets the ring through; nonzero
   parks the message without ringing (the gate protects attention, not the
   mailbox). Absent or empty is today's behavior — no gate.
+- `run_as` / `container` (+ `container_args`, all default absent): OS-level
+  isolation for every member turn (plans/ISOLATE-SPEC.md). Isolation is a
+  per-project decision — one Unix user or one container image serves the org's
+  whole roster whatever rig runs a member — so it lives here, not on the
+  machine-global rig. `run_as` and `container` are mutually exclusive.
+  The mechanics live in isolate.py; dispatch wraps the turn from this setting.
 
 Graduation is trivial: copy ROSTER.md + MISSION.md into the repo and drop the
 `repo` key (or the whole file, if it carries no settings). Resolution falls
@@ -44,8 +50,10 @@ back to the in-repo default with no other change.
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
+
+from isolate import Isolation
 
 ORG_CONFIG_NAME = "r4t-org.json"
 
@@ -66,6 +74,7 @@ class Org:
     leader_sees_lateral: bool = False
     egress: bool = True
     doorbell_check: str | None = None
+    isolation: Isolation = field(default_factory=Isolation)
 
     @property
     def is_portable(self) -> bool:
@@ -115,6 +124,43 @@ def _parse_str(raw: object, key: str) -> tuple[str | None, str | None]:
     return raw, None
 
 
+def _parse_isolation(data: dict) -> tuple[Isolation, list[str]]:
+    """OS-level isolation for every member turn. `run_as` and `container` are
+    mutually exclusive; both set is a config error and the org degrades to no
+    isolation (fail closed reports through check_org). `container_args` needs a
+    `container` to attach to."""
+    errors: list[str] = []
+    iso = Isolation()
+    run_as = data.get("run_as")
+    container = data.get("container")
+    if run_as is not None and container is not None:
+        errors.append(
+            'org config "run_as" and "container" are mutually exclusive; set only one'
+        )
+    else:
+        if run_as is not None:
+            if not isinstance(run_as, str) or not run_as.strip():
+                errors.append('org config "run_as" must be a non-empty username string')
+            else:
+                iso.run_as = run_as.strip()
+        if container is not None:
+            if not isinstance(container, str) or not container.strip():
+                errors.append('org config "container" must be a non-empty image string')
+            else:
+                iso.container = container.strip()
+    container_args = data.get("container_args")
+    if container_args is not None:
+        if not isinstance(container_args, list) or not all(
+            isinstance(a, str) for a in container_args
+        ):
+            errors.append('org config "container_args" must be a list of strings')
+        elif iso.container is None:
+            errors.append('org config "container_args" set but "container" is not')
+        else:
+            iso.container_args = list(container_args)
+    return iso, errors
+
+
 def _parse_settings(data: dict) -> tuple[dict, list[str]]:
     errors: list[str] = []
     comms = data.get("comms", COMMS_OPEN)
@@ -130,11 +176,14 @@ def _parse_settings(data: dict) -> tuple[dict, list[str]]:
     doorbell_check, err = _parse_str(data.get("doorbell_check"), "doorbell_check")
     if err:
         errors.append(err)
+    isolation, iso_errors = _parse_isolation(data)
+    errors.extend(iso_errors)
     return {
         "comms": comms,
         "leader_sees_lateral": lsl,
         "egress": egress,
         "doorbell_check": doorbell_check,
+        "isolation": isolation,
     }, errors
 
 

--- a/apps/r4t/plans/ISOLATE-SPEC.md
+++ b/apps/r4t/plans/ISOLATE-SPEC.md
@@ -1,5 +1,7 @@
 # The isolation phase — implementation spec
 
+*2026-07-16 ruling: isolation config moved rig → org (per-project decision; rigs span the system); border unchanged. Implemented in the PR that carries this note.*
+
 *2026-07-15. Follows the verification round (VERIFY-SPEC.md) and Neil's
 ruling that morning: run-as-user and run-via-container become first-class
 r4t features, buildable in parallel with the verification work. One issue,

--- a/apps/r4t/r4t.py
+++ b/apps/r4t/r4t.py
@@ -158,6 +158,7 @@ def _context(args: argparse.Namespace, node: str) -> DispatchContext:
         leader_sees_lateral=org.leader_sees_lateral,
         egress=org.egress,
         doorbell_check=org.doorbell_check,
+        isolation=org.isolation,
         definition_path=(
             Path(defn).expanduser() if (defn := getattr(args, "definition", None)) else None
         ),
@@ -192,8 +193,7 @@ def _print_rig_summary(config_path: Path, roster_path: Path | None = None) -> No
                 f" rig-budget={rig.rig_budget_max:g}/"
                 f"+{rig.rig_budget_earn_per_hour:g}per-h"
             )
-        iso = _isolation_tag(rig)
-        print(f"  {name}: {argv}  ({limits})" + (f"  {iso}" if iso else ""))
+        print(f"  {name}: {argv}  ({limits})")
     if config.pins:
         print("  pins:")
         for agent in sorted(config.pins):
@@ -480,12 +480,13 @@ def _roster_rows(
     return rows
 
 
-def _isolation_tag(rig) -> str:
-    """The rig's OS-level boundary at a glance, or "" for a bare rig."""
-    if rig.run_as:
-        return f"[user:{rig.run_as}]"
-    if rig.container:
-        return f"[container:{rig.container}]"
+def _isolation_tag(isolation) -> str:
+    """The org's OS-level boundary at a glance, or "" for a bare org. Isolation
+    is per-org (org.py), so one badge covers the whole roster."""
+    if isolation.run_as:
+        return f"[user:{isolation.run_as}]"
+    if isolation.container:
+        return f"[container:{isolation.container}]"
     return ""
 
 
@@ -518,9 +519,7 @@ def _rig_rows(
                 f" rig-budget={rig.rig_budget_max:g}/"
                 f"+{rig.rig_budget_earn_per_hour:g}per-h"
             )
-        iso = _isolation_tag(rig)
-        detail = f"{argv}  ({limits})" + (f"  {iso}" if iso else "")
-        rows.append((True, name, detail, None))
+        rows.append((True, name, f"{argv}  ({limits})", None))
     for agent in sorted(config.pins):
         rows.append((None, "pin", f"{agent} -> {config.pins[agent]}", None))
     rows.append((
@@ -596,6 +595,9 @@ def cmd_status(args: argparse.Namespace) -> int:
     ctx = _context(args, node)
     print(f"team: {node}")
     print(f"state: {state.team_dir(node)}")
+    iso = _isolation_tag(ctx.isolation)
+    if iso:
+        print(f"isolation: {iso}  (every member turn runs behind this boundary)")
     print()
 
     roster = None

--- a/apps/r4t/rig.py
+++ b/apps/r4t/rig.py
@@ -35,12 +35,10 @@ record it). It defaults the text knobs (`history_max_bytes` /
 `history_body_max` / `prompt_body_max`) by the preset's text tier (TEXT_TIERS);
 explicit values always win, and a rig with no preset gets the small tier.
 
-`run_as` / `container` — OS-level isolation (mutually exclusive; both set is a
-config error and the rig fails closed). `run_as: "<username>"` wraps the invoke
-in `sudo -u <user>`; `container: "<image>"` runs it under `docker run --rm`,
-with `container_args` appended verbatim. Prerequisites are operator-provisioned
-and probed per turn — r4t never creates users, sudoers grants, or images. See
-apps/r4t/docs/isolation.md.
+OS-level isolation (`run_as` / `container`) is NOT a rig key — it is a
+per-org decision (rigs are machine-global and shared across orgs, so one Unix
+user or image serves an org's whole roster). It lives in `r4t-org.json`; see
+org.py and apps/r4t/docs/isolation.md.
 
 Keys starting with `_` anywhere are ignored so shipped examples can carry
 notes.
@@ -349,9 +347,6 @@ class Rig:
     prompt_body_max: int = DEFAULT_PROMPT_BODY_MAX
     model: str | None = None
     model_resolver: str | None = None
-    run_as: str | None = None
-    container: str | None = None
-    container_args: list = field(default_factory=list)
     error: str | None = None
 
     def pool(self) -> list[list[str]]:
@@ -975,35 +970,6 @@ def _parse_rig(name: str, raw: object) -> Rig:
                 problems.append(f"rig_budget_earn_per_hour: {err}")
     elif raw_rig_earn is not None:
         problems.append("rig_budget_earn_per_hour set but rig_budget_max missing")
-
-    # OS-level isolation (plans/ISOLATE-SPEC.md). run_as and container are
-    # mutually exclusive — both set is a config error and the rig fails closed,
-    # same posture as a rig missing from config.
-    run_as = raw.get("run_as")
-    container = raw.get("container")
-    if run_as is not None and container is not None:
-        problems.append("run_as and container are mutually exclusive; set only one")
-    else:
-        if run_as is not None:
-            if not isinstance(run_as, str) or not run_as.strip():
-                problems.append("run_as must be a non-empty username string")
-            else:
-                rig.run_as = run_as.strip()
-        if container is not None:
-            if not isinstance(container, str) or not container.strip():
-                problems.append("container must be a non-empty image string")
-            else:
-                rig.container = container.strip()
-    container_args = raw.get("container_args")
-    if container_args is not None:
-        if not isinstance(container_args, list) or not all(
-            isinstance(a, str) for a in container_args
-        ):
-            problems.append("container_args must be a list of strings")
-        elif container is None:
-            problems.append("container_args set but container is not")
-        else:
-            rig.container_args = list(container_args)
 
     if problems:
         rig.error = "; ".join(problems)

--- a/apps/r4t/tests/conftest.py
+++ b/apps/r4t/tests/conftest.py
@@ -13,6 +13,18 @@ _PKG = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_PKG))
 
 
+def pytest_configure(config):
+    # Registered so a future in-pytest hook for the real-boundary docker test
+    # has a home. The current integration lives entirely in tests/docker/ and
+    # is driven by run-as.sh (Docker is the only entry point), so nothing under
+    # the default suite carries this marker today.
+    config.addinivalue_line(
+        "markers",
+        "isolation_integration: real OS-boundary test; run via "
+        "tests/docker/run-as.sh, excluded from the default suite",
+    )
+
+
 @pytest.fixture(autouse=True)
 def _restore_tell_outbox_env():
     """r4t's seat/chat CLIs set TELL_OUTBOX_DIR in os.environ (so child `tell`

--- a/apps/r4t/tests/docker/inside.sh
+++ b/apps/r4t/tests/docker/inside.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Runs as root INSIDE the ubuntu:24.04 container (see run-as.sh). Provisions the
+# operator prerequisites r4t never automates, then drives a real org-level
+# `run_as` dispatch turn as a non-root router user and asserts the boundary.
+set -euo pipefail
+
+echo "== provisioning (the operator's job; r4t never does this) =="
+apt-get update -qq
+apt-get install -y -qq python3 sudo >/dev/null
+
+# A container-owned, writable copy of the r4t tree (the mount is read-only).
+cp -a /src-r4t /opt/r4t
+export PYTHONDONTWRITEBYTECODE=1
+
+# --- users and groups ---------------------------------------------------------
+# router: the a8s/r4t machinery user (non-root, holds the scoped sudo grant).
+# agent:  the sandbox — NO sudo group, NO sudoers entry of its own.
+groupadd r4t-work
+useradd -m -s /bin/bash router
+useradd -m -s /bin/bash agent
+usermod -aG r4t-work router
+usermod -aG r4t-work agent
+# r4t re-asserts the staging dir to router:<agent primary group>; a non-root
+# router can only chgrp to a group it belongs to, so it must join the agent
+# group. (Provisioning fact, not a code path — documented in isolation.md.)
+usermod -aG agent router
+# The border: the agent must not be able to read the router's home.
+chmod 700 /home/router
+
+# --- scoped, passwordless sudo (NOT blanket NOPASSWD: ALL) ---------------------
+# router may act ONLY as agent, ONLY via the shapes r4t actually invokes: the
+# `bash --login -c` wake wrapper and the `true` grant probe.
+# `type -P` returns the on-disk binary, skipping the `true` shell builtin —
+# sudoers Cmnd_Alias entries must be absolute paths.
+BASH_BIN="$(type -P bash)"
+TRUE_BIN="$(type -P true)"
+cat >/etc/sudoers.d/r4t-agent <<EOF
+Cmnd_Alias R4T_AGENT = ${BASH_BIN} --login -c *, ${TRUE_BIN}
+router ALL=(agent) NOPASSWD: R4T_AGENT
+EOF
+chmod 0440 /etc/sudoers.d/r4t-agent
+visudo -cf /etc/sudoers.d/r4t-agent   # fail loudly on a malformed drop-in
+
+# --- r4t state + the shared workplace ----------------------------------------
+install -d -o router -g router /var/lib/r4t                 # R4T_HOME (router-owned)
+install -d -o router -g r4t-work -m 2770 /work             # workplace: setgid, group-writable
+# Portable org dir: router-readable ROSTER/MISSION + the run_as/repo pointer.
+install -d -o router -g router /etc/r4t-org
+cat >/etc/r4t-org/ROSTER.md <<'EOF'
+# Team
+
+### Worker
+- **Status:** AI
+- **Rig:** solo
+- **Leader:** yes
+EOF
+cat >/etc/r4t-org/r4t-org.json <<'EOF'
+{ "run_as": "agent", "repo": "/work" }
+EOF
+cat >/etc/r4t-rigs.json <<'EOF'
+{
+  "throttle": { "max_concurrent": 0, "min_seconds_between_turn_starts": 0 },
+  "cell_budget_max": 100, "cell_budget_earn_per_hour": 100,
+  "solo": {
+    "invoke": ["python3", "/opt/r4t/tests/docker/member.py", "{prompt}"],
+    "timeout_seconds": 60, "budget_max": 50, "budget_earn_per_hour": 50
+  }
+}
+EOF
+chown -R router:router /etc/r4t-org /etc/r4t-rigs.json
+chmod -R a+rX /opt/r4t   # the wrapped agent must be able to read member.py
+
+echo "== running a real org-level run_as dispatch turn (as the router user) =="
+sudo -u router env \
+  R4T_HOME=/var/lib/r4t \
+  PYTHONDONTWRITEBYTECODE=1 \
+  PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+  python3 /opt/r4t/r4t.py dispatch \
+    --root /etc/r4t-org \
+    --from boss --to acme:worker --message "prove the boundary" \
+    --rig-config /etc/r4t-rigs.json --no-notify
+
+echo "== asserting invariants from the agent's own report =="
+RESULTS=/work/agent-results.json
+if [ ! -f "$RESULTS" ]; then
+  echo "FAIL: the member never wrote ${RESULTS} — the turn did not run as the agent." >&2
+  exit 1
+fi
+cat "$RESULTS"
+
+python3 - "$RESULTS" <<'PY'
+import json, sys
+
+r = json.load(open(sys.argv[1]))
+failures = []
+
+def want(cond, msg):
+    if not cond:
+        failures.append(msg)
+
+# 1. the member turn's effective user is the agent user
+want(r["effective_user"] == "agent",
+     f'effective_user is {r["effective_user"]!r}, expected "agent" '
+     "(the turn did NOT run behind the boundary)")
+
+# 2. TELL_OUTBOX_DIR survived the env_reset positional dance
+want(bool(r["tell_outbox_dir"]),
+     "TELL_OUTBOX_DIR was empty inside the turn (env_reset stripped it; the "
+     "positional bootstrap did not re-export it)")
+want(r["outbox_writable"] is True,
+     "the agent could not write into TELL_OUTBOX_DIR (staging not group-writable)")
+
+# 3. staging writes land group-owned per the setgid re-assertion (functional:
+#    the file the agent created inherited the staging dir's group)
+want(r["outbox_file_group_matches_dir"] is True,
+     "a file the agent created in staging did not inherit the staging group "
+     "(setgid 2770 re-assertion did not take)")
+
+# 4. negative-sudo: the agent user CANNOT sudo
+want(r["agent_can_sudo"] is False,
+     "the agent user CAN sudo — the sandbox is not sudo-less")
+
+# 5. the agent cannot cross the border into the router's home
+want(r["can_read_router_home"] is False,
+     "the agent could read the router's home (border leak)")
+want(r["can_write_router_home"] is False,
+     "the agent could write into the router's home (border leak)")
+
+if failures:
+    print("\nISOLATION INVARIANTS VIOLATED:", file=sys.stderr)
+    for f in failures:
+        print(f"  - {f}", file=sys.stderr)
+    sys.exit(1)
+print("\nALL ISOLATION INVARIANTS HELD")
+PY

--- a/apps/r4t/tests/docker/member.py
+++ b/apps/r4t/tests/docker/member.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Scripted r4t member for the real run_as isolation test (tests/docker).
+
+This runs as the *agent* user, wrapped by `sudo -u agent bash --login -c ...`
+(dispatch.run_harness -> isolate.wrap_run_as). It makes no LLM call: it probes
+the boundary from the inside with functional checks — actual writes, real
+`sudo` attempts, real reads — and records the outcome to `<cwd>/agent-results.json`
+(cwd is the workplace, /work). inside.sh asserts on that report.
+
+It deliberately does NOT emit a tell; dispatch's stdout fallback handles the
+empty staging. The point is the report, not the reply.
+"""
+from __future__ import annotations
+
+import getpass
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+def _effective_user() -> str:
+    try:
+        return getpass.getuser()
+    except Exception:
+        return f"uid:{os.getuid()}"
+
+
+def _outbox_checks() -> dict:
+    """Prove TELL_OUTBOX_DIR survived env_reset and that the agent can write
+    there, and that a created file inherits the staging group (setgid 2770)."""
+    outbox = os.environ.get("TELL_OUTBOX_DIR", "")
+    result = {
+        "tell_outbox_dir": outbox,
+        "outbox_writable": False,
+        "outbox_file_group_matches_dir": False,
+    }
+    if not outbox:
+        return result
+    d = Path(outbox)
+    try:
+        d.mkdir(parents=True, exist_ok=True)
+        probe = d / "_boundary-probe.txt"
+        probe.write_text("agent was here\n", encoding="utf-8")
+        result["outbox_writable"] = True
+        # Functional setgid evidence: the file's group == the dir's group,
+        # which r4t chgrp'd to the agent's own group before the turn.
+        result["outbox_file_group_matches_dir"] = (
+            probe.stat().st_gid == d.stat().st_gid
+        )
+        probe.unlink()
+    except OSError:
+        pass
+    return result
+
+
+def _agent_can_sudo() -> bool:
+    """The sandbox must be sudo-LESS. `sudo -n true` must be refused."""
+    try:
+        proc = subprocess.run(
+            ["sudo", "-n", "true"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False  # cannot even run sudo -> certainly cannot escalate
+    return proc.returncode == 0
+
+
+def _can_read_router_home() -> bool:
+    try:
+        os.listdir("/home/router")
+        return True
+    except OSError:
+        return False
+
+
+def _can_write_router_home() -> bool:
+    target = Path("/home/router/_agent-escape.txt")
+    try:
+        target.write_text("x", encoding="utf-8")
+        target.unlink()
+        return True
+    except OSError:
+        return False
+
+
+def main() -> int:
+    report = {
+        "effective_user": _effective_user(),
+        "agent_can_sudo": _agent_can_sudo(),
+        "can_read_router_home": _can_read_router_home(),
+        "can_write_router_home": _can_write_router_home(),
+        **_outbox_checks(),
+    }
+    # cwd is the workplace (/work); dispatch cd'd here via the bootstrap's `cd "$2"`.
+    Path("agent-results.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print("member: boundary probe complete for user", report["effective_user"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/r4t/tests/docker/run-as.sh
+++ b/apps/r4t/tests/docker/run-as.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Real run_as isolation — the boundary that the org-level refactor wraps every
+# member turn in (plans/ISOLATE-SPEC.md; the 2026-07-16 rig -> org ruling).
+#
+# Builds an ubuntu:24.04 container and, as root INSIDE it, provisions the exact
+# operator setup the docs prescribe — a sudo-LESS agent user, a shared work
+# group, a scoped `visudo`-validated sudoers drop-in, setgid 2770 staging +
+# workplace dirs — then runs a REAL org-level `run_as` dispatch turn and asserts
+# the boundary holds from inside: the turn's effective user is the agent, env
+# survived sudoers env_reset, staging writes land group-owned, the agent cannot
+# sudo, and it cannot read the router's home. Functional checks throughout — a
+# real user doing real writes, not trusting mode bits.
+#
+# The container is the only entry point; the same script runs locally (Docker
+# Desktop) and in CI. Slow (~1-2 min: it apt-installs python3+sudo) by design.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+R4T_DIR="$(cd "$HERE/../.." && pwd)"   # apps/r4t
+# ubuntu:24.04 is the CI default; override to reuse an already-pulled base
+# locally (e.g. R4T_TEST_IMAGE=ubuntu:latest) when a registry pull is awkward.
+IMAGE="${R4T_TEST_IMAGE:-ubuntu:24.04}"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "run-as.sh: docker not found — this test needs Docker (Desktop locally, or CI)." >&2
+  exit 2
+fi
+if ! docker info >/dev/null 2>&1; then
+  echo "run-as.sh: docker daemon not reachable — start Docker and retry." >&2
+  exit 2
+fi
+
+echo "run-as.sh: launching ${IMAGE} (installs python3+sudo; slow by design)..."
+exec docker run --rm \
+  -v "$R4T_DIR":/src-r4t:ro \
+  -e DEBIAN_FRONTEND=noninteractive \
+  "$IMAGE" \
+  bash /src-r4t/tests/docker/inside.sh

--- a/apps/r4t/tests/test_isolate.py
+++ b/apps/r4t/tests/test_isolate.py
@@ -1,5 +1,9 @@
 """OS-level isolation — run_as and container variants (plans/ISOLATE-SPEC.md §7).
 
+Isolation is a PER-ORG setting (the 2026-07-16 ruling): one Unix user or one
+image serves an org's whole roster, so it lives in r4t-org.json, not on the
+machine-global rig. The org's choice rides to run_harness through the turn env.
+
 Wrapper argv is asserted EXACTLY; the prereq probe and the container kill run
 against fake `sudo`/`docker` binaries put on PATH — no real sudo, docker, or
 LLM. State stays under the tmp R4T_HOME the shared fixtures set; the live
@@ -13,14 +17,15 @@ import stat
 import sys
 import textwrap
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
 
 import isolate
 import state
 from dispatch import DispatchContext, drain, handle_message, run_harness
-from rig import Rig, RigConfig, Throttle, load_rig_config
+from isolate import Isolation
+from org import ORG_CONFIG_NAME, check_org, load_org
+from rig import Rig, load_rig_config
 from roster import Member
 
 NODE = "acme"
@@ -106,40 +111,66 @@ class TestBuildContainer:
         assert isolate.container_name("ac me", "Phil/1", ts=7) == "r4t-ac-me-Phil-1-7"
 
 
-class TestMutualExclusion:
-    def _load(self, tmp_path, entry: dict) -> RigConfig:
-        path = tmp_path / "rigs.json"
-        path.write_text(json.dumps({"iso": {"invoke": ["h", "{prompt}"], **entry}}))
-        return load_rig_config(path)
+class TestOrgConfigValidation:
+    """Isolation now parses out of r4t-org.json (org.py), validated where
+    `doorbell_check` is: load_org degrades to no isolation on a bad value,
+    check_org reports it."""
+
+    def _write(self, tmp_path, settings: dict) -> Path:
+        (tmp_path / ORG_CONFIG_NAME).write_text(json.dumps(settings), encoding="utf-8")
+        return tmp_path
 
     def test_both_set_is_config_error(self, tmp_path):
-        config = self._load(tmp_path, {"run_as": "u", "container": "img"})
-        assert "mutually exclusive" in (config.rigs["iso"].error or "")
+        self._write(tmp_path, {"run_as": "u", "container": "img"})
+        assert any("mutually exclusive" in m for m in check_org(tmp_path))
 
-    def test_both_set_fails_closed_no_run(self, tmp_path):
-        config = self._load(tmp_path, {"run_as": "u", "container": "img"})
-        member = Member(name="Bob", rig="iso")
-        rig, error, _pinned = config.rig_for(member)
-        assert rig is None and "invalid" in (error or "")
+    def test_both_set_degrades_to_no_isolation(self, tmp_path):
+        self._write(tmp_path, {"run_as": "u", "container": "img"})
+        assert not load_org(tmp_path).isolation.active  # fail closed: neither applies
 
     def test_container_args_without_container_errors(self, tmp_path):
-        config = self._load(tmp_path, {"container_args": ["--gpus", "all"]})
-        assert "container_args set but container is not" in (config.rigs["iso"].error or "")
+        self._write(tmp_path, {"container_args": ["--gpus", "all"]})
+        assert any(
+            'container_args" set but "container" is not' in m for m in check_org(tmp_path)
+        )
 
     def test_blank_run_as_errors(self, tmp_path):
-        config = self._load(tmp_path, {"run_as": "   "})
-        assert "non-empty username" in (config.rigs["iso"].error or "")
+        self._write(tmp_path, {"run_as": "   "})
+        assert any("non-empty username" in m for m in check_org(tmp_path))
 
     def test_valid_run_as_parses(self, tmp_path):
-        config = self._load(tmp_path, {"run_as": "agent-x"})
-        assert config.rigs["iso"].error is None
-        assert config.rigs["iso"].run_as == "agent-x"
+        self._write(tmp_path, {"run_as": "agent-x"})
+        org = load_org(tmp_path)
+        assert check_org(tmp_path) == []
+        assert org.isolation.run_as == "agent-x" and org.isolation.active
 
     def test_valid_container_parses_with_args(self, tmp_path):
-        config = self._load(tmp_path, {"container": "img", "container_args": ["-v", "/c:/c:ro"]})
-        rig = config.rigs["iso"]
-        assert rig.error is None
-        assert rig.container == "img" and rig.container_args == ["-v", "/c:/c:ro"]
+        self._write(tmp_path, {"container": "img", "container_args": ["-v", "/c:/c:ro"]})
+        org = load_org(tmp_path)
+        assert check_org(tmp_path) == []
+        assert org.isolation.container == "img"
+        assert org.isolation.container_args == ["-v", "/c:/c:ro"]
+
+    def test_absent_isolation_is_the_default(self, tmp_path):
+        assert not load_org(tmp_path).isolation.active
+
+
+class TestEnvRoundTrip:
+    """The org's choice reaches run_harness through the turn env only — the
+    run_fn contract stays (rig, prompt, cwd, env, variant)."""
+
+    def test_run_as_round_trips(self):
+        env = Isolation(run_as="agent-x").to_env()
+        assert isolate.isolation_from_env(env).run_as == "agent-x"
+
+    def test_container_and_args_round_trip(self):
+        env = Isolation(container="img", container_args=["-v", "/c:/c:ro"]).to_env()
+        got = isolate.isolation_from_env(env)
+        assert got.container == "img" and got.container_args == ["-v", "/c:/c:ro"]
+
+    def test_bare_org_adds_nothing_to_env(self):
+        assert Isolation().to_env() == {}
+        assert not isolate.isolation_from_env({}).active
 
 
 class TestSharedDirAssertion:
@@ -190,7 +221,7 @@ ROSTER = textwrap.dedent(
 )
 
 
-def _iso_config(tmp_path, fake_harness, junior_extra: dict) -> Path:
+def _iso_config(tmp_path, fake_harness) -> Path:
     script, _out = fake_harness
     invoke = [sys.executable, str(script), "{prompt}"]
     payload = {
@@ -200,7 +231,7 @@ def _iso_config(tmp_path, fake_harness, junior_extra: dict) -> Path:
         "leader": {"invoke": invoke, "timeout_seconds": 30, "budget_max": 100, "budget_earn_per_hour": 50},
         "junior-dev": {
             "invoke": invoke, "timeout_seconds": 30, "budget_max": 100,
-            "budget_earn_per_hour": 50, **junior_extra,
+            "budget_earn_per_hour": 50,
         },
         "pins": {"gerry": "leader"},
     }
@@ -211,7 +242,7 @@ def _iso_config(tmp_path, fake_harness, junior_extra: dict) -> Path:
 
 @pytest.fixture
 def iso_ctx_factory(r4t_home, tmp_path, fake_harness, tells):
-    def make(junior_extra: dict) -> DispatchContext:
+    def make(isolation: dict | None = None) -> DispatchContext:
         root = tmp_path / "iso-repo"
         root.mkdir(exist_ok=True)
         (root / "ROSTER.md").write_text(ROSTER, encoding="utf-8")
@@ -220,8 +251,9 @@ def iso_ctx_factory(r4t_home, tmp_path, fake_harness, tells):
             root=root,
             node=NODE,
             roster_path=root / "ROSTER.md",
-            config_path=_iso_config(tmp_path, fake_harness, junior_extra),
+            config_path=_iso_config(tmp_path, fake_harness),
             tell_fn=capture,
+            isolation=Isolation(**(isolation or {})),
         )
 
     return make
@@ -241,14 +273,74 @@ class TestRunAsProbeFailsClosed:
         assert state.queue_depth(NODE, "phil") >= 1  # message returned to the queue
         assert state.read_meta(NODE, "phil")["consecutive_failures"] == 1  # breaker counts it
 
-    def test_probe_error_surfaces_the_fix(self, iso_ctx_factory, fakebin):
+    def test_probe_error_surfaces_the_fix(self, fakebin):
         _fake_bin(fakebin, "sudo", "import sys\nsys.exit(1)\n")
-        rig = Rig(name="junior-dev", invoke=["true", "{prompt}"], run_as="agent-x")
-        code, out, _dur, timed = run_harness(
-            rig, "p", Path("/tmp"), env={"TELL_OUTBOX_DIR": "/tmp/s"}
-        )
+        rig = Rig(name="junior-dev", invoke=["true", "{prompt}"])
+        env = {"TELL_OUTBOX_DIR": "/tmp/s", **Isolation(run_as="agent-x").to_env()}
+        code, out, _dur, timed = run_harness(rig, "p", Path("/tmp"), env=env)
         assert code == 126 and not timed
         assert "no passwordless sudo" in out and "docs/isolation.md" in out
+
+
+class TestOrgIsolationAppliesToEveryRig:
+    """One org setting wraps every member turn identically, whatever rig runs
+    it — the whole point of moving the knob rig -> org."""
+
+    def test_same_run_as_wraps_two_different_rigs_identically(self, tmp_path, fakebin):
+        record = tmp_path / "sudo-argv.txt"
+        _fake_bin(
+            fakebin, "sudo",
+            f"""
+            import sys
+            a = sys.argv[1:]
+            # record only the real wrapped invoke (the bootstrap -c string), not
+            # the two prereq probes; then exit 0 so probes pass and the run is a
+            # no-op we can inspect.
+            if "-c" in a and a[a.index("-c") + 1].startswith("export TELL_OUTBOX_DIR"):
+                open({str(record)!r}, "a").write(repr(a) + "\\n")
+            sys.exit(0)
+            """,
+        )
+        env = dict(os.environ)  # keep PATH so the real wrapped `sudo` resolves the stub
+        env["TELL_OUTBOX_DIR"] = str(tmp_path / "stg")
+        env.update(Isolation(run_as="agent-x").to_env())
+        leader = Rig(name="leader", invoke=["claude-harness", "-p", "{prompt}"])
+        junior = Rig(name="junior", invoke=["codex-harness", "exec", "{prompt}"])
+
+        run_harness(leader, "P", tmp_path, env=dict(env))
+        run_harness(junior, "P", tmp_path, env=dict(env))
+
+        lines = record.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 2
+        recorded = [eval(line) for line in lines]  # noqa: S307 — test-owned stub output
+        # Both turns are wrapped by the SAME boundary (sudo -u agent-x ...); only
+        # the trailing harness argv differs, proving isolation is rig-agnostic.
+        for a in recorded:
+            assert a[:5] == ["-u", "agent-x", "bash", "--login", "-c"]
+        assert recorded[0][-3:] == ["claude-harness", "-p", "P"]
+        assert recorded[1][-3:] == ["codex-harness", "exec", "P"]
+
+
+class TestRigLevelIsolationIsGone:
+    """Rig-level run_as/container ceased to exist (pre-v1 scorch-the-earth). A
+    stray key in rigs.json follows rig.py's unknown-key convention: ignored,
+    not an error — and it never wraps a turn."""
+
+    def test_rig_run_as_and_container_keys_are_ignored_not_errors(self, tmp_path):
+        path = tmp_path / "rigs.json"
+        path.write_text(
+            json.dumps(
+                {"iso": {"invoke": ["h", "{prompt}"], "run_as": "u", "container": "img"}}
+            ),
+            encoding="utf-8",
+        )
+        config = load_rig_config(path)
+        rig = config.rigs["iso"]
+        assert rig.error is None  # unknown keys are ignored, not rejected
+        assert not hasattr(rig, "run_as") and not hasattr(rig, "container")
+        member = Member(name="Bob", rig="iso")
+        resolved, err, _pinned = config.rig_for(member)
+        assert resolved is not None and err is None  # the rig still runs; no isolation
 
 
 class TestContainerTimeoutKill:
@@ -265,14 +357,12 @@ class TestContainerTimeoutKill:
                 open({str(record)!r}, "a").write(args[1] + "\\n")
             """,
         )
-        rig = Rig(
-            name="c", invoke=["harness", "{prompt}"], container="img",
-            timeout_seconds=0.5,
-        )
+        rig = Rig(name="c", invoke=["harness", "{prompt}"], timeout_seconds=0.5)
         env = dict(os.environ)
         env["TELL_OUTBOX_DIR"] = str(tmp_path / "stg")
         env["R4T_NODE"] = "acme"
         env["R4T_MEMBER"] = "phil"
+        env.update(Isolation(container="img").to_env())
 
         _code, _out, _dur, timed_out = run_harness(rig, "p", tmp_path, env=env)
 
@@ -286,21 +376,23 @@ class TestStatusRowRendering:
     def test_isolation_tag(self):
         from r4t import _isolation_tag
 
-        assert _isolation_tag(Rig(name="a", run_as="agent-x")) == "[user:agent-x]"
-        assert _isolation_tag(Rig(name="b", container="img:1")) == "[container:img:1]"
-        assert _isolation_tag(Rig(name="c")) == ""
+        assert _isolation_tag(Isolation(run_as="agent-x")) == "[user:agent-x]"
+        assert _isolation_tag(Isolation(container="img:1")) == "[container:img:1]"
+        assert _isolation_tag(Isolation()) == ""
 
-    def test_rig_row_shows_boundary(self):
-        from r4t import _rig_rows
+    def test_status_header_shows_the_org_boundary(self, r4t_home, tmp_path, fake_harness, capsys):
+        # The badge is one org-level line now, not a per-rig tag.
+        from r4t import main as r4t_main
 
-        config = RigConfig(
-            path=Path("/x/rigs.json"),
-            rigs={
-                "iso": Rig(name="iso", invoke=["claude", "-p", "{prompt}"], run_as="agent-x"),
-            },
-            throttle=Throttle(),
+        org_dir = tmp_path / "iso-repo"
+        org_dir.mkdir()
+        (org_dir / "ROSTER.md").write_text(ROSTER, encoding="utf-8")
+        (org_dir / ORG_CONFIG_NAME).write_text(
+            json.dumps({"run_as": "agent-x"}), encoding="utf-8"
         )
-        ctx = SimpleNamespace(node=NODE, config_path=config.path)
-        rows = _rig_rows(ctx, config)
-        iso_row = next(r for r in rows if r[1] == "iso")
-        assert "[user:agent-x]" in iso_row[2]
+        state.stamp_root(NODE, org_dir)
+        cfg = _iso_config(tmp_path, fake_harness)
+        rc = r4t_main(["status", "--node", NODE, "--rig-config", str(cfg)])
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "isolation: [user:agent-x]" in out


### PR DESCRIPTION
## Why

OS-level isolation (`run_as` / `container`, shipped in #218 as **per-rig** settings) is a **per-project** decision, not a machine-global one. A rig maps to a real subscription and is shared across every r4t org on the box, so the containment choice cannot ride it: an org with ten rigs must need **one** Unix user (or one image), not ten. A production box runs one agent user whose `$HOME` holds the credentials for every CLI, and every rig runs as that one user.

The containment **border is unchanged** from #218: r4t/a8s machinery is deterministic code and runs as the operator/a8s user; the boundary applies at the moment a roster member's turn invoke runs. **Machinery outside, hands inside.** One user serves an arbitrary roster.

Per the 2026-07-16 ruling. Pre-v1 scorch-the-earth — no migration, no shims.

## What moved

- `run_as` / `container` / `container_args` now parse from **`r4t-org.json`** (org.py), validated where `doorbell_check` is; `run_as`/`container` stay mutually exclusive, and a bad value degrades to no isolation with `roster check` reporting it.
- **dispatch** wraps every member turn from the **org** setting. The choice rides to `run_harness` through the turn env (like `R4T_NODE`/`R4T_MEMBER`), so the `run_fn` contract `(rig, prompt, cwd, env, variant)` is not widened. The wrapping mechanics in `isolate.py` (sudo-with-positionals, `docker run --rm`, probe-only prereqs, fail-closed) are untouched.
- **rig.py**: rig-level `run_as`/`container`/`container_args` fields and parsing **removed**. A stray key left in `rigs.json` follows rig.py's existing unknown-key convention — silently ignored, not an error.
- **Display**: the boundary badge (`[user:x]` / `[container:img]`) moves from per-rig rows to **one org-level line** in the `r4t status` header.
- Docs: `docs/isolation.md` rewritten for org-level config (r4t-org.json snippets), keeping the mechanics/prereqs, plus the one-border rationale and a whole-node-containment note; `docs/org.md` settings table gains the three keys; `plans/ISOLATE-SPEC.md` carries the dated ruling line; the stale `walled` example rig is removed.

## Scope extension — real-boundary Docker test (approved via the coordinator)

`apps/r4t/tests/docker/run-as.sh` builds `ubuntu:24.04` and, as root inside, provisions the exact operator setup the docs prescribe — a sudo-**less** agent user, a shared work group, a **scoped `visudo`-validated** sudoers drop-in (`chmod 0440`), setgid `2770` staging + workplace dirs — then runs a **real** org-level `run_as` dispatch turn and asserts from inside with functional checks:

- the member turn's effective user **is** the agent user
- `TELL_OUTBOX_DIR` survived the sudoers `env_reset` positional dance
- staging writes land group-owned per the setgid re-assertion
- **negative-sudo**: the agent user **cannot** sudo
- the agent **cannot** read/write the router's home (700)

A new CI job (`r4t-isolation`) runs it on `apps/r4t/**` changes only, via the existing `dorny/paths-filter` pattern. The `isolation_integration` pytest marker is registered (the integration is shell-only, so nothing under the default suite carries it today). **Locally verified green** against a real Unix boundary (all invariants held).

## Tests

Full r4t suite green: **544 passed** (`venv/bin/python3 -m pytest apps/r4t/tests/ -q`). The #218 isolation tests were migrated to org-level config; added: org isolation wraps two different rigs identically, env round-trip, and rig-level keys are ignored per rig-validation convention.

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)