### PR TITLE
feat(a8s): move conversation history to SQLite

### DIFF
--- a/apps/a8s/DEVELOPMENT.md
+++ b/apps/a8s/DEVELOPMENT.md
@@ -37,9 +37,10 @@ Read `README.md` first for concept and usage.
   machine-wide keys; `a8s config` (no args) catalogs every knob including
   definition, registry, and network fields. Env vars apply only when a key
   is absent from the file. `A8S_HOME` relocates the whole state dir.
-- **`conversations.jsonl` is machine-wide.** One routed row per logical message
-  (alias fan-out is one row). Rotates at `convo_max_limit` (default 1000).
-  Queried by `a8s convo <agent>` — not per-agent storage.
+- **`conversations.sqlite3` is machine-wide.** One routed row per logical
+  message (alias fan-out is one row). Inserts do not prune. `a8s update`
+  retains `convo_max_rows` (default 50000) during housekeeping. Queried by
+  `a8s convo <agent>` — not per-agent storage; `--limit` only controls display.
 
 ## Per-tool quirks
 

--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -222,6 +222,8 @@ any prefixes pointing at it.
 
 Env vars apply only when a key is absent from `settings.json` (e.g. `A8S_CONVO_MAX_ROWS`, `A8S_LOOP_INTERVAL`). `a8s config` with no arguments lists every knob — machine-wide, per-agent definition, registry, network, env, and constants — even read-only ones.
 
+Pre-v1 rename: `convo_max_limit` / `A8S_CONVO_MAX_LIMIT` were replaced by `convo_max_rows` / `A8S_CONVO_MAX_ROWS`. Existing values under the old names are ignored.
+
 
 ### Skills
 

--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -190,7 +190,7 @@ any prefixes pointing at it.
 | `a8s step <name>`  | Attach, do one route+drain pass, release. Heavyweight: detaches the current handler if any.                                                                                                                                                                                         |
 | `a8s stop <name> [--force]` | SIGTERM the handler, then **wait** until it has detached. Idle stops immediately; a busy wake finishes first (like first Ctrl+C). `--force` / `-f` sends a second SIGTERM to kill the in-flight wake (like second Ctrl+C), then waits. |
 | `a8s restart <name> [--force]` | `stop` (wait until detached) then `start`. `--force` is passed to stop. If not running, just starts. |
-| `a8s update [--force]` | Restart every running node so handlers re-exec current on-disk a8s (handy after `git pull`). Alias co-handlers that match an alias are restarted as one process. No code fetch yet — that comes with standalone releases. |
+| `a8s update [--force]` | Run conversation housekeeping, then restart every running node so handlers re-exec current on-disk a8s (handy after `git pull`). Alias co-handlers that match an alias are restarted as one process. No code fetch yet — that comes with standalone releases. |
 | `a8s kill <name>`  | Per-agent force-detach: writes a kill-request, SIGUSR1s the holder. Holder kills the in-flight wake subprocess iff it's for that agent and releases the attachment; siblings keep running. Falls back to whole-process SIGTERM only if the holder doesn't honor the request in 10s. |
 | `a8s exit`         | SIGTERM every running handler.                                                                                                                                                                                                                                                      |
 | `a8s ps [-q]`      | List only running node processes: NAME, PID, UPTIME, ROOT. `-q` prints just names. Empty state hints at `a8s ls`.                                                                                                                                                                    |
@@ -205,7 +205,7 @@ any prefixes pointing at it.
 | `tell <name> <msg>` (top-level shim, `[~/bin/tell](/Users/neilo/bin/tell)`) | Delegates to `a8s tell` (`apps/a8s/tell.py`). Outbox: `TELL_OUTBOX_DIR` if set, else a unique configured outbox matched from CWD when `~/.a8s` is readable (see [filedrop.md](docs/filedrop.md)). Drops a JSON envelope. When the registry is reachable, recipient validation and `from` stamping apply. Windows: `tell.cmd`. Operator internals: `[docs/tell.md](docs/tell.md)`. |
 | `tells [-f] [--timeout SEC] [--glow [theme]]` (shim `[~/bin/tells](/Users/neilo/bin/tells)`) | Receive-side complement of `tell` (`apps/a8s/tells.py`). Same outbox resolution as `tell`; watches `.inbox` beside it. Default: wait up to 5s for a burst. `-f` / `--timeout 0`: follow until Ctrl+C. `--glow` / headings share convo's markdown formatting. Non-destructive. Prefer over `convo -f` for filedrop inbound-only loops. |
 | `a8s logs <name>... [--tail N] [-f]`                                        | Read per-agent log files; one agent in append order, multiple merge by ISO timestamp. `-f` follows.                                                                                                                                                                                                                       |
-| `a8s convo <name> [--limit N] [-f] [--glow [theme]]`                        | Markdown history of messages to or from an agent. Default `--limit 10`. `-f` tails `~/.a8s/conversations.jsonl` (shows outbound too — use `tells -f` for filedrop inbound-only). Archive rotates at `convo_max_limit` (`a8s config`). |
+| `a8s convo <name> [--limit N] [-f] [--glow [theme]]`                        | Markdown history of messages to or from an agent. Default `--limit 10`; this controls display only. `-f` follows sequence-numbered rows in `conversations.sqlite3` (shows outbound too — use `tells -f` for filedrop inbound-only). `a8s update` retains `convo_max_rows` rows (default 50000). |
 | `a8s trace <ULID>`                                                          | Show locally observed transaction boundaries for one envelope: routing, remote publication/resolution, inbox write, delivery receipt, and agent wake. |
 | `a8s drain <name>`                                                          | Move pending inbox JSON to trash without waking the agent.                                                                                                                                                                                                                                                                |
 
@@ -220,7 +220,7 @@ any prefixes pointing at it.
 | `a8s config set <key> <value>` | Persist to `~/.a8s/settings.json`. |
 | `a8s config unset <key>` | Remove key from settings.json; fall back to env then default. |
 
-Env vars apply only when a key is absent from `settings.json` (e.g. `A8S_CONVO_MAX_LIMIT`, `A8S_LOOP_INTERVAL`). `a8s config` with no arguments lists every knob — machine-wide, per-agent definition, registry, network, env, and constants — even read-only ones.
+Env vars apply only when a key is absent from `settings.json` (e.g. `A8S_CONVO_MAX_ROWS`, `A8S_LOOP_INTERVAL`). `a8s config` with no arguments lists every knob — machine-wide, per-agent definition, registry, network, env, and constants — even read-only ones.
 
 
 ### Skills
@@ -398,7 +398,7 @@ The state root resolves as follows when `A8S_HOME` is unset: use `~/.config/a8s`
 ├── network.json              remotes / services (non-secret)
 ├── secrets.json              remote secrets (`pass` / `password`; mode 0600)
 ├── seen-ids                  cluster-wide ULID ring for receive-side dedup
-├── conversations.jsonl       routed message archive for `a8s convo` (see convo_max_limit)
+├── conversations.sqlite3     routed message archive (`a8s update` retains convo_max_rows)
 ├── log.txt                   process-scoped supervisor log
 └── agents/
     └── <NAME>/

--- a/apps/a8s/commands.py
+++ b/apps/a8s/commands.py
@@ -1505,7 +1505,7 @@ def _update_restart_targets(by_pid: dict[int, list[str]]) -> list[str]:
 
 
 def cmd_update(args: list[str]) -> int:
-    """`a8s update [--force]` — restart every running node (refresh handlers).
+    """`a8s update [--force]` — housekeep state and restart every running node.
 
     v1: no code pull — stop+start so background handlers re-exec the current
     on-disk ``a8s`` entrypoint. Use after ``git pull``. Later iterations may
@@ -1519,6 +1519,19 @@ def cmd_update(args: list[str]) -> int:
     if rest:
         print("usage: a8s update [--force]", file=sys.stderr)
         return 2
+    from convo import ConversationArchiveError, prune_conversations
+    from settings import get_int
+
+    try:
+        pruned = prune_conversations()
+    except ConversationArchiveError as e:
+        print(f"update: conversation housekeeping failed: {e}", file=sys.stderr)
+        return 1
+    max_rows = get_int("convo_max_rows")
+    print(
+        f"conversation housekeeping: retained up to {max_rows} row(s), "
+        f"pruned {pruned}"
+    )
     by_pid = _running_nodes_by_pid()
     if not by_pid:
         print("no nodes running")
@@ -1800,8 +1813,7 @@ def cmd_convo(args: list[str]) -> int:
         decode_template,
         follow_conversation,
         format_conversation,
-        involves_agent,
-        load_entries,
+        load_agent_entries,
         open_glow_stdout,
         print_entries,
     )
@@ -1818,7 +1830,7 @@ def cmd_convo(args: list[str]) -> int:
         "-f",
         "--follow",
         action="store_true",
-        help="print backlog then tail ~/.a8s/conversations.jsonl for new rows",
+        help="print backlog then follow new rows in conversations.sqlite3",
     )
     parser.add_argument(
         "--limit",
@@ -1851,6 +1863,9 @@ def cmd_convo(args: list[str]) -> int:
         parsed = parser.parse_args(args)
     except SystemExit as e:
         return int(e.code if e.code is not None else 0)
+    if parsed.limit < 1:
+        print("a8s convo: --limit must be a positive integer", file=sys.stderr)
+        return 2
 
     heading_out = (
         decode_template("\n".join(parsed.heading_out))
@@ -1883,8 +1898,7 @@ def cmd_convo(args: list[str]) -> int:
             pass
         return 0
 
-    rows = [e for e in load_entries() if involves_agent(e, agent_name)]
-    rows = rows[-parsed.limit :]
+    rows = load_agent_entries(agent_name, limit=parsed.limit)
     if glow_theme is not None:
         glow_stream = None
         try:

--- a/apps/a8s/convo.py
+++ b/apps/a8s/convo.py
@@ -483,6 +483,8 @@ def follow_conversation(
                 ).fetchone()
                 minimum = int(bounds[0]) if bounds[0] is not None else None
                 high_water = int(bounds[1])
+                reset = bool(cursor and high_water < cursor)
+                query_cursor = 0 if reset else cursor
                 rows = conn.execute(
                     """
                     SELECT m.seq, m.entry_json
@@ -491,10 +493,17 @@ def follow_conversation(
                     WHERE a.agent_key = ? AND m.seq > ? AND m.seq <= ?
                     ORDER BY m.seq
                     """,
-                    (_name_key(agent), cursor, high_water),
+                    (_name_key(agent), query_cursor, high_water),
                 ).fetchall()
                 conn.commit()
-            if minimum is not None and cursor and minimum > cursor + 1:
+            if reset:
+                print(
+                    "a8s convo: conversation archive sequence reset "
+                    f"from {cursor} to {high_water}; following from the beginning",
+                    file=sys.stderr,
+                    flush=True,
+                )
+            elif minimum is not None and cursor and minimum > cursor + 1:
                 print(
                     "a8s convo: conversation housekeeping advanced past "
                     f"{minimum - cursor - 1} row(s); messages may have been missed",

--- a/apps/a8s/convo.py
+++ b/apps/a8s/convo.py
@@ -1,20 +1,21 @@
-"""Conversation archive — append-only jsonl of routed messages for `a8s convo`.
+"""SQLite conversation archive for routed messages shown by `a8s convo`.
 
 One record per logical message (alias fan-out stores the alias in `to` and
-lists local deliverees in `recipients`). Rotates to `convo_max_limit` entries
-from `~/.a8s/settings.json` (default 1000).
+lists local deliverees in `recipients`). Inserts never prune history.
+`a8s update` retains the newest `convo_max_rows` entries during housekeeping.
 """
 from __future__ import annotations
 
 import json
-import os
+import sqlite3
 import sys
 import time
+from contextlib import closing
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from core import conversations_path, inbound_bundle_dir
+from core import conversations_path, inbound_bundle_dir, out
 from settings import get_int
 
 __all__ = [
@@ -29,9 +30,11 @@ __all__ = [
     "format_entry",
     "follow_conversation",
     "involves_agent",
+    "load_agent_entries",
     "load_entries",
     "open_glow_stdout",
     "print_entries",
+    "prune_conversations",
     "record",
     "write_block",
 ]
@@ -113,12 +116,60 @@ environment:
 """
 
 
-def _max_limit() -> int:
-    return get_int("convo_max_limit")
-
-
 def _name_key(name: str) -> str:
     return (name or "").strip().lower()
+
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS messages (
+    seq INTEGER PRIMARY KEY,
+    message_id TEXT,
+    entry_json TEXT NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS messages_message_id
+    ON messages(message_id)
+    WHERE message_id IS NOT NULL;
+CREATE TABLE IF NOT EXISTS message_agents (
+    seq INTEGER NOT NULL REFERENCES messages(seq) ON DELETE CASCADE,
+    agent_key TEXT NOT NULL,
+    PRIMARY KEY (seq, agent_key)
+);
+CREATE INDEX IF NOT EXISTS message_agents_agent_seq
+    ON message_agents(agent_key, seq);
+"""
+
+
+class ConversationArchiveError(RuntimeError):
+    pass
+
+
+def _connect() -> sqlite3.Connection:
+    path = conversations_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path, timeout=5.0)
+    try:
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute("PRAGMA busy_timeout = 5000")
+        conn.execute("PRAGMA journal_mode = WAL")
+        conn.executescript(_SCHEMA)
+    except sqlite3.Error:
+        conn.close()
+        raise
+    return conn
+
+
+def _entry_agents(entry: dict[str, Any]) -> set[str]:
+    names = [entry.get("from", ""), entry.get("to", "")]
+    names.extend(entry.get("recipients") or [])
+    return {key for name in names if (key := _name_key(str(name)))}
+
+
+def _decode_entry(raw: str) -> dict[str, Any] | None:
+    try:
+        entry = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    return entry if isinstance(entry, dict) else None
 
 
 def involves_agent(entry: dict[str, Any], agent: str) -> bool:
@@ -160,64 +211,125 @@ def load_entries() -> list[dict[str, Any]]:
     path = conversations_path()
     if not path.is_file():
         return []
-    out: list[dict[str, Any]] = []
+    entries: list[dict[str, Any]] = []
     try:
-        with path.open("r", encoding="utf-8") as f:
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    row = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                if isinstance(row, dict):
-                    out.append(row)
-    except OSError:
+        with closing(_connect()) as conn:
+            rows = conn.execute(
+                "SELECT entry_json FROM messages ORDER BY seq"
+            ).fetchall()
+        for (raw,) in rows:
+            entry = _decode_entry(raw)
+            if entry is not None:
+                entries.append(entry)
+    except (OSError, sqlite3.Error):
         return []
-    return out
+    return entries
+
+
+def _rows_to_entries(rows: list[tuple[int, str]]) -> list[tuple[int, dict[str, Any]]]:
+    entries: list[tuple[int, dict[str, Any]]] = []
+    for seq, raw in rows:
+        entry = _decode_entry(raw)
+        if entry is not None:
+            entries.append((int(seq), entry))
+    return entries
+
+
+def _latest_agent_entries(
+    conn: sqlite3.Connection,
+    agent: str,
+    limit: int,
+    *,
+    through_seq: int | None = None,
+) -> list[tuple[int, dict[str, Any]]]:
+    if limit < 1:
+        return []
+    params: list[Any] = [_name_key(agent)]
+    through = ""
+    if through_seq is not None:
+        through = "AND m.seq <= ?"
+        params.append(through_seq)
+    params.append(limit)
+    rows = conn.execute(
+        f"""
+        SELECT m.seq, m.entry_json
+        FROM messages AS m
+        JOIN message_agents AS a ON a.seq = m.seq
+        WHERE a.agent_key = ? {through}
+        ORDER BY m.seq DESC
+        LIMIT ?
+        """,
+        params,
+    ).fetchall()
+    rows.reverse()
+    return _rows_to_entries(rows)
+
+
+def load_agent_entries(agent: str, *, limit: int) -> list[dict[str, Any]]:
+    if limit < 1 or not conversations_path().is_file():
+        return []
+    try:
+        with closing(_connect()) as conn:
+            return [entry for _, entry in _latest_agent_entries(conn, agent, limit)]
+    except (OSError, sqlite3.Error):
+        return []
 
 
 def record(msg: dict[str, Any], *, recipients: list[str]) -> None:
     """Append one logical message when delivery completes (local inbox, remote
     receive, or outbound remote publish). `recipients` lists local deliverees
     for routed/RECEIVED_REMOTE rows, or the logical `to` name for outbound
-    remote-only sends.
-
-    Under the cap this appends one jsonl line (so `a8s convo -f` can tail).
-    Over the cap it rewrites the file with the newest ``convo_max_limit`` rows.
+    remote-only sends. Retention is applied by `a8s update`, never here.
     """
     if not recipients:
         return
     entry = entry_from_message(msg, recipients=recipients)
-    msg_id = entry.get("id") or ""
+    msg_id = entry.get("id") or None
     try:
-        rows = load_entries()
-        if msg_id and any(r.get("id") == msg_id for r in rows):
-            return
-        rows.append(entry)
-        path = conversations_path()
-        path.parent.mkdir(parents=True, exist_ok=True)
-        cap = _max_limit()
-        if len(rows) <= cap:
-            with path.open("a", encoding="utf-8") as f:
-                f.write(json.dumps(entry, ensure_ascii=False) + "\n")
-                f.flush()
-                os.fsync(f.fileno())
-            return
-        # Atomic replace so followers see an inode change (in-place truncate+"w"
-        # keeps the inode; a reader parked at the old EOF then misses new rows
-        # when the rewritten file is the same size or larger).
-        rows = rows[-cap:]
-        tmp = path.with_suffix(path.suffix + ".tmp")
-        with tmp.open("w", encoding="utf-8") as f:
-            for row in rows:
-                f.write(json.dumps(row, ensure_ascii=False) + "\n")
-            f.flush()
-            os.fsync(f.fileno())
-        os.replace(tmp, path)
-    except OSError:
-        pass
+        with closing(_connect()) as conn, conn:
+            cursor = conn.execute(
+                "INSERT OR IGNORE INTO messages(message_id, entry_json) VALUES (?, ?)",
+                (msg_id, json.dumps(entry, ensure_ascii=False)),
+            )
+            if cursor.rowcount == 0:
+                return
+            seq = int(cursor.lastrowid)
+            conn.executemany(
+                "INSERT INTO message_agents(seq, agent_key) VALUES (?, ?)",
+                [(seq, key) for key in sorted(_entry_agents(entry))],
+            )
+    except (OSError, sqlite3.Error) as e:
+        label = msg_id or "without-id"
+        out(f"WARN conversation archive failed id={label}: {e}")
+
+
+def prune_conversations(max_rows: int | None = None) -> int:
+    """Retain the newest configured number of rows and return rows removed."""
+    keep = max_rows if max_rows is not None else get_int("convo_max_rows")
+    if keep < 1:
+        raise ValueError("max_rows must be positive")
+    try:
+        with closing(_connect()) as conn:
+            with conn:
+                before = int(
+                    conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+                )
+                removed = 0
+                if before > keep:
+                    cutoff = conn.execute(
+                        "SELECT seq FROM messages ORDER BY seq DESC LIMIT 1 OFFSET ?",
+                        (keep - 1,),
+                    ).fetchone()
+                    if cutoff is not None:
+                        conn.execute(
+                            "DELETE FROM messages WHERE seq < ?", (int(cutoff[0]),)
+                        )
+                        removed = before - keep
+            conn.execute("PRAGMA optimize")
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            return removed
+    except (OSError, sqlite3.Error) as e:
+        raise ConversationArchiveError(str(e)) from e
 
 
 def _format_heading(template: str, entry: dict[str, Any]) -> str:
@@ -321,26 +433,12 @@ def format_conversation(
     """Return markdown for the last `limit` messages involving `agent`."""
     if limit < 1:
         return ""
-    rows = [e for e in load_entries() if involves_agent(e, agent)]
-    rows = rows[-limit:]
+    rows = load_agent_entries(agent, limit=limit)
     parts = [
         format_entry(agent, entry, heading_out=heading_out, heading_in=heading_in)
         for entry in rows
     ]
     return "\n\n".join(parts)
-
-
-def _entry_follow_key(entry: dict[str, Any]) -> str:
-    """Stable dedupe key for follow: prefer message id, else content fingerprint."""
-    msg_id = (entry.get("id") or "").strip()
-    if msg_id:
-        return f"id:{msg_id}"
-    return "fp:{0}|{1}|{2}|{3}".format(
-        (entry.get("date") or "").strip(),
-        (entry.get("from") or "").strip(),
-        (entry.get("to") or "").strip(),
-        entry.get("content", ""),
-    )
 
 
 def follow_conversation(
@@ -352,13 +450,7 @@ def follow_conversation(
     poll_interval: float = 1.0,
     glow_theme: str | None = None,
 ) -> None:
-    """Print the last `limit` messages, then block printing new archive rows.
-
-    Re-reads the archive each poll and emits unseen rows. Offset/EOF tailing is
-    unsafe at the rotation cap: in-place rewrite keeps the inode and a reader
-    parked at the old EOF misses same-or-larger rewrites (typical for inbound
-    replies right after an outbound record).
-    """
+    """Print the last `limit` messages, then emit rows after a sequence cursor."""
     glow_stream = None
     if glow_theme is not None:
         try:
@@ -367,26 +459,49 @@ def follow_conversation(
             print("a8s convo: glow not found on PATH", file=sys.stderr)
 
     try:
-        rows = [e for e in load_entries() if involves_agent(e, agent)]
+        with closing(_connect()) as conn:
+            conn.execute("BEGIN")
+            cursor = int(
+                conn.execute("SELECT COALESCE(MAX(seq), 0) FROM messages").fetchone()[0]
+            )
+            rows = _latest_agent_entries(conn, agent, limit, through_seq=cursor)
+            conn.commit()
         print_entries(
             agent,
-            rows[-limit:],
+            [entry for _, entry in rows],
             glow_stream=glow_stream,
             heading_out=heading_out,
             heading_in=heading_in,
         )
-        # Seed with every known row for this agent — not only the printed
-        # window — so a truncate/rewrite cannot replay older history.
-        seen = {_entry_follow_key(e) for e in rows if _entry_follow_key(e)}
 
         while True:
             time.sleep(poll_interval)
-            for entry in load_entries():
-                if not involves_agent(entry, agent):
-                    continue
-                key = _entry_follow_key(entry)
-                if not key or key in seen:
-                    continue
+            with closing(_connect()) as conn:
+                conn.execute("BEGIN")
+                bounds = conn.execute(
+                    "SELECT MIN(seq), COALESCE(MAX(seq), 0) FROM messages"
+                ).fetchone()
+                minimum = int(bounds[0]) if bounds[0] is not None else None
+                high_water = int(bounds[1])
+                rows = conn.execute(
+                    """
+                    SELECT m.seq, m.entry_json
+                    FROM messages AS m
+                    JOIN message_agents AS a ON a.seq = m.seq
+                    WHERE a.agent_key = ? AND m.seq > ? AND m.seq <= ?
+                    ORDER BY m.seq
+                    """,
+                    (_name_key(agent), cursor, high_water),
+                ).fetchall()
+                conn.commit()
+            if minimum is not None and cursor and minimum > cursor + 1:
+                print(
+                    "a8s convo: conversation housekeeping advanced past "
+                    f"{minimum - cursor - 1} row(s); messages may have been missed",
+                    file=sys.stderr,
+                    flush=True,
+                )
+            for _, entry in _rows_to_entries(rows):
                 print_entries(
                     agent,
                     [entry],
@@ -394,8 +509,7 @@ def follow_conversation(
                     heading_out=heading_out,
                     heading_in=heading_in,
                 )
-                seen.add(key)
+            cursor = high_water
     finally:
         if glow_stream is not None:
             glow_stream.close()
-

--- a/apps/a8s/core.py
+++ b/apps/a8s/core.py
@@ -362,7 +362,7 @@ def user_definitions_dir() -> Path:
 
 
 def conversations_path() -> Path:
-    """`~/.a8s/conversations.sqlite3` — routed message archive for `a8s convo`."""
+    """Conversation archive under the resolved a8s state root."""
     return _a8s_dir() / "conversations.sqlite3"
 
 

--- a/apps/a8s/core.py
+++ b/apps/a8s/core.py
@@ -362,8 +362,8 @@ def user_definitions_dir() -> Path:
 
 
 def conversations_path() -> Path:
-    """`~/.a8s/conversations.jsonl` — routed message archive for `a8s convo`."""
-    return _a8s_dir() / "conversations.jsonl"
+    """`~/.a8s/conversations.sqlite3` — routed message archive for `a8s convo`."""
+    return _a8s_dir() / "conversations.sqlite3"
 
 
 def seen_ids_path() -> Path:

--- a/apps/a8s/settings.py
+++ b/apps/a8s/settings.py
@@ -37,12 +37,12 @@ class Knob:
 KNOBS: tuple[Knob, ...] = (
     # --- machine-wide (settings.json) ---
     Knob(
-        "convo_max_limit",
-        1000,
+        "convo_max_rows",
+        50_000,
         "machine",
         True,
-        "A8S_CONVO_MAX_LIMIT",
-        "Max rows in ~/.a8s/conversations.jsonl before rotation",
+        "A8S_CONVO_MAX_ROWS",
+        "Rows retained in conversations.sqlite3 when a8s update runs housekeeping",
     ),
     Knob(
         "loop_interval",
@@ -169,7 +169,7 @@ def save_settings_file(data: dict[str, Any]) -> None:
 
 
 def _coerce(key: str, raw: str) -> Any:
-    if key in ("convo_max_limit", "max_file_bytes", "max_seen_ids"):
+    if key in ("convo_max_rows", "max_file_bytes", "max_seen_ids"):
         return int(raw)
     if key == "loop_interval":
         return float(raw)
@@ -177,10 +177,10 @@ def _coerce(key: str, raw: str) -> Any:
 
 
 def _validate(key: str, value: Any) -> Any:
-    if key == "convo_max_limit":
+    if key == "convo_max_rows":
         n = int(value)
         if n < 1:
-            raise ValueError("convo_max_limit must be a positive integer")
+            raise ValueError("convo_max_rows must be a positive integer")
         return n
     if key == "max_file_bytes":
         n = int(value)
@@ -291,4 +291,3 @@ def list_catalog() -> list[tuple[str, list[Knob]]]:
     for knob in KNOBS:
         by_group[knob.group].append(knob)
     return [( _GROUP_LABELS[g], by_group[g]) for g in _GROUP_ORDER if by_group[g]]
-

--- a/apps/a8s/tests/mqtt_cluster.py
+++ b/apps/a8s/tests/mqtt_cluster.py
@@ -171,7 +171,7 @@ def wait_convo(
             if predicate(rows):
                 return rows
             time.sleep(0.05)
-    raise AssertionError(f"conversations.jsonl condition not met within {timeout}s")
+    raise AssertionError(f"conversations.sqlite3 condition not met within {timeout}s")
 
 
 def wait_agent_log(

--- a/apps/a8s/tests/test_commands.py
+++ b/apps/a8s/tests/test_commands.py
@@ -690,7 +690,23 @@ class TestCmdStopAndRestart:
 class TestCmdUpdate:
     def test_no_nodes_running(self, fake_home, capsys):
         assert cmd_update([]) == 0
-        assert "no nodes running" in capsys.readouterr().out
+        out = capsys.readouterr().out
+        assert "conversation housekeeping" in out
+        assert "no nodes running" in out
+
+    def test_housekeeping_prunes_when_no_nodes_running(self, fake_home, capsys):
+        from convo import load_entries, record
+        from settings import set_setting
+
+        set_setting("convo_max_rows", 2)
+        for i in range(4):
+            record(
+                {"id": f"01UPDATE{i}", "from": "A", "to": "B", "content": str(i)},
+                recipients=["B"],
+            )
+        assert cmd_update([]) == 0
+        assert [row["content"] for row in load_entries()] == ["2", "3"]
+        assert "pruned 2" in capsys.readouterr().out
 
     def test_prefers_alias_for_shared_pid(self, fake_home, tmp_path):
         a = tmp_path / "a"; a.mkdir()
@@ -1473,4 +1489,3 @@ class TestCmdTrace:
         msg_id = new_ulid()
         assert cmd_trace([msg_id]) == 1
         assert f"no transaction events for {msg_id}" in capsys.readouterr().err
-

--- a/apps/a8s/tests/test_convo.py
+++ b/apps/a8s/tests/test_convo.py
@@ -13,6 +13,7 @@ from convo import (
     load_entries,
     open_glow_stdout,
     print_entries,
+    prune_conversations,
     record,
     write_block,
 )
@@ -73,8 +74,27 @@ class TestRecord:
         record(msg, recipients=["B"])
         assert len(load_entries()) == 1
 
-    def test_rotates_to_max_limit(self, fake_home, monkeypatch):
-        monkeypatch.setenv("A8S_CONVO_MAX_LIMIT", "3")
+    def test_concurrent_writers_do_not_lose_rows(self, fake_home):
+        from concurrent.futures import ThreadPoolExecutor
+
+        def write(i: int) -> None:
+            record(
+                {
+                    "id": f"01JCONCURRENT{i:012d}",
+                    "from": "A",
+                    "to": "B",
+                    "content": str(i),
+                },
+                recipients=["B"],
+            )
+
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            list(pool.map(write, range(40)))
+        assert {row["content"] for row in load_entries()} == {
+            str(i) for i in range(40)
+        }
+
+    def test_housekeeping_prunes_to_max_rows(self, fake_home):
         for i in range(5):
             record(
                 {
@@ -86,6 +106,8 @@ class TestRecord:
                 },
                 recipients=["B"],
             )
+        assert len(load_entries()) == 5
+        assert prune_conversations(3) == 2
         rows = load_entries()
         assert len(rows) == 3
         assert rows[0]["content"] == "m2"
@@ -424,6 +446,10 @@ class TestCmdConvo:
         assert cmd_convo(["nope"]) == 1
         assert "no agent named" in capsys.readouterr().err
 
+    def test_rejects_non_positive_limit(self, fake_home, capsys):
+        assert cmd_convo(["bob", "--limit", "0"]) == 2
+        assert "--limit must be a positive integer" in capsys.readouterr().err
+
     def test_follow_flag_parses(self, fake_home, tmp_path, monkeypatch):
         from registry import save_registry
 
@@ -467,13 +493,13 @@ class TestCmdConvo:
 
 class TestConversationsPath:
     def test_default_under_a8s_home(self, fake_home):
-        assert conversations_path() == fake_home / ".a8s" / "conversations.jsonl"
+        assert conversations_path() == fake_home / ".a8s" / "conversations.sqlite3"
 
     def test_respects_a8s_home(self, fake_home, monkeypatch, tmp_path):
         custom = tmp_path / "custom"
         monkeypatch.setenv("A8S_HOME", str(custom))
         custom.mkdir()
-        assert conversations_path() == custom / "conversations.jsonl"
+        assert conversations_path() == custom / "conversations.sqlite3"
 
 
 class TestRoutingIntegration:
@@ -532,8 +558,8 @@ class TestRoutingIntegration:
         assert text.index("question") < text.index("answer")
 
 
-def test_default_max_limit_is_1000():
-    assert DEFAULTS["convo_max_limit"] == 1000
+def test_default_max_rows_is_50000():
+    assert DEFAULTS["convo_max_rows"] == 50_000
 
 
 class TestFollowConversation:
@@ -579,63 +605,44 @@ class TestFollowConversation:
         assert "old" in out
         assert "fresh" in out
 
-    def test_record_appends_under_cap(self, fake_home, monkeypatch):
-        from core import conversations_path
+    def test_archive_is_sqlite(self, fake_home):
+        import sqlite3
 
-        monkeypatch.setattr("convo._max_limit", lambda: 100)
         record(
-            {"id": "01A", "from": "A", "to": "B", "content": "one", "date": "2026-01-01T00:00:00Z"},
+            {"id": "01A", "from": "A", "to": "B", "content": "one"},
             recipients=["B"],
         )
-        record(
-            {"id": "01B", "from": "A", "to": "B", "content": "two", "date": "2026-01-01T00:01:00Z"},
-            recipients=["B"],
-        )
-        text = conversations_path().read_text(encoding="utf-8")
-        assert text.count("\n") == 2
-        assert "one" in text and "two" in text
-
-    def test_follow_does_not_replay_history_on_rewrite(
-        self, fake_home, tmp_path, capsys, monkeypatch
-    ):
-        """Regression: every record used to truncate+rewrite; follow did seek(0)
-        with seen only holding --limit ids, flooding the terminal with old rows."""
-        from registry import save_registry
-        from core import conversations_path
-
-        root = tmp_path / "bob"
-        root.mkdir()
-        save_registry({"Bob": {"root": str(root)}})
-        monkeypatch.setattr("convo._max_limit", lambda: 3)
-
-        for i, content in enumerate(("alpha", "beta", "gamma"), start=1):
-            record(
-                {
-                    "id": f"01OLD{i:020d}",
-                    "date": f"2026-06-18T10:0{i}:00.000000Z",
-                    "from": "Alice",
-                    "to": "Bob",
-                    "content": content,
-                },
-                recipients=["Bob"],
+        with sqlite3.connect(conversations_path()) as conn:
+            assert conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0] == 1
+            assert (
+                conn.execute(
+                    "SELECT agent_key FROM message_agents ORDER BY agent_key"
+                ).fetchall()
+                == [("a",), ("b",)]
             )
 
+    def test_follow_surfaces_every_message_between_polls(
+        self, fake_home, capsys, monkeypatch
+    ):
+        record(
+            {"id": "01OLD", "from": "Alice", "to": "Bob", "content": "old"},
+            recipients=["Bob"],
+        )
         sleeps = {"n": 0}
 
         def fake_sleep(_interval: float) -> None:
             sleeps["n"] += 1
             if sleeps["n"] == 1:
-                # Over cap → rewrite. Must not dump alpha/beta/gamma again.
-                record(
-                    {
-                        "id": "01NEW000000000000000001",
-                        "date": "2026-06-18T11:00:00.000000Z",
-                        "from": "Alice",
-                        "to": "Bob",
-                        "content": "delta",
-                    },
-                    recipients=["Bob"],
-                )
+                for i in range(4):
+                    record(
+                        {
+                            "id": f"01NEW{i}",
+                            "from": "Alice",
+                            "to": "Bob",
+                            "content": f"new-{i}",
+                        },
+                        recipients=["Bob"],
+                    )
                 return
             raise KeyboardInterrupt
 
@@ -643,107 +650,60 @@ class TestFollowConversation:
         with pytest.raises(KeyboardInterrupt):
             follow_conversation("Bob", limit=1, poll_interval=0.01)
         out = capsys.readouterr().out
-        # Initial window printed gamma once; follow should add delta once.
-        assert out.count("gamma") == 1
-        assert out.count("delta") == 1
-        assert out.count("alpha") == 0
-        assert out.count("beta") == 0
-        # Rotated file still on disk with newest three.
-        rows = load_entries()
-        assert [r["content"] for r in rows] == ["beta", "gamma", "delta"]
-        assert conversations_path().is_file()
+        assert out.count("old") == 1
+        for i in range(4):
+            assert out.count(f"new-{i}") == 1
 
-    def test_record_rotation_replaces_inode(self, fake_home, monkeypatch):
-        from core import conversations_path
-
-        monkeypatch.setattr("convo._max_limit", lambda: 2)
-        record(
-            {"id": "01A", "from": "A", "to": "B", "content": "one", "date": "2026-01-01T00:00:00Z"},
-            recipients=["B"],
-        )
-        record(
-            {"id": "01B", "from": "A", "to": "B", "content": "two", "date": "2026-01-01T00:01:00Z"},
-            recipients=["B"],
-        )
-        path = conversations_path()
-        ino_before = path.stat().st_ino
-        record(
-            {
-                "id": "01C",
-                "from": "A",
-                "to": "B",
-                "content": "three-longer-so-file-grows",
-                "date": "2026-01-01T00:02:00Z",
-            },
-            recipients=["B"],
-        )
-        assert path.stat().st_ino != ino_before
-        assert [r["content"] for r in load_entries()] == ["two", "three-longer-so-file-grows"]
-
-    def test_follow_sees_inbound_after_larger_rewrite(
-        self, fake_home, tmp_path, capsys, monkeypatch
+    def test_housekeeping_does_not_change_follow_display_limit(
+        self, fake_home, capsys, monkeypatch
     ):
-        """At cap, outbound+inbound each rewrite. In-place "w" with a same-or-larger
-        file leaves an EOF reader blind; polling load_entries must still show reply."""
-        from registry import save_registry
-
-        root = tmp_path / "bob"
-        root.mkdir()
-        save_registry({"Bob": {"root": str(root)}})
-        monkeypatch.setattr("convo._max_limit", lambda: 2)
-
-        record(
-            {
-                "id": "01OUT0000000000000000001",
-                "date": "2026-06-18T10:00:00.000000Z",
-                "from": "Bob",
-                "to": "chatroom",
-                "content": "/list",
-            },
-            recipients=["chatroom"],
+        for i in range(5):
+            record(
+                {"id": f"01{i}", "from": "Alice", "to": "Bob", "content": f"m{i}"},
+                recipients=["Bob"],
+            )
+        assert prune_conversations(3) == 2
+        monkeypatch.setattr(
+            "convo.time.sleep",
+            lambda _: (_ for _ in ()).throw(KeyboardInterrupt()),
         )
+        with pytest.raises(KeyboardInterrupt):
+            follow_conversation("Bob", limit=1, poll_interval=0.01)
+        out = capsys.readouterr().out
+        assert "m4" in out
+        assert "m2" not in out
+        assert "m3" not in out
+
+    def test_follow_warns_when_housekeeping_advances_past_cursor(
+        self, fake_home, capsys, monkeypatch
+    ):
         record(
-            {
-                "id": "01IN00000000000000000001",
-                "date": "2026-06-18T10:00:01.000000Z",
-                "from": "chatroom",
-                "to": "Bob",
-                "content": "no chat rooms",
-            },
+            {"id": "01OLD", "from": "Alice", "to": "Bob", "content": "old"},
             recipients=["Bob"],
         )
-
         sleeps = {"n": 0}
 
         def fake_sleep(_interval: float) -> None:
             sleeps["n"] += 1
             if sleeps["n"] == 1:
-                record(
-                    {
-                        "id": "01OUT0000000000000000002",
-                        "date": "2026-06-18T11:00:00.000000Z",
-                        "from": "Bob",
-                        "to": "chatroom",
-                        "content": "/list again with more bytes",
-                    },
-                    recipients=["chatroom"],
-                )
-                record(
-                    {
-                        "id": "01IN00000000000000000002",
-                        "date": "2026-06-18T11:00:01.000000Z",
-                        "from": "chatroom",
-                        "to": "Bob",
-                        "content": "still no chat rooms — longer reply body here",
-                    },
-                    recipients=["Bob"],
-                )
+                for i in range(3):
+                    record(
+                        {
+                            "id": f"01GAP{i}",
+                            "from": "Alice",
+                            "to": "Bob",
+                            "content": f"gap-{i}",
+                        },
+                        recipients=["Bob"],
+                    )
+                prune_conversations(1)
                 return
             raise KeyboardInterrupt
 
         monkeypatch.setattr("convo.time.sleep", fake_sleep)
         with pytest.raises(KeyboardInterrupt):
-            follow_conversation("Bob", limit=2, poll_interval=0.01)
-        out = capsys.readouterr().out
-        assert out.count("/list again with more bytes") == 1
-        assert out.count("still no chat rooms — longer reply body here") == 1
+            follow_conversation("Bob", limit=1, poll_interval=0.01)
+        captured = capsys.readouterr()
+        assert "messages may have been missed" in captured.err
+        assert "gap-2" in captured.out
+        assert "gap-0" not in captured.out

--- a/apps/a8s/tests/test_convo.py
+++ b/apps/a8s/tests/test_convo.py
@@ -707,3 +707,37 @@ class TestFollowConversation:
         assert "messages may have been missed" in captured.err
         assert "gap-2" in captured.out
         assert "gap-0" not in captured.out
+
+    def test_follow_recovers_when_archive_sequence_resets(
+        self, fake_home, capsys, monkeypatch
+    ):
+        for i in range(3):
+            record(
+                {"id": f"01OLD{i}", "from": "Alice", "to": "Bob", "content": f"old-{i}"},
+                recipients=["Bob"],
+            )
+        sleeps = {"n": 0}
+
+        def fake_sleep(_interval: float) -> None:
+            sleeps["n"] += 1
+            if sleeps["n"] == 1:
+                conversations_path().unlink()
+                record(
+                    {
+                        "id": "01REPLACEMENT",
+                        "from": "Alice",
+                        "to": "Bob",
+                        "content": "replacement-row",
+                    },
+                    recipients=["Bob"],
+                )
+                return
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr("convo.time.sleep", fake_sleep)
+        with pytest.raises(KeyboardInterrupt):
+            follow_conversation("Bob", limit=1, poll_interval=0.01)
+        captured = capsys.readouterr()
+        assert "conversation archive sequence reset from 3 to 1" in captured.err
+        assert captured.out.count("old-2") == 1
+        assert captured.out.count("replacement-row") == 1

--- a/apps/a8s/tests/test_remote_dual_cluster.py
+++ b/apps/a8s/tests/test_remote_dual_cluster.py
@@ -1,5 +1,5 @@
 """Two-cluster MQTT integration — sender and recipient on opposite A8S_HOME
-trees with real mosquitto, exercising publish/receive, conversations.jsonl,
+trees with real mosquitto, exercising publish/receive, conversations.sqlite3,
 and `a8s convo` end to end."""
 from __future__ import annotations
 
@@ -33,7 +33,7 @@ class TestDualClusterRemote:
     def test_bidirectional_delivery_convo_and_cmd(self, tmp_path, mqtt_broker, capsys):
         """Two handlers on separate A8S_HOME dirs share one broker topic.
         Messages published from each side arrive at the other; both
-        conversations.jsonl archives and `a8s convo` show inbound/outbound."""
+        conversations.sqlite3 archives and `a8s convo` show inbound/outbound."""
         topic = _unique_topic("dual")
         alice_a8s = tmp_path / "alice_a8s"
         bob_a8s = tmp_path / "bob_a8s"

--- a/apps/a8s/tests/test_settings.py
+++ b/apps/a8s/tests/test_settings.py
@@ -11,39 +11,39 @@ from commands import cmd_config
 
 class TestSettingsResolution:
     def test_default_when_file_and_env_missing(self, fake_home):
-        assert sm.get_int("convo_max_limit") == 1000
+        assert sm.get_int("convo_max_rows") == 50_000
         assert sm.get_float("loop_interval") == 1.0
         assert sm.get_int("max_file_bytes") == 50 * 1024 * 1024
         assert sm.get_int("max_seen_ids") == 10000
 
     def test_settings_file_takes_precedence_over_env(self, fake_home, monkeypatch):
-        monkeypatch.setenv("A8S_CONVO_MAX_LIMIT", "50")
-        sm.set_setting("convo_max_limit", 200)
-        assert sm.get_int("convo_max_limit") == 200
+        monkeypatch.setenv("A8S_CONVO_MAX_ROWS", "50")
+        sm.set_setting("convo_max_rows", 200)
+        assert sm.get_int("convo_max_rows") == 200
 
     def test_env_used_when_key_absent_from_file(self, fake_home, monkeypatch):
         monkeypatch.setenv("A8S_LOOP_INTERVAL", "2.5")
         assert sm.get_float("loop_interval") == 2.5
 
     def test_unset_falls_back_to_env_then_default(self, fake_home, monkeypatch):
-        sm.set_setting("convo_max_limit", 200)
-        sm.unset_setting("convo_max_limit")
-        monkeypatch.setenv("A8S_CONVO_MAX_LIMIT", "75")
-        assert sm.get_int("convo_max_limit") == 75
-        monkeypatch.delenv("A8S_CONVO_MAX_LIMIT", raising=False)
-        assert sm.get_int("convo_max_limit") == 1000
+        sm.set_setting("convo_max_rows", 200)
+        sm.unset_setting("convo_max_rows")
+        monkeypatch.setenv("A8S_CONVO_MAX_ROWS", "75")
+        assert sm.get_int("convo_max_rows") == 75
+        monkeypatch.delenv("A8S_CONVO_MAX_ROWS", raising=False)
+        assert sm.get_int("convo_max_rows") == 50_000
 
     def test_set_rejects_non_positive(self, fake_home):
         with pytest.raises(ValueError, match="positive"):
-            sm.set_setting("convo_max_limit", 0)
+            sm.set_setting("convo_max_rows", 0)
         with pytest.raises(ValueError, match="positive"):
             sm.set_setting("loop_interval", 0)
 
     def test_persists_to_settings_json(self, fake_home):
-        sm.set_setting("convo_max_limit", 1500)
+        sm.set_setting("convo_max_rows", 1500)
         sm.set_setting("loop_interval", 0.5)
         raw = json.loads(sm.settings_path().read_text())
-        assert raw == {"convo_max_limit": 1500, "loop_interval": 0.5}
+        assert raw == {"convo_max_rows": 1500, "loop_interval": 0.5}
 
     def test_cannot_set_read_only_knob(self, fake_home):
         with pytest.raises(KeyError):
@@ -71,7 +71,7 @@ class TestCmdConfig:
     def test_list_shows_catalog(self, fake_home, capsys):
         assert cmd_config([]) == 0
         out = capsys.readouterr().out
-        assert "convo_max_limit: 1000" in out
+        assert "convo_max_rows: 50000" in out
         assert "definition.invoke" in out
         assert "registry.agents" in out
         assert "network.remotes" in out
@@ -79,13 +79,13 @@ class TestCmdConfig:
         assert "remote.backoff_schedule" in out
 
     def test_get_set_unset_writable(self, fake_home, capsys):
-        assert cmd_config(["set", "convo_max_limit", "2500"]) == 0
-        assert "convo_max_limit=2500" in capsys.readouterr().out
+        assert cmd_config(["set", "convo_max_rows", "2500"]) == 0
+        assert "convo_max_rows=2500" in capsys.readouterr().out
         capsys.readouterr()
-        assert cmd_config(["get", "convo_max_limit"]) == 0
+        assert cmd_config(["get", "convo_max_rows"]) == 0
         assert capsys.readouterr().out.strip() == "2500"
-        assert cmd_config(["unset", "convo_max_limit"]) == 0
-        assert "effective 1000" in capsys.readouterr().out
+        assert cmd_config(["unset", "convo_max_rows"]) == 0
+        assert "effective 50000" in capsys.readouterr().out
 
     def test_get_read_only_knob(self, fake_home, capsys):
         assert cmd_config(["get", "definition.batch.limit"]) == 0

--- a/apps/a8s/tests/test_tells.py
+++ b/apps/a8s/tests/test_tells.py
@@ -105,6 +105,7 @@ def test_tells_timeout_exits_1(tmp_path, monkeypatch, capsys):
 
 def test_tells_without_outbox_env_fails(tmp_path, monkeypatch, capsys):
     monkeypatch.delenv(TELL_OUTBOX_DIR_ENV, raising=False)
+    monkeypatch.setenv("A8S_HOME", str(tmp_path / "empty-a8s-home"))
     rc = tells_main([])
     err = capsys.readouterr().err
     assert rc == 1


### PR DESCRIPTION
## Summary

- replace the machine-wide `conversations.jsonl` archive with a WAL-backed SQLite database
- index each message by a local sequence and normalized participants so `a8s convo -f` can query every row after its cursor
- keep `a8s convo --limit` as a display-only backlog window
- rename the retention setting to `convo_max_rows` and default it to 50,000 rows
- prune conversation history during `a8s update`, not during message insertion
- detect archive replacement/reset and resume the follower from the replacement database

## Why

The bounded JSONL archive was serving as both retained history and a live event stream. At the row cap, compaction could remove messages before a follower's next poll, and concurrent handlers could race during read-modify-rewrite rotation. SQLite provides transactional message-ID deduplication, serialized concurrent writes, indexed participant queries, and a monotonic sequence cursor for follow.

Because a8s is pre-v1, this intentionally does not migrate or delete an existing `conversations.jsonl`. Fresh conversation state is created in `conversations.sqlite3`.

## Behavior

`a8s update` now runs conversation housekeeping even when no nodes are running. It retains the newest configured `convo_max_rows`, runs SQLite optimization/checkpoint work, and then performs the existing handler restart flow. Inserts never prune rows.

If housekeeping advances beyond a live follower's sequence cursor, follow emits a visible warning that messages may have been missed.

## Validation

- `venv/bin/python3 -m pytest apps/a8s/tests/ -q`
- 767 passed
- `venv/bin/python3 -m compileall -q apps/a8s`
- `git diff --check`
