### PR TITLE
fix(a8s): show inbound messages while following convo at rotation cap

### DIFF
--- a/apps/a8s/convo.py
+++ b/apps/a8s/convo.py
@@ -7,6 +7,7 @@ from `~/.a8s/settings.json` (default 1000).
 from __future__ import annotations
 
 import json
+import os
 import sys
 import time
 from datetime import datetime, timezone
@@ -201,11 +202,20 @@ def record(msg: dict[str, Any], *, recipients: list[str]) -> None:
         if len(rows) <= cap:
             with path.open("a", encoding="utf-8") as f:
                 f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+                f.flush()
+                os.fsync(f.fileno())
             return
+        # Atomic replace so followers see an inode change (in-place truncate+"w"
+        # keeps the inode; a reader parked at the old EOF then misses new rows
+        # when the rewritten file is the same size or larger).
         rows = rows[-cap:]
-        with path.open("w", encoding="utf-8") as f:
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        with tmp.open("w", encoding="utf-8") as f:
             for row in rows:
                 f.write(json.dumps(row, ensure_ascii=False) + "\n")
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
     except OSError:
         pass
 
@@ -277,6 +287,12 @@ def write_block(block: str, glow_stream: object | None) -> None:
         return
     if glow_stream is not None:
         glow_stream.write(block + "\n\n")
+        # Each convo entry is complete markdown. Force a final flush so an
+        # unclosed fence (common in agent replies) cannot hold the message
+        # in GlowStream's buffer until Ctrl+C.
+        finalize = getattr(glow_stream, "finalize", None)
+        if callable(finalize):
+            finalize()
         return
     print(block, flush=True)
     print(flush=True)
@@ -327,28 +343,6 @@ def _entry_follow_key(entry: dict[str, Any]) -> str:
     )
 
 
-def _parse_convo_line(line: str) -> dict[str, Any] | None:
-    line = line.strip()
-    if not line:
-        return None
-    try:
-        row = json.loads(line)
-    except json.JSONDecodeError:
-        return None
-    return row if isinstance(row, dict) else None
-
-
-def _open_convo_tail(path: Path):
-    """Open archive for follow, positioned at EOF. Returns (handle, inode)."""
-    handle = path.open("r", encoding="utf-8")
-    handle.seek(0, 2)
-    try:
-        ino = path.stat().st_ino
-    except OSError:
-        ino = None
-    return handle, ino
-
-
 def follow_conversation(
     agent: str,
     *,
@@ -360,9 +354,10 @@ def follow_conversation(
 ) -> None:
     """Print the last `limit` messages, then block printing new archive rows.
 
-    ``record`` appends under the cap; when the archive rotates (rewrite) or is
-    replaced, this reopens/seeks carefully and dedupes with a full seed of
-    already-known entry keys so history is not flooded back to the terminal.
+    Re-reads the archive each poll and emits unseen rows. Offset/EOF tailing is
+    unsafe at the rotation cap: in-place rewrite keeps the inode and a reader
+    parked at the old EOF misses same-or-larger rewrites (typical for inbound
+    replies right after an outbound record).
     """
     glow_stream = None
     if glow_theme is not None:
@@ -371,7 +366,6 @@ def follow_conversation(
         except FileNotFoundError:
             print("a8s convo: glow not found on PATH", file=sys.stderr)
 
-    handle = None
     try:
         rows = [e for e in load_entries() if involves_agent(e, agent)]
         print_entries(
@@ -385,19 +379,13 @@ def follow_conversation(
         # window — so a truncate/rewrite cannot replay older history.
         seen = {_entry_follow_key(e) for e in rows if _entry_follow_key(e)}
 
-        path = conversations_path()
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.touch(exist_ok=True)
-
-        handle, ino = _open_convo_tail(path)
         while True:
-            line = handle.readline()
-            if line:
-                entry = _parse_convo_line(line)
-                if entry is None or not involves_agent(entry, agent):
+            time.sleep(poll_interval)
+            for entry in load_entries():
+                if not involves_agent(entry, agent):
                     continue
                 key = _entry_follow_key(entry)
-                if key in seen:
+                if not key or key in seen:
                     continue
                 print_entries(
                     agent,
@@ -407,38 +395,7 @@ def follow_conversation(
                     heading_in=heading_in,
                 )
                 seen.add(key)
-                continue
-
-            try:
-                st = path.stat()
-            except OSError:
-                time.sleep(poll_interval)
-                continue
-
-            rotated = False
-            if ino is not None and st.st_ino != ino:
-                rotated = True
-            elif handle.tell() > st.st_size:
-                rotated = True
-
-            if rotated:
-                handle.close()
-                handle = path.open("r", encoding="utf-8")
-                try:
-                    ino = path.stat().st_ino
-                except OSError:
-                    ino = None
-                # Rescan from the start with dedupe so a rewrite that includes
-                # a brand-new trailing row is still picked up; known keys skip.
-                continue
-
-            time.sleep(poll_interval)
     finally:
-        if handle is not None:
-            try:
-                handle.close()
-            except OSError:
-                pass
         if glow_stream is not None:
             glow_stream.close()
 

--- a/apps/a8s/tests/test_convo.py
+++ b/apps/a8s/tests/test_convo.py
@@ -14,6 +14,7 @@ from convo import (
     open_glow_stdout,
     print_entries,
     record,
+    write_block,
 )
 from core import conversations_path
 from commands import cmd_convo
@@ -229,6 +230,9 @@ class TestGlowOutput:
                 writes.append(text)
                 return len(text)
 
+            def finalize(self) -> None:
+                pass
+
             def close(self) -> None:
                 writes.append("__close__")
 
@@ -279,6 +283,9 @@ class TestGlowOutput:
             def write(self, text: str) -> int:
                 return len(text)
 
+            def finalize(self) -> None:
+                pass
+
             def close(self) -> None:
                 pass
 
@@ -299,12 +306,39 @@ class TestGlowOutput:
             def write(self, text: str) -> int:
                 return len(text)
 
+            def finalize(self) -> None:
+                pass
+
             def close(self) -> None:
                 pass
 
         monkeypatch.setattr("convo.open_glow_stdout", lambda theme: (opened.append(theme) or FakeGlow()))
         assert cmd_convo(["bob", "--limit", "1"]) == 0
         assert opened == ["tokyo-night"]
+
+    def test_write_block_finalizes_glow_for_fenced_markdown(self):
+        """Agent replies often include ``` fences; without finalize, GlowStream
+        holds the entry until the stream closes (looks like silent inbound)."""
+        class CapturingGlow:
+            def __init__(self):
+                self.writes: list[str] = []
+                self.finalized = 0
+
+            def write(self, text: str) -> int:
+                self.writes.append(text)
+                return len(text)
+
+            def finalize(self) -> None:
+                self.finalized += 1
+
+            def close(self) -> None:
+                pass
+
+        glow = CapturingGlow()
+        body = "### from remote to bob\n\nHere:\n\n```\ncode\n"
+        write_block(body, glow)
+        assert glow.finalized == 1
+        assert any("```" in w for w in glow.writes)
 
 
 class TestHeadingTemplates:
@@ -618,3 +652,98 @@ class TestFollowConversation:
         rows = load_entries()
         assert [r["content"] for r in rows] == ["beta", "gamma", "delta"]
         assert conversations_path().is_file()
+
+    def test_record_rotation_replaces_inode(self, fake_home, monkeypatch):
+        from core import conversations_path
+
+        monkeypatch.setattr("convo._max_limit", lambda: 2)
+        record(
+            {"id": "01A", "from": "A", "to": "B", "content": "one", "date": "2026-01-01T00:00:00Z"},
+            recipients=["B"],
+        )
+        record(
+            {"id": "01B", "from": "A", "to": "B", "content": "two", "date": "2026-01-01T00:01:00Z"},
+            recipients=["B"],
+        )
+        path = conversations_path()
+        ino_before = path.stat().st_ino
+        record(
+            {
+                "id": "01C",
+                "from": "A",
+                "to": "B",
+                "content": "three-longer-so-file-grows",
+                "date": "2026-01-01T00:02:00Z",
+            },
+            recipients=["B"],
+        )
+        assert path.stat().st_ino != ino_before
+        assert [r["content"] for r in load_entries()] == ["two", "three-longer-so-file-grows"]
+
+    def test_follow_sees_inbound_after_larger_rewrite(
+        self, fake_home, tmp_path, capsys, monkeypatch
+    ):
+        """At cap, outbound+inbound each rewrite. In-place "w" with a same-or-larger
+        file leaves an EOF reader blind; polling load_entries must still show reply."""
+        from registry import save_registry
+
+        root = tmp_path / "bob"
+        root.mkdir()
+        save_registry({"Bob": {"root": str(root)}})
+        monkeypatch.setattr("convo._max_limit", lambda: 2)
+
+        record(
+            {
+                "id": "01OUT0000000000000000001",
+                "date": "2026-06-18T10:00:00.000000Z",
+                "from": "Bob",
+                "to": "chatroom",
+                "content": "/list",
+            },
+            recipients=["chatroom"],
+        )
+        record(
+            {
+                "id": "01IN00000000000000000001",
+                "date": "2026-06-18T10:00:01.000000Z",
+                "from": "chatroom",
+                "to": "Bob",
+                "content": "no chat rooms",
+            },
+            recipients=["Bob"],
+        )
+
+        sleeps = {"n": 0}
+
+        def fake_sleep(_interval: float) -> None:
+            sleeps["n"] += 1
+            if sleeps["n"] == 1:
+                record(
+                    {
+                        "id": "01OUT0000000000000000002",
+                        "date": "2026-06-18T11:00:00.000000Z",
+                        "from": "Bob",
+                        "to": "chatroom",
+                        "content": "/list again with more bytes",
+                    },
+                    recipients=["chatroom"],
+                )
+                record(
+                    {
+                        "id": "01IN00000000000000000002",
+                        "date": "2026-06-18T11:00:01.000000Z",
+                        "from": "chatroom",
+                        "to": "Bob",
+                        "content": "still no chat rooms — longer reply body here",
+                    },
+                    recipients=["Bob"],
+                )
+                return
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr("convo.time.sleep", fake_sleep)
+        with pytest.raises(KeyboardInterrupt):
+            follow_conversation("Bob", limit=2, poll_interval=0.01)
+        out = capsys.readouterr().out
+        assert out.count("/list again with more bytes") == 1
+        assert out.count("still no chat rooms — longer reply body here") == 1

--- a/apps/a8s/tests/test_tells.py
+++ b/apps/a8s/tests/test_tells.py
@@ -272,6 +272,9 @@ def test_tells_glow_renders_through_stream(tmp_path, monkeypatch, capsys):
             writes.append(text)
             return len(text)
 
+        def finalize(self) -> None:
+            pass
+
         def close(self) -> None:
             writes.append("__close__")
 

--- a/apps/l9m/glow_stream.py
+++ b/apps/l9m/glow_stream.py
@@ -195,6 +195,11 @@ class GlowStream:
 
     def finalize(self) -> None:
         self._flush_safe(final=True)
+        # Drop rendered prefix so long-lived streams (a8s convo -f) do not grow
+        # without bound after each forced per-entry finalize.
+        if self._rendered:
+            self._buffer = self._buffer[self._rendered :]
+            self._rendered = 0
 
     def _flush_safe(self, final: bool = False) -> None:
         while True:


### PR DESCRIPTION
## Summary
- At `convo_max_limit`, each `record()` rewrote `conversations.jsonl` in place (same inode). `a8s convo -f` stayed at the old EOF and missed same-or-larger rewrites, so remote replies (e.g. `tell chatroom /list`) stayed invisible until restart.
- Follow now re-polls `load_entries()` with a full dedupe seed; cap rotation uses temp + `os.replace` so the inode always changes.
- Also finalize GlowStream per entry (and compact its buffer) so unclosed fences cannot hold a complete entry until Ctrl+C.

## Test plan
- [x] `python3 -m pytest apps/a8s/tests/test_convo.py`
- [x] Live: `a8s convo neil-macbook -f` then `tell chatroom /list` — outbound and `no chat rooms` reply both appear without restart
- [ ] After merge: `a8s update` (or restart handlers) so the daemon writer picks up atomic replace


Made with [Cursor](https://cursor.com)