### PR TITLE
feat(a8s): definitions/defs for user-installed templates

### DIFF
--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -118,9 +118,10 @@ That's the full loop. Members don't know they're "in a8s" — they just see a `t
 
 |                                |                                                                                                                                                                |
 | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `a8s add <name> <dir> [<def>]` | Register an agent. Auto-detects definition from `<dir>`'s marker file unless `<def>` is given (path, or bare name like `human` / `claude` from bundled `definitions/`). |
+| `a8s add <name> <dir> [<def>]` | Register an agent. Auto-detects definition from `<dir>`'s marker file unless `<def>` is given (path, or bare name from bundled `definitions/` or `a8s defs add`). |
 | `a8s remove <name>` / `a8s rm <name>` | Unregister an agent. Wipes `~/.a8s/agents/<NAME>/` and prunes the agent from any alias's member list (deletes empty aliases). Refuses if a handler is running. |
-| `a8s define <name> [<path>]`   | Show or set the agent's definition file.                                                                                                                       |
+| `a8s define <name> [<path>]`   | Show or set the agent's definition file (path or bare name).                                                                                              |
+| `a8s definitions` / `a8s defs` | Manage user-installed templates in `~/.a8s/definitions/` (`add` / `rm` / `ls`). Basename must not collide with a repo built-in; bare names then work with `add`/`define`. |
 | `a8s discover <path>`          | Walk a path for marker files; print suggested `add`+`define` commands. Read-only.                                                                              |
 | `a8s ls [-q]`                  | List every registered node, running or not: NAME, STATUS (`running (pid N)` / `stopped`), DEFINITION, ROOT, and bound namespaces. `-q` prints just names. |
 
@@ -321,7 +322,9 @@ Argv elements run through six substitutions:
 
 `$TIMESTAMP` and `$AGE` are empty for any message without a `date` field (defensive — every `_write_outbox` stamps one).
 
-Override per-agent with `a8s define <name> <definition>` — a filesystem path or a bare bundled name (`filedrop`, `claude`). The file isn't moved or copied; the registry stores the resolved path.
+Override per-agent with `a8s define <name> <definition>` — a filesystem path or a bare name (`filedrop`, `claude`, or a user template from `a8s defs add`). The file isn't moved or copied into the agent root; the registry stores the resolved path.
+
+Install reusable custom templates with `a8s defs add /path/to/mine.json` (copies into `~/.a8s/definitions/mine.json`). Basename must not collide with a repo built-in. `a8s defs ls` lists both; `a8s defs rm <name>` removes user installs only.
 
 ### max_wake_seconds (optional)
 

--- a/apps/a8s/cli.py
+++ b/apps/a8s/cli.py
@@ -10,6 +10,7 @@ from commands import (
     cmd_alias,
     cmd_aliases,
     cmd_define,
+    cmd_definitions,
     cmd_discover,
     cmd_drain,
     cmd_config,
@@ -47,7 +48,9 @@ COMMANDS: list[tuple[str, str, str]] = [
     ("rm",       "<name>",                    "Alias for remove."),
     ("ls",       "[-q]",                      "List all registered nodes, running or not."),
     ("discover", "<path>",                    "Scan a path for nodes and suggest `add` commands."),
-    ("define",   "<name> [<def>]",            "Show or set an agent's definition (path or bare bundled name)."),
+    ("define",   "<name> [<def>]",            "Show or set an agent's definition (path or bare name)."),
+    ("definitions", "[add|rm|ls ...]",       "Manage user-installed definition templates (~/.a8s/definitions)."),
+    ("defs",     "[add|rm|ls ...]",          "Alias for definitions."),
     ("alias",    "[<name> [<member>]]",       "Group agents under an alias name; show one with `<name>`."),
     ("unalias",  "<alias> [<member>]",        "Remove a member from an alias, or the whole alias."),
     ("aliases",  "",                          "List aliases and their members."),
@@ -103,6 +106,8 @@ def dispatch(cmd: str, args: list[str], interval: float) -> int:
         return cmd_discover(args)
     if cmd == "define":
         return cmd_define(args)
+    if cmd in ("definitions", "defs"):
+        return cmd_definitions(args)
     if cmd == "alias":
         return cmd_alias(args)
     if cmd == "unalias":

--- a/apps/a8s/commands.py
+++ b/apps/a8s/commands.py
@@ -39,8 +39,16 @@ from core import (
     pid_path,
     trash_dir,
     unique_path,
+    user_definitions_dir,
 )
-from definitions import _autodiscover_definition, default_definition_path, resolve_definition_arg
+from definitions import (
+    _autodiscover_definition,
+    builtin_definition_stems,
+    default_definition_path,
+    definition_stem,
+    list_definition_entries,
+    resolve_definition_arg,
+)
 from daemon import (
     _clear_kill_request,
     _read_handler_pid,
@@ -174,8 +182,9 @@ def cmd_add(args: list[str]) -> int:
     auto-linked. Multiple or zero markers fall back to the bundled default.
 
     With `<definition>`, the JSON file is validated and set as the agent's
-    definition. A bare name (`filedrop`, `claude`, `filedrop.json`) resolves against
-    bundled `apps/a8s/definitions/`; any other path is used as-is.
+    definition. A bare name (`filedrop`, `claude`, `filedrop.json`) resolves
+    against bundled `apps/a8s/definitions/`, then user-installed
+    ``~/.a8s/definitions/`` (`a8s defs add`); any other path is used as-is.
 
     Errors on duplicate name (vs. agents or aliases) or non-directory path."""
     if len(args) < 2 or len(args) > 3:
@@ -355,6 +364,121 @@ def cmd_define(args: list[str]) -> int:
     info["definition"] = str(path)
     save_registry(reg)
     print(f"{target_key}: definition set to {path}")
+    return 0
+
+
+_DEF_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+
+
+def _definitions_usage() -> int:
+    print(
+        "usage: a8s definitions|defs                        # list all\n"
+        "       a8s definitions|defs list|ls                # list all\n"
+        "       a8s definitions|defs add <path.json>        # install as bare name\n"
+        "       a8s definitions|defs remove|rm <name>       # uninstall user definition\n"
+        "\n"
+        "Copies into ~/.a8s/definitions/<basename>.json. Basename must not\n"
+        "collide with a repo built-in. Bare names then work with add/define.",
+        file=sys.stderr,
+    )
+    return 2
+
+
+def cmd_definitions(args: list[str]) -> int:
+    """`a8s definitions|defs` — manage user-installed definition templates.
+
+    Forms:
+      a8s defs                         list builtin + user
+      a8s defs list|ls                 list
+      a8s defs add <path.json>         copy into ~/.a8s/definitions/
+      a8s defs remove|rm <name>        delete a user definition (not builtins)
+    """
+    if len(args) == 0:
+        return _cmd_definitions_list()
+    sub = args[0]
+    if sub in ("list", "ls"):
+        if len(args) != 1:
+            return _definitions_usage()
+        return _cmd_definitions_list()
+    if sub == "add":
+        if len(args) != 2:
+            return _definitions_usage()
+        return _cmd_definitions_add(args[1])
+    if sub in ("remove", "rm"):
+        if len(args) != 2:
+            return _definitions_usage()
+        return _cmd_definitions_remove(args[1])
+    return _definitions_usage()
+
+
+def _cmd_definitions_list() -> int:
+    rows = [
+        (name, source, str(path))
+        for name, source, path in list_definition_entries()
+    ]
+    if not rows:
+        print("(no definitions)")
+        return 0
+    _print_table(["NAME", "SOURCE", "PATH"], rows)
+    return 0
+
+
+def _cmd_definitions_add(src: str) -> int:
+    path = Path(src).expanduser()
+    if not path.is_file():
+        print(f"not a file: {src}", file=sys.stderr)
+        return 1
+    if path.suffix != ".json":
+        print(f"definition must be a .json file: {src}", file=sys.stderr)
+        return 2
+    name = definition_stem(path.name)
+    if not _DEF_NAME_RE.match(name):
+        print(
+            f"definition name must be alphanumeric (with -, _, .): {name!r}",
+            file=sys.stderr,
+        )
+        return 2
+    builtins = {s.lower() for s in builtin_definition_stems()}
+    if name.lower() in builtins:
+        print(
+            f"cannot install {name!r}: conflicts with a repo built-in",
+            file=sys.stderr,
+        )
+        return 1
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            json.loads(f.read())
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"definition is not valid JSON: {e}", file=sys.stderr)
+        return 1
+    dest_dir = user_definitions_dir()
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest = dest_dir / f"{name}.json"
+    overwriting = dest.is_file()
+    shutil.copy2(path, dest)
+    verb = "updated" if overwriting else "added"
+    print(f"{verb} definition {name} -> {dest}")
+    return 0
+
+
+def _cmd_definitions_remove(name: str) -> int:
+    stem = definition_stem(name)
+    if not _DEF_NAME_RE.match(stem):
+        print(
+            f"definition name must be alphanumeric (with -, _, .): {stem!r}",
+            file=sys.stderr,
+        )
+        return 2
+    builtins = {s.lower() for s in builtin_definition_stems()}
+    if stem.lower() in builtins:
+        print(f"cannot remove built-in definition: {stem}", file=sys.stderr)
+        return 1
+    dest = user_definitions_dir() / f"{stem}.json"
+    if not dest.is_file():
+        print(f"no user definition named {stem!r}", file=sys.stderr)
+        return 1
+    dest.unlink()
+    print(f"removed definition {stem}")
     return 0
 
 

--- a/apps/a8s/core.py
+++ b/apps/a8s/core.py
@@ -323,6 +323,15 @@ def settings_path() -> Path:
     return _a8s_dir() / "settings.json"
 
 
+def user_definitions_dir() -> Path:
+    """User-installed definition templates under ``~/.a8s/definitions/``.
+
+    Bare names for ``a8s add`` / ``a8s define`` resolve here after the
+    repo-bundled ``DEFINITIONS_DIR``. Install with ``a8s defs add``.
+    """
+    return _a8s_dir() / "definitions"
+
+
 def conversations_path() -> Path:
     """`~/.a8s/conversations.jsonl` — routed message archive for `a8s convo`."""
     return _a8s_dir() / "conversations.jsonl"

--- a/apps/a8s/definitions.py
+++ b/apps/a8s/definitions.py
@@ -28,6 +28,7 @@ from core import (
     resolve_files_path,
     resolve_inbox_path,
     resolve_outbox_path,
+    user_definitions_dir,
 )
 from registry import load_registry
 
@@ -38,11 +39,42 @@ def default_definition_path(kind: str) -> Path:
     return DEFINITIONS_DIR / f"{kind}.json"
 
 
+def definition_stem(raw: str) -> str:
+    """Basename without ``.json`` — the short name used for bare resolution."""
+    name = Path(raw).name
+    if name.endswith(".json"):
+        name = name[:-5]
+    return name
+
+
+def builtin_definition_stems() -> set[str]:
+    return {p.stem for p in DEFINITIONS_DIR.glob("*.json") if p.is_file()}
+
+
+def list_definition_entries() -> list[tuple[str, str, Path]]:
+    """All known templates as ``(name, source, path)``, sorted by name.
+
+    ``source`` is ``builtin`` (repo) or ``user`` (``~/.a8s/definitions``).
+    Builtin wins when both exist for the same stem.
+    """
+    entries: dict[str, tuple[str, str, Path]] = {}
+    user_dir = user_definitions_dir()
+    if user_dir.is_dir():
+        for p in sorted(user_dir.glob("*.json")):
+            if p.is_file():
+                entries[p.stem] = (p.stem, "user", p.resolve())
+    for p in sorted(DEFINITIONS_DIR.glob("*.json")):
+        if p.is_file():
+            entries[p.stem] = (p.stem, "builtin", p.resolve())
+    return [entries[k] for k in sorted(entries)]
+
+
 def resolve_definition_arg(spec: str) -> Path:
     """Resolve an `a8s add` / `a8s define` definition argument.
 
     Prefers an existing filesystem path. A bare name (`filedrop` or `filedrop.json`)
-    that is not a local file resolves against bundled `definitions/`.
+    that is not a local file resolves against bundled `definitions/`, then
+    user-installed ``~/.a8s/definitions/``.
     """
     raw = Path(spec).expanduser()
     if raw.is_file():
@@ -56,12 +88,13 @@ def resolve_definition_arg(spec: str) -> Path:
 
     if len(raw.parts) == 1:
         name = raw.name
-        candidates = [DEFINITIONS_DIR / name]
-        if not name.endswith(".json"):
-            candidates.append(DEFINITIONS_DIR / f"{name}.json")
-        for cand in candidates:
-            if cand.is_file():
-                return cand.resolve()
+        for base in (DEFINITIONS_DIR, user_definitions_dir()):
+            candidates = [base / name]
+            if not name.endswith(".json"):
+                candidates.append(base / f"{name}.json")
+            for cand in candidates:
+                if cand.is_file():
+                    return cand.resolve()
 
     raise FileNotFoundError(spec)
 

--- a/apps/a8s/tests/test_cli.py
+++ b/apps/a8s/tests/test_cli.py
@@ -22,3 +22,14 @@ def test_remove_still_dispatches_to_same_handler(monkeypatch):
 
     assert cli.dispatch("remove", ["alice"], interval=1.0) == 0
     assert calls == [["alice"]]
+
+
+def test_defs_is_alias_for_definitions(monkeypatch):
+    assert "defs" in cli.KNOWN_COMMANDS
+    assert "definitions" in cli.KNOWN_COMMANDS
+    calls = []
+    monkeypatch.setattr(cli, "cmd_definitions", lambda args: calls.append(args) or 3)
+
+    assert cli.dispatch("defs", ["ls"], interval=1.0) == 3
+    assert cli.dispatch("definitions", ["add", "x.json"], interval=1.0) == 3
+    assert calls == [["ls"], ["add", "x.json"]]

--- a/apps/a8s/tests/test_commands.py
+++ b/apps/a8s/tests/test_commands.py
@@ -13,6 +13,7 @@ import pytest
 from commands import (
     cmd_add,
     cmd_alias,
+    cmd_definitions,
     cmd_kill,
     cmd_logs,
     cmd_ls,
@@ -29,10 +30,11 @@ from commands import (
     cmd_unremote,
     cmd_unstorage,
 )
-from core import Participant, TELL_OUTBOX_DIR_ENV, agent_dir, agent_log_path, files_dir, kill_request_path, outbox_bundle_dir, outbox_dir, pid_path
+from core import Participant, TELL_OUTBOX_DIR_ENV, agent_dir, agent_log_path, files_dir, kill_request_path, outbox_bundle_dir, outbox_dir, pid_path, user_definitions_dir
 from mailbox import ensure_mailboxes
 from network import load_network_config, save_network_config
 from registry import load_aliases, load_namespaces, load_registry, save_namespaces, save_registry
+from definitions import resolve_definition_arg
 
 
 @pytest.fixture
@@ -601,6 +603,62 @@ class TestCmdPs:
         rc = cmd_ps(["-q"])
         assert rc == 0
         assert capsys.readouterr().out == ""
+
+
+class TestCmdDefinitions:
+    def test_list_includes_builtins(self, fake_home, capsys):
+        rc = cmd_definitions([])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "NAME" in out and "SOURCE" in out and "PATH" in out
+        assert "builtin" in out
+        assert "filedrop" in out
+
+    def test_add_then_resolve_and_rm(self, fake_home, tmp_path, capsys):
+        src = tmp_path / "my-custom-definition.json"
+        src.write_text('{"invoke": ["echo", "hi"]}')
+        rc = cmd_definitions(["add", str(src)])
+        assert rc == 0
+        dest = user_definitions_dir() / "my-custom-definition.json"
+        assert dest.is_file()
+        assert resolve_definition_arg("my-custom-definition") == dest.resolve()
+        capsys.readouterr()
+        rc = cmd_definitions(["ls"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "my-custom-definition" in out
+        assert "user" in out
+        rc = cmd_definitions(["rm", "my-custom-definition"])
+        assert rc == 0
+        assert not dest.exists()
+
+    def test_add_rejects_builtin_name(self, fake_home, tmp_path, capsys):
+        src = tmp_path / "filedrop.json"
+        src.write_text('{"invoke": ["echo"]}')
+        rc = cmd_definitions(["add", str(src)])
+        assert rc == 1
+        assert "conflicts with a repo built-in" in capsys.readouterr().err
+        assert not (user_definitions_dir() / "filedrop.json").exists()
+
+    def test_rm_rejects_builtin(self, fake_home, capsys):
+        rc = cmd_definitions(["remove", "claude"])
+        assert rc == 1
+        assert "cannot remove built-in" in capsys.readouterr().err
+
+    def test_add_rejects_invalid_json(self, fake_home, tmp_path, capsys):
+        src = tmp_path / "broken.json"
+        src.write_text("{not json")
+        rc = cmd_definitions(["add", str(src)])
+        assert rc == 1
+        assert "not valid JSON" in capsys.readouterr().err
+
+    def test_add_then_bare_add_agent(self, fake_home, tmp_path, agent_root):
+        src = tmp_path / "my-custom-definition.json"
+        src.write_text('{"invoke": ["echo"]}')
+        assert cmd_definitions(["add", str(src)]) == 0
+        assert cmd_add(["alice", str(agent_root), "my-custom-definition"]) == 0
+        reg = load_registry()
+        assert Path(reg["alice"]["definition"]).name == "my-custom-definition.json"
 
 
 class TestCmdRemote:

--- a/apps/a8s/tests/test_definitions.py
+++ b/apps/a8s/tests/test_definitions.py
@@ -273,6 +273,28 @@ class TestResolveDefinitionArg:
         with pytest.raises(FileNotFoundError):
             resolve_definition_arg("no-such-definition-kind")
 
+    def test_user_installed_bare(self, fake_home):
+        from core import user_definitions_dir
+        from definitions import list_definition_entries
+
+        d = user_definitions_dir()
+        d.mkdir(parents=True)
+        custom = d / "my-custom-definition.json"
+        custom.write_text('{"invoke": ["echo"]}')
+        assert resolve_definition_arg("my-custom-definition") == custom.resolve()
+        assert resolve_definition_arg("my-custom-definition.json") == custom.resolve()
+        entries = {name: source for name, source, _ in list_definition_entries()}
+        assert entries["my-custom-definition"] == "user"
+        assert entries["filedrop"] == "builtin"
+
+    def test_builtin_wins_over_user_same_stem(self, fake_home):
+        from core import user_definitions_dir
+
+        d = user_definitions_dir()
+        d.mkdir(parents=True)
+        (d / "filedrop.json").write_text('{"invoke": ["echo", "shadow"]}')
+        assert resolve_definition_arg("filedrop") == default_definition_path("filedrop").resolve()
+
 
 # ---------- _autodiscover_definition ----------
 


### PR DESCRIPTION
## Summary
- Add `a8s definitions` / `a8s defs` with `add` / `remove|rm` / `list|ls` to manage user templates in `~/.a8s/definitions/`
- Bare names for `add`/`define` resolve bundled first, then user installs; basename must not collide with a repo built-in
- `ls` lists builtin + user with a SOURCE column; built-ins cannot be removed

## Test plan
- [x] `a8s defs ls` shows built-ins with SOURCE=`builtin`
- [x] `a8s defs add /tmp/my-custom-definition.json` installs; bare `my-custom-definition` works with `a8s add` / `a8s define`
- [x] `a8s defs add …/filedrop.json` fails (builtin conflict)
- [x] `a8s defs rm filedrop` fails; `a8s defs rm my-custom-definition` removes user install
- [x] `venv/bin/python3 -m pytest apps/a8s/tests/test_definitions.py apps/a8s/tests/test_cli.py apps/a8s/tests/test_commands.py::TestCmdDefinitions -q`