### PR TITLE
feat(a8s): per-node vars, ollama-opencode, waiting stop/restart

### DIFF
--- a/apps/a8s/DEVELOPMENT.md
+++ b/apps/a8s/DEVELOPMENT.md
@@ -7,9 +7,11 @@ Read `README.md` first for concept and usage.
 
 - **`cmd_start` re-execs via `core.ENTRYPOINT`**, not `__file__`.
 - **Argv interpolation** (`$SENDER`, `$RECIPIENT`, `$MESSAGE`, `$TIMESTAMP`,
-  `$AGE`, `$A8S_DIR`) expands via `definitions._expand_argv`. Per-message
-  wakes use `invoke` via `build_command`; batch wakes use `batch.invoke` via
-  `build_batch_command` with message file paths appended as trailing argv.
+  `$AGE`, `$A8S_DIR`, `$DEFINITION_PATH`, plus per-node a8s vars as `$KEY`)
+  expands via `definitions._expand_argv`. Vars are registry-backed (`a8s vars`),
+  not OS environment. Used-but-unset raises `UndefinedVarsError` before spawn.
+  Per-message wakes use `invoke` via `build_command`; batch wakes use
+  `batch.invoke` via `build_batch_command` with a composed prompt appended.
 - **`core.PRINT_LOCK` is the cross-module log lock.** Only set when
   `daemon.attached_loop` starts.
 - **`run_with_prefix` uses `start_new_session=True`** — don't drop this.

--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -118,10 +118,11 @@ That's the full loop. Members don't know they're "in a8s" — they just see a `t
 
 |                                |                                                                                                                                                                |
 | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `a8s add <name> <dir> [<def>]` | Register an agent. Auto-detects definition from `<dir>`'s marker file unless `<def>` is given (path, or bare name from bundled `definitions/` or `a8s defs add`). |
+| `a8s add <name> <dir> [<def>] [--KEY=value …]` | Register an agent. Auto-detects definition from `<dir>`'s marker file unless `<def>` is given (path, or bare name from bundled `definitions/` or `a8s defs add`). Trailing `--KEY=value` sets per-node a8s vars (case-insensitive; same as `a8s vars`). |
 | `a8s remove <name>` / `a8s rm <name>` | Unregister an agent. Wipes `~/.a8s/agents/<NAME>/` and prunes the agent from any alias's member list (deletes empty aliases). Refuses if a handler is running. |
 | `a8s define <name> [<path>]`   | Show or set the agent's definition file (path or bare name).                                                                                              |
 | `a8s definitions` / `a8s defs` | Manage user-installed templates in `~/.a8s/definitions/` (`add` / `rm` / `ls`). Basename must not collide with a repo built-in; bare names then work with `add`/`define`. |
+| `a8s vars <name> [set\|unset …]` | Per-node a8s vars for `$KEY` in definition argv (not OS env). Used-but-unset fails wake. |
 | `a8s discover <path>`          | Walk a path for marker files; print suggested `add`+`define` commands. Read-only.                                                                              |
 | `a8s ls [-q]`                  | List every registered node, running or not: NAME, STATUS (`running (pid N)` / `stopped`), DEFINITION, ROOT, and bound namespaces. `-q` prints just names. |
 
@@ -187,7 +188,8 @@ any prefixes pointing at it.
 | `a8s start <name>` | Spawn a detached background process to handle the agent (or every member of an alias, in one process).                                                                                                                                                                              |
 | `a8s run <name>`   | Foreground attached loop. Aliases produce one process with interleaved output. Ctrl+C: graceful detach. 2nd Ctrl+C: kill the wake subprocess group.                                                                                                                                 |
 | `a8s step <name>`  | Attach, do one route+drain pass, release. Heavyweight: detaches the current handler if any.                                                                                                                                                                                         |
-| `a8s stop <name>`  | SIGTERM the handler. Aliases dedupe by PID — one signal per multi-agent handler. Graceful detach.                                                                                                                                                                                   |
+| `a8s stop <name> [--force]` | SIGTERM the handler, then **wait** until it has detached. Idle stops immediately; a busy wake finishes first (like first Ctrl+C). `--force` / `-f` sends a second SIGTERM to kill the in-flight wake (like second Ctrl+C), then waits. |
+| `a8s restart <name> [--force]` | `stop` (wait until detached) then `start`. `--force` is passed to stop. If not running, just starts. |
 | `a8s kill <name>`  | Per-agent force-detach: writes a kill-request, SIGUSR1s the holder. Holder kills the in-flight wake subprocess iff it's for that agent and releases the attachment; siblings keep running. Falls back to whole-process SIGTERM only if the holder doesn't honor the request in 10s. |
 | `a8s exit`         | SIGTERM every running handler.                                                                                                                                                                                                                                                      |
 | `a8s ps [-q]`      | List only running node processes: NAME, PID, UPTIME, ROOT. `-q` prints just names. Empty state hints at `a8s ls`.                                                                                                                                                                    |
@@ -271,6 +273,7 @@ Each agent has a definition file: a JSON document describing how to invoke its C
 | `copilot.json`  | GitHub Copilot CLI with `--allow-all-tools` (required for non-interactive `-p` mode) + `--continue`. Marker is `.github/copilot-instructions.md` (Copilot's native repo-instructions location).                                                    |
 | `cursor.json`   | Cursor Agent CLI (`agent`) with `-p --trust --force --approve-mcps --continue` for headless tool use. Marker is `CURSOR.md`.                                                                                                                       |
 | `opencode.json` | [OpenCode](https://opencode.ai/) — BYO model. `opencode run --continue --dangerously-skip-permissions`. Operator picks the provider/model in each agent's own `opencode.json` (e.g. `{"model": "ollama/gpt-oss:20b"}`), not in the a8s definition. |
+| `ollama-opencode.json` | OpenCode via `ollama launch` — requires a8s var `MODEL`. Example: `a8s add bob ./ ollama-opencode --model=qwen3.6`. |
 | `filedrop.json` | Filedrop seat — file-proxy delivery into `<root>/.inbox/`; no CLI wake. Watch with `tells -f`. See [docs/filedrop.md](docs/filedrop.md). Bare name: `a8s add <name> <dir> filedrop`.                                                              |
 | `claude-proxy.json` | Claude Code filedrop variant (same file-proxy shape).                                                                                                                                                                                           |
 | `default.json`  | Fallback — runs `dummy-cli` and prints "no real CLI configured"                                                                                                                                                                                    |
@@ -311,7 +314,7 @@ Strict opacity (issues #69, #70) still holds: a routed message looks identical w
 }
 ```
 
-Argv elements run through six substitutions:
+Argv elements run through built-in substitutions plus any per-node **a8s vars**:
 
 - `$SENDER` → sender's canonical name (always non-empty — every message has a force-stamped agent `from`).
 - `$RECIPIENT` → what the sender wrote in `to` (alias name for fanned messages, agent name for direct ones).
@@ -319,8 +322,19 @@ Argv elements run through six substitutions:
 - `$TIMESTAMP` → ISO 8601 UTC timestamp the message was queued (e.g. `2026-04-28T14:30:00.123456Z`). Useful when you want a stable machine-readable time.
 - `$AGE` → human-readable age relative to now (e.g. `5 minutes ago`). Computed at wake time, so a long backlog gets accurate values per message. Pick this OR `$TIMESTAMP` per definition based on which the LLM will read more naturally.
 - `$A8S_DIR` → `apps/a8s/` itself, so definitions can point at bundled scripts (`default.json` uses this for `dummy-cli`).
+- `$DEFINITION_PATH` → resolved path of this agent's definition file.
+- `$KEY` → any key from `a8s vars <name> set KEY value` (registry `vars` map). **Not** OS environment — no correlation with process env. If the definition references `$KEY` and that var is unset, wake fails closed.
 
 `$TIMESTAMP` and `$AGE` are empty for any message without a `date` field (defensive — every `_write_outbox` stamps one).
+
+```bash
+a8s add bob ./ ollama-opencode --model=qwen3.6
+a8s vars bob set MODEL qwen3.6   # same effect after the fact; keys case-insensitive
+a8s vars bob
+a8s vars bob unset model
+```
+
+A shared definition can then use `"--model", "$MODEL"`; each node supplies its own value.
 
 Override per-agent with `a8s define <name> <definition>` — a filesystem path or a bare name (`filedrop`, `claude`, or a user template from `a8s defs add`). The file isn't moved or copied into the agent root; the registry stores the resolved path.
 

--- a/apps/a8s/cli.py
+++ b/apps/a8s/cli.py
@@ -27,6 +27,7 @@ from commands import (
     cmd_namespaces,
     cmd_remote,
     cmd_remove,
+    cmd_restart,
     cmd_run,
     cmd_start,
     cmd_step,
@@ -39,11 +40,12 @@ from commands import (
     cmd_unnamespace,
     cmd_unremote,
     cmd_unstorage,
+    cmd_vars,
 )
 
 
 COMMANDS: list[tuple[str, str, str]] = [
-    ("add",      "<name> <dir> [<def>]",      "Register a node."),
+    ("add",      "<name> <dir> [<def>] [--K=v ...]", "Register a node (optional a8s vars)."),
     ("remove",   "<name>",                    "Unregister a node and delete its mailbox."),
     ("rm",       "<name>",                    "Alias for remove."),
     ("ls",       "[-q]",                      "List all registered nodes, running or not."),
@@ -51,6 +53,7 @@ COMMANDS: list[tuple[str, str, str]] = [
     ("define",   "<name> [<def>]",            "Show or set an agent's definition (path or bare name)."),
     ("definitions", "[add|rm|ls ...]",       "Manage user-installed definition templates (~/.a8s/definitions)."),
     ("defs",     "[add|rm|ls ...]",          "Alias for definitions."),
+    ("vars",     "<name> [set|unset ...]",   "Get/set per-node a8s vars for definition $KEY interpolation."),
     ("alias",    "[<name> [<member>]]",       "Group agents under an alias name; show one with `<name>`."),
     ("unalias",  "<alias> [<member>]",        "Remove a member from an alias, or the whole alias."),
     ("aliases",  "",                          "List aliases and their members."),
@@ -60,7 +63,8 @@ COMMANDS: list[tuple[str, str, str]] = [
     ("start",    "<name>",                    "Run an agent in the background."),
     ("run",      "<name> [--drain <sec>]",     "Run an agent in the foreground."),
     ("step",     "<name>",                    "Run an agent for one pass and exit."),
-    ("stop",     "<name>",                    "Stop a running agent."),
+    ("stop",     "<name> [--force]",          "Stop a node; wait until detached (finish current wake unless --force)."),
+    ("restart",  "<name> [--force]",          "Stop (wait) then start a node."),
     ("kill",     "<name>",                    "Force-stop a running agent."),
     ("exit",     "",                          "Stop every running agent."),
     ("ps",       "[-q]",                      "List running node processes."),
@@ -108,6 +112,8 @@ def dispatch(cmd: str, args: list[str], interval: float) -> int:
         return cmd_define(args)
     if cmd in ("definitions", "defs"):
         return cmd_definitions(args)
+    if cmd == "vars":
+        return cmd_vars(args)
     if cmd == "alias":
         return cmd_alias(args)
     if cmd == "unalias":
@@ -128,6 +134,8 @@ def dispatch(cmd: str, args: list[str], interval: float) -> int:
         return cmd_step(args, interval)
     if cmd == "stop":
         return cmd_stop(args)
+    if cmd == "restart":
+        return cmd_restart(args)
     if cmd == "kill":
         return cmd_kill(args)
     if cmd == "exit":

--- a/apps/a8s/commands.py
+++ b/apps/a8s/commands.py
@@ -48,6 +48,7 @@ from definitions import (
     definition_stem,
     list_definition_entries,
     resolve_definition_arg,
+    validate_var_name,
 )
 from daemon import (
     _clear_kill_request,
@@ -170,7 +171,7 @@ def _install_skills_into(base: Path) -> int:
 # ---------- registry management commands ----------
 
 def cmd_add(args: list[str]) -> int:
-    """`a8s add <name> <dir> [<definition>]` — register a new agent.
+    """`a8s add <name> <dir> [<definition>] [--KEY=value ...]` — register a node.
 
     The name is canonicalized (lowercase, alphanumeric) at registration so
     `a8s add CLAUDE` and `a8s add claude` collapse to the same agent — closes
@@ -182,16 +183,40 @@ def cmd_add(args: list[str]) -> int:
     auto-linked. Multiple or zero markers fall back to the bundled default.
 
     With `<definition>`, the JSON file is validated and set as the agent's
-    definition. A bare name (`filedrop`, `claude`, `filedrop.json`) resolves
+    definition. A bare name (`filedrop`, `claude`, `ollama-opencode`) resolves
     against bundled `apps/a8s/definitions/`, then user-installed
     ``~/.a8s/definitions/`` (`a8s defs add`); any other path is used as-is.
 
+    Trailing ``--KEY=value`` flags set per-node a8s vars (same as
+    ``a8s vars <name> set KEY value``). Keys are case-insensitive.
+
     Errors on duplicate name (vs. agents or aliases) or non-directory path."""
-    if len(args) < 2 or len(args) > 3:
-        print("usage: a8s add <name> <dir> [<definition>]", file=sys.stderr)
+    if len(args) < 2:
+        print(
+            "usage: a8s add <name> <dir> [<definition>] [--KEY=value ...]",
+            file=sys.stderr,
+        )
         return 2
     raw_name, dir_str = args[0], args[1]
-    definition_arg = args[2] if len(args) == 3 else None
+    rest = args[2:]
+    definition_arg: str | None = None
+    var_tokens: list[str] = []
+    for tok in rest:
+        if tok.startswith("--"):
+            var_tokens.append(tok)
+        elif definition_arg is None and not var_tokens:
+            definition_arg = tok
+        else:
+            print(
+                "usage: a8s add <name> <dir> [<definition>] [--KEY=value ...]",
+                file=sys.stderr,
+            )
+            return 2
+    try:
+        initial_vars = _parse_add_var_flags(var_tokens)
+    except ValueError as e:
+        print(str(e), file=sys.stderr)
+        return 2
     try:
         name = canonical_name(raw_name)
     except ValueError as e:
@@ -238,11 +263,33 @@ def cmd_add(args: list[str]) -> int:
     else:
         definition_path, note = _autodiscover_definition(root)
 
-    reg[name] = {"root": str(root), "definition": definition_path}
+    entry: dict = {"root": str(root), "definition": definition_path}
+    if initial_vars:
+        entry["vars"] = dict(sorted(initial_vars.items()))
+    reg[name] = entry
     save_registry(reg)
     print(f"added {name} -> {root}")
     print(f"definition: {definition_path}  ({note})")
+    for k, v in sorted(initial_vars.items()):
+        print(f"var: {k}={v}")
     return 0
+
+
+def _parse_add_var_flags(tokens: list[str]) -> dict[str, str]:
+    """Parse ``--KEY=value`` tokens into a canonical (uppercase) vars map."""
+    out: dict[str, str] = {}
+    for tok in tokens:
+        if not tok.startswith("--") or len(tok) < 3:
+            raise ValueError(f"expected --KEY=value, got: {tok!r}")
+        body = tok[2:]
+        if "=" not in body:
+            raise ValueError(f"expected --KEY=value, got: {tok!r}")
+        raw_key, _, value = body.partition("=")
+        if not raw_key:
+            raise ValueError(f"expected --KEY=value, got: {tok!r}")
+        key = validate_var_name(raw_key)
+        out[key] = value
+    return out
 
 
 def cmd_remove(args: list[str]) -> int:
@@ -479,6 +526,120 @@ def _cmd_definitions_remove(name: str) -> int:
         return 1
     dest.unlink()
     print(f"removed definition {stem}")
+    return 0
+
+
+def _vars_usage() -> int:
+    print(
+        "usage: a8s vars <name>                 # list a8s vars for a node\n"
+        "       a8s vars <name> set <KEY> <val> # set (not OS environment)\n"
+        "       a8s vars <name> unset <KEY>     # remove\n"
+        "\n"
+        "Per-node placeholders for definition argv ($KEY). Names are\n"
+        "case-insensitive (stored uppercase). Built-in names ($SENDER,\n"
+        "$MESSAGE, …) are reserved. Used-but-unset is a wake error.",
+        file=sys.stderr,
+    )
+    return 2
+
+
+def cmd_vars(args: list[str]) -> int:
+    """`a8s vars` — per-node a8s variables for definition interpolation.
+
+    Stored on the agent in the registry (`vars` map). Expanded as `$KEY` in
+    invoke argv; never read from or written to the process environment.
+    """
+    if len(args) < 1:
+        return _vars_usage()
+    match = resolve_recipient(args[0])
+    if match is None:
+        print(f"no agent named {args[0]!r}", file=sys.stderr)
+        return 1
+    agent_key, info = match
+    if len(args) == 1:
+        return _cmd_vars_list(agent_key, info)
+    sub = args[1]
+    if sub == "set":
+        if len(args) != 4:
+            return _vars_usage()
+        return _cmd_vars_set(agent_key, info, args[2], args[3])
+    if sub == "unset":
+        if len(args) != 3:
+            return _vars_usage()
+        return _cmd_vars_unset(agent_key, info, args[2])
+    return _vars_usage()
+
+
+def _cmd_vars_list(agent_key: str, info: dict) -> int:
+    raw = info.get("vars")
+    vars_map = raw if isinstance(raw, dict) else {}
+    items: dict[str, str] = {}
+    for k, v in vars_map.items():
+        if isinstance(k, str) and isinstance(v, str):
+            items[k.upper()] = v
+    if not items:
+        print(f"{agent_key}: (no vars)")
+        return 0
+    width = max(len(k) for k in items)
+    for k in sorted(items):
+        print(f"{k.ljust(width)}  {items[k]}")
+    return 0
+
+
+def _cmd_vars_set(agent_key: str, info: dict, key: str, value: str) -> int:
+    try:
+        key = validate_var_name(key)
+    except ValueError as e:
+        print(str(e), file=sys.stderr)
+        return 2
+    reg = load_registry()
+    entry = reg.get(agent_key)
+    if entry is None:
+        print(f"no agent named {agent_key!r}", file=sys.stderr)
+        return 1
+    vars_map = entry.get("vars")
+    if not isinstance(vars_map, dict):
+        vars_map = {}
+        entry["vars"] = vars_map
+    overwriting = False
+    for existing in list(vars_map):
+        if isinstance(existing, str) and existing.upper() == key:
+            del vars_map[existing]
+            overwriting = True
+    vars_map[key] = value
+    save_registry(reg)
+    verb = "updated" if overwriting else "set"
+    print(f"{agent_key}: {verb} {key}={value}")
+    return 0
+
+
+def _cmd_vars_unset(agent_key: str, info: dict, key: str) -> int:
+    try:
+        key = validate_var_name(key)
+    except ValueError as e:
+        print(str(e), file=sys.stderr)
+        return 2
+    reg = load_registry()
+    entry = reg.get(agent_key)
+    if entry is None:
+        print(f"no agent named {agent_key!r}", file=sys.stderr)
+        return 1
+    vars_map = entry.get("vars")
+    if not isinstance(vars_map, dict):
+        print(f"{agent_key}: no var named {key!r}", file=sys.stderr)
+        return 1
+    found = False
+    for existing in list(vars_map):
+        if isinstance(existing, str) and existing.upper() == key:
+            del vars_map[existing]
+            found = True
+    if not found:
+        print(f"{agent_key}: no var named {key!r}", file=sys.stderr)
+        return 1
+    if not vars_map:
+        entry.pop("vars", None)
+    save_registry(reg)
+    print(f"{agent_key}: unset {key}")
     return 0
 
 
@@ -1164,15 +1325,62 @@ def cmd_step(args: list[str], interval: float) -> int:
     return attached_loop(members, interval, single_pass=True)
 
 
+STOP_WAIT_S = 600.0
+STOP_FORCE_WAIT_S = 30.0
+STOP_POLL_S = 0.1
+
+
+def _split_force_flag(args: list[str]) -> tuple[list[str], bool]:
+    force = False
+    rest: list[str] = []
+    for a in args:
+        if a in ("--force", "-f"):
+            force = True
+        else:
+            rest.append(a)
+    return rest, force
+
+
+def _handlers_still_holding(members: list[str], signaled_pids: set[int]) -> bool:
+    """True while any member is still attached to one of the signaled PIDs,
+    or any of those PIDs is still alive (shutting down after release)."""
+    for name in members:
+        pid = _read_handler_pid(name)
+        if pid is not None and pid in signaled_pids and _pid_alive(pid):
+            return True
+    return any(_pid_alive(pid) for pid in signaled_pids)
+
+
+def _wait_handlers_stopped(
+    members: list[str],
+    signaled_pids: set[int],
+    timeout: float,
+) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if not _handlers_still_holding(members, signaled_pids):
+            return True
+        time.sleep(STOP_POLL_S)
+    return not _handlers_still_holding(members, signaled_pids)
+
+
 def cmd_stop(args: list[str]) -> int:
-    """`a8s stop <name>` — SIGTERM the handler(s). One handler may serve
-    multiple members of an alias; we dedupe by PID so we signal each unique
-    handler exactly once. Detaches the WHOLE handler (collateral on any other
-    members it was handling)."""
-    if len(args) != 1:
-        print("usage: a8s stop <name>", file=sys.stderr)
+    """`a8s stop <name> [--force]` — SIGTERM the handler(s), then wait until
+    they have actually detached.
+
+    Like Ctrl+C on `a8s run`: the first signal asks for a graceful detach
+    after the current wake. Idle nodes stop immediately; a busy wake finishes
+    first. ``--force`` / ``-f`` sends a second SIGTERM so the daemon kills the
+    in-flight wake subprocess group (same as a second Ctrl+C), then waits.
+
+    One handler may serve multiple alias members; we dedupe by PID so each
+    unique handler is signaled once. Detaches the WHOLE handler.
+    """
+    rest, force = _split_force_flag(args)
+    if len(rest) != 1:
+        print("usage: a8s stop <name> [--force]", file=sys.stderr)
         return 2
-    members = _expand_to_agents(args[0])
+    members = _expand_to_agents(rest[0])
     if members is None:
         return 1
     seen_pids: dict[int, str] = {}
@@ -1194,9 +1402,56 @@ def cmd_stop(args: list[str]) -> int:
             print(f"{label}: sent SIGTERM to PID {pid}")
         except OSError as e:
             print(f"{label}: could not signal PID {pid}: {e}", file=sys.stderr)
+    if force:
+        time.sleep(0.05)
+        for pid, label in seen_pids.items():
+            try:
+                os.kill(pid, signal.SIGTERM)
+                print(f"{label}: sent second SIGTERM (force) to PID {pid}")
+            except ProcessLookupError:
+                pass
+            except OSError as e:
+                print(f"{label}: could not signal PID {pid}: {e}", file=sys.stderr)
+    wait_s = STOP_FORCE_WAIT_S if force else STOP_WAIT_S
+    print(f"waiting up to {wait_s:g}s for stop…")
+    if not _wait_handlers_stopped(members, set(seen_pids), wait_s):
+        print(
+            f"still running after {wait_s:g}s"
+            + ("" if force else " — try `a8s stop --force` or `a8s kill`"),
+            file=sys.stderr,
+        )
+        return 1
+    for n in members:
+        if n not in not_running:
+            print(f"{n}: stopped")
     for n in not_running:
         print(f"{n}: not running")
     return 0
+
+
+def cmd_restart(args: list[str]) -> int:
+    """`a8s restart <name> [--force]` — stop (wait until detached) then start.
+
+    If the node is not running, skip straight to start. ``--force`` is passed
+    through to stop so an in-flight wake is interrupted.
+    """
+    rest, force = _split_force_flag(args)
+    if len(rest) != 1:
+        print("usage: a8s restart <name> [--force]", file=sys.stderr)
+        return 2
+    name = rest[0]
+    members = _expand_to_agents(name)
+    if members is None:
+        return 1
+    any_running = any(_read_handler_pid(n) is not None for n in members)
+    if any_running:
+        stop_args = [name]
+        if force:
+            stop_args.append("--force")
+        rc = cmd_stop(stop_args)
+        if rc != 0:
+            return rc
+    return cmd_start([name])
 
 
 KILL_TIMEOUT_S = 10.0

--- a/apps/a8s/daemon.py
+++ b/apps/a8s/daemon.py
@@ -54,6 +54,7 @@ from core import (
 )
 from definitions import (
     BatchEntry,
+    UndefinedVarsError,
     batch_limit,
     build_batch_command,
     build_command,
@@ -62,6 +63,7 @@ from definitions import (
     has_batch_invoke,
     idle_timeout_seconds,
     is_file_proxy,
+    load_agent_vars,
     load_definition,
     resolve_definition_path,
     max_wake_seconds,
@@ -359,7 +361,17 @@ def wake_once(p: Participant, msg_path: Path, *, async_wake: bool = False) -> bo
     msg_path.rename(trashed)
     out_agent(p.name, f"[{p.name}] waking from {trashed.name}: {_preview(msg.get('content', ''))}")
     p.files_path().mkdir(parents=True, exist_ok=True)
-    cmd = build_command(definition, msg, p.root, resolve_definition_path(p.name))
+    try:
+        cmd = build_command(
+            definition,
+            msg,
+            p.root,
+            resolve_definition_path(p.name),
+            vars=load_agent_vars(p.name),
+        )
+    except UndefinedVarsError as e:
+        out_agent(p.name, f"[{p.name}] wake aborted: {e}")
+        return False
     out_agent(p.name, f"[{p.name}] exec: {shlex.join(cmd)}")
     max_sec = max_wake_seconds(definition)
     if async_wake:
@@ -415,7 +427,17 @@ def wake_batch(
         f"[{p.name}] batch waking ({len(trashed)}): {summary}",
     )
     p.files_path().mkdir(parents=True, exist_ok=True)
-    cmd = build_batch_command(definition, p.name, entries, resolve_definition_path(p.name))
+    try:
+        cmd = build_batch_command(
+            definition,
+            p.name,
+            entries,
+            resolve_definition_path(p.name),
+            vars=load_agent_vars(p.name),
+        )
+    except UndefinedVarsError as e:
+        out_agent(p.name, f"[{p.name}] batch wake aborted: {e}")
+        return False
     out_agent(p.name, f"[{p.name}] batch exec: {shlex.join(cmd)}")
     max_sec = max_wake_seconds(definition)
     if async_wake:
@@ -488,9 +510,6 @@ def maybe_run_idle(p: Participant, *, async_wake: bool = False) -> bool:
         touch_last_active(p.name)
         return True
 
-    cmd = build_idle_command(definition, p.name, resolve_definition_path(p.name))
-    if cmd is None:
-        return False
     last = read_last_active(p.name)
     if last is None:
         # No prior activity recorded — initialize and let the next iteration
@@ -499,6 +518,18 @@ def maybe_run_idle(p: Participant, *, async_wake: bool = False) -> bool:
         return False
     elapsed = (datetime.now(timezone.utc) - last).total_seconds()
     if elapsed < timeout:
+        return False
+    try:
+        cmd = build_idle_command(
+            definition,
+            p.name,
+            resolve_definition_path(p.name),
+            vars=load_agent_vars(p.name),
+        )
+    except UndefinedVarsError as e:
+        out_agent(p.name, f"[{p.name}] idle aborted: {e}")
+        return False
+    if cmd is None:
         return False
     out_agent(
         p.name,

--- a/apps/a8s/definitions.py
+++ b/apps/a8s/definitions.py
@@ -2,10 +2,15 @@
 
 Each agent has a definition JSON (built-in or custom) that encodes one argv
 under the `invoke` key. `build_command` substitutes `$SENDER` / `$RECIPIENT`
-/ `$MESSAGE` / `$TIMESTAMP` / `$AGE` / `$A8S_DIR` / `$DEFINITION_PATH` into it.
+/ `$MESSAGE` / `$TIMESTAMP` / `$AGE` / `$A8S_DIR` / `$DEFINITION_PATH` into it,
+plus any per-node a8s vars (`a8s vars <name> set KEY value`) as `$KEY`.
 `$DEFINITION_PATH` is the resolved path of the agent's own definition file, so
 a self-contained node (e.g. r4t) can read its own definition for settings the
 wire does not carry.
+
+A8s vars are NOT process environment variables — they live on the agent in
+the registry and expand only through this interpolator. A `$NAME` that is
+neither a built-in placeholder nor a set a8s var is a hard error.
 
 Strict opacity (issues #69, #70): the recipient sees only sender + message
 content — no `alias` or `others_count` leak. A direct tell and an
@@ -17,6 +22,7 @@ mailing list: you know it came via the list, you don't know who else got it).
 from __future__ import annotations
 
 import json
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import NamedTuple
@@ -30,9 +36,75 @@ from core import (
     resolve_outbox_path,
     user_definitions_dir,
 )
-from registry import load_registry
+from registry import load_registry, resolve_recipient
 
 ATTACHED_FILE_PREFIX = "ATTACHED FILE: "
+
+BUILTIN_PLACEHOLDERS = frozenset({
+    "SENDER",
+    "RECIPIENT",
+    "MESSAGE",
+    "TIMESTAMP",
+    "AGE",
+    "A8S_DIR",
+    "DEFINITION_PATH",
+})
+
+PLACEHOLDER_RE = re.compile(r"\$([A-Za-z_][A-Za-z0-9_]*)")
+VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+class UndefinedVarsError(ValueError):
+    """Definition argv referenced `$NAME` that is not a built-in and not set."""
+
+    def __init__(self, names: list[str]):
+        self.names = list(names)
+        label = "undefined a8s var" if len(self.names) == 1 else "undefined a8s vars"
+        refs = ", ".join(f"${n}" for n in self.names)
+        super().__init__(f"{label}: {refs}")
+
+
+def validate_var_name(name: str) -> str:
+    """Return the canonical (uppercase) a8s var key, or raise ValueError.
+
+    Names are case-insensitive: ``model`` and ``MODEL`` are the same var.
+    """
+    if not VAR_NAME_RE.match(name):
+        raise ValueError(
+            f"var name must match [A-Za-z_][A-Za-z0-9_]*: {name!r}"
+        )
+    canon = name.upper()
+    if canon in BUILTIN_PLACEHOLDERS:
+        raise ValueError(f"var name {name!r} is reserved for built-in interpolation")
+    return canon
+
+
+def load_agent_vars(name: str) -> dict[str, str]:
+    """Per-node a8s vars from the registry (`agents.<name>.vars`).
+
+    Keys are returned uppercase (canonical). Duplicate spellings collapse.
+    """
+    match = resolve_recipient(name)
+    if match is None:
+        return {}
+    _, info = match
+    raw = info.get("vars")
+    if not isinstance(raw, dict):
+        return {}
+    out: dict[str, str] = {}
+    for k, v in raw.items():
+        if isinstance(k, str) and isinstance(v, str):
+            out[k.upper()] = v
+    return out
+
+
+def placeholder_names(argv: list[str]) -> set[str]:
+    """All `$NAME` identifiers referenced in an argv template."""
+    found: set[str] = set()
+    for a in argv:
+        for m in PLACEHOLDER_RE.finditer(a):
+            found.add(m.group(1))
+    return found
 
 
 def default_definition_path(kind: str) -> Path:
@@ -269,37 +341,54 @@ def _expand_argv(
     timestamp: str = "",
     age: str = "",
     definition_path: str = "",
+    vars: dict[str, str] | None = None,
 ) -> list[str]:
-    """Expand placeholders in argv:
+    """Expand placeholders in argv.
+
+    Built-ins:
       - `$SENDER`     sender's canonical name (empty for senderless prompts)
       - `$RECIPIENT`  what the sender wrote in `to` (alias for fanned, agent for direct)
       - `$MESSAGE`    content + any ATTACHED FILE: lines
-      - `$TIMESTAMP`  ISO 8601 UTC time the message was queued (e.g.,
-                      `2026-04-28T14:30:00.123456Z`); empty for invokeClear
-                      and for messages without a `date` field
-      - `$AGE`        human-readable age relative to now (e.g.,
-                      `5 minutes ago`); same emptiness rules as $TIMESTAMP
-      - `$A8S_DIR`    the apps/a8s/ directory (so default.json can reference
-                      bundled scripts like dummy-cli without hardcoding paths)
-      - `$DEFINITION_PATH`  the resolved path of this agent's definition file
-                      (empty when the caller did not resolve it)
+      - `$TIMESTAMP`  ISO 8601 UTC time the message was queued
+      - `$AGE`        human-readable age relative to now
+      - `$A8S_DIR`    the apps/a8s/ directory
+      - `$DEFINITION_PATH`  this agent's definition file path
+
+    Plus per-node a8s vars (`vars`) as `$KEY` (case-insensitive). Not OS
+    environment. Any `$NAME` that is neither a built-in nor present in `vars`
+    raises ``UndefinedVarsError``.
     """
-    a8s_dir = str(SCRIPT_DIR)
-    out: list[str] = []
-    for a in argv:
-        a = a.replace("$SENDER", sender)
-        a = a.replace("$RECIPIENT", recipient)
-        a = a.replace("$MESSAGE", message)
-        a = a.replace("$TIMESTAMP", timestamp)
-        a = a.replace("$AGE", age)
-        a = a.replace("$A8S_DIR", a8s_dir)
-        a = a.replace("$DEFINITION_PATH", definition_path)
-        out.append(a)
-    return out
+    node_vars = {k.upper(): v for k, v in (vars or {}).items()}
+    refs = {n.upper() for n in placeholder_names(argv)}
+    missing = sorted(
+        n for n in refs if n not in BUILTIN_PLACEHOLDERS and n not in node_vars
+    )
+    if missing:
+        raise UndefinedVarsError(missing)
+
+    values: dict[str, str] = {
+        **node_vars,
+        "SENDER": sender,
+        "RECIPIENT": recipient,
+        "MESSAGE": message,
+        "TIMESTAMP": timestamp,
+        "AGE": age,
+        "A8S_DIR": str(SCRIPT_DIR),
+        "DEFINITION_PATH": definition_path,
+    }
+
+    def repl(m: re.Match[str]) -> str:
+        return values[m.group(1).upper()]
+
+    return [PLACEHOLDER_RE.sub(repl, a) for a in argv]
 
 
 def build_command(
-    definition: dict, msg: dict, agent_root: Path, definition_path: str = ""
+    definition: dict,
+    msg: dict,
+    agent_root: Path,
+    definition_path: str = "",
+    vars: dict[str, str] | None = None,
 ) -> list[str]:
     """Pick the `invoke` argv from `definition` and expand interpolation
     variables. There is one verb — every routed message is a `tell` — so
@@ -318,12 +407,22 @@ def build_command(
     date_str = (msg.get("date") or "").strip()
     age = _format_age(date_str)
     return _expand_argv(
-        list(argv), sender, recipient, body, date_str, age, definition_path
+        list(argv),
+        sender,
+        recipient,
+        body,
+        date_str,
+        age,
+        definition_path,
+        vars=vars,
     )
 
 
 def build_idle_command(
-    definition: dict, agent_name: str, definition_path: str = ""
+    definition: dict,
+    agent_name: str,
+    definition_path: str = "",
+    vars: dict[str, str] | None = None,
 ) -> list[str] | None:
     """Pick the `idle.invoke` argv from `definition` and expand the same
     interpolation variables `build_command` does. Returns None if the agent
@@ -339,7 +438,9 @@ def build_idle_command(
     argv = idle.get("invoke")
     if not argv:
         return None
-    return _expand_argv(list(argv), "", agent_name, "", "", "", definition_path)
+    return _expand_argv(
+        list(argv), "", agent_name, "", "", "", definition_path, vars=vars
+    )
 
 
 def pause_seconds(definition: dict) -> float:
@@ -444,6 +545,7 @@ def build_batch_command(
     agent_name: str,
     entries: list[BatchEntry],
     definition_path: str = "",
+    vars: dict[str, str] | None = None,
 ) -> list[str]:
     """Expand `batch.invoke` like idle (no incoming message) and append ONE
     composed prompt string (see `build_batch_prompt`) as the trailing argv
@@ -454,7 +556,9 @@ def build_batch_command(
     argv = batch.get("invoke")
     if not argv:
         raise ValueError("definition missing 'batch.invoke'")
-    cmd = _expand_argv(list(argv), "", agent_name, "", "", "", definition_path)
+    cmd = _expand_argv(
+        list(argv), "", agent_name, "", "", "", definition_path, vars=vars
+    )
     cmd.append(build_batch_prompt(agent_name, entries))
     return cmd
 

--- a/apps/a8s/definitions/ollama-opencode.json
+++ b/apps/a8s/definitions/ollama-opencode.json
@@ -1,0 +1,15 @@
+{
+  "description": "OpenCode via `ollama launch` — local models, no cloud quota. Requires a8s var MODEL (`a8s add ... --model=...` or `a8s vars <name> set MODEL ...`).",
+  "invoke": [
+    "ollama",
+    "launch",
+    "opencode",
+    "--model",
+    "$MODEL",
+    "--",
+    "run",
+    "--continue",
+    "--dangerously-skip-permissions",
+    "$SENDER tells $RECIPIENT ($AGE): $MESSAGE"
+  ]
+}

--- a/apps/a8s/registry.py
+++ b/apps/a8s/registry.py
@@ -2,12 +2,14 @@
 
 Schema:
   {
-    "agents":     {"<NAME>": {"root": "...", "definition": "...?", "safe_dirs": ["..."]}},
+    "agents":     {"<NAME>": {"root": "...", "definition": "...?", "safe_dirs": ["..."], "vars": {"KEY": "..."}}},
     "aliases":    {"<ALIAS>": ["<NAME-or-ALIAS>", ...]},
     "namespaces": {"<PREFIX>": "<AGENT>"}
   }
   `safe_dirs` — optional extra directories (absolute paths) where FILE
   attachments may originate at routing time, in addition to `root`.
+  `vars` — optional per-node a8s variables (`a8s vars`); expanded as `$KEY` in
+  definition argv. Not OS environment variables.
   `namespaces` — prefix routing (#148): a recipient `<PREFIX>:<sub-address>`
   routes to the single bound agent with the full address preserved in `to`.
 Aliases are disjoint from both agents and namespaces. A namespace prefix may

--- a/apps/a8s/tests/test_cli.py
+++ b/apps/a8s/tests/test_cli.py
@@ -33,3 +33,19 @@ def test_defs_is_alias_for_definitions(monkeypatch):
     assert cli.dispatch("defs", ["ls"], interval=1.0) == 3
     assert cli.dispatch("definitions", ["add", "x.json"], interval=1.0) == 3
     assert calls == [["ls"], ["add", "x.json"]]
+
+
+def test_vars_dispatches(monkeypatch):
+    assert "vars" in cli.KNOWN_COMMANDS
+    calls = []
+    monkeypatch.setattr(cli, "cmd_vars", lambda args: calls.append(args) or 0)
+    assert cli.dispatch("vars", ["bob", "set", "MODEL", "x"], interval=1.0) == 0
+    assert calls == [["bob", "set", "MODEL", "x"]]
+
+
+def test_restart_dispatches(monkeypatch):
+    assert "restart" in cli.KNOWN_COMMANDS
+    calls = []
+    monkeypatch.setattr(cli, "cmd_restart", lambda args: calls.append(args) or 0)
+    assert cli.dispatch("restart", ["qwen", "--force"], interval=1.0) == 0
+    assert calls == [["qwen", "--force"]]

--- a/apps/a8s/tests/test_commands.py
+++ b/apps/a8s/tests/test_commands.py
@@ -22,6 +22,9 @@ from commands import (
     cmd_namespaces,
     cmd_remote,
     cmd_remove,
+    cmd_restart,
+    cmd_start,
+    cmd_stop,
     cmd_storage,
     cmd_tell,
     cmd_trace,
@@ -29,6 +32,7 @@ from commands import (
     cmd_unnamespace,
     cmd_unremote,
     cmd_unstorage,
+    cmd_vars,
 )
 from core import Participant, TELL_OUTBOX_DIR_ENV, agent_dir, agent_log_path, files_dir, kill_request_path, outbox_bundle_dir, outbox_dir, pid_path, user_definitions_dir
 from mailbox import ensure_mailboxes
@@ -110,6 +114,35 @@ class TestCmdAddBundledDefinition:
         custom.write_text('{"proxy": "file"}')
         assert cmd_add(["seat", str(agent_root), str(custom)]) == 0
         assert load_registry()["seat"]["definition"] == str(custom.resolve())
+
+    def test_add_with_var_flag(self, fake_home, agent_root, capsys):
+        from definitions import default_definition_path
+
+        rc = cmd_add([
+            "bob", str(agent_root), "ollama-opencode", "--model=qwen3.6",
+        ])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "var: MODEL=qwen3.6" in out
+        reg = load_registry()["bob"]
+        assert reg["definition"] == str(default_definition_path("ollama-opencode"))
+        assert reg["vars"] == {"MODEL": "qwen3.6"}
+
+    def test_add_var_flag_case_insensitive(self, fake_home, agent_root):
+        assert cmd_add([
+            "bob", str(agent_root), "ollama-opencode", "--Model=qwen3.6",
+        ]) == 0
+        assert load_registry()["bob"]["vars"]["MODEL"] == "qwen3.6"
+
+    def test_add_rejects_bad_var_flag(self, fake_home, agent_root, capsys):
+        rc = cmd_add(["bob", str(agent_root), "filedrop", "--model"])
+        assert rc == 2
+        assert "expected --KEY=value" in capsys.readouterr().err
+
+    def test_add_rejects_var_named_builtin(self, fake_home, agent_root, capsys):
+        rc = cmd_add(["bob", str(agent_root), "filedrop", "--message=x"])
+        assert rc == 2
+        assert "reserved" in capsys.readouterr().err
 
 
 class TestCmdAddAliasCollision:
@@ -504,6 +537,154 @@ class TestCmdKillPerAgent:
         assert "not running" in out
 
 
+class TestCmdStopAndRestart:
+    def test_stop_waits_until_pid_gone(self, fake_home, tmp_path, monkeypatch, capsys):
+        d = tmp_path / "x"; d.mkdir()
+        save_registry({"claude": {"root": str(d)}})
+        holder = os.getppid()
+        pid_path("claude").parent.mkdir(parents=True, exist_ok=True)
+        pid_path("claude").write_text(str(holder))
+
+        signaled = []
+        polls = {"n": 0}
+
+        def fake_kill(pid, sig):
+            if sig == 0:
+                if not pid_path("claude").is_file():
+                    raise ProcessLookupError()
+                return
+            signaled.append((pid, sig))
+
+        def fake_alive(pid):
+            polls["n"] += 1
+            if polls["n"] >= 3:
+                pid_path("claude").unlink(missing_ok=True)
+                return False
+            return pid == holder
+
+        monkeypatch.setattr("commands.os.kill", fake_kill)
+        monkeypatch.setattr("daemon.os.kill", fake_kill)
+        monkeypatch.setattr("core.os.kill", fake_kill)
+        monkeypatch.setattr("commands._pid_alive", fake_alive)
+        monkeypatch.setattr("daemon._pid_alive", lambda pid: pid_path("claude").is_file())
+        monkeypatch.setattr("core._pid_alive", lambda pid: pid_path("claude").is_file())
+        monkeypatch.setattr("commands.STOP_POLL_S", 0.01)
+        monkeypatch.setattr("commands.STOP_WAIT_S", 2.0)
+
+        rc = cmd_stop(["claude"])
+        assert rc == 0
+        assert signaled == [(holder, signal.SIGTERM)]
+        out = capsys.readouterr().out
+        assert "waiting" in out
+        assert "stopped" in out
+
+    def test_stop_force_sends_second_sigterm(self, fake_home, tmp_path, monkeypatch, capsys):
+        d = tmp_path / "x"; d.mkdir()
+        save_registry({"claude": {"root": str(d)}})
+        holder = os.getppid()
+        pid_path("claude").parent.mkdir(parents=True, exist_ok=True)
+        pid_path("claude").write_text(str(holder))
+
+        signaled = []
+
+        def fake_kill(pid, sig):
+            if sig == 0:
+                if not pid_path("claude").is_file():
+                    raise ProcessLookupError()
+                return
+            signaled.append((pid, sig))
+            if len(signaled) >= 2:
+                pid_path("claude").unlink(missing_ok=True)
+
+        monkeypatch.setattr("commands.os.kill", fake_kill)
+        monkeypatch.setattr("daemon.os.kill", fake_kill)
+        monkeypatch.setattr("core.os.kill", fake_kill)
+        monkeypatch.setattr("commands._pid_alive", lambda pid: pid_path("claude").is_file())
+        monkeypatch.setattr("commands.STOP_POLL_S", 0.01)
+        monkeypatch.setattr("commands.STOP_FORCE_WAIT_S", 2.0)
+
+        rc = cmd_stop(["claude", "--force"])
+        assert rc == 0
+        assert signaled == [(holder, signal.SIGTERM), (holder, signal.SIGTERM)]
+        assert "second SIGTERM" in capsys.readouterr().out
+
+    def test_stop_timeout_suggests_force(self, fake_home, tmp_path, monkeypatch, capsys):
+        d = tmp_path / "x"; d.mkdir()
+        save_registry({"claude": {"root": str(d)}})
+        holder = os.getppid()
+        pid_path("claude").parent.mkdir(parents=True, exist_ok=True)
+        pid_path("claude").write_text(str(holder))
+
+        def fake_kill(pid, sig):
+            if sig == 0:
+                return
+            return None
+
+        monkeypatch.setattr("commands.os.kill", fake_kill)
+        monkeypatch.setattr("daemon.os.kill", fake_kill)
+        monkeypatch.setattr("core.os.kill", fake_kill)
+        monkeypatch.setattr("commands._pid_alive", lambda pid: True)
+        monkeypatch.setattr("daemon._pid_alive", lambda pid: True)
+        monkeypatch.setattr("commands.STOP_POLL_S", 0.01)
+        monkeypatch.setattr("commands.STOP_WAIT_S", 0.05)
+
+        rc = cmd_stop(["claude"])
+        assert rc == 1
+        assert "try `a8s stop --force`" in capsys.readouterr().err
+
+    def test_restart_stops_then_starts(self, fake_home, tmp_path, monkeypatch, capsys):
+        d = tmp_path / "x"; d.mkdir()
+        save_registry({"claude": {"root": str(d)}})
+        holder = os.getppid()
+        pid_path("claude").parent.mkdir(parents=True, exist_ok=True)
+        pid_path("claude").write_text(str(holder))
+
+        calls = []
+
+        def fake_kill(pid, sig):
+            if sig == 0:
+                if not pid_path("claude").is_file():
+                    raise ProcessLookupError()
+                return
+            calls.append(("kill", pid, sig))
+            pid_path("claude").unlink(missing_ok=True)
+
+        class FakeProc:
+            pid = 99999
+
+        def fake_popen(*a, **k):
+            calls.append(("popen", a[0]))
+            return FakeProc()
+
+        monkeypatch.setattr("commands.os.kill", fake_kill)
+        monkeypatch.setattr("daemon.os.kill", fake_kill)
+        monkeypatch.setattr("core.os.kill", fake_kill)
+        monkeypatch.setattr("commands._pid_alive", lambda pid: False)
+        monkeypatch.setattr("commands.subprocess.Popen", fake_popen)
+        monkeypatch.setattr("commands.STOP_POLL_S", 0.01)
+
+        rc = cmd_restart(["claude"])
+        assert rc == 0
+        assert any(c[0] == "kill" for c in calls)
+        assert any(c[0] == "popen" for c in calls)
+        out = capsys.readouterr().out
+        assert "started claude" in out
+
+    def test_restart_when_not_running_just_starts(self, fake_home, tmp_path, monkeypatch, capsys):
+        d = tmp_path / "x"; d.mkdir()
+        save_registry({"claude": {"root": str(d)}})
+
+        class FakeProc:
+            pid = 42
+
+        monkeypatch.setattr(
+            "commands.subprocess.Popen", lambda *a, **k: FakeProc()
+        )
+        rc = cmd_restart(["claude"])
+        assert rc == 0
+        assert "started claude as PID 42" in capsys.readouterr().out
+
+
 def _claim(name: str) -> None:
     """Write a live pid file so `name` reads as running (the pytest process
     is alive, so its own pid passes the liveness check)."""
@@ -659,6 +840,61 @@ class TestCmdDefinitions:
         assert cmd_add(["alice", str(agent_root), "my-custom-definition"]) == 0
         reg = load_registry()
         assert Path(reg["alice"]["definition"]).name == "my-custom-definition.json"
+
+
+class TestCmdVars:
+    def test_set_list_unset(self, fake_home, agent_root, capsys):
+        assert cmd_add(["bob", str(agent_root)]) == 0
+        capsys.readouterr()
+        assert cmd_vars(["bob", "set", "MODEL", "qwen3.6"]) == 0
+        assert load_registry()["bob"]["vars"]["MODEL"] == "qwen3.6"
+        capsys.readouterr()
+        assert cmd_vars(["bob"]) == 0
+        out = capsys.readouterr().out
+        assert "MODEL" in out and "qwen3.6" in out
+        assert cmd_vars(["bob", "unset", "MODEL"]) == 0
+        assert "vars" not in load_registry()["bob"]
+
+    def test_vars_case_insensitive(self, fake_home, agent_root):
+        assert cmd_add(["bob", str(agent_root)]) == 0
+        assert cmd_vars(["bob", "set", "model", "qwen3.6"]) == 0
+        assert load_registry()["bob"]["vars"] == {"MODEL": "qwen3.6"}
+        assert cmd_vars(["bob", "unset", "MoDeL"]) == 0
+        assert "vars" not in load_registry()["bob"]
+
+    def test_set_rejects_builtin_name(self, fake_home, agent_root, capsys):
+        assert cmd_add(["bob", str(agent_root)]) == 0
+        capsys.readouterr()
+        assert cmd_vars(["bob", "set", "message", "x"]) == 2
+        assert "reserved" in capsys.readouterr().err
+
+    def test_build_command_uses_registry_vars(self, fake_home, agent_root):
+        from definitions import build_command, load_agent_vars
+
+        assert cmd_add(["bob", str(agent_root)]) == 0
+        assert cmd_vars(["bob", "set", "model", "qwen3.6"]) == 0
+        defn = {"invoke": ["x", "--model", "$MODEL", "$MESSAGE"]}
+        argv = build_command(
+            defn,
+            {"from": "a", "to": "bob", "content": "hi"},
+            agent_root,
+            vars=load_agent_vars("bob"),
+        )
+        assert argv == ["x", "--model", "qwen3.6", "hi"]
+
+    def test_lowercase_placeholder_matches_var(self, fake_home, agent_root):
+        from definitions import build_command, load_agent_vars
+
+        assert cmd_add(["bob", str(agent_root)]) == 0
+        assert cmd_vars(["bob", "set", "MODEL", "qwen3.6"]) == 0
+        defn = {"invoke": ["x", "$model"]}
+        argv = build_command(
+            defn,
+            {"from": "a", "to": "bob", "content": "hi"},
+            agent_root,
+            vars=load_agent_vars("bob"),
+        )
+        assert argv == ["x", "qwen3.6"]
 
 
 class TestCmdRemote:

--- a/apps/a8s/tests/test_definitions.py
+++ b/apps/a8s/tests/test_definitions.py
@@ -9,6 +9,7 @@ import pytest
 from datetime import datetime, timezone
 
 from definitions import (
+    UndefinedVarsError,
     _autodiscover_definition,
     _expand_argv,
     _format_age,
@@ -20,6 +21,7 @@ from definitions import (
     resolve_files_dir,
     resolve_inbox_dir,
     resolve_outbox_dir,
+    validate_var_name,
 )
 
 
@@ -254,6 +256,53 @@ class TestExpandArgv:
         from core import SCRIPT_DIR
         assert _expand_argv(["$A8S_DIR/x"], "", "", "") == [f"{SCRIPT_DIR}/x"]
 
+    def test_node_var_expands(self):
+        assert _expand_argv(
+            ["ollama", "--model", "$MODEL", "$MESSAGE"],
+            "A",
+            "B",
+            "hi",
+            vars={"MODEL": "qwen3.6"},
+        ) == ["ollama", "--model", "qwen3.6", "hi"]
+
+    def test_var_case_insensitive(self):
+        assert _expand_argv(
+            ["$model"],
+            "A",
+            "B",
+            "hi",
+            vars={"MoDeL": "qwen3.6"},
+        ) == ["qwen3.6"]
+
+    def test_undefined_var_raises(self):
+        with pytest.raises(UndefinedVarsError) as ei:
+            _expand_argv(["--model", "$MODEL"], "A", "B", "hi")
+        assert ei.value.names == ["MODEL"]
+        assert "$MODEL" in str(ei.value)
+
+    def test_os_environ_does_not_fill_var(self, monkeypatch):
+        monkeypatch.setenv("MODEL", "from-shell")
+        with pytest.raises(UndefinedVarsError):
+            _expand_argv(["$MODEL"], "A", "B", "hi")
+
+    def test_builtin_not_overridden_by_vars_map(self):
+        assert _expand_argv(
+            ["$SENDER"],
+            "alice",
+            "bob",
+            "x",
+            vars={"SENDER": "eve"},
+        ) == ["alice"]
+
+    def test_lowercase_builtin_still_builtin(self):
+        assert _expand_argv(["$message"], "A", "B", "hi") == ["hi"]
+
+    def test_validate_var_name_rejects_builtin(self):
+        with pytest.raises(ValueError, match="reserved"):
+            validate_var_name("message")
+
+    def test_validate_var_name_canonicalizes(self):
+        assert validate_var_name("model") == "MODEL"
 
 # ---------- resolve_definition_arg ----------
 


### PR DESCRIPTION
## Summary
- Per-node a8s vars (`a8s vars` / `a8s add … --KEY=value`) for `$KEY` interpolation — registry-backed, case-insensitive, not OS env; used-but-unset fails wake
- Bundled `ollama-opencode` definition using `$MODEL` (e.g. `a8s add bob ./ ollama-opencode --model=qwen3.6`)
- `a8s stop` waits until detached (finish current wake); `--force` second SIGTERM like Ctrl+C×2; `a8s restart` = stop-wait then start

## Test plan
- [x] `a8s vars bob set model qwen3.6` then `$MODEL` / `$model` expand; unset fails wake if referenced
- [x] `a8s add bob ./ ollama-opencode --model=qwen3.6` sets `MODEL` and resolves the bundled def
- [x] `a8s stop bob` waits for idle/wake finish; `a8s stop bob --force` interrupts wake; `a8s restart bob` comes back up
- [x] `venv/bin/python3 -m pytest apps/a8s/tests/test_definitions.py apps/a8s/tests/test_commands.py::TestCmdVars apps/a8s/tests/test_commands.py::TestCmdStopAndRestart apps/a8s/tests/test_commands.py::TestCmdAddBundledDefinition apps/a8s/tests/test_cli.py -q`