### PR TITLE
feat(a8s): tell multi-attach, size bounce, and --split

### DIFF
--- a/apps/a8s/core.py
+++ b/apps/a8s/core.py
@@ -52,6 +52,7 @@ SKILLS_DIR = SCRIPT_DIR / "skills"
 BIN_ROOT = SCRIPT_DIR.parent.parent
 DEFINITIONS_DIR = SCRIPT_DIR / "definitions"
 TELL_OUTBOX_DIR_ENV = "TELL_OUTBOX_DIR"
+TELL_FILE_MAX_ENV = "TELL_FILE_MAX"
 # Explicit path for `cmd_start`'s re-exec. After the modular split, `__file__`
 # resolved inside any module would point at that module — not the entry script.
 ENTRYPOINT = SCRIPT_DIR / "a8s.py"

--- a/apps/a8s/daemon.py
+++ b/apps/a8s/daemon.py
@@ -278,7 +278,13 @@ def run_with_prefix(
 
 
 def _tell_outbox_env(p: Participant) -> dict[str, str]:
-    return {TELL_OUTBOX_DIR_ENV: str(p.outbox_path())}
+    from core import TELL_FILE_MAX_ENV
+    from settings import get_int
+
+    return {
+        TELL_OUTBOX_DIR_ENV: str(p.outbox_path()),
+        TELL_FILE_MAX_ENV: str(get_int("max_file_bytes")),
+    }
 
 
 def _deliver_file_proxy(p: Participant) -> None:

--- a/apps/a8s/docs/tell.md
+++ b/apps/a8s/docs/tell.md
@@ -21,7 +21,7 @@ filedrop setup: [filedrop.md](filedrop.md).
    otherwise may resolve a unique configured outbox from CWD when the registry
    is reachable (see [filedrop.md](filedrop.md)). `install-client`
    tell-only installs always need the env var.
-2. Build message body (argv, stdin, or `-`); parse trailing `FILE:` lines via `mailbox._split_content_and_files`. `--attach` / `--file` append to the same `files` array. Any source path tell can read is attachable. Allocate `msg_id`, copy each file into `<outbox>/<msg_id>/<basename>`, then write `<outbox>/<msg_id>.json` with **filename-only** `files` entries (no `path` field).
+2. Build message body (argv, stdin, or `-`); parse trailing `FILE:` lines via `mailbox._split_content_and_files`. `--attach` / `--file` append to the same `files` array (`--attach=PATH` and multiple paths after one flag are supported). Oversized sources fail immediately unless `--split` chunks them under `TELL_FILE_MAX` / `max_file_bytes`. Allocate `msg_id`, copy each file into `<outbox>/<msg_id>/<basename>`, then write `<outbox>/<msg_id>.json` with **filename-only** `files` entries (no `path` field).
 3. Optionally read `~/.a8s` (or `A8S_HOME`) to validate recipient and stamp `from` when CWD sits inside a registered agent root.
 
 Envelope shape:

--- a/apps/a8s/settings.py
+++ b/apps/a8s/settings.py
@@ -58,7 +58,7 @@ KNOBS: tuple[Knob, ...] = (
         "machine",
         True,
         "A8S_MAX_FILE_BYTES",
-        "Attachment size cap at routing time (bytes)",
+        "Attachment size cap at routing time (bytes); a8s also injects TELL_FILE_MAX on wake for tell",
     ),
     Knob(
         "max_seen_ids",

--- a/apps/a8s/skills/tell/SKILL.md
+++ b/apps/a8s/skills/tell/SKILL.md
@@ -8,11 +8,12 @@ description: "Send an asynchronous message with the `tell` CLI. Delivery is not 
 Send messages via the shell (not by printing the command as text):
 
 ```
-tell [--attach PATH] <recipient> [<message...>]
+tell [--attach PATH ...] [--split] <recipient> [<message...>]
 ```
 
 - `<recipient>` is an opaque name — do not guess who/what it is or change tone.
 - Omit `<message>` when piping stdin (`echo hi | tell BOB`, or `tell BOB -`).
-- `--attach` / `--file` may repeat; flags may appear before or after `<recipient>`.
+- `--attach` / `--file` may repeat (or list existing paths after one flag); `--attach=PATH` works.
+- Oversized attachments fail immediately unless `--split` chunks them under the size limit.
 - Returns immediately. Delivery may take seconds or longer; do not expect a reply in-session.
 - If `tell` fails with “cannot send from this directory”, tell the user — do not `cd` to work around it.

--- a/apps/a8s/tell.py
+++ b/apps/a8s/tell.py
@@ -24,9 +24,11 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-from core import _preview, out_agent, outbox_bundle_dir, TELL_OUTBOX_DIR_ENV
+from core import _preview, out_agent, outbox_bundle_dir, TELL_FILE_MAX_ENV, TELL_OUTBOX_DIR_ENV
 from mailbox import _split_content_and_files
 from ulid import new as new_ulid
+
+DEFAULT_FILE_MAX_BYTES = 50 * 1024 * 1024
 
 
 def _probe_outbox_writable(outbox: Path) -> str | None:
@@ -170,23 +172,151 @@ def _normalize_file_entries(entries: list[dict]) -> list[dict]:
     return normalized
 
 
-def _validate_attachment_sources(entries: list[dict]) -> int:
-    if not entries:
-        return 0
-    for entry in entries:
+def _argv_looks_like_option(arg: str) -> bool:
+    return arg.startswith("-") and arg != "-"
+
+
+def parse_byte_size(raw: str) -> int:
+    """Parse a positive byte size: plain int, or with k/kb/m/mb/g/gb suffix."""
+    text = raw.strip().lower().replace("_", "")
+    if not text:
+        raise ValueError("empty size")
+    mult = 1
+    for suffix, factor in (
+        ("kb", 1024),
+        ("k", 1024),
+        ("mb", 1024**2),
+        ("m", 1024**2),
+        ("gb", 1024**3),
+        ("g", 1024**3),
+        ("b", 1),
+    ):
+        if text.endswith(suffix):
+            text = text[: -len(suffix)].strip()
+            mult = factor
+            break
+    value = int(text)
+    if value < 0:
+        raise ValueError("size must be zero or positive")
+    return value * mult
+
+
+def file_max_bytes() -> int:
+    """Effective attachment size cap for tell.
+
+    Prefer `TELL_FILE_MAX` (set by a8s on wake, or by the operator). Else
+    `max_file_bytes` from settings when `~/.a8s` is reachable. Else 50 MiB.
+    """
+    raw = os.environ.get(TELL_FILE_MAX_ENV, "").strip()
+    if raw:
+        try:
+            return parse_byte_size(raw)
+        except ValueError as e:
+            raise ValueError(f"{TELL_FILE_MAX_ENV}={raw!r}: {e}") from e
+    try:
+        from settings import get_int
+
+        return get_int("max_file_bytes")
+    except (OSError, ValueError, ImportError):
+        return DEFAULT_FILE_MAX_BYTES
+
+
+def _format_bytes(n: int) -> str:
+    if n < 1024:
+        return f"{n} bytes"
+    if n < 1024**2:
+        return f"{n / 1024:.1f} KiB"
+    if n < 1024**3:
+        return f"{n / (1024**2):.1f} MiB"
+    return f"{n / (1024**3):.2f} GiB"
+
+
+def _split_path_into_parts(src: Path, chunk_size: int, dest_dir: Path) -> list[Path]:
+    size = src.stat().st_size
+    if size <= chunk_size:
+        return [src]
+    n_parts = (size + chunk_size - 1) // chunk_size
+    width = max(3, len(str(n_parts)))
+    parts: list[Path] = []
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    with src.open("rb") as handle:
+        for index in range(1, n_parts + 1):
+            name = f"{src.name}.part{index:0{width}d}of{n_parts:0{width}d}"
+            part_path = dest_dir / name
+            remaining = chunk_size
+            with part_path.open("wb") as out:
+                while remaining > 0:
+                    buf = handle.read(min(65536, remaining))
+                    if not buf:
+                        break
+                    out.write(buf)
+                    remaining -= len(buf)
+            parts.append(part_path)
+    return parts
+
+
+def _prepare_attachment_entries(
+    files: list[dict],
+    *,
+    split: bool,
+    work_dir: Path,
+) -> tuple[list[dict], int]:
+    """Validate sources, enforce size cap, optionally split oversized files.
+
+    Returns `(entries_with_paths, 0)` on success or `([], exit_code)` on error.
+    """
+    try:
+        limit = file_max_bytes()
+    except ValueError as e:
+        print(f"tell: {e}", file=sys.stderr)
+        return [], 1
+    if limit <= 0:
+        print(f"tell: file size limit must be positive (got {limit})", file=sys.stderr)
+        return [], 1
+
+    prepared: list[dict] = []
+    for entry in files:
         raw = (entry.get("path") or "").strip()
         if not raw:
             print("tell: attachment path required", file=sys.stderr)
-            return 1
+            return [], 1
         try:
             resolved = Path(raw).resolve()
         except (OSError, RuntimeError) as e:
             print(f"tell: attachment path invalid: {raw}: {e}", file=sys.stderr)
-            return 1
+            return [], 1
         if not resolved.is_file():
             print(f"tell: attachment not found: {resolved}", file=sys.stderr)
-            return 1
-    return 0
+            return [], 1
+        try:
+            size = resolved.stat().st_size
+        except OSError as e:
+            print(f"tell: cannot stat attachment {resolved}: {e}", file=sys.stderr)
+            return [], 1
+        if size <= limit:
+            prepared.append({"filename": resolved.name, "path": str(resolved)})
+            continue
+        if not split:
+            print(
+                f"tell: attachment {resolved.name!r} is {_format_bytes(size)} "
+                f"(limit {_format_bytes(limit)} via {TELL_FILE_MAX_ENV} / max_file_bytes); "
+                f"pass --split to send as parts",
+                file=sys.stderr,
+            )
+            return [], 1
+        try:
+            parts = _split_path_into_parts(resolved, limit, work_dir)
+        except OSError as e:
+            print(f"tell: failed to split {resolved}: {e}", file=sys.stderr)
+            return [], 1
+        print(
+            f"tell: splitting {resolved.name!r} ({_format_bytes(size)}) into "
+            f"{len(parts)} parts of up to {_format_bytes(limit)}",
+            file=sys.stderr,
+        )
+        for part in parts:
+            prepared.append({"filename": part.name, "path": str(part)})
+    return prepared, 0
 
 
 def stage_outbox_attachments(
@@ -235,20 +365,35 @@ def join_args(args: list[str]) -> str:
 
 def parse_tell_argv(
     argv: list[str],
-) -> tuple[str | None, list[str], list[str], bool]:
-    """Return `(recipient, attachments, message_argv, check)`."""
+) -> tuple[str | None, list[str], list[str], bool, bool]:
+    """Return `(recipient, attachments, message_argv, check, split)`."""
     attachments: list[str] = []
     recipient: str | None = None
     message_argv: list[str] = []
     check = False
+    split = False
     i = 0
     while i < len(argv):
         arg = argv[i]
-        if arg in ("--attach", "--file"):
+        if arg.startswith("--attach=") or arg.startswith("--file="):
+            path = arg.split("=", 1)[1]
+            if not path.strip():
+                raise TellUsageError("--attach requires a path")
+            attachments.append(path)
+        elif arg in ("--attach", "--file"):
             i += 1
-            if i >= len(argv):
+            if i >= len(argv) or _argv_looks_like_option(argv[i]):
                 raise TellUsageError("--attach requires a path")
             attachments.append(argv[i])
+            while (
+                i + 1 < len(argv)
+                and not _argv_looks_like_option(argv[i + 1])
+                and Path(argv[i + 1]).expanduser().is_file()
+            ):
+                i += 1
+                attachments.append(argv[i])
+        elif arg == "--split":
+            split = True
         elif arg == "--check":
             check = True
         elif arg in ("-h", "--help"):
@@ -258,7 +403,7 @@ def parse_tell_argv(
         else:
             message_argv.append(arg)
         i += 1
-    return recipient, attachments, message_argv, check
+    return recipient, attachments, message_argv, check, split
 
 
 def resolve_message_body(message_argv: list[str]) -> str | None:
@@ -313,11 +458,14 @@ class TellHelp(Exception):
     pass
 
 
-_USAGE = "usage: tell [--attach PATH] <name> [<message...>]"
+_USAGE = "usage: tell [--attach PATH ...] [--split] <name> [<message...>]"
 
 
 def _print_usage() -> None:
     print(_USAGE, file=sys.stderr)
+    print("       --attach/--file may repeat; multiple paths after one flag OK if they exist", file=sys.stderr)
+    print("       --split: chunk attachments over the size limit into .partNNNofMMM files", file=sys.stderr)
+    print(f"       size limit: {TELL_FILE_MAX_ENV} (bytes or 50m), else max_file_bytes / 50MiB", file=sys.stderr)
     print("       message may be `-` to read stdin; stdin is used when piped", file=sys.stderr)
 
 
@@ -401,7 +549,7 @@ def run_check(recipient: str | None) -> int:
 
 def tell_main(argv: list[str]) -> int:
     try:
-        recipient, attachments, message_argv, check = parse_tell_argv(argv)
+        recipient, attachments, message_argv, check, split = parse_tell_argv(argv)
     except TellHelp:
         _print_usage()
         return 0
@@ -411,8 +559,8 @@ def tell_main(argv: list[str]) -> int:
         return 2
 
     if check:
-        if attachments or message_argv:
-            print("tell: --check does not accept a message or attachments", file=sys.stderr)
+        if attachments or message_argv or split:
+            print("tell: --check does not accept a message, attachments, or --split", file=sys.stderr)
             return 2
         return run_check(recipient)
 
@@ -435,16 +583,24 @@ def tell_main(argv: list[str]) -> int:
         _report_outbox_unavailable()
         return 1
 
-    rc = _validate_attachment_sources(files)
-    if rc != 0:
-        return rc
-
     msg_id = new_ulid()
+    split_dir = outbox / f".{msg_id}.parts"
     try:
-        staged_files = stage_outbox_attachments(outbox, msg_id, files) if files else []
-    except OSError as e:
-        print(f"tell: attachment staging failed: {e}", file=sys.stderr)
-        return 1
+        prepared, prep_rc = _prepare_attachment_entries(
+            files, split=split, work_dir=split_dir
+        )
+        if prep_rc != 0:
+            return prep_rc
+        try:
+            staged_files = (
+                stage_outbox_attachments(outbox, msg_id, prepared) if prepared else []
+            )
+        except OSError as e:
+            print(f"tell: attachment staging failed: {e}", file=sys.stderr)
+            return 1
+    finally:
+        if split_dir.is_dir():
+            shutil.rmtree(split_dir, ignore_errors=True)
 
     sender = _optional_sender()
     to = recipient

--- a/apps/a8s/tests/test_daemon.py
+++ b/apps/a8s/tests/test_daemon.py
@@ -328,7 +328,9 @@ class TestTellOutboxEnv:
         assert captured["env"][TELL_OUTBOX_DIR_ENV] == str(external.resolve())
 
     def test_wake_env_matches_participant_outbox_path(self, tmp_path):
+        from core import TELL_FILE_MAX_ENV, TELL_OUTBOX_DIR_ENV
         from daemon import _tell_outbox_env
+        from settings import get_int
 
         agent_root = tmp_path / "agent"
         agent_root.mkdir()
@@ -336,6 +338,7 @@ class TestTellOutboxEnv:
         p = Participant("X", agent_root, outbox=external)
         assert _tell_outbox_env(p) == {
             TELL_OUTBOX_DIR_ENV: str(external.resolve()),
+            TELL_FILE_MAX_ENV: str(get_int("max_file_bytes")),
         }
 
 

--- a/apps/a8s/tests/test_tell.py
+++ b/apps/a8s/tests/test_tell.py
@@ -313,6 +313,69 @@ def test_tell_multiple_attachments(tmp_path):
     _assert_staged_files(tmp_path / ".outbox", msg, ["a.txt", "b.txt"])
 
 
+def test_tell_attach_equals_form(tmp_path):
+    (tmp_path / ".outbox").mkdir()
+    (tmp_path / "a.txt").write_text("a")
+    (tmp_path / "b.txt").write_text("b")
+    res = _run(tmp_path, "gerry", "--attach=./a.txt", "--file=./b.txt", "eq form")
+    assert res.returncode == 0, res.stderr
+    _name, msg = _read_outbox(tmp_path / ".outbox")
+    _assert_staged_files(tmp_path / ".outbox", msg, ["a.txt", "b.txt"])
+
+
+def test_tell_attach_multiple_paths_after_one_flag(tmp_path):
+    (tmp_path / ".outbox").mkdir()
+    (tmp_path / "a.txt").write_text("a")
+    (tmp_path / "b.txt").write_text("b")
+    res = _run(tmp_path, "gerry", "--attach", "./a.txt", "./b.txt", "multi path")
+    assert res.returncode == 0, res.stderr
+    _name, msg = _read_outbox(tmp_path / ".outbox")
+    _assert_staged_files(tmp_path / ".outbox", msg, ["a.txt", "b.txt"])
+
+
+def test_tell_rejects_oversized_attachment_without_split(tmp_path, monkeypatch):
+    from core import TELL_FILE_MAX_ENV
+
+    (tmp_path / ".outbox").mkdir()
+    big = tmp_path / "big.bin"
+    big.write_bytes(b"x" * 2000)
+    monkeypatch.setenv(TELL_FILE_MAX_ENV, "1000")
+    res = _run(tmp_path, "gerry", "--attach", str(big), "too big")
+    assert res.returncode == 1
+    assert "pass --split" in res.stderr
+    assert "big.bin" in res.stderr
+    assert list((tmp_path / ".outbox").glob("*.json")) == []
+
+
+def test_tell_split_chunks_oversized_attachment(tmp_path, monkeypatch):
+    from core import TELL_FILE_MAX_ENV
+
+    (tmp_path / ".outbox").mkdir()
+    big = tmp_path / "big.bin"
+    big.write_bytes(b"abcdefghij" * 200)  # 2000 bytes
+    monkeypatch.setenv(TELL_FILE_MAX_ENV, "1000")
+    res = _run(tmp_path, "gerry", "--attach", str(big), "--split", "chunked")
+    assert res.returncode == 0, res.stderr
+    assert "splitting" in res.stderr
+    _name, msg = _read_outbox(tmp_path / ".outbox")
+    names = [e["filename"] for e in msg["files"]]
+    assert names == ["big.bin.part001of002", "big.bin.part002of002"]
+    outbox = tmp_path / ".outbox"
+    bundle = outbox_bundle_dir(outbox, msg["id"])
+    assert (bundle / names[0]).stat().st_size == 1000
+    assert (bundle / names[1]).stat().st_size == 1000
+    assert not (outbox / f".{msg['id']}.parts").exists()
+
+
+def test_parse_byte_size_suffixes():
+    from tell import parse_byte_size
+
+    assert parse_byte_size("1000") == 1000
+    assert parse_byte_size("2k") == 2048
+    assert parse_byte_size("1MB") == 1024 * 1024
+    assert parse_byte_size("50m") == 50 * 1024 * 1024
+
+
 def test_tell_staged_duplicate_basenames_use_separate_message_dirs(tmp_path):
     (tmp_path / ".outbox").mkdir()
     doc = tmp_path / "untitled.doc"


### PR DESCRIPTION
## Summary
- **Multi-attach:** `--attach=PATH` works; multiple existing paths after one `--attach`/`--file` are accepted (repeatable flags still work)
- **Size bounce:** oversized files fail at `tell` time with a clear error (no silent non-delivery). Cap from `TELL_FILE_MAX`, else `max_file_bytes`, else 50 MiB
- **Wake inject:** a8s sets `TELL_FILE_MAX` from `max_file_bytes` alongside `TELL_OUTBOX_DIR`
- **`--split`:** chunks oversized attachments into `name.part001of002` … parts under the limit

## Test plan
- [ ] `tell bob --attach=a.txt --attach=b.txt hi`
- [ ] `tell bob --attach a.txt b.txt hi` (both files exist)
- [ ] `TELL_FILE_MAX=1k tell bob --attach big.bin hi` → fails with `--split` hint
- [ ] `TELL_FILE_MAX=1k tell bob --attach big.bin --split hi` → parts staged
- [ ] `pytest apps/a8s/tests/test_tell.py apps/a8s/tests/test_daemon.py::TestTellOutboxEnv`


Made with [Cursor](https://cursor.com)