### PR TITLE
fix(a8s): convo -f replay flood and stall on archive rewrite

### DIFF
--- a/apps/a8s/convo.py
+++ b/apps/a8s/convo.py
@@ -181,7 +181,11 @@ def record(msg: dict[str, Any], *, recipients: list[str]) -> None:
     """Append one logical message when delivery completes (local inbox, remote
     receive, or outbound remote publish). `recipients` lists local deliverees
     for routed/RECEIVED_REMOTE rows, or the logical `to` name for outbound
-    remote-only sends."""
+    remote-only sends.
+
+    Under the cap this appends one jsonl line (so `a8s convo -f` can tail).
+    Over the cap it rewrites the file with the newest ``convo_max_limit`` rows.
+    """
     if not recipients:
         return
     entry = entry_from_message(msg, recipients=recipients)
@@ -191,11 +195,14 @@ def record(msg: dict[str, Any], *, recipients: list[str]) -> None:
         if msg_id and any(r.get("id") == msg_id for r in rows):
             return
         rows.append(entry)
-        cap = _max_limit()
-        if len(rows) > cap:
-            rows = rows[-cap:]
         path = conversations_path()
         path.parent.mkdir(parents=True, exist_ok=True)
+        cap = _max_limit()
+        if len(rows) <= cap:
+            with path.open("a", encoding="utf-8") as f:
+                f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+            return
+        rows = rows[-cap:]
         with path.open("w", encoding="utf-8") as f:
             for row in rows:
                 f.write(json.dumps(row, ensure_ascii=False) + "\n")
@@ -307,10 +314,17 @@ def format_conversation(
     return "\n\n".join(parts)
 
 
-def _remember_entry_id(seen: set[str], entry: dict[str, Any]) -> None:
+def _entry_follow_key(entry: dict[str, Any]) -> str:
+    """Stable dedupe key for follow: prefer message id, else content fingerprint."""
     msg_id = (entry.get("id") or "").strip()
     if msg_id:
-        seen.add(msg_id)
+        return f"id:{msg_id}"
+    return "fp:{0}|{1}|{2}|{3}".format(
+        (entry.get("date") or "").strip(),
+        (entry.get("from") or "").strip(),
+        (entry.get("to") or "").strip(),
+        entry.get("content", ""),
+    )
 
 
 def _parse_convo_line(line: str) -> dict[str, Any] | None:
@@ -324,6 +338,17 @@ def _parse_convo_line(line: str) -> dict[str, Any] | None:
     return row if isinstance(row, dict) else None
 
 
+def _open_convo_tail(path: Path):
+    """Open archive for follow, positioned at EOF. Returns (handle, inode)."""
+    handle = path.open("r", encoding="utf-8")
+    handle.seek(0, 2)
+    try:
+        ino = path.stat().st_ino
+    except OSError:
+        ino = None
+    return handle, ino
+
+
 def follow_conversation(
     agent: str,
     *,
@@ -333,7 +358,12 @@ def follow_conversation(
     poll_interval: float = 1.0,
     glow_theme: str | None = None,
 ) -> None:
-    """Print the last `limit` messages, then block printing new archive rows."""
+    """Print the last `limit` messages, then block printing new archive rows.
+
+    ``record`` appends under the cap; when the archive rotates (rewrite) or is
+    replaced, this reopens/seeks carefully and dedupes with a full seed of
+    already-known entry keys so history is not flooded back to the terminal.
+    """
     glow_stream = None
     if glow_theme is not None:
         try:
@@ -341,7 +371,7 @@ def follow_conversation(
         except FileNotFoundError:
             print("a8s convo: glow not found on PATH", file=sys.stderr)
 
-    seen: set[str] = set()
+    handle = None
     try:
         rows = [e for e in load_entries() if involves_agent(e, agent)]
         print_entries(
@@ -351,42 +381,64 @@ def follow_conversation(
             heading_out=heading_out,
             heading_in=heading_in,
         )
-        for entry in rows[-limit:]:
-            _remember_entry_id(seen, entry)
+        # Seed with every known row for this agent — not only the printed
+        # window — so a truncate/rewrite cannot replay older history.
+        seen = {_entry_follow_key(e) for e in rows if _entry_follow_key(e)}
 
         path = conversations_path()
         path.parent.mkdir(parents=True, exist_ok=True)
         path.touch(exist_ok=True)
 
-        with path.open("r", encoding="utf-8") as handle:
-            handle.seek(0, 2)
-            while True:
-                line = handle.readline()
-                if line:
-                    entry = _parse_convo_line(line)
-                    if entry is None or not involves_agent(entry, agent):
-                        continue
-                    msg_id = (entry.get("id") or "").strip()
-                    if msg_id and msg_id in seen:
-                        continue
-                    print_entries(
-                        agent,
-                        [entry],
-                        glow_stream=glow_stream,
-                        heading_out=heading_out,
-                        heading_in=heading_in,
-                    )
-                    _remember_entry_id(seen, entry)
+        handle, ino = _open_convo_tail(path)
+        while True:
+            line = handle.readline()
+            if line:
+                entry = _parse_convo_line(line)
+                if entry is None or not involves_agent(entry, agent):
                     continue
+                key = _entry_follow_key(entry)
+                if key in seen:
+                    continue
+                print_entries(
+                    agent,
+                    [entry],
+                    glow_stream=glow_stream,
+                    heading_out=heading_out,
+                    heading_in=heading_in,
+                )
+                seen.add(key)
+                continue
 
-                try:
-                    size = path.stat().st_size
-                except OSError:
-                    size = 0
-                if handle.tell() > size:
-                    handle.seek(0)
+            try:
+                st = path.stat()
+            except OSError:
                 time.sleep(poll_interval)
+                continue
+
+            rotated = False
+            if ino is not None and st.st_ino != ino:
+                rotated = True
+            elif handle.tell() > st.st_size:
+                rotated = True
+
+            if rotated:
+                handle.close()
+                handle = path.open("r", encoding="utf-8")
+                try:
+                    ino = path.stat().st_ino
+                except OSError:
+                    ino = None
+                # Rescan from the start with dedupe so a rewrite that includes
+                # a brand-new trailing row is still picked up; known keys skip.
+                continue
+
+            time.sleep(poll_interval)
     finally:
+        if handle is not None:
+            try:
+                handle.close()
+            except OSError:
+                pass
         if glow_stream is not None:
             glow_stream.close()
 

--- a/apps/a8s/tests/test_convo.py
+++ b/apps/a8s/tests/test_convo.py
@@ -544,3 +544,77 @@ class TestFollowConversation:
         out = capsys.readouterr().out
         assert "old" in out
         assert "fresh" in out
+
+    def test_record_appends_under_cap(self, fake_home, monkeypatch):
+        from core import conversations_path
+
+        monkeypatch.setattr("convo._max_limit", lambda: 100)
+        record(
+            {"id": "01A", "from": "A", "to": "B", "content": "one", "date": "2026-01-01T00:00:00Z"},
+            recipients=["B"],
+        )
+        record(
+            {"id": "01B", "from": "A", "to": "B", "content": "two", "date": "2026-01-01T00:01:00Z"},
+            recipients=["B"],
+        )
+        text = conversations_path().read_text(encoding="utf-8")
+        assert text.count("\n") == 2
+        assert "one" in text and "two" in text
+
+    def test_follow_does_not_replay_history_on_rewrite(
+        self, fake_home, tmp_path, capsys, monkeypatch
+    ):
+        """Regression: every record used to truncate+rewrite; follow did seek(0)
+        with seen only holding --limit ids, flooding the terminal with old rows."""
+        from registry import save_registry
+        from core import conversations_path
+
+        root = tmp_path / "bob"
+        root.mkdir()
+        save_registry({"Bob": {"root": str(root)}})
+        monkeypatch.setattr("convo._max_limit", lambda: 3)
+
+        for i, content in enumerate(("alpha", "beta", "gamma"), start=1):
+            record(
+                {
+                    "id": f"01OLD{i:020d}",
+                    "date": f"2026-06-18T10:0{i}:00.000000Z",
+                    "from": "Alice",
+                    "to": "Bob",
+                    "content": content,
+                },
+                recipients=["Bob"],
+            )
+
+        sleeps = {"n": 0}
+
+        def fake_sleep(_interval: float) -> None:
+            sleeps["n"] += 1
+            if sleeps["n"] == 1:
+                # Over cap → rewrite. Must not dump alpha/beta/gamma again.
+                record(
+                    {
+                        "id": "01NEW000000000000000001",
+                        "date": "2026-06-18T11:00:00.000000Z",
+                        "from": "Alice",
+                        "to": "Bob",
+                        "content": "delta",
+                    },
+                    recipients=["Bob"],
+                )
+                return
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr("convo.time.sleep", fake_sleep)
+        with pytest.raises(KeyboardInterrupt):
+            follow_conversation("Bob", limit=1, poll_interval=0.01)
+        out = capsys.readouterr().out
+        # Initial window printed gamma once; follow should add delta once.
+        assert out.count("gamma") == 1
+        assert out.count("delta") == 1
+        assert out.count("alpha") == 0
+        assert out.count("beta") == 0
+        # Rotated file still on disk with newest three.
+        rows = load_entries()
+        assert [r["content"] for r in rows] == ["beta", "gamma", "delta"]
+        assert conversations_path().is_file()


### PR DESCRIPTION
## Summary
- `record()` now appends under `convo_max_limit` and only rewrites on rotation (was truncating the jsonl on every message)
- `a8s convo -f` seeds dedupe with all known agent rows and reopens on truncate/inode change instead of `seek(0)` with a tiny seen set — stops history floods and EOF stalls

## Test plan
- [ ] `a8s convo <agent> -f` while messages arrive: only new rows print (no dump of old history)
- [ ] Force rotation (set low `convo_max_limit`, send past the cap): follow keeps going without reprinting the archive
- [ ] `venv/bin/python3 -m pytest apps/a8s/tests/test_convo.py -q`


Made with [Cursor](https://cursor.com)