### PR TITLE
feat(a8s): split remote secrets and prefer ~/.config/a8s

### DIFF
--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -239,7 +239,7 @@ Env vars apply only when a key is absent from `settings.json` (e.g. `A8S_CONVO_M
 | -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `a8s remote`                                                   | List configured remotes (transport, broker, topic, opts; passwords masked).                                                                                                                                                                                                                                                                                                                                                            |
 | `a8s remote <name>`                                            | Show one remote's spec.                                                                                                                                                                                                                                                                                                                                                                                                                |
-| `a8s remote <name> <broker-url> <topic> [--<opt> <value> ...]` | Register or overwrite a remote. Broker URL is `mqtt://host[:1883]` or `mqtts://host[:8883]`. Persistent session + QoS 1 are wired automatically so an offline cluster catches up on reconnect. Any `--<opt> <value>` past the broker and topic is forwarded verbatim to the transport — common ones are `--user U --pass P`, `--client_id ID`, `--keepalive N`. The transport rejects unknown options at load time so typos fail loud. |
+| `a8s remote <name> <broker-url> <topic> [--<opt> <value> ...]` | Register or overwrite a remote. Broker URL is `mqtt://host[:1883]` or `mqtts://host[:8883]`. Persistent session + QoS 1 are wired automatically so an offline cluster catches up on reconnect. Non-secret opts land in `network.json`; `--pass` / `--password` go to `secrets.json` (0600) in the same command — `--pass` is optional. Unknown options are rejected by the transport at load time so typos fail loud. |
 | `a8s unremote <name>`                                          | Forget a remote. Running daemons keep using the prior config until restart.                                                                                                                                                                                                                                                                                                                                                            |
 
 
@@ -389,13 +389,14 @@ The default definitions follow the opacity rule — `$SENDER tells $RECIPIENT: $
 
 ## State on disk
 
-The state root is `$HOME/.a8s` by default; set `A8S_HOME` to relocate it. This is the only relocation knob — everything below is relative to whichever path `A8S_HOME` points at (or the default). Useful for sandboxed end-to-end tests that mustn't touch the operator's real configuration.
+The state root resolves as follows when `A8S_HOME` is unset: use `~/.config/a8s` if it exists, else `~/.a8s` if it exists (legacy), else create/use `~/.config/a8s`. Set `A8S_HOME` to relocate the whole tree (tests, sandboxes). Everything below is relative to that root.
 
 ```
-~/.a8s/                       (or wherever A8S_HOME points)
+~/.config/a8s/                (or ~/.a8s legacy, or wherever A8S_HOME points)
 ├── a8s.json                  registry: { agents: {...}, aliases: {...}, namespaces: {...} }
 ├── settings.json             operator settings (`a8s config`; env fills gaps)
-├── network.json              configured remotes (absent → local-only)
+├── network.json              remotes / services (non-secret)
+├── secrets.json              remote secrets (`pass` / `password`; mode 0600)
 ├── seen-ids                  cluster-wide ULID ring for receive-side dedup
 ├── conversations.jsonl       routed message archive for `a8s convo` (see convo_max_limit)
 ├── log.txt                   process-scoped supervisor log
@@ -415,7 +416,7 @@ The state root is `$HOME/.a8s` by default; set `A8S_HOME` to relocate it. This i
 
 <agent-root>/
 └── .outbox/                  agent writes here; a8s renames out — never
-                              read-modify-writes — to ~/.a8s/agents/<NAME>/pending/
+                              read-modify-writes — to <a8s-home>/agents/<NAME>/pending/
 ```
 
 The outbox lives in the agent's own dir because some sandboxes (codex `--full-auto`) only let the agent write inside its workspace. Inbox/trash/pending live under `~/.a8s/` where the agent can't see them — and per the agent-directory invariant, a8s never sidecars or rewrites in `.outbox/`. New outbox files are atomically renamed to `pending/` on every routing pass; everything from there (sidecars, retries, trash, remote publishes) happens in `~/.a8s/`.

--- a/apps/a8s/commands.py
+++ b/apps/a8s/commands.py
@@ -58,9 +58,13 @@ from daemon import (
 )
 from network import (
     configured_remote_ids,
+    delete_remote_secrets,
     detect_service_kind,
     load_network_config,
+    merge_remote_secrets,
+    put_remote_secrets,
     save_network_config,
+    split_secret_keys,
 )
 from registry import (
     _scan_for_markers,
@@ -2122,8 +2126,9 @@ def _remote_usage() -> int:
         "       a8s unremote <name>                                # remove\n"
         "\n"
         "Any --<opt> <value> pair past the broker and topic is passed verbatim\n"
-        "to the transport (e.g. --user / --pass for mqtt). Unknown options are\n"
-        "rejected by the transport at load time.",
+        "to the transport (e.g. --user / --pass for mqtt). --pass/--password are\n"
+        "stored in secrets.json (not network.json). Unknown options are rejected\n"
+        "by the transport at load time.",
         file=sys.stderr,
     )
     return 2
@@ -2145,7 +2150,11 @@ def _format_remote_summary(spec: dict) -> str:
 
 
 def cmd_remote(args: list[str]) -> int:
-    """`a8s remote` — manage cross-cluster remotes declared in `~/.a8s/network.json`.
+    """`a8s remote` — manage cross-cluster remotes.
+
+    Non-secret fields live in ``network.json``; ``pass`` / ``password`` go to
+    ``secrets.json`` (mode 0600). One ``a8s remote … --pass …`` call writes
+    both — ``--pass`` is optional.
 
     Forms (mirror `a8s alias`):
       a8s remote                                          list all
@@ -2170,7 +2179,9 @@ def _cmd_remote_list() -> int:
         return 0
     name_w = max(len(n) for n in remotes)
     for name, spec in remotes.items():
-        print(f"  {name.ljust(name_w)}  {_format_remote_summary(spec)}")
+        if not isinstance(spec, dict):
+            continue
+        print(f"  {name.ljust(name_w)}  {_format_remote_summary(merge_remote_secrets(name, spec))}")
     return 0
 
 
@@ -2179,7 +2190,11 @@ def _cmd_remote_show(name: str) -> int:
     if name not in cfg["remotes"]:
         print(f"no remote named {name!r}", file=sys.stderr)
         return 1
-    print(f"{name}: {_format_remote_summary(cfg['remotes'][name])}")
+    spec = cfg["remotes"][name]
+    if not isinstance(spec, dict):
+        print(f"remote {name!r} config is not an object", file=sys.stderr)
+        return 1
+    print(f"{name}: {_format_remote_summary(merge_remote_secrets(name, spec))}")
     return 0
 
 
@@ -2206,11 +2221,14 @@ def _cmd_remote_set(name: str, broker: str, topic: str, opt_tokens: list[str]) -
         i += 1
     cfg = load_network_config()
     overwriting = name in cfg["remotes"]
-    spec: dict = {"transport": "mqtt", "broker": broker, "topic": topic, **extras}
-    cfg["remotes"][name] = spec
+    public, secrets = split_secret_keys(
+        {"transport": "mqtt", "broker": broker, "topic": topic, **extras}
+    )
+    cfg["remotes"][name] = public
     save_network_config(cfg)
+    put_remote_secrets(name, secrets)
     verb = "updated" if overwriting else "added"
-    print(f"{verb} remote {name} ({_format_remote_summary(spec)})")
+    print(f"{verb} remote {name} ({_format_remote_summary(merge_remote_secrets(name, public))})")
     return 0
 
 
@@ -2227,6 +2245,7 @@ def cmd_unremote(args: list[str]) -> int:
         return 1
     del cfg["remotes"][name]
     save_network_config(cfg)
+    delete_remote_secrets(name)
     print(f"removed remote {name}")
     return 0
 

--- a/apps/a8s/core.py
+++ b/apps/a8s/core.py
@@ -62,14 +62,39 @@ ENTRYPOINT = SCRIPT_DIR / "a8s.py"
 PRINT_LOCK: threading.Lock | None = None
 
 
-# ---------- ~/.a8s/ paths ----------
+# ---------- a8s state paths ----------
+
+def resolve_a8s_home() -> Path:
+    """State-root directory (registry, mailboxes, network, secrets).
+
+    Resolution order:
+      1. ``A8S_HOME`` if set (tests, sandboxes, explicit relocate)
+      2. ``~/.config/a8s`` if that directory already exists
+      3. ``~/.a8s`` if that directory already exists (legacy)
+      4. ``~/.config/a8s`` (default for new installs)
+
+    Does not create the directory — callers that write should mkdir.
+    """
+    override = os.environ.get("A8S_HOME", "").strip()
+    if override:
+        return Path(override).expanduser()
+    config = Path.home() / ".config" / "a8s"
+    legacy = Path.home() / ".a8s"
+    if config.is_dir():
+        return config
+    if legacy.is_dir():
+        return legacy
+    return config
+
 
 def _a8s_dir() -> Path:
-    """State directory for the registry, mailboxes, and process logs. Defaults
-    to `$HOME/.a8s` and can be overridden by setting `A8S_HOME` — useful for
-    sandboxed test runs that must not touch the real configuration."""
-    override = os.environ.get("A8S_HOME")
-    base = Path(override) if override else Path.home() / ".a8s"
+    """State directory for the registry, mailboxes, and process logs.
+
+    See ``resolve_a8s_home`` for path selection. Creates the directory on
+    first use. Overridden wholesale via ``A8S_HOME`` (not ``A8S_DIR`` —
+    that token is reserved for the install path in definition argv).
+    """
+    base = resolve_a8s_home()
     base.mkdir(parents=True, exist_ok=True)
     return base
 
@@ -313,9 +338,13 @@ def registry_path() -> Path:
 
 
 def network_config_path() -> Path:
-    """`~/.a8s/network.json` — the list of configured remotes. Absent file
-    means "no remotes configured" — a8s is local-only."""
+    """Configured remotes / services (non-secret). Absent → local-only."""
     return _a8s_dir() / "network.json"
+
+
+def secrets_config_path() -> Path:
+    """Secret overlay for remotes/services (mode 0600). Merged at load time."""
+    return _a8s_dir() / "secrets.json"
 
 
 def settings_path() -> Path:

--- a/apps/a8s/network.py
+++ b/apps/a8s/network.py
@@ -38,6 +38,7 @@ from core import (
     network_config_path,
     out,
     out_agent,
+    secrets_config_path,
     seen_ids_path,
 )
 from delivery_receipt import (
@@ -89,7 +90,12 @@ def _remote_drop_diagnostic(
     )
 
 
-# ---------- network.json ----------
+# ---------- network.json + secrets.json ----------
+
+# Keys that belong in secrets.json, never network.json. Transport-agnostic
+# (mqtt user/pass today; any future transport can reuse the same names).
+SECRET_SPEC_KEYS = frozenset({"pass", "password"})
+
 
 def load_network_config() -> dict:
     p = network_config_path()
@@ -99,7 +105,7 @@ def load_network_config() -> dict:
         with p.open("r", encoding="utf-8") as f:
             data = json.load(f)
     except (OSError, json.JSONDecodeError) as e:
-        out(f"WARN: ~/.a8s/network.json malformed ({e}); treating as empty")
+        out(f"WARN: network.json malformed ({e}); treating as empty")
         return {"remotes": {}, "services": {}}
     if not isinstance(data, dict):
         return {"remotes": {}, "services": {}}
@@ -117,6 +123,92 @@ def save_network_config(cfg: dict) -> None:
     p.parent.mkdir(parents=True, exist_ok=True)
     with p.open("w", encoding="utf-8") as f:
         json.dump(cfg, f, indent=2)
+
+
+def load_secrets_config() -> dict:
+    p = secrets_config_path()
+    if not p.is_file():
+        return {"remotes": {}, "services": {}}
+    try:
+        with p.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        out(f"WARN: secrets.json malformed ({e}); treating as empty")
+        return {"remotes": {}, "services": {}}
+    if not isinstance(data, dict):
+        return {"remotes": {}, "services": {}}
+    data.setdefault("remotes", {})
+    if not isinstance(data["remotes"], dict):
+        data["remotes"] = {}
+    data.setdefault("services", {})
+    if not isinstance(data["services"], dict):
+        data["services"] = {}
+    return data
+
+
+def save_secrets_config(cfg: dict) -> None:
+    """Atomic write of secrets.json with mode 0600."""
+    p = secrets_config_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(cfg, indent=2) + "\n"
+    tmp = p.with_suffix(p.suffix + ".tmp")
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        f.write(payload)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp, p)
+    try:
+        p.chmod(0o600)
+    except OSError:
+        pass
+
+
+def split_secret_keys(spec: dict) -> tuple[dict, dict]:
+    """Split a remote/service spec into (public, secrets) dicts."""
+    public: dict = {}
+    secrets: dict = {}
+    for key, value in spec.items():
+        if key in SECRET_SPEC_KEYS:
+            secrets[key] = value
+        else:
+            public[key] = value
+    return public, secrets
+
+
+def merge_remote_secrets(name: str, spec: dict) -> dict:
+    """Overlay secrets.json (and any legacy inline secrets) onto a remote spec.
+
+    secrets.json wins for secret keys. Inline values still in network.json
+    remain effective until the next `a8s remote` rewrite strips them.
+    """
+    merged = dict(spec)
+    stored = (load_secrets_config().get("remotes") or {}).get(name)
+    if isinstance(stored, dict):
+        for key, value in stored.items():
+            if key in SECRET_SPEC_KEYS:
+                merged[key] = value
+    return merged
+
+
+def put_remote_secrets(name: str, secrets: dict) -> None:
+    """Merge ``secrets`` into secrets.json for remote ``name`` (no-op if empty)."""
+    if not secrets:
+        return
+    cfg = load_secrets_config()
+    prev = cfg["remotes"].get(name)
+    merged = dict(prev) if isinstance(prev, dict) else {}
+    merged.update(secrets)
+    cfg["remotes"][name] = merged
+    save_secrets_config(cfg)
+
+
+def delete_remote_secrets(name: str) -> None:
+    cfg = load_secrets_config()
+    if name not in cfg["remotes"]:
+        return
+    del cfg["remotes"][name]
+    save_secrets_config(cfg)
 
 
 # Top-level keys in a network.json entry that are not transport options
@@ -145,9 +237,12 @@ def _build_transport(name: str, spec: dict) -> Transport:
 
 
 def load_remotes() -> list[Transport]:
-    """Return Transport instances for every entry in `~/.a8s/network.json`.
-    Failures (bad config, missing transport module) are logged and skipped —
-    never block a8s startup."""
+    """Return Transport instances for every configured remote.
+
+    Merges ``secrets.json`` secret keys into each network.json spec before
+    building the transport. Failures are logged and skipped — never block
+    a8s startup.
+    """
     cfg = load_network_config()
     out_list: list[Transport] = []
     for name, spec in cfg["remotes"].items():
@@ -155,7 +250,7 @@ def load_remotes() -> list[Transport]:
             out(f"WARN: remote {name!r} config is not an object; skipping")
             continue
         try:
-            out_list.append(_build_transport(name, spec))
+            out_list.append(_build_transport(name, merge_remote_secrets(name, spec)))
         except Exception as e:
             out(f"WARN: remote {name!r} skipped: {e}")
     return out_list

--- a/apps/a8s/settings.py
+++ b/apps/a8s/settings.py
@@ -90,7 +90,7 @@ KNOBS: tuple[Knob, ...] = (
     Knob("network.remotes.<name>", None, "network", False, note="Cross-machine MQTT transport config"),
     Knob("network.services.<name>", None, "network", False, note="Shared file storage for cross-cluster attachments"),
     # --- runtime environment ---
-    Knob("A8S_HOME", None, "env", False, note="Relocate entire ~/.a8s state tree (tests, sandboxes)"),
+    Knob("A8S_HOME", None, "env", False, note="Relocate entire a8s state tree (default: ~/.config/a8s, or legacy ~/.a8s if present)"),
     Knob("TELL_OUTBOX_DIR", None, "env", False, note="Tell write path; a8s sets on wake from definition.outbox_dir"),
     # --- code constants (not in settings.json) ---
     Knob(

--- a/apps/a8s/tests/conftest.py
+++ b/apps/a8s/tests/conftest.py
@@ -31,6 +31,8 @@ def fake_home(tmp_path, monkeypatch):
     monkeypatch.delenv("USERPROFILE", raising=False)
     # Don't let a globally-set A8S_HOME leak into tests.
     monkeypatch.delenv("A8S_HOME", raising=False)
+    # Prefer legacy ~/.a8s when present so existing path assertions stay stable.
+    (tmp_path / ".a8s").mkdir(parents=True, exist_ok=True)
 
     import core
     # Make sure no prior test left a Lock attached.

--- a/apps/a8s/tests/test_commands.py
+++ b/apps/a8s/tests/test_commands.py
@@ -1011,6 +1011,8 @@ class TestCmdRemote:
         assert spec["user"] == "alice"
 
     def test_set_passes_arbitrary_options_to_spec(self, fake_home):
+        from network import load_secrets_config
+
         rc = cmd_remote([
             "hub", "mqtts://x", "t",
             "--user", "alice", "--pass", "secret",
@@ -1018,10 +1020,11 @@ class TestCmdRemote:
         ])
         assert rc == 0
         spec = load_network_config()["remotes"]["hub"]
-        # Stored under the user-typed key — no translation here.
+        # Non-secrets stay in network.json; pass goes to secrets.json.
         assert spec["user"] == "alice"
-        assert spec["pass"] == "secret"
+        assert "pass" not in spec
         assert spec["keepalive"] == "120"
+        assert load_secrets_config()["remotes"]["hub"]["pass"] == "secret"
 
     def test_set_rejects_dangling_option(self, fake_home, capsys):
         rc = cmd_remote(["hub", "mqtt://x", "t", "--user"])
@@ -1050,6 +1053,38 @@ class TestCmdRemote:
         out = capsys.readouterr().out
         assert "TOPSECRET" not in out
         assert "--pass=***" in out
+
+    def test_pass_stored_in_secrets_not_network(self, fake_home):
+        from core import secrets_config_path
+        from network import load_secrets_config
+
+        cmd_remote(["hub", "mqtts://x", "t", "--user", "alice", "--pass", "TOPSECRET"])
+        net = load_network_config()["remotes"]["hub"]
+        assert "pass" not in net
+        assert net["user"] == "alice"
+        secrets = load_secrets_config()["remotes"]["hub"]
+        assert secrets["pass"] == "TOPSECRET"
+        mode = secrets_config_path().stat().st_mode & 0o777
+        assert mode == 0o600
+
+    def test_pass_optional_and_preserved_on_rewrite(self, fake_home):
+        from network import load_secrets_config
+
+        cmd_remote(["hub", "mqtt://x", "t", "--pass", "KEEPME"])
+        cmd_remote(["hub", "mqtt://y", "t2", "--user", "bob"])
+        net = load_network_config()["remotes"]["hub"]
+        assert net["broker"] == "mqtt://y"
+        assert net["user"] == "bob"
+        assert "pass" not in net
+        assert load_secrets_config()["remotes"]["hub"]["pass"] == "KEEPME"
+
+    def test_unremote_clears_secrets(self, fake_home):
+        from network import load_secrets_config
+
+        cmd_remote(["hub", "mqtt://x", "t", "--pass", "X"])
+        cmd_unremote(["hub"])
+        assert "hub" not in load_network_config()["remotes"]
+        assert "hub" not in load_secrets_config()["remotes"]
 
 
 class TestCmdUnremote:

--- a/apps/a8s/tests/test_core.py
+++ b/apps/a8s/tests/test_core.py
@@ -75,6 +75,30 @@ class TestA8sHomeOverride:
     def test_default_under_home(self, fake_home):
         assert _a8s_dir() == fake_home / ".a8s"
 
+    def test_prefers_config_a8s_when_present(self, fake_home, monkeypatch):
+        from core import resolve_a8s_home
+
+        config = fake_home / ".config" / "a8s"
+        config.mkdir(parents=True)
+        assert resolve_a8s_home() == config
+
+    def test_uses_legacy_when_only_dot_a8s(self, fake_home):
+        from core import resolve_a8s_home
+
+        assert (fake_home / ".a8s").is_dir()
+        assert not (fake_home / ".config" / "a8s").exists()
+        assert resolve_a8s_home() == fake_home / ".a8s"
+
+    def test_new_install_defaults_to_config_a8s(self, tmp_path, monkeypatch):
+        from core import resolve_a8s_home
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.delenv("A8S_HOME", raising=False)
+        monkeypatch.delenv("USERPROFILE", raising=False)
+        assert resolve_a8s_home() == tmp_path / ".config" / "a8s"
+        assert _a8s_dir() == tmp_path / ".config" / "a8s"
+        assert (tmp_path / ".config" / "a8s").is_dir()
+
     def test_env_var_overrides(self, fake_home, tmp_path, monkeypatch):
         sandbox = tmp_path / "sandbox-a8s"
         monkeypatch.setenv("A8S_HOME", str(sandbox))

--- a/apps/a8s/tests/test_network.py
+++ b/apps/a8s/tests/test_network.py
@@ -98,6 +98,27 @@ class TestNetworkConfig:
         ids = configured_remote_ids()
         assert ids == ["a", "z", "m"]
 
+    def test_secrets_overlay_merged_at_load(self, fake_home, monkeypatch):
+        from network import put_remote_secrets, merge_remote_secrets
+
+        save_network_config({
+            "remotes": {
+                "hub": {
+                    "transport": "mqtt",
+                    "broker": "mqtt://localhost:1883",
+                    "topic": "t",
+                    "user": "alice",
+                }
+            }
+        })
+        put_remote_secrets("hub", {"pass": "s3cret"})
+        merged = merge_remote_secrets("hub", load_network_config()["remotes"]["hub"])
+        assert merged["user"] == "alice"
+        assert merged["pass"] == "s3cret"
+        # Legacy inline pass still works until rewritten.
+        inline = {"transport": "mqtt", "broker": "mqtt://x", "topic": "t", "pass": "old"}
+        assert merge_remote_secrets("missing", inline)["pass"] == "old"
+
 
 class TestLoadRemotes:
     def test_unknown_transport_skipped(self, fake_home):

--- a/apps/a8s/txlog.py
+++ b/apps/a8s/txlog.py
@@ -9,7 +9,6 @@ receive -> recipient wake.
 """
 from __future__ import annotations
 
-import os
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal
@@ -44,9 +43,9 @@ HEADER = "\t".join(_COLUMNS)
 
 
 def _txlog_path() -> Path:
-    override = os.environ.get("A8S_HOME")
-    base = Path(override) if override else Path.home() / ".a8s"
-    return base / "transactions.tsv"
+    from core import resolve_a8s_home
+
+    return resolve_a8s_home() / "transactions.tsv"
 
 
 def _ts() -> str:


### PR DESCRIPTION
## Summary
- Store remote `pass` / `password` in `secrets.json` (mode 0600), not `network.json`. One `a8s remote … --pass …` still writes both; `--pass` remains optional and is preserved across rewrites without it.
- State root when `A8S_HOME` is unset: `~/.config/a8s` if present, else legacy `~/.a8s` if present, else `~/.config/a8s` for new installs. (`A8S_DIR` stays the definition install-path token.)
- Legacy inline secrets in `network.json` still load until the remote is rewritten.

## Test plan
- [x] `pytest` core / commands / network / txlog (215 passed)
- [ ] `a8s remote hub mqtts://… topic --user U --pass P` → pass only in secrets.json (0600); list/show masks it
- [ ] Rewrite remote without `--pass` → password kept
- [ ] `a8s unremote hub` → clears secrets entry
- [ ] Existing `~/.a8s` install still resolves there; fresh machine gets `~/.config/a8s`
- [ ] After merge: `a8s update` so daemons reload remotes with secrets overlay


Made with [Cursor](https://cursor.com)