### PR TITLE
feat(n0b): switch ai research to gpt-5.6-sol

### DIFF
--- a/.claude/skills/research/SKILL.md
+++ b/.claude/skills/research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research
-description: "Deep research via n0b ai research (o4-mini-deep-research). Requires OPENAI_API_KEY."
+description: "Deep research via n0b ai research (gpt-5.6-sol). Requires OPENAI_API_KEY."
 disable-model-invocation: false
 allowed-tools: Bash(n0b ai research *)
 argument-hint: "prompt text"
@@ -15,4 +15,4 @@ Canonical documentation: [`apps/n0b/docs/research.md`](../../apps/n0b/docs/resea
 n0b ai research "Your research prompt here"
 ```
 
-Implementation: `apps/n0b/research.py` (stdlib only). Cache: `.files/research/<hash>.json`.
+Implementation: `apps/n0b/research.py` (stdlib only; model `gpt-5.6-sol`). Cache: `.files/research/<hash>.json`.

--- a/apps/n0b/README.md
+++ b/apps/n0b/README.md
@@ -22,7 +22,7 @@ Detailed docs live in [`docs/`](docs/):
 |-----|---------|---------|
 | [json.md](docs/json.md) | `n0b json` | Pretty-print JSON via stdlib `json.tool` |
 | [ltx-video.md](docs/ltx-video.md) | `n0b ai video` | LTX-Video generation, models, setup guide |
-| [research.md](docs/research.md) | `n0b ai research` | OpenAI o4-mini-deep-research |
+| [research.md](docs/research.md) | `n0b ai research` | OpenAI deep research (`gpt-5.6-sol`) |
 | [secrets.md](docs/secrets.md) | `n0b secrets` | Get/set secrets — env, `~/lib`, Keychain, dotenv |
 | [ai-speak.md](docs/ai-speak.md) | `n0b ai speak` | Text-to-speech — macOS `say` or offline Kokoro |
 | [z-image.md](docs/z-image.md) | `n0b ai image` | Z-Image-Turbo text-to-image and `--ref` img2img |

--- a/apps/n0b/cli.py
+++ b/apps/n0b/cli.py
@@ -159,7 +159,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     ai_p = sub.add_parser("ai", help="AI generation and research")
     ai_sub = ai_p.add_subparsers(dest="ai_kind", required=True)
-    ai_research = ai_sub.add_parser("research", help="Deep research via o4-mini-deep-research")
+    ai_research = ai_sub.add_parser("research", help="Deep research via gpt-5.6-sol")
     ai_research.add_argument("prompt", nargs=argparse.REMAINDER)
     ai_speak = ai_sub.add_parser(
         "speak",

--- a/apps/n0b/docs/research.md
+++ b/apps/n0b/docs/research.md
@@ -1,12 +1,15 @@
 ---
 name: "n0b-research"
-description: "Deep research via n0b ai research (o4-mini-deep-research). Requires OPENAI_API_KEY."
+description: "Deep research via n0b ai research (gpt-5.6-sol). Requires OPENAI_API_KEY."
 allowed-tools: Bash(n0b ai research *)
 ---
 
 # n0b ai research
 
-CLI for OpenAI's Deep Research API (`o4-mini-deep-research`) — multi-step, agentic research with source transparency.
+CLI for OpenAI deep research via the Responses API (`gpt-5.6-sol`, with
+`web_search_preview`) — multi-step, agentic research with source transparency.
+(`o4-mini-deep-research` shut down 2026-07-23; OpenAI's replacement is
+`gpt-5.6-sol`.)
 
 ## Usage
 
@@ -29,3 +32,4 @@ All arguments after `research` are concatenated into a single prompt.
 
 - **CLI:** `n0b ai research`
 - **Code:** `apps/n0b/research.py` (stdlib only)
+- **Model:** `gpt-5.6-sol`

--- a/apps/n0b/research.py
+++ b/apps/n0b/research.py
@@ -1,4 +1,8 @@
-"""OpenAI o4-mini-deep-research (stdlib only)."""
+"""OpenAI deep research via the Responses API (stdlib only).
+
+Uses ``gpt-5.6-sol`` (OpenAI's replacement after ``o4-mini-deep-research``
+shut down 2026-07-23).
+"""
 from __future__ import annotations
 
 import hashlib
@@ -10,6 +14,8 @@ import urllib.request
 
 from commands.secrets_cmd import resolve
 from paths import BIN_ROOT
+
+RESEARCH_MODEL = "gpt-5.6-sol"
 
 
 def _get_hash(prompt: str) -> str:
@@ -24,7 +30,7 @@ def _call_openai(api_key: str, prompt: str) -> dict:
         "Content-Type": "application/json",
     }
     data = {
-        "model": "o4-mini-deep-research",
+        "model": RESEARCH_MODEL,
         "input": prompt,
         "tools": [{"type": "web_search_preview"}],
         "background": True,


### PR DESCRIPTION
## Summary
- Point `n0b ai research` at `gpt-5.6-sol` after `o4-mini-deep-research` shut down (2026-07-23)
- Update CLI help, README, docs, and research skill to match

## Test plan
- [ ] `n0b ai research --help` shows `gpt-5.6-sol`
- [ ] With `OPENAI_API_KEY` set, run a short research prompt and confirm the Responses API accepts the model (polls to `completed`)
- [ ] Confirm cached runs under `.files/research/` still resume by response id (old caches for the retired model may fail — delete and re-run if needed)


Made with [Cursor](https://cursor.com)