### PR TITLE
feat(h4l): proxy attachments to room members

### DIFF
--- a/apps/a8s/tests/requirements.txt
+++ b/apps/a8s/tests/requirements.txt
@@ -1,2 +1,2 @@
 # Canonical deps: requirements/a8s-test.txt
--r ../../requirements/a8s-test.txt
+-r ../../../requirements/a8s-test.txt

--- a/apps/h4l/README.md
+++ b/apps/h4l/README.md
@@ -92,6 +92,8 @@ Room slugs: `[a-z0-9_-]+`, case-insensitive, stored lowercase.
 - Posting auto-creates the room and auto-joins the poster.
 - Malformed input → `tell` error back to sender.
 - Successful post → stdout ACK + `tell` ACK to sender; other members get truncated notify.
+- Attachments: a8s wake appends `ATTACHED FILE:` lines; hall re-`tell --attach`s them to
+  other room members (one inbound attach, N outbound copies via a8s).
 
 ## Tests
 

--- a/apps/h4l/attachments.py
+++ b/apps/h4l/attachments.py
@@ -1,0 +1,30 @@
+"""Parse a8s wake `ATTACHED FILE:` lines from an inbound hall message."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ATTACHED_FILE_PREFIX = "ATTACHED FILE: "
+
+
+def split_attached_files(text: str) -> tuple[str, list[Path]]:
+    """Strip trailing `ATTACHED FILE: <path>` lines; return body + existing paths.
+
+    Missing paths are skipped with a stderr warning (wake still proceeds).
+    """
+    lines = text.splitlines()
+    files: list[Path] = []
+    while lines and lines[-1].startswith(ATTACHED_FILE_PREFIX):
+        raw = lines.pop()[len(ATTACHED_FILE_PREFIX) :].strip()
+        if not raw:
+            continue
+        path = Path(raw)
+        if not path.is_file():
+            print(
+                f"h4l: skipping missing attachment {raw!r}",
+                file=sys.stderr,
+            )
+            continue
+        files.insert(0, path)
+    body = "\n".join(lines).rstrip()
+    return body, files

--- a/apps/h4l/dispatch.py
+++ b/apps/h4l/dispatch.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
+from pathlib import Path
+
+from attachments import split_attached_files
 from format import format_room_view, parse_view_args
 from notify import TellFn, ack, error, notify_agent, notify_members, usage_help
+from rooms import RoomStore, normalize_agent, normalize_slug
 
 _CMD_ALIASES = {
     "part": "leave",
     "names": "members",
     "kick": "remove",
 }
-from rooms import RoomStore, normalize_agent, normalize_slug
 
 
 def _join_names(names: list[str]) -> str:
@@ -53,9 +56,12 @@ def dispatch_slash(
     tell_fn: TellFn,
 ) -> int:
     sender = normalize_agent(sender)
-    body = message.strip()
+    body, attachments = split_attached_files(message.strip())
+    body = body.strip()
     if body.startswith("#"):
-        return _dispatch_hash_post(store, sender, node, body, tell_fn)
+        return _dispatch_hash_post(
+            store, sender, node, body, tell_fn, attachments=attachments
+        )
     if not body.startswith("/"):
         error(
             tell_fn,
@@ -82,7 +88,9 @@ def dispatch_slash(
 
     try:
         if cmd == "post":
-            return _cmd_post(store, sender, node, args, tell_fn)
+            return _cmd_post(
+                store, sender, node, args, tell_fn, attachments=attachments
+            )
         if cmd == "join":
             return _cmd_join(store, sender, node, args, tell_fn)
         if cmd == "leave":
@@ -139,9 +147,11 @@ def _dispatch_hash_post(
     node: str,
     body: str,
     tell_fn: TellFn,
+    *,
+    attachments: list[Path] | None = None,
 ) -> int:
     tokens = body.split()
-    if len(tokens) < 2:
+    if not tokens:
         error(
             tell_fn,
             sender,
@@ -158,7 +168,7 @@ def _dispatch_hash_post(
     message_tokens = tokens[1:]
     mentions = _leading_mention_agents(message_tokens)
     content = " ".join(message_tokens).strip()
-    if not content:
+    if not content and not attachments:
         error(
             tell_fn,
             sender,
@@ -167,7 +177,16 @@ def _dispatch_hash_post(
             hint="#<room> [@agent...] <message>",
         )
         return 1
-    return _do_post(store, sender, node, slug, content, tell_fn, mentions=mentions)
+    return _do_post(
+        store,
+        sender,
+        node,
+        slug,
+        content,
+        tell_fn,
+        mentions=mentions,
+        attachments=attachments,
+    )
 
 
 def _cmd_post(
@@ -176,8 +195,10 @@ def _cmd_post(
     node: str,
     args: list[str],
     tell_fn: TellFn,
+    *,
+    attachments: list[Path] | None = None,
 ) -> int:
-    if len(args) < 2:
+    if not args:
         error(
             tell_fn,
             sender,
@@ -190,7 +211,7 @@ def _cmd_post(
     message_tokens = args[1:]
     mentions = _leading_mention_agents(message_tokens)
     content = " ".join(message_tokens).strip()
-    if not content:
+    if not content and not attachments:
         error(
             tell_fn,
             sender,
@@ -199,7 +220,16 @@ def _cmd_post(
             hint="#<room> [@agent...] <message>",
         )
         return 1
-    return _do_post(store, sender, node, slug, content, tell_fn, mentions=mentions)
+    return _do_post(
+        store,
+        sender,
+        node,
+        slug,
+        content,
+        tell_fn,
+        mentions=mentions,
+        attachments=attachments,
+    )
 
 
 def _do_post(
@@ -211,6 +241,7 @@ def _do_post(
     tell_fn: TellFn,
     *,
     mentions: list[str] | None = None,
+    attachments: list[Path] | None = None,
 ) -> int:
     meta = store.ensure_room(slug)
     if not store.has_member(meta, sender):
@@ -222,7 +253,14 @@ def _do_post(
     meta = store.touch_activity(slug, meta)
     store.save_meta(slug, meta)
 
-    store.append_message(slug, sender=sender, content=content, kind="post")
+    paths = list(attachments or [])
+    store.append_message(
+        slug,
+        sender=sender,
+        content=content,
+        kind="post",
+        files=[{"filename": p.name} for p in paths],
+    )
     members = store.member_names(meta)
     notify_members(
         tell_fn=tell_fn,
@@ -235,6 +273,7 @@ def _do_post(
         headline=f"{sender} posted in #{slug}:",
         body=content,
         skip={sender},
+        attachments=paths,
     )
     return 0
 

--- a/apps/h4l/format.py
+++ b/apps/h4l/format.py
@@ -6,6 +6,20 @@ HEADING_OUT = "## from {from} to {to} at {timestamp}"
 HEADING_IN = "### from {from} to {to} at {timestamp}"
 
 
+def _attachment_lines(entry: dict) -> list[str]:
+    files = entry.get("files") or []
+    if not isinstance(files, list):
+        return []
+    lines: list[str] = []
+    for item in files:
+        if not isinstance(item, dict):
+            continue
+        name = (item.get("filename") or "").strip()
+        if name:
+            lines.append(f"- attachment: {name}")
+    return lines
+
+
 def _format_heading(template: str, entry: dict, room: str) -> str:
     ts = (entry.get("date") or "").strip()
     return template.format(
@@ -104,9 +118,14 @@ def format_room_view(
             room,
         )
         content = entry.get("content", "")
+        file_lines = _attachment_lines(entry)
         block = heading
+        body_parts: list[str] = []
         if content:
-            block = f"{heading}\n\n{content}"
+            body_parts.append(content)
+        body_parts.extend(file_lines)
+        if body_parts:
+            block = f"{heading}\n\n" + "\n".join(body_parts)
         parts.append(block)
 
     if node:

--- a/apps/h4l/notify.py
+++ b/apps/h4l/notify.py
@@ -3,32 +3,53 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
-from collections.abc import Callable
-from typing import TYPE_CHECKING, TypeAlias
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
     from rooms import RoomStore
 
-TellFn: TypeAlias = Callable[[str, str], None]
+
+class TellFn(Protocol):
+    def __call__(
+        self,
+        agent: str,
+        body: str,
+        attachments: list[Path] | None = None,
+    ) -> None: ...
 
 MAX_NOTIFY_CHARS = 1000
 SIMULATE_ENV = "H4L_SIMULATE_TELL"
 
 
-def default_tell(agent: str, body: str) -> None:
-    subprocess.run(
-        ["tell", agent, body],
-        check=False,
-    )
+def default_tell(
+    agent: str,
+    body: str,
+    attachments: list[Path] | None = None,
+) -> None:
+    cmd = ["tell"]
+    for path in attachments or []:
+        cmd.extend(["--attach", str(path)])
+    cmd.extend([agent, body])
+    subprocess.run(cmd, check=False)
 
 
-def simulate_tell(agent: str, body: str) -> None:
-    print(f"h4l> tell {agent}:", file=sys.stderr)
+def simulate_tell(
+    agent: str,
+    body: str,
+    attachments: list[Path] | None = None,
+) -> None:
+    attach_bits = "".join(f" --attach {path}" for path in (attachments or []))
+    print(f"h4l> tell{attach_bits} {agent}:", file=sys.stderr)
     for line in body.splitlines():
         print(f"h4l>   {line}", file=sys.stderr)
 
 
-def noop_tell(_agent: str, _body: str) -> None:
+def noop_tell(
+    _agent: str,
+    _body: str,
+    _attachments: list[Path] | None = None,
+) -> None:
     return None
 
 
@@ -69,6 +90,7 @@ def usage_help(node: str) -> str:
         f'tell {node} "/help"',
         "",
         "Also: /post, /leave, /members, /kick; # prefix optional on room names.",
+        "Attachments: tell --attach PATH ... reaches room members via hall proxy.",
     ]
     return "\n".join(lines)
 
@@ -104,9 +126,11 @@ def notify_members(
     headline: str,
     body: str,
     skip: set[str] | None = None,
+    attachments: list[Path] | None = None,
 ) -> None:
     omitted = {m.lower() for m in (skip or set())}
     text = truncate(body)
+    paths = list(attachments or [])
     meta = store.load_meta(slug)
     dirty = False
     for member in members:
@@ -115,7 +139,7 @@ def notify_members(
         suffix, meta, changed = _onboard_suffix(store, meta, member, node, room)
         dirty = dirty or changed
         message = f"{headline}\n\n{text}{suffix}"
-        tell_fn(member, message)
+        tell_fn(member, message, paths if paths else None)
     if dirty:
         store.save_meta(slug, meta)
 

--- a/apps/h4l/rooms.py
+++ b/apps/h4l/rooms.py
@@ -132,17 +132,20 @@ class RoomStore:
         sender: str,
         content: str,
         kind: str = "post",
+        files: list[dict] | None = None,
     ) -> dict:
         slug = normalize_slug(slug)
         msg_id = new_ulid()
         now = utc_now()
-        payload = {
+        payload: dict = {
             "id": msg_id,
             "date": now,
             "from": normalize_agent(sender),
             "kind": kind,
             "content": content,
         }
+        if files:
+            payload["files"] = list(files)
         msg_dir = self.messages_dir(slug)
         msg_dir.mkdir(parents=True, exist_ok=True)
         path = msg_dir / f"{msg_id}.json"

--- a/apps/h4l/tests/test_attachments.py
+++ b/apps/h4l/tests/test_attachments.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from attachments import ATTACHED_FILE_PREFIX, split_attached_files
+
+
+class TestSplitAttachedFiles:
+    def test_no_attachments(self):
+        body, files = split_attached_files("#war hello")
+        assert body == "#war hello"
+        assert files == []
+
+    def test_trailing_attached_file(self, tmp_path):
+        path = tmp_path / "doc.txt"
+        path.write_text("x", encoding="utf-8")
+        raw = f"#war hello\n{ATTACHED_FILE_PREFIX}{path.resolve()}"
+        body, files = split_attached_files(raw)
+        assert body == "#war hello"
+        assert files == [path.resolve()]
+
+    def test_blank_line_before_attachments(self, tmp_path):
+        path = tmp_path / "doc.txt"
+        path.write_text("x", encoding="utf-8")
+        raw = f"#war hello\n\n{ATTACHED_FILE_PREFIX}{path.resolve()}"
+        body, files = split_attached_files(raw)
+        assert body == "#war hello"
+        assert files == [path.resolve()]
+
+    def test_preserves_order(self, tmp_path):
+        a = tmp_path / "a.txt"
+        b = tmp_path / "b.txt"
+        a.write_text("a", encoding="utf-8")
+        b.write_text("b", encoding="utf-8")
+        raw = (
+            f"body\n"
+            f"{ATTACHED_FILE_PREFIX}{a.resolve()}\n"
+            f"{ATTACHED_FILE_PREFIX}{b.resolve()}"
+        )
+        body, files = split_attached_files(raw)
+        assert body == "body"
+        assert files == [a.resolve(), b.resolve()]

--- a/apps/h4l/tests/test_format.py
+++ b/apps/h4l/tests/test_format.py
@@ -56,6 +56,20 @@ class TestFormatRoomView:
         assert "Newer:" not in text
         assert "MSG" not in text
 
+    def test_shows_attachment_basenames(self):
+        messages = [
+            {
+                "id": "MSG001",
+                "date": "2026-01-01T12:00:00.000000Z",
+                "from": "ALICE",
+                "content": "see attached",
+                "files": [{"filename": "report.pdf"}],
+            }
+        ]
+        text = format_room_view("war", messages, "BOB", node="HALL")
+        assert "see attached" in text
+        assert "- attachment: report.pdf" in text
+
     def test_default_limit_is_ten(self):
         messages = _room_messages(12)
         text = format_room_view("war", messages, "ALICE", node="HALL")

--- a/apps/h4l/tests/test_h4l.py
+++ b/apps/h4l/tests/test_h4l.py
@@ -14,10 +14,10 @@ def store(tmp_path):
 
 @pytest.fixture
 def tells():
-    sent: list[tuple[str, str]] = []
+    sent: list[tuple[str, str, list]] = []
 
-    def capture(agent: str, body: str) -> None:
-        sent.append((agent, body))
+    def capture(agent: str, body: str, attachments=None) -> None:
+        sent.append((agent, body, list(attachments or [])))
 
     return sent, capture
 
@@ -55,9 +55,12 @@ class TestPost:
         messages = store.list_messages("war")
         assert len(messages) == 1
         assert messages[0]["content"] == "hello everyone"
-        alice_msgs = [b for a, b in sent if a == "ALICE"]
+        alice_msgs = [b for a, b, _ in sent if a == "ALICE"]
         assert not alice_msgs
-        assert not any(a == "ALICE" and "hello everyone" in b and "posted in" in b for a, b in sent)
+        assert not any(
+            a == "ALICE" and "hello everyone" in b and "posted in" in b
+            for a, b, _ in sent
+        )
 
     def test_hash_prefix_room_same_as_plain(self, store, tells):
         sent, tell_fn = tells
@@ -99,7 +102,7 @@ class TestPost:
         messages = store.list_messages("everyone")
         assert len(messages) == 1
         assert messages[0]["content"] == "hello"
-        assert not [b for a, b in sent if a == "ALICE"]
+        assert not [b for a, b, _ in sent if a == "ALICE"]
 
     def test_irc_style_matches_slash_post(self, store, tells):
         sent, tell_fn = tells
@@ -132,7 +135,7 @@ class TestPost:
             message="/post war update",
             tell_fn=tell_fn,
         )
-        bob_msgs = [b for a, b in sent if a == "BOB"]
+        bob_msgs = [b for a, b, _ in sent if a == "BOB"]
         assert len(bob_msgs) == 1
         assert "ALICE posted in #war" in bob_msgs[0]
         assert "update" in bob_msgs[0]
@@ -153,7 +156,7 @@ class TestPost:
                 message=msg,
                 tell_fn=tell_fn,
             )
-        bob_msgs = [b for a, b in sent if a == "BOB"]
+        bob_msgs = [b for a, b, _ in sent if a == "BOB"]
         assert len(bob_msgs) == 2
         assert "Post a message:" in bob_msgs[0]
         assert "Post a message:" not in bob_msgs[1]
@@ -174,7 +177,7 @@ class TestPost:
         messages = store.list_messages("everyone")
         assert len(messages) == 1
         assert messages[0]["content"] == "@pat I'm testing out chat rooms."
-        pat_msgs = [b for a, b in sent if a.lower() == "pat"]
+        pat_msgs = [b for a, b, _ in sent if a.lower() == "pat"]
         assert len(pat_msgs) == 1
         assert "@pat I'm testing out chat rooms." in pat_msgs[0]
         assert "posted in #everyone" in pat_msgs[0]
@@ -193,8 +196,8 @@ class TestPost:
         members = {m.upper() for m in store.member_names(meta)}
         assert members >= {"ALICE", "BOB", "CAROL"}
         assert store.list_messages("war")[0]["content"] == "@bob @carol hello team"
-        assert len([b for a, b in sent if a.upper() == "BOB"]) == 1
-        assert len([b for a, b in sent if a.upper() == "CAROL"]) == 1
+        assert len([b for a, b, _ in sent if a.upper() == "BOB"]) == 1
+        assert len([b for a, b, _ in sent if a.upper() == "CAROL"]) == 1
 
     def test_at_mention_only_at_message_start(self, store, tells):
         sent, tell_fn = tells
@@ -208,7 +211,7 @@ class TestPost:
         meta = store.load_meta("war")
         assert "BOB" not in {m.upper() for m in store.member_names(meta)}
         assert store.list_messages("war")[0]["content"] == "ping @bob later"
-        assert not [b for a, b in sent if a == "BOB"]
+        assert not [b for a, b, _ in sent if a == "BOB"]
 
 
 class TestInvite:
@@ -225,10 +228,10 @@ class TestInvite:
         meta = store.load_meta("war")
         members = {m.upper() for m in store.member_names(meta)}
         assert members == {"BOB", "CAROL"}
-        bob_invite = [b for a, b in sent if a == "BOB"][0]
+        bob_invite = [b for a, b, _ in sent if a == "BOB"][0]
         assert "invited" in bob_invite
         assert "Post a message: tell HALL #war" in bob_invite
-        assert any(a == "BOB" and "invited" in b for a, b in sent)
+        assert any(a == "BOB" and "invited" in b for a, b, _ in sent)
         system = [m for m in store.list_messages("war") if m["kind"] == "system"]
         assert system
         assert "BOB" in system[0]["content"] and "CAROL" in system[0]["content"]
@@ -250,7 +253,7 @@ class TestRemove:
         meta = store.load_meta("war")
         members = {m.upper() for m in store.member_names(meta)}
         assert members == {"ALICE", "CAROL"}
-        bob_msgs = [b for a, b in sent if a.upper() == "BOB"]
+        bob_msgs = [b for a, b, _ in sent if a.upper() == "BOB"]
         assert len(bob_msgs) == 1
         assert "removed you from #war" in bob_msgs[0]
         system = [m for m in store.list_messages("war") if m["kind"] == "system"]
@@ -286,7 +289,7 @@ class TestRemove:
         )
         meta = store.load_meta("war")
         assert "ALICE" in store.member_names(meta)
-        ack = [b for a, b in sent if a == "ALICE"][-1]
+        ack = [b for a, b, _ in sent if a == "ALICE"][-1]
         assert "use /leave" in ack
 
     def test_kick_alias(self, store, tells):
@@ -318,7 +321,7 @@ class TestView:
             message="/view war",
             tell_fn=tell_fn,
         )
-        ack = [b for a, b in sent if a == "ALICE"][-1]
+        ack = [b for a, b, _ in sent if a == "ALICE"][-1]
         assert "## from ALICE to #war at" in ack
         assert "hello" in ack
         assert "### from BOB to #war at" in ack
@@ -341,7 +344,7 @@ class TestView:
             message="/list",
             tell_fn=tell_fn,
         )
-        ack = [b for a, b in sent if a == "ALICE"][-1]
+        ack = [b for a, b, _ in sent if a == "ALICE"][-1]
         assert "#war: ALICE, BOB" in ack
         assert "#peace: CAROL" in ack
 
@@ -358,8 +361,9 @@ class TestErrors:
         )
         assert rc == 1
         assert len(sent) == 1
-        agent, body = sent[0]
+        agent, body, atts = sent[0]
         assert agent == "ALICE"
+        assert atts == []
         assert body.startswith("Error: send #<room> <message> or a /command")
         assert "h4l" not in body.lower()
         assert 'tell CHATROOM "#<room> <message>"' in body
@@ -375,7 +379,7 @@ class TestErrors:
             tell_fn=tell_fn,
         )
         assert rc == 0
-        ack = [b for a, b in sent if a == "ALICE"][-1]
+        ack = [b for a, b, _ in sent if a == "ALICE"][-1]
         assert "Post (IRC style):" in ack
         assert 'tell CHATROOM "#<room> <message>"' in ack
         assert 'tell CHATROOM "/help"' in ack
@@ -408,7 +412,166 @@ class TestErrors:
             tell_fn=tell_fn,
         )
         assert rc == 0
-        assert any("left #war" in b for a, b in sent if a == "ALICE")
+        assert any("left #war" in b for a, b, _ in sent if a == "ALICE")
+
+
+class TestAttachmentProxy:
+    def test_strips_attached_file_lines_from_stored_content(self, store, tells, tmp_path):
+        sent, tell_fn = tells
+        payload = tmp_path / "report.pdf"
+        payload.write_bytes(b"%PDF")
+        meta = store.ensure_room("war")
+        meta, _ = store.add_member(meta, "ALICE")
+        meta, _ = store.add_member(meta, "BOB")
+        store.save_meta("war", meta)
+
+        message = f"#war see this\nATTACHED FILE: {payload.resolve()}"
+        rc = dispatch_slash(
+            store,
+            sender="ALICE",
+            node="HALL",
+            message=message,
+            tell_fn=tell_fn,
+        )
+        assert rc == 0
+        messages = store.list_messages("war")
+        assert len(messages) == 1
+        assert messages[0]["content"] == "see this"
+        assert messages[0]["files"] == [{"filename": "report.pdf"}]
+        assert "ATTACHED FILE:" not in messages[0]["content"]
+
+    def test_fanout_reattaches_to_other_members(self, store, tells, tmp_path):
+        sent, tell_fn = tells
+        payload = tmp_path / "notes.txt"
+        payload.write_text("secret", encoding="utf-8")
+        meta = store.ensure_room("war")
+        meta, _ = store.add_member(meta, "ALICE")
+        meta, _ = store.add_member(meta, "BOB")
+        meta, _ = store.add_member(meta, "CAROL")
+        store.save_meta("war", meta)
+
+        rc = dispatch_slash(
+            store,
+            sender="ALICE",
+            node="HALL",
+            message=f"/post war shared\nATTACHED FILE: {payload.resolve()}",
+            tell_fn=tell_fn,
+        )
+        assert rc == 0
+        bob = [(a, b, atts) for a, b, atts in sent if a == "BOB"]
+        carol = [(a, b, atts) for a, b, atts in sent if a == "CAROL"]
+        assert len(bob) == 1
+        assert len(carol) == 1
+        assert bob[0][2] == [payload.resolve()]
+        assert carol[0][2] == [payload.resolve()]
+        assert "shared" in bob[0][1]
+        assert not any(a == "ALICE" for a, _, _ in sent)
+
+    def test_multiple_attachments(self, store, tells, tmp_path):
+        sent, tell_fn = tells
+        a = tmp_path / "a.bin"
+        b = tmp_path / "b.bin"
+        a.write_bytes(b"a")
+        b.write_bytes(b"b")
+        meta = store.ensure_room("war")
+        meta, _ = store.add_member(meta, "ALICE")
+        meta, _ = store.add_member(meta, "BOB")
+        store.save_meta("war", meta)
+
+        rc = dispatch_slash(
+            store,
+            sender="ALICE",
+            node="HALL",
+            message=(
+                f"#war two files\n"
+                f"ATTACHED FILE: {a.resolve()}\n"
+                f"ATTACHED FILE: {b.resolve()}"
+            ),
+            tell_fn=tell_fn,
+        )
+        assert rc == 0
+        bob_atts = [atts for agent, _, atts in sent if agent == "BOB"][0]
+        assert bob_atts == [a.resolve(), b.resolve()]
+        assert store.list_messages("war")[0]["files"] == [
+            {"filename": "a.bin"},
+            {"filename": "b.bin"},
+        ]
+
+    def test_attachment_only_post_allowed(self, store, tells, tmp_path):
+        sent, tell_fn = tells
+        payload = tmp_path / "solo.png"
+        payload.write_bytes(b"PNG")
+        meta = store.ensure_room("war")
+        meta, _ = store.add_member(meta, "ALICE")
+        meta, _ = store.add_member(meta, "BOB")
+        store.save_meta("war", meta)
+
+        rc = dispatch_slash(
+            store,
+            sender="ALICE",
+            node="HALL",
+            message=f"#war\nATTACHED FILE: {payload.resolve()}",
+            tell_fn=tell_fn,
+        )
+        assert rc == 0
+        msg = store.list_messages("war")[0]
+        assert msg["content"] == ""
+        assert msg["files"] == [{"filename": "solo.png"}]
+        bob_atts = [atts for agent, _, atts in sent if agent == "BOB"][0]
+        assert bob_atts == [payload.resolve()]
+
+    def test_missing_attachment_skipped(self, store, tells, tmp_path, capsys):
+        sent, tell_fn = tells
+        missing = tmp_path / "gone.txt"
+        meta = store.ensure_room("war")
+        meta, _ = store.add_member(meta, "ALICE")
+        meta, _ = store.add_member(meta, "BOB")
+        store.save_meta("war", meta)
+
+        rc = dispatch_slash(
+            store,
+            sender="ALICE",
+            node="HALL",
+            message=f"#war still here\nATTACHED FILE: {missing.resolve()}",
+            tell_fn=tell_fn,
+        )
+        assert rc == 0
+        msg = store.list_messages("war")[0]
+        assert msg["content"] == "still here"
+        assert "files" not in msg
+        bob = [(b, atts) for a, b, atts in sent if a == "BOB"]
+        assert len(bob) == 1
+        assert bob[0][1] == []
+        assert "skipping missing attachment" in capsys.readouterr().err
+
+    def test_default_tell_passes_attach_flags(self, tmp_path, monkeypatch):
+        from notify import default_tell
+
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, check=False):
+            calls.append(list(cmd))
+
+            class R:
+                returncode = 0
+
+            return R()
+
+        monkeypatch.setattr("notify.subprocess.run", fake_run)
+        payload = tmp_path / "x.txt"
+        payload.write_text("x", encoding="utf-8")
+        default_tell("BOB", "hello", [payload])
+        assert calls == [["tell", "--attach", str(payload), "BOB", "hello"]]
+
+    def test_simulate_shows_attach(self, tmp_path, capsys):
+        from notify import simulate_tell
+
+        payload = tmp_path / "y.txt"
+        payload.write_text("y", encoding="utf-8")
+        simulate_tell("BOB", "hi\nthere", [payload])
+        err = capsys.readouterr().err
+        assert f"h4l> tell --attach {payload} BOB:" in err
+        assert "h4l>   hi" in err
 
 
 class TestSimulateTell:


### PR DESCRIPTION
## Summary
- Parse trailing a8s `ATTACHED FILE:` lines off inbound `$MESSAGE` and re-`tell --attach` them when notifying other room members
- Persist attachment basenames on room messages and show them in `/view`
- Allow attachment-only posts (`#room` + files, no caption)

## Test plan
- [x] `venv/bin/python3 -m pytest apps/h4l/tests/` (54 passed)
- [ ] Manual: `tell chatroom --attach /tmp/x.txt '#war hello'` with ≥2 members; confirm each non-poster gets the file under their `files_dir`
- [ ] Confirm poster is skipped on fan-out and stored content has no `ATTACHED FILE:` lines


Made with [Cursor](https://cursor.com)