### PR TITLE
feat(r4t): continue core (#253)

### DIFF
--- a/apps/r4t/dispatch.py
+++ b/apps/r4t/dispatch.py
@@ -521,8 +521,15 @@ def run_harness(
     the choice rides in via the turn env and the argv is wrapped in the OS-level
     boundary — every member turn of that org, whatever rig. An isolation prereq
     that fails closed returns a nonzero exit like any other failed turn — the
-    batch stays queued and the breaker counts it."""
-    argv = rig.argv(prompt, variant)
+    batch stays queued and the breaker counts it.
+
+    `R4T_CONTINUE` in the env (set for a member with `Continue: on`) appends the
+    rig's continue tokens so the CLI resumes the conversation it already has in
+    `cwd`. It rides the env for the same reason isolation does: the run_fn
+    contract stays narrow."""
+    argv = rig.argv(
+        prompt, variant, continue_conversation=(env or {}).get("R4T_CONTINUE") == "1"
+    )
     if rig.model_resolver == "agy-live":
         # Resolve the friendly --model against the live `agy models` list before
         # every turn — the display names drift as agy ships versions, and agy
@@ -1173,6 +1180,12 @@ def _run_turn(
     # (r4t-<node>-<member>-<ts>) without widening the run_fn contract.
     env["R4T_NODE"] = ctx.node
     env["R4T_MEMBER"] = member.name
+    # `Continue: on` — the member's own CLI conversation carries its recent work
+    # forward and the provider cache prices the wake as a continuation rather
+    # than a fresh full prompt. rig_for has already refused any member whose rig
+    # cannot continue, so no second check is needed here.
+    if member.continue_conversation:
+        env["R4T_CONTINUE"] = "1"
     # The org's OS-level boundary (org.py) rides in the same way — one setting
     # wraps every member turn regardless of rig (machinery outside, hands inside).
     env.update(ctx.isolation.to_env())
@@ -1188,6 +1201,27 @@ def _run_turn(
     exit_code, output, duration, timed_out = run_fn(
         rig, prompt, ctx.workplace, env=env, variant=variant
     )
+
+    # Some CLIs (cursor) refuse to launch at all when asked to continue a
+    # conversation that does not exist yet — the state every continuing member
+    # starts in. Retry that ONE failure cold: the turn founds the conversation
+    # every later turn continues. Any other failure falls through to the normal
+    # requeue-and-breaker path.
+    if (
+        member.continue_conversation
+        and (timed_out or exit_code != 0)
+        and rig.had_no_prior_conversation(output)
+    ):
+        state.append_log(
+            ctx.node,
+            f"r4t: CONTINUE-COLD {member.name.lower()} (rig {rig.name}) exit "
+            f"{exit_code}: no conversation to continue in {ctx.workplace} — "
+            "retrying once without it to found one",
+        )
+        del env["R4T_CONTINUE"]
+        exit_code, output, duration, timed_out = run_fn(
+            rig, prompt, ctx.workplace, env=env, variant=variant
+        )
 
     outcome = f"exit {exit_code} in {duration:.1f}s"
     if timed_out:

--- a/apps/r4t/docs/rigs.md
+++ b/apps/r4t/docs/rigs.md
@@ -33,20 +33,17 @@ A member with `- **Continue:** on` in the roster runs its turns inside its
 CLI's own conversation instead of a cold prompt every wake: the agent keeps
 its recent work, and the provider cache prices the wake as a continuation.
 It needs a rig whose preset supports it — `claude`, `cursor`, `opencode`,
-`opencode-ollama`, `copilot`, `agy` (`r4t rig presets` marks them); anything
-else fails closed at `r4t roster check` and at dispatch. `codex` is absent
-because it resumes through the `codex exec resume` subcommand, which no
-appended flag can reach.
+`opencode-ollama`, `agy` (`r4t rig presets` marks them); anything else fails
+closed at `r4t roster check` and at dispatch. `codex` is unsupported because
+it resumes through the `codex exec resume` subcommand, which no appended flag
+can reach. `copilot` is unsupported because its `--continue` resumes the
+machine's most recent session whatever the directory, so members cannot be
+kept apart; supporting it cleanly means pinning a session id per member
+(issue #256).
 
 A CLI keeps ONE conversation per directory, so two members running the same
 CLI in the team workplace land in the same one. `r4t roster check` warns when
 that happens — it never blocks, but the fix is to put them on different CLIs.
-
-`copilot` is the exception: its `--continue` resumes the machine's most recent
-session whatever the directory, so two continuing copilot members share one
-conversation even from different directories — and so does any other org
-running copilot on the same machine. Give at most one member on a machine a
-continuing copilot rig.
 
 ## Picking a model (`--model`)
 

--- a/apps/r4t/docs/rigs.md
+++ b/apps/r4t/docs/rigs.md
@@ -32,14 +32,14 @@ if a roster member or pin still references the rig, naming what does; pass
 A member with `- **Continue:** on` in the roster runs its turns inside its
 CLI's own conversation instead of a cold prompt every wake: the agent keeps
 its recent work, and the provider cache prices the wake as a continuation.
-It needs a rig whose preset supports it — `claude`, `cursor`, `opencode`,
-`opencode-ollama`, `agy` (`r4t rig presets` marks them); anything else fails
-closed at `r4t roster check` and at dispatch. `codex` is unsupported because
-it resumes through the `codex exec resume` subcommand, which no appended flag
-can reach. `copilot` is unsupported because its `--continue` resumes the
-machine's most recent session whatever the directory, so members cannot be
-kept apart; supporting it cleanly means pinning a session id per member
-(issue #256).
+It needs a rig whose preset supports it — `claude`, `codex`, `cursor`,
+`opencode`, `opencode-ollama`, `agy` (`r4t rig presets` marks them); anything
+else fails closed at `r4t roster check` and at dispatch. Most presets append a
+`--continue` flag; `codex` resumes through the `exec resume --last` subcommand,
+so its tokens are inserted after `exec` instead. `copilot` is the one
+unsupported CLI: its `--continue` resumes the machine's most recent session
+whatever the directory, so members cannot be kept apart, and supporting it
+cleanly means pinning a session id per member (issue #256).
 
 A CLI keeps ONE conversation per directory, so two members running the same
 CLI in the team workplace land in the same one. `r4t roster check` warns when

--- a/apps/r4t/docs/rigs.md
+++ b/apps/r4t/docs/rigs.md
@@ -33,9 +33,10 @@ A member with `- **Continue:** on` in the roster runs its turns inside its
 CLI's own conversation instead of a cold prompt every wake: the agent keeps
 its recent work, and the provider cache prices the wake as a continuation.
 It needs a rig whose preset supports it — `claude`, `cursor`, `opencode`,
-`copilot`, `agy` (`r4t rig presets` marks them); anything else fails closed
-at `r4t roster check` and at dispatch. `codex` is absent because it resumes
-through the `codex exec resume` subcommand, which no appended flag can reach.
+`opencode-ollama`, `copilot`, `agy` (`r4t rig presets` marks them); anything
+else fails closed at `r4t roster check` and at dispatch. `codex` is absent
+because it resumes through the `codex exec resume` subcommand, which no
+appended flag can reach.
 
 A CLI keeps ONE conversation per directory, so two members running the same
 CLI in the team workplace land in the same one. `r4t roster check` warns when

--- a/apps/r4t/docs/rigs.md
+++ b/apps/r4t/docs/rigs.md
@@ -41,6 +41,12 @@ A CLI keeps ONE conversation per directory, so two members running the same
 CLI in the team workplace land in the same one. `r4t roster check` warns when
 that happens — it never blocks, but the fix is to put them on different CLIs.
 
+`copilot` is the exception: its `--continue` resumes the machine's most recent
+session whatever the directory, so two continuing copilot members share one
+conversation even from different directories — and so does any other org
+running copilot on the same machine. Give at most one member on a machine a
+continuing copilot rig.
+
 ## Picking a model (`--model`)
 
 `r4t rig add` and `r4t rig swap` take an optional `--model`. For most presets

--- a/apps/r4t/docs/rigs.md
+++ b/apps/r4t/docs/rigs.md
@@ -27,6 +27,20 @@ r4t rig remove worker                 # drop a rig (alias: rm)
 if a roster member or pin still references the rig, naming what does; pass
 `--force` to remove anyway.
 
+## Continuing a conversation
+
+A member with `- **Continue:** on` in the roster runs its turns inside its
+CLI's own conversation instead of a cold prompt every wake: the agent keeps
+its recent work, and the provider cache prices the wake as a continuation.
+It needs a rig whose preset supports it — `claude`, `cursor`, `opencode`,
+`copilot`, `agy` (`r4t rig presets` marks them); anything else fails closed
+at `r4t roster check` and at dispatch. `codex` is absent because it resumes
+through the `codex exec resume` subcommand, which no appended flag can reach.
+
+A CLI keeps ONE conversation per directory, so two members running the same
+CLI in the team workplace land in the same one. `r4t roster check` warns when
+that happens — it never blocks, but the fix is to put them on different CLIs.
+
 ## Picking a model (`--model`)
 
 `r4t rig add` and `r4t rig swap` take an optional `--model`. For most presets

--- a/apps/r4t/r4t.py
+++ b/apps/r4t/r4t.py
@@ -28,7 +28,6 @@ from dispatch import (
     split_recipient,
 )
 from rig import (
-    CONTINUE_SCOPE_GLOBAL,
     RigError,
     HARNESS_PRESETS,
     add_preset_rig,
@@ -973,15 +972,9 @@ def cmd_rig_presets(_args: argparse.Namespace) -> int:
         print(f"  {'':<{width}}  headless: {entry['headless']}")
         print(f"  {'':<{width}}  invoke: {format_preset_invoke(name)}")
         if entry.get("continue_argv"):
-            scope = (
-                " — resumes the machine's most recent session, not this "
-                "directory's"
-                if entry.get("continue_scope") == CONTINUE_SCOPE_GLOBAL
-                else ""
-            )
             print(
                 f"  {'':<{width}}  continue: {' '.join(entry['continue_argv'])} "
-                f"(roster `- **Continue:** on`){scope}"
+                "(roster `- **Continue:** on`)"
             )
     print()
     print("Add one: r4t rig add <rig-name> <preset>")

--- a/apps/r4t/r4t.py
+++ b/apps/r4t/r4t.py
@@ -28,6 +28,7 @@ from dispatch import (
     split_recipient,
 )
 from rig import (
+    CONTINUE_SCOPE_GLOBAL,
     RigError,
     HARNESS_PRESETS,
     add_preset_rig,
@@ -972,9 +973,15 @@ def cmd_rig_presets(_args: argparse.Namespace) -> int:
         print(f"  {'':<{width}}  headless: {entry['headless']}")
         print(f"  {'':<{width}}  invoke: {format_preset_invoke(name)}")
         if entry.get("continue_argv"):
+            scope = (
+                " — resumes the machine's most recent session, not this "
+                "directory's"
+                if entry.get("continue_scope") == CONTINUE_SCOPE_GLOBAL
+                else ""
+            )
             print(
                 f"  {'':<{width}}  continue: {' '.join(entry['continue_argv'])} "
-                "(roster `- **Continue:** on`)"
+                f"(roster `- **Continue:** on`){scope}"
             )
     print()
     print("Add one: r4t rig add <rig-name> <preset>")

--- a/apps/r4t/r4t.py
+++ b/apps/r4t/r4t.py
@@ -32,6 +32,7 @@ from rig import (
     HARNESS_PRESETS,
     add_preset_rig,
     build_preset_invoke,
+    continue_collisions,
     default_config_path,
     default_config_payload,
     format_preset_invoke,
@@ -970,6 +971,11 @@ def cmd_rig_presets(_args: argparse.Namespace) -> int:
         print(f"  {name:<{width}}  {entry['description']}")
         print(f"  {'':<{width}}  headless: {entry['headless']}")
         print(f"  {'':<{width}}  invoke: {format_preset_invoke(name)}")
+        if entry.get("continue_argv"):
+            print(
+                f"  {'':<{width}}  continue: {' '.join(entry['continue_argv'])} "
+                "(roster `- **Continue:** on`)"
+            )
     print()
     print("Add one: r4t rig add <rig-name> <preset>")
     print("Example: r4t rig add worker opencode")
@@ -1247,6 +1253,10 @@ def cmd_roster_check(args: argparse.Namespace) -> int:
         )
         problems += 1
     warnings = 0
+    if config is not None:
+        for message in continue_collisions(roster, config):
+            print(f"warning: {message}")
+            warnings += 1
     for severity, message in roster.tree_problems():
         if severity == "error":
             print(message)

--- a/apps/r4t/rig.py
+++ b/apps/r4t/rig.py
@@ -33,7 +33,11 @@ plan always declares a refill rate.
 `preset` — the harness preset the rig was created from (`r4t rig add`/`swap`
 record it). It defaults the text knobs (`history_max_bytes` /
 `history_body_max` / `prompt_body_max`) by the preset's text tier (TEXT_TIERS);
-explicit values always win, and a rig with no preset gets the small tier.
+explicit values always win, and a rig with no preset gets the small tier. It
+also carries the preset's `continue_argv` — the tokens that make the CLI resume
+its own conversation instead of starting from a cold prompt. A rig with no
+preset, or one whose preset has no `continue_argv`, cannot continue; a roster
+member asking for it fails closed (see `RigConfig.rig_for`).
 
 OS-level isolation (`run_as` / `container`) is NOT a rig key — it is a
 per-org decision (rigs are machine-global and shared across orgs, so one Unix
@@ -51,7 +55,7 @@ import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from roster import Member
+from roster import Member, Roster
 from state import atomic_write_json, r4t_home
 
 PROMPT_PLACEHOLDER = "{prompt}"
@@ -66,6 +70,13 @@ RESERVED_CONFIG_KEYS = frozenset({
     "quiet_task_seconds",
 })
 
+# `continue_argv` is present only where the CLI's own `--help` was read and the
+# flag verified against the installed binary; a preset without it does not
+# support continuing, which is a fine state. `no_prior_conversation` is the
+# regex (matched case-insensitively against a failed turn's output) that says
+# the CLI refused to launch because there is no conversation in this directory
+# yet — only cursor does that; claude, copilot, opencode and agy quietly found
+# one and exit 0, so they need no pattern.
 HARNESS_PRESETS: dict[str, dict] = {
     "claude": {
         "text_tier": "big",
@@ -82,8 +93,11 @@ HARNESS_PRESETS: dict[str, dict] = {
             "{prompt}",
         ],
         "model_argv": ["--model", "{model}"],
+        "continue_argv": ["--continue"],
     },
     "codex": {
+        # No continue_argv: codex resumes via the `codex exec resume` SUBCOMMAND,
+        # which cannot be expressed as tokens appended to an existing argv.
         "text_tier": "big",
         "description": "OpenAI Codex CLI — matches apps/a8s/definitions/codex.json",
         "a8s_definition": "codex.json",
@@ -112,6 +126,8 @@ HARNESS_PRESETS: dict[str, dict] = {
             "{prompt}",
         ],
         "model_argv": ["--model", "{model}"],
+        "continue_argv": ["--continue"],
+        "no_prior_conversation": r"no previous chats found",
     },
     "opencode": {
         "text_tier": "moderate",
@@ -130,6 +146,7 @@ HARNESS_PRESETS: dict[str, dict] = {
         ],
         "model_argv": ["-m", "{model}"],
         "model_anchor": "run",
+        "continue_argv": ["--continue"],
     },
     "opencode-ollama": {
         "text_tier": "small",
@@ -258,6 +275,7 @@ HARNESS_PRESETS: dict[str, dict] = {
         ],
         "model_argv": ["--model", "{model}"],
         "model_resolver": "agy-live",
+        "continue_argv": ["--continue"],
     },
     "copilot": {
         "text_tier": "moderate",
@@ -270,6 +288,7 @@ HARNESS_PRESETS: dict[str, dict] = {
             "-p",
             "{prompt}",
         ],
+        "continue_argv": ["--continue"],
     },
 }
 
@@ -347,7 +366,37 @@ class Rig:
     prompt_body_max: int = DEFAULT_PROMPT_BODY_MAX
     model: str | None = None
     model_resolver: str | None = None
+    preset: str | None = None
     error: str | None = None
+
+    @property
+    def continue_argv(self) -> list[str]:
+        """Tokens that make this rig's CLI resume the conversation it already
+        has in the turn directory. Empty when the preset (or its absence) gives
+        no verified way to continue."""
+        return list(HARNESS_PRESETS.get(self.preset or "", {}).get("continue_argv", ()))
+
+    @property
+    def supports_continue(self) -> bool:
+        return bool(self.continue_argv)
+
+    @property
+    def cli(self) -> str:
+        """The CLI binary this rig drives — what a conversation is keyed on,
+        together with the directory. `ollama launch <tool>` drives <tool>."""
+        argv = next(iter(self.pool()), [])
+        if not argv:
+            return ""
+        binary = Path(argv[0]).name
+        if binary == "ollama" and argv[1:2] == ["launch"] and len(argv) > 2:
+            return argv[2]
+        return binary
+
+    def had_no_prior_conversation(self, output: str) -> bool:
+        """True when a failed turn's output is the CLI saying it had no
+        conversation here to continue — the one failure worth retrying cold."""
+        pattern = HARNESS_PRESETS.get(self.preset or "", {}).get("no_prior_conversation")
+        return bool(pattern) and re.search(pattern, output, re.IGNORECASE) is not None
 
     def pool(self) -> list[list[str]]:
         """`invoke` is one argv (list of str) or a pool (list of argvs) —
@@ -361,10 +410,15 @@ class Rig:
     def pool_size(self) -> int:
         return len(self.pool())
 
-    def argv(self, prompt: str, index: int = 0) -> list[str]:
+    def argv(
+        self, prompt: str, index: int = 0, *, continue_conversation: bool = False
+    ) -> list[str]:
         pool = self.pool()
         chosen = pool[index % len(pool)]
-        return [a.replace(PROMPT_PLACEHOLDER, prompt) for a in chosen]
+        argv = [a.replace(PROMPT_PLACEHOLDER, prompt) for a in chosen]
+        if continue_conversation:
+            argv += self.continue_argv
+        return argv
 
 
 @dataclass
@@ -405,6 +459,15 @@ class RigConfig:
             )
         if rig.error:
             return None, f"rig {rig_name!r} is invalid: {rig.error}", pinned
+        if member.continue_conversation and not rig.supports_continue:
+            return (
+                None,
+                f"{member.name} has Continue: on but rig {rig_name!r} does not "
+                f"support it (preset {rig.preset or 'none'}; presets that "
+                f"continue: {', '.join(continue_presets())}) — "
+                f"try: r4t rig swap {rig_name} <preset>",
+                pinned,
+            )
         return rig, None, pinned
 
 
@@ -414,6 +477,43 @@ def default_config_path() -> Path:
 
 def preset_names() -> list[str]:
     return sorted(HARNESS_PRESETS)
+
+
+def continue_presets() -> list[str]:
+    """Presets whose CLI can resume its own conversation."""
+    return [n for n in preset_names() if HARNESS_PRESETS[n].get("continue_argv")]
+
+
+def continue_collisions(roster: Roster, config: RigConfig) -> list[str]:
+    """Warn (never block) where `Continue: on` will cross wires with a teammate.
+
+    A CLI keys its conversation on the directory it runs from, so two members
+    driving the SAME CLI from the same directory land in one conversation —
+    reading each other's turns and overwriting each other's tail. The other
+    member does not have to be continuing to clobber it; it only has to run the
+    same CLI there. Today every member works in the one team workplace, so the
+    CLI alone identifies the conversation; a per-member workdir would widen the
+    key to (directory, CLI)."""
+    seats: list[tuple[Member, Rig]] = []
+    for m in roster.members:
+        if m.is_human or m.errors:
+            continue
+        rig, _err, _pinned = config.rig_for(m)
+        if rig is not None:
+            seats.append((m, rig))
+    out: list[str] = []
+    for member, rig in seats:
+        if not member.continue_conversation:
+            continue
+        others = [o.name for o, r in seats if o is not member and r.cli == rig.cli]
+        if others:
+            out.append(
+                f"{member.name}: Continue: on, but {', '.join(others)} also run "
+                f"{rig.cli!r} in the same directory — one CLI keeps one "
+                f"conversation per directory, so their turns will land in "
+                f"{member.name}'s (try: move one of them to a rig on another CLI)"
+            )
+    return out
 
 
 def format_preset_invoke(preset: str) -> str:
@@ -911,6 +1011,7 @@ def _parse_rig(name: str, raw: object) -> Rig:
         rig.error = err
         return rig
     rig.invoke = invoke
+    rig.preset = _entry_preset(raw)
 
     resolver = raw.get("model_resolver")
     if resolver is not None:
@@ -946,7 +1047,7 @@ def _parse_rig(name: str, raw: object) -> Rig:
     # — a 0.6B local member and an agy seat should not share a history budget.
     # Explicit values in rigs.json win; a rig with no `preset` (custom CLI)
     # gets the conservative small tier.
-    defaults = text_defaults(raw.get("preset") if isinstance(raw.get("preset"), str) else None)
+    defaults = text_defaults(rig.preset)
     for knob in ("history_max_bytes", "history_body_max", "prompt_body_max"):
         value, err = _positive_number(raw.get(knob), defaults[knob])
         if err:

--- a/apps/r4t/rig.py
+++ b/apps/r4t/rig.py
@@ -75,8 +75,13 @@ RESERVED_CONFIG_KEYS = frozenset({
 # support continuing, which is a fine state. `no_prior_conversation` is the
 # regex (matched case-insensitively against a failed turn's output) that says
 # the CLI refused to launch because there is no conversation in this directory
-# yet — only cursor does that; claude, copilot, opencode and agy quietly found
-# one and exit 0, so they need no pattern.
+# yet — only cursor does that; the others quietly found one and exit 0, so they
+# need no pattern. `continue_scope` says what the CLI's "most recent
+# conversation" is scoped to; absent means the directory it runs from, which is
+# every verified CLI but copilot.
+CONTINUE_SCOPE_DIRECTORY = "directory"
+CONTINUE_SCOPE_GLOBAL = "global"
+
 HARNESS_PRESETS: dict[str, dict] = {
     "claude": {
         "text_tier": "big",
@@ -289,6 +294,10 @@ HARNESS_PRESETS: dict[str, dict] = {
             "{prompt}",
         ],
         "continue_argv": ["--continue"],
+        # Verified live: a --continue run in a virgin directory resumed a
+        # session planted in an unrelated one, same session id in both footers.
+        # copilot's "most recent session" is the machine's, not the cwd's.
+        "continue_scope": CONTINUE_SCOPE_GLOBAL,
     },
 }
 
@@ -379,6 +388,17 @@ class Rig:
     @property
     def supports_continue(self) -> bool:
         return bool(self.continue_argv)
+
+    @property
+    def continue_scope(self) -> str:
+        """What the CLI's "most recent conversation" is scoped to. Every
+        verified CLI but copilot keys it on the directory the turn runs from;
+        copilot resumes the machine's most recent session whatever the cwd, so
+        no working directory can ever separate two continuing copilot members —
+        not even members of different orgs on the same machine."""
+        return HARNESS_PRESETS.get(self.preset or "", {}).get(
+            "continue_scope", CONTINUE_SCOPE_DIRECTORY
+        )
 
     @property
     def cli(self) -> str:
@@ -493,7 +513,10 @@ def continue_collisions(roster: Roster, config: RigConfig) -> list[str]:
     member does not have to be continuing to clobber it; it only has to run the
     same CLI there. Today every member works in the one team workplace, so the
     CLI alone identifies the conversation; a per-member workdir would widen the
-    key to (directory, CLI)."""
+    key to (directory, CLI) — but only for directory-scoped CLIs. A
+    global-scope CLI (copilot) ignores the directory, so no workdir will ever
+    separate two of its continuing members, and the reach is the whole machine
+    rather than the team."""
     seats: list[tuple[Member, Rig]] = []
     for m in roster.members:
         if m.is_human or m.errors:
@@ -506,7 +529,18 @@ def continue_collisions(roster: Roster, config: RigConfig) -> list[str]:
         if not member.continue_conversation:
             continue
         others = [o.name for o, r in seats if o is not member and r.cli == rig.cli]
-        if others:
+        if not others:
+            continue
+        if rig.continue_scope == CONTINUE_SCOPE_GLOBAL:
+            out.append(
+                f"{member.name}: Continue: on, but {rig.cli!r} resumes the "
+                f"machine's most recent session whatever the directory — "
+                f"{', '.join(others)} will land in {member.name}'s conversation, "
+                f"and so will any other org running {rig.cli!r} on this machine; "
+                f"no workdir can separate them "
+                f"(try: move one of them to a rig on another CLI)"
+            )
+        else:
             out.append(
                 f"{member.name}: Continue: on, but {', '.join(others)} also run "
                 f"{rig.cli!r} in the same directory — one CLI keeps one "

--- a/apps/r4t/rig.py
+++ b/apps/r4t/rig.py
@@ -76,12 +76,7 @@ RESERVED_CONFIG_KEYS = frozenset({
 # regex (matched case-insensitively against a failed turn's output) that says
 # the CLI refused to launch because there is no conversation in this directory
 # yet — only cursor does that; the others quietly found one and exit 0, so they
-# need no pattern. `continue_scope` says what the CLI's "most recent
-# conversation" is scoped to; absent means the directory it runs from, which is
-# every verified CLI but copilot.
-CONTINUE_SCOPE_DIRECTORY = "directory"
-CONTINUE_SCOPE_GLOBAL = "global"
-
+# need no pattern.
 HARNESS_PRESETS: dict[str, dict] = {
     "claude": {
         "text_tier": "big",
@@ -287,6 +282,10 @@ HARNESS_PRESETS: dict[str, dict] = {
         "continue_argv": ["--continue"],
     },
     "copilot": {
+        # No continue_argv: `copilot --continue` resumes the machine's most
+        # recent session whatever the directory, so members cannot be kept
+        # apart. Clean support means pinning `--resume=<session-id>` per
+        # member; that is issue #256, not this preset.
         "text_tier": "moderate",
         "description": "GitHub Copilot CLI — matches apps/a8s/definitions/copilot.json",
         "a8s_definition": "copilot.json",
@@ -297,11 +296,6 @@ HARNESS_PRESETS: dict[str, dict] = {
             "-p",
             "{prompt}",
         ],
-        "continue_argv": ["--continue"],
-        # Verified live: a --continue run in a virgin directory resumed a
-        # session planted in an unrelated one, same session id in both footers.
-        # copilot's "most recent session" is the machine's, not the cwd's.
-        "continue_scope": CONTINUE_SCOPE_GLOBAL,
     },
 }
 
@@ -392,17 +386,6 @@ class Rig:
     @property
     def supports_continue(self) -> bool:
         return bool(self.continue_argv)
-
-    @property
-    def continue_scope(self) -> str:
-        """What the CLI's "most recent conversation" is scoped to. Every
-        verified CLI but copilot keys it on the directory the turn runs from;
-        copilot resumes the machine's most recent session whatever the cwd, so
-        no working directory can ever separate two continuing copilot members —
-        not even members of different orgs on the same machine."""
-        return HARNESS_PRESETS.get(self.preset or "", {}).get(
-            "continue_scope", CONTINUE_SCOPE_DIRECTORY
-        )
 
     @property
     def cli(self) -> str:
@@ -517,10 +500,7 @@ def continue_collisions(roster: Roster, config: RigConfig) -> list[str]:
     member does not have to be continuing to clobber it; it only has to run the
     same CLI there. Today every member works in the one team workplace, so the
     CLI alone identifies the conversation; a per-member workdir would widen the
-    key to (directory, CLI) — but only for directory-scoped CLIs. A
-    global-scope CLI (copilot) ignores the directory, so no workdir will ever
-    separate two of its continuing members, and the reach is the whole machine
-    rather than the team."""
+    key to (directory, CLI)."""
     seats: list[tuple[Member, Rig]] = []
     for m in roster.members:
         if m.is_human or m.errors:
@@ -533,18 +513,7 @@ def continue_collisions(roster: Roster, config: RigConfig) -> list[str]:
         if not member.continue_conversation:
             continue
         others = [o.name for o, r in seats if o is not member and r.cli == rig.cli]
-        if not others:
-            continue
-        if rig.continue_scope == CONTINUE_SCOPE_GLOBAL:
-            out.append(
-                f"{member.name}: Continue: on, but {rig.cli!r} resumes the "
-                f"machine's most recent session whatever the directory — "
-                f"{', '.join(others)} will land in {member.name}'s conversation, "
-                f"and so will any other org running {rig.cli!r} on this machine; "
-                f"no workdir can separate them "
-                f"(try: move one of them to a rig on another CLI)"
-            )
-        else:
+        if others:
             out.append(
                 f"{member.name}: Continue: on, but {', '.join(others)} also run "
                 f"{rig.cli!r} in the same directory — one CLI keeps one "

--- a/apps/r4t/rig.py
+++ b/apps/r4t/rig.py
@@ -76,7 +76,9 @@ RESERVED_CONFIG_KEYS = frozenset({
 # regex (matched case-insensitively against a failed turn's output) that says
 # the CLI refused to launch because there is no conversation in this directory
 # yet — only cursor does that; the others quietly found one and exit 0, so they
-# need no pattern.
+# need no pattern. `continue_anchor` places the tokens immediately after that
+# argv token instead of at the end, the way `model_anchor` does — a CLI whose
+# continuation is a subcommand cannot be appended to a finished argv.
 HARNESS_PRESETS: dict[str, dict] = {
     "claude": {
         "text_tier": "big",
@@ -96,8 +98,12 @@ HARNESS_PRESETS: dict[str, dict] = {
         "continue_argv": ["--continue"],
     },
     "codex": {
-        # No continue_argv: codex resumes via the `codex exec resume` SUBCOMMAND,
-        # which cannot be expressed as tokens appended to an existing argv.
+        # Continuation is the `resume --last` SUBCOMMAND, so it cannot be
+        # appended to a finished argv — it goes immediately after `exec`, the
+        # same anchor the model flags use, leaving
+        # `codex exec resume --last -m MODEL <flags> <prompt>`.
+        # `resume` also takes an optional [SESSION_ID] in place of --last: the
+        # native way to pin ONE conversation, which is where #256 will look.
         "text_tier": "big",
         "description": "OpenAI Codex CLI — matches apps/a8s/definitions/codex.json",
         "a8s_definition": "codex.json",
@@ -111,6 +117,8 @@ HARNESS_PRESETS: dict[str, dict] = {
         ],
         "model_argv": ["-m", "{model}"],
         "model_anchor": "exec",
+        "continue_argv": ["resume", "--last"],
+        "continue_anchor": "exec",
     },
     "cursor": {
         "text_tier": "moderate",
@@ -384,8 +392,21 @@ class Rig:
         return list(HARNESS_PRESETS.get(self.preset or "", {}).get("continue_argv", ()))
 
     @property
+    def continue_anchor(self) -> str | None:
+        """The argv token the continue tokens go immediately after. None (every
+        flag-shaped CLI) means append at the end; codex needs one because
+        `resume --last` is a subcommand and only reads in that position."""
+        return HARNESS_PRESETS.get(self.preset or "", {}).get("continue_anchor")
+
+    @property
     def supports_continue(self) -> bool:
-        return bool(self.continue_argv)
+        """False unless the tokens have somewhere to go. An anchored preset
+        whose invoke was hand-edited past its anchor fails closed here rather
+        than building an argv the CLI would read as something else."""
+        if not self.continue_argv:
+            return False
+        anchor = self.continue_anchor
+        return anchor is None or all(anchor in argv for argv in self.pool())
 
     @property
     def cli(self) -> str:
@@ -423,8 +444,10 @@ class Rig:
         pool = self.pool()
         chosen = pool[index % len(pool)]
         argv = [a.replace(PROMPT_PLACEHOLDER, prompt) for a in chosen]
-        if continue_conversation:
-            argv += self.continue_argv
+        if continue_conversation and self.continue_argv:
+            anchor = self.continue_anchor
+            at = argv.index(anchor) + 1 if anchor else len(argv)
+            argv[at:at] = self.continue_argv
         return argv
 
 

--- a/apps/r4t/rig.py
+++ b/apps/r4t/rig.py
@@ -174,6 +174,10 @@ HARNESS_PRESETS: dict[str, dict] = {
             ".",
             "{prompt}",
         ],
+        # `ollama launch` passes the appended flag through to opencode, whose
+        # own per-directory session store then works normally (verified live
+        # against a local model: planted, resumed, and founded cold cleanly).
+        "continue_argv": ["--continue"],
     },
     "claude-ollama": {
         "text_tier": "small",

--- a/apps/r4t/roster.py
+++ b/apps/r4t/roster.py
@@ -7,7 +7,14 @@ Format: `### <Name>` blocks with bullet fields:
     - **Rig:** junior-dev
     - **Role:** Lead Backend Engineer
     - **Leader:** yes
+    - **Continue:** on
     Free persona prose lives anywhere in the block.
+
+`Continue:` (default off) runs the member's turns inside its CLI's own
+conversation instead of a fresh prompt every wake — the agent keeps its recent
+work, and the provider cache makes an expensive rig affordable. It needs a rig
+whose preset supports it (rig.py), and members sharing a CLI in one directory
+share that conversation, so `r4t roster check` warns about the overlap.
 
 Humans (`- **Status:** Human`) are never dispatched; an optional
 `- **Address:** <a8s-name>` tells teammates how to reach them. The Rig
@@ -41,6 +48,7 @@ class Member:
     role: str = ""
     leader: bool = False
     address: str | None = None
+    continue_conversation: bool = False
     cell: str = ""
     lead: str = ""
     persona: str = ""
@@ -191,7 +199,7 @@ def _clean(value: str) -> str:
 
 
 def _is_true(value: str) -> bool:
-    return value.strip().lower() in ("yes", "true", "y", "1")
+    return value.strip().lower() in ("yes", "true", "y", "1", "on")
 
 
 def _member_from_block(name: str, lines: list[str]) -> Member:
@@ -215,6 +223,7 @@ def _member_from_block(name: str, lines: list[str]) -> Member:
     m.role = fields.get("role", fields.get("mandate", ""))
     m.leader = _is_true(fields.get("leader", ""))
     m.address = fields.get("address") or None
+    m.continue_conversation = _is_true(fields.get("continue", ""))
     m.cell = fields.get("cell", "")
     m.lead = fields.get("lead", "")
 

--- a/apps/r4t/tests/test_dispatch.py
+++ b/apps/r4t/tests/test_dispatch.py
@@ -1782,7 +1782,7 @@ class TestCli:
         )
         config = tmp_path / "nocontinue-rigs.json"
         config.write_text(
-            json.dumps({"solo": {"preset": "codex", "invoke": ["codex", "exec", "{prompt}"]}}),
+            json.dumps({"solo": {"preset": "copilot", "invoke": ["copilot", "-p", "{prompt}"]}}),
             encoding="utf-8",
         )
         rc = self.run("roster", "check", "--root", str(root), "--rig-config", str(config))

--- a/apps/r4t/tests/test_dispatch.py
+++ b/apps/r4t/tests/test_dispatch.py
@@ -663,6 +663,127 @@ class TestFailureBreaker:
         assert drain(ctx, run_fn=ok_run) == 0  # reopened for another cooldown
 
 
+CONTINUE_ROSTER = textwrap.dedent(
+    """\
+    # Continue Team
+
+    ### Ana
+    - **Status:** AI
+    - **Rig:** resuming
+    - **Leader:** yes
+    - **Continue:** on
+
+    ### Bob
+    - **Status:** AI
+    - **Rig:** cold
+    """
+)
+
+
+@pytest.fixture
+def continue_ctx(r4t_home, tmp_path, tells):
+    """A team whose CLI refuses to launch with --continue until a conversation
+    exists in the turn directory — the real cursor behavior, faked. The marker
+    file stands in for that conversation."""
+    from dispatch import DispatchContext
+
+    calls = tmp_path / "continue-calls"
+    calls.mkdir()
+    marker = tmp_path / "conversation-exists"
+    script = tmp_path / "continue-harness.py"
+    script.write_text(
+        textwrap.dedent(
+            f"""\
+            import json, os, sys
+            calls_dir = {str(calls)!r}
+            n = len(os.listdir(calls_dir))
+            with open(os.path.join(calls_dir, f"call-{{n:03d}}.json"), "w") as f:
+                json.dump(sys.argv[1:], f)
+            if "--continue" in sys.argv and not os.path.exists({str(marker)!r}):
+                sys.stderr.write("No previous chats found.\\n")
+                sys.exit(1)
+            open({str(marker)!r}, "w").close()
+            print("continue harness ran")
+            """
+        ),
+        encoding="utf-8",
+    )
+    rig = {
+        "preset": "cursor",
+        "invoke": [sys.executable, str(script), "{prompt}"],
+        "timeout_seconds": 30,
+        "budget_max": 100,
+        "budget_earn_per_hour": 50,
+    }
+    config = {
+        "throttle": {"max_concurrent": 0, "min_seconds_between_turn_starts": 0},
+        "cell_budget_max": 200,
+        "cell_budget_earn_per_hour": 100,
+        "resuming": rig,
+        "cold": dict(rig),
+    }
+    config_path = tmp_path / "continue-rigs.json"
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    root = tmp_path / "continue-repo"
+    root.mkdir()
+    (root / "ROSTER.md").write_text(CONTINUE_ROSTER, encoding="utf-8")
+    _sent, capture = tells
+    ctx = DispatchContext(
+        root=root,
+        node=NODE,
+        roster_path=root / "ROSTER.md",
+        config_path=config_path,
+        tell_fn=capture,
+    )
+    return ctx, calls
+
+
+def continue_argvs(calls):
+    return [json.loads(p.read_text(encoding="utf-8")) for p in sorted(calls.iterdir())]
+
+
+class TestContinueTurns:
+    def test_founding_turn_retries_once_without_continue(self, continue_ctx):
+        ctx, calls = continue_ctx
+        assert run_one(ctx, "boss", "acme:ana", "first task") == 1
+        first, second = continue_argvs(calls)
+        assert first[-1] == "--continue"  # asked to resume; the CLI refused
+        assert "--continue" not in second  # founded the conversation instead
+        assert "CONTINUE-COLD ana" in read_log()
+
+    def test_founding_turn_is_not_a_failure(self, continue_ctx):
+        ctx, calls = continue_ctx
+        assert run_one(ctx, "boss", "acme:ana", "first task") == 1
+        assert state.queue_depth(NODE, "ana") == 0  # batch released, not requeued
+        assert state.read_meta(NODE, "ana")["consecutive_failures"] == 0
+
+    def test_later_turns_continue_the_conversation(self, continue_ctx):
+        ctx, calls = continue_ctx
+        run_one(ctx, "boss", "acme:ana", "first task")
+        assert run_one(ctx, "boss", "acme:ana", "second task") == 1
+        assert len(continue_argvs(calls)) == 3  # 2 to found, 1 continuing
+        assert continue_argvs(calls)[2][-1] == "--continue"
+        assert read_log().count("CONTINUE-COLD") == 1  # retried once, ever
+
+    def test_member_without_continue_never_gets_the_flag(self, continue_ctx):
+        ctx, calls = continue_ctx
+        assert run_one(ctx, "acme:ana", "acme:bob", "task") == 1
+        argvs = continue_argvs(calls)
+        assert len(argvs) == 1 and "--continue" not in argvs[0]
+
+    def test_other_failures_are_not_retried(self, continue_ctx):
+        ctx, _calls = continue_ctx
+        seen = []
+
+        def broken(rig, prompt, cwd, *, env=None, variant=0):
+            seen.append(env.get("R4T_CONTINUE"))
+            return 1, "segfault", 0.1, False
+
+        assert run_one(ctx, "boss", "acme:ana", "task", run_fn=broken) == 1
+        assert seen == ["1"]  # one attempt only
+        assert state.queue_depth(NODE, "ana") == 1  # normal requeue path
+
+
 ANSWER = "Here is my long detailed answer about the payload format. " * 3
 
 
@@ -1630,6 +1751,44 @@ class TestCli:
         assert rc == 0  # a warning does not fail the check
         assert "warning" in out and "soft cap 6" in out
         assert "1 warning(s)" in out
+
+    def test_roster_check_warns_on_shared_continue_cli(self, r4t_home, tmp_path, capsys):
+        root = tmp_path / "sharedcli"
+        root.mkdir()
+        (root / "ROSTER.md").write_text(
+            "### Ana\n- **Status:** AI\n- **Rig:** solo\n- **Leader:** yes\n"
+            "- **Continue:** on\n"
+            "### Bob\n- **Status:** AI\n- **Rig:** solo\n",
+            encoding="utf-8",
+        )
+        config = tmp_path / "shared-rigs.json"
+        config.write_text(
+            json.dumps({"solo": {"preset": "claude", "invoke": ["claude", "-p", "{prompt}"]}}),
+            encoding="utf-8",
+        )
+        rc = self.run("roster", "check", "--root", str(root), "--rig-config", str(config))
+        out = capsys.readouterr().out
+        assert rc == 0  # a warning does not fail the check
+        assert "Ana: Continue: on" in out and "Bob" in out
+        assert "1 warning(s)" in out
+
+    def test_roster_check_errors_on_continue_without_support(self, r4t_home, tmp_path, capsys):
+        root = tmp_path / "nocontinue"
+        root.mkdir()
+        (root / "ROSTER.md").write_text(
+            "### Ana\n- **Status:** AI\n- **Rig:** solo\n- **Leader:** yes\n"
+            "- **Continue:** on\n",
+            encoding="utf-8",
+        )
+        config = tmp_path / "nocontinue-rigs.json"
+        config.write_text(
+            json.dumps({"solo": {"preset": "codex", "invoke": ["codex", "exec", "{prompt}"]}}),
+            encoding="utf-8",
+        )
+        rc = self.run("roster", "check", "--root", str(root), "--rig-config", str(config))
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "does not support it" in out and "r4t rig swap solo <preset>" in out
 
     def test_roster_check_errors_on_unknown_lead(self, r4t_home, tmp_path, rig_config, capsys):
         root = tmp_path / "badlead"

--- a/apps/r4t/tests/test_rig.py
+++ b/apps/r4t/tests/test_rig.py
@@ -20,6 +20,8 @@ from rig import (
     RigError,
     add_preset_rig,
     build_preset_invoke,
+    continue_collisions,
+    continue_presets,
     default_config_payload,
     format_preset_invoke,
     fuzzy_match_model,
@@ -33,7 +35,7 @@ from rig import (
     swap_preset_rig,
     unset_rig_value,
 )
-from roster import Member
+from roster import Member, parse_roster
 from r4t import main as r4t_main
 
 
@@ -265,6 +267,135 @@ class TestArgv:
             write_config(tmp_path, {"t": {"invoke": ["run", "prompt={prompt}"]}})
         )
         assert config.rigs["t"].argv("X") == ["run", "prompt=X"]
+
+
+class TestContinue:
+    def test_only_verified_presets_declare_continue(self):
+        # Each of these was verified against the installed CLI's own --help.
+        # codex is absent on purpose: it resumes with the `codex exec resume`
+        # subcommand, which no appended argv can express.
+        assert continue_presets() == [
+            "agy", "claude", "copilot", "cursor", "opencode",
+        ]
+
+    def test_continue_tokens_are_appended_to_the_argv(self, tmp_path):
+        config = load_rig_config(write_config(tmp_path, {
+            "t": {"preset": "claude", "invoke": ["claude", "-p", "{prompt}"]},
+        }))
+        rig = config.rigs["t"]
+        assert rig.supports_continue
+        assert rig.argv("hi") == ["claude", "-p", "hi"]
+        assert rig.argv("hi", continue_conversation=True) == [
+            "claude", "-p", "hi", "--continue",
+        ]
+
+    def test_rig_without_preset_cannot_continue(self, tmp_path):
+        config = load_rig_config(write_config(tmp_path, {"t": {"invoke": ["run", "{prompt}"]}}))
+        rig = config.rigs["t"]
+        assert rig.supports_continue is False
+        assert rig.argv("hi", continue_conversation=True) == ["run", "hi"]
+
+    def test_added_preset_rig_carries_its_preset(self, tmp_path):
+        path = tmp_path / "rigs.json"
+        add_preset_rig(path, "solo", "cursor")
+        rig = load_rig_config(path).rigs["solo"]
+        assert rig.preset == "cursor"
+        assert rig.argv("hi", continue_conversation=True)[-1] == "--continue"
+
+    def test_no_prior_conversation_pattern_is_per_preset(self, tmp_path):
+        config = load_rig_config(write_config(tmp_path, {
+            "c": {"preset": "cursor", "invoke": ["agent", "-p", "{prompt}"]},
+            "k": {"preset": "claude", "invoke": ["claude", "-p", "{prompt}"]},
+        }))
+        assert config.rigs["c"].had_no_prior_conversation("No previous chats found.")
+        assert config.rigs["c"].had_no_prior_conversation("no PREVIOUS chats found")
+        assert not config.rigs["c"].had_no_prior_conversation("some other failure")
+        # claude founds a conversation silently, so it declares no pattern.
+        assert not config.rigs["k"].had_no_prior_conversation("No previous chats found.")
+
+    def test_cli_key_sees_through_ollama_launch(self, tmp_path):
+        config = load_rig_config(write_config(tmp_path, {
+            "direct": {"preset": "claude", "invoke": ["claude", "-p", "{prompt}"]},
+            "local": {
+                "preset": "claude-ollama",
+                "invoke": ["ollama", "launch", "claude", "-y", "--", "-p", "{prompt}"],
+            },
+            "bare": {"preset": "ollama", "invoke": ["ollama", "run", "m", "{prompt}"]},
+            "custom": {"invoke": ["/opt/bin/agent", "{prompt}"]},
+        }))
+        assert config.rigs["direct"].cli == "claude"
+        assert config.rigs["local"].cli == "claude"
+        assert config.rigs["bare"].cli == "ollama"
+        assert config.rigs["custom"].cli == "agent"
+
+    def test_continue_on_unsupported_rig_fails_closed(self, tmp_path):
+        config = load_rig_config(write_config(tmp_path, {
+            "t": {"preset": "codex", "invoke": ["codex", "exec", "{prompt}"]},
+        }))
+        asker = member(name="Ana", rig="t")
+        asker.continue_conversation = True
+        rig, err, _pinned = config.rig_for(asker)
+        assert rig is None
+        assert "Continue: on" in err
+        assert "claude" in err
+        assert "try: r4t rig swap t <preset>" in err
+
+    def test_continue_off_runs_on_any_rig(self, tmp_path):
+        config = load_rig_config(write_config(tmp_path, {
+            "t": {"preset": "codex", "invoke": ["codex", "exec", "{prompt}"]},
+        }))
+        rig, err, _pinned = config.rig_for(member(name="Ana", rig="t"))
+        assert rig is not None and err is None
+
+
+COLLISION_CONFIG = {
+    "solo": {"preset": "claude", "invoke": ["claude", "-p", "{prompt}"]},
+    "twin": {"preset": "claude", "invoke": ["claude", "--model", "x", "-p", "{prompt}"]},
+    "other": {"preset": "cursor", "invoke": ["agent", "-p", "{prompt}"]},
+}
+
+
+class TestContinueCollisions:
+    def collisions(self, tmp_path, roster_text):
+        config = load_rig_config(write_config(tmp_path, COLLISION_CONFIG))
+        roster = parse_roster(roster_text, Path("ROSTER.md"))
+        return continue_collisions(roster, config)
+
+    def test_no_warning_when_clis_differ(self, tmp_path):
+        assert self.collisions(tmp_path, (
+            "### Ana\n- **Status:** AI\n- **Rig:** solo\n- **Continue:** on\n\n"
+            "### Bob\n- **Status:** AI\n- **Rig:** other\n"
+        )) == []
+
+    def test_no_warning_when_nobody_continues(self, tmp_path):
+        assert self.collisions(tmp_path, (
+            "### Ana\n- **Status:** AI\n- **Rig:** solo\n\n"
+            "### Bob\n- **Status:** AI\n- **Rig:** solo\n"
+        )) == []
+
+    def test_warns_when_a_teammate_shares_the_cli(self, tmp_path):
+        # Bob does not continue — he still writes the conversation Ana resumes.
+        warnings = self.collisions(tmp_path, (
+            "### Ana\n- **Status:** AI\n- **Rig:** solo\n- **Continue:** on\n\n"
+            "### Bob\n- **Status:** AI\n- **Rig:** solo\n"
+        ))
+        assert len(warnings) == 1
+        assert warnings[0].startswith("Ana: Continue: on")
+        assert "Bob" in warnings[0] and "'claude'" in warnings[0]
+
+    def test_warns_across_different_rigs_on_one_cli(self, tmp_path):
+        warnings = self.collisions(tmp_path, (
+            "### Ana\n- **Status:** AI\n- **Rig:** solo\n- **Continue:** on\n\n"
+            "### Bob\n- **Status:** AI\n- **Rig:** twin\n"
+        ))
+        assert len(warnings) == 1 and "Bob" in warnings[0]
+
+    def test_humans_and_broken_members_never_collide(self, tmp_path):
+        assert self.collisions(tmp_path, (
+            "### Ana\n- **Status:** AI\n- **Rig:** solo\n- **Continue:** on\n\n"
+            "### Cid\n- **Status:** Human\n- **Address:** cid\n\n"
+            "### Dot\n- **Status:** AI\n"
+        )) == []
 
 
 class TestDefaultPayload:

--- a/apps/r4t/tests/test_rig.py
+++ b/apps/r4t/tests/test_rig.py
@@ -275,7 +275,7 @@ class TestContinue:
         # codex is absent on purpose: it resumes with the `codex exec resume`
         # subcommand, which no appended argv can express.
         assert continue_presets() == [
-            "agy", "claude", "copilot", "cursor", "opencode",
+            "agy", "claude", "copilot", "cursor", "opencode", "opencode-ollama",
         ]
 
     def test_continue_tokens_are_appended_to_the_argv(self, tmp_path):
@@ -340,6 +340,18 @@ class TestContinue:
         assert config.rigs["bare"].cli == "ollama"
         assert config.rigs["custom"].cli == "agent"
 
+    def test_launched_opencode_shares_the_opencode_conversation(self, tmp_path):
+        # The session store belongs to opencode and is per-directory whether or
+        # not `ollama launch` started it, so both rigs collide as one CLI.
+        path = tmp_path / "rigs.json"
+        add_preset_rig(path, "cloud", "opencode")
+        add_preset_rig(path, "local", "opencode-ollama", model="qwen3")
+        config = load_rig_config(path)
+        assert config.rigs["local"].cli == config.rigs["cloud"].cli == "opencode"
+        assert config.rigs["local"].supports_continue
+        assert config.rigs["local"].argv("hi", continue_conversation=True)[-1] == "--continue"
+        assert config.rigs["local"].continue_scope == "directory"
+
     def test_continue_on_unsupported_rig_fails_closed(self, tmp_path):
         config = load_rig_config(write_config(tmp_path, {
             "t": {"preset": "codex", "invoke": ["codex", "exec", "{prompt}"]},
@@ -365,6 +377,11 @@ COLLISION_CONFIG = {
     "twin": {"preset": "claude", "invoke": ["claude", "--model", "x", "-p", "{prompt}"]},
     "other": {"preset": "cursor", "invoke": ["agent", "-p", "{prompt}"]},
     "wide": {"preset": "copilot", "invoke": ["copilot", "-p", "{prompt}"]},
+    "cloud": {"preset": "opencode", "invoke": ["opencode", "run", "--dir", ".", "{prompt}"]},
+    "launched": {
+        "preset": "opencode-ollama",
+        "invoke": ["ollama", "launch", "opencode", "--model", "m", "--", "run", "{prompt}"],
+    },
 }
 
 
@@ -427,6 +444,17 @@ class TestContinueCollisions:
             "### Ana\n- **Status:** AI\n- **Rig:** wide\n- **Continue:** on\n\n"
             "### Bob\n- **Status:** AI\n- **Rig:** other\n"
         )) == []
+
+    def test_launcher_does_not_hide_a_shared_conversation(self, tmp_path):
+        # One member reaches opencode through `ollama launch`, the other runs it
+        # directly — same per-directory session store, so they still collide.
+        warnings = self.collisions(tmp_path, (
+            "### Ana\n- **Status:** AI\n- **Rig:** launched\n- **Continue:** on\n\n"
+            "### Bob\n- **Status:** AI\n- **Rig:** cloud\n"
+        ))
+        assert len(warnings) == 1
+        assert "Bob" in warnings[0] and "'opencode'" in warnings[0]
+        assert "per directory" in warnings[0]
 
     def test_humans_and_broken_members_never_collide(self, tmp_path):
         assert self.collisions(tmp_path, (

--- a/apps/r4t/tests/test_rig.py
+++ b/apps/r4t/tests/test_rig.py
@@ -271,11 +271,13 @@ class TestArgv:
 
 class TestContinue:
     def test_only_verified_presets_declare_continue(self):
-        # Each of these was verified against the installed CLI's own --help.
-        # codex is absent on purpose: it resumes with the `codex exec resume`
-        # subcommand, which no appended argv can express.
+        # Each of these was verified against the installed CLI's own --help and
+        # then live. Two are absent on purpose: codex resumes with the
+        # `codex exec resume` subcommand, which no appended argv can express,
+        # and copilot resumes the machine's most recent session whatever the
+        # directory, which no working directory can keep apart (#256).
         assert continue_presets() == [
-            "agy", "claude", "copilot", "cursor", "opencode", "opencode-ollama",
+            "agy", "claude", "cursor", "opencode", "opencode-ollama",
         ]
 
     def test_continue_tokens_are_appended_to_the_argv(self, tmp_path):
@@ -313,17 +315,15 @@ class TestContinue:
         # claude founds a conversation silently, so it declares no pattern.
         assert not config.rigs["k"].had_no_prior_conversation("No previous chats found.")
 
-    def test_continue_scope_defaults_to_the_directory(self, tmp_path):
-        # copilot resumes the machine's most recent session whatever the cwd
-        # (verified live); every other CLI keys on the directory it runs from.
+    def test_copilot_is_unsupported_until_sessions_are_pinned(self, tmp_path):
+        # Its --continue reaches the machine's most recent session whatever the
+        # directory, so no member can be kept apart from another (#256).
         config = load_rig_config(write_config(tmp_path, {
-            "wide": {"preset": "copilot", "invoke": ["copilot", "-p", "{prompt}"]},
-            "here": {"preset": "claude", "invoke": ["claude", "-p", "{prompt}"]},
-            "none": {"invoke": ["run", "{prompt}"]},
+            "t": {"preset": "copilot", "invoke": ["copilot", "-p", "{prompt}"]},
         }))
-        assert config.rigs["wide"].continue_scope == "global"
-        assert config.rigs["here"].continue_scope == "directory"
-        assert config.rigs["none"].continue_scope == "directory"
+        rig = config.rigs["t"]
+        assert rig.supports_continue is False
+        assert rig.argv("hi", continue_conversation=True) == ["copilot", "-p", "hi"]
 
     def test_cli_key_sees_through_ollama_launch(self, tmp_path):
         config = load_rig_config(write_config(tmp_path, {
@@ -350,7 +350,6 @@ class TestContinue:
         assert config.rigs["local"].cli == config.rigs["cloud"].cli == "opencode"
         assert config.rigs["local"].supports_continue
         assert config.rigs["local"].argv("hi", continue_conversation=True)[-1] == "--continue"
-        assert config.rigs["local"].continue_scope == "directory"
 
     def test_continue_on_unsupported_rig_fails_closed(self, tmp_path):
         config = load_rig_config(write_config(tmp_path, {
@@ -376,7 +375,6 @@ COLLISION_CONFIG = {
     "solo": {"preset": "claude", "invoke": ["claude", "-p", "{prompt}"]},
     "twin": {"preset": "claude", "invoke": ["claude", "--model", "x", "-p", "{prompt}"]},
     "other": {"preset": "cursor", "invoke": ["agent", "-p", "{prompt}"]},
-    "wide": {"preset": "copilot", "invoke": ["copilot", "-p", "{prompt}"]},
     "cloud": {"preset": "opencode", "invoke": ["opencode", "run", "--dir", ".", "{prompt}"]},
     "launched": {
         "preset": "opencode-ollama",
@@ -419,31 +417,6 @@ class TestContinueCollisions:
             "### Bob\n- **Status:** AI\n- **Rig:** twin\n"
         ))
         assert len(warnings) == 1 and "Bob" in warnings[0]
-
-    def test_global_scope_warning_says_machine_wide(self, tmp_path):
-        warnings = self.collisions(tmp_path, (
-            "### Ana\n- **Status:** AI\n- **Rig:** wide\n- **Continue:** on\n\n"
-            "### Bob\n- **Status:** AI\n- **Rig:** wide\n"
-        ))
-        assert len(warnings) == 1
-        assert "machine's most recent session" in warnings[0]
-        assert "any other org" in warnings[0]
-        assert "no workdir can separate them" in warnings[0]
-
-    def test_directory_scope_warning_stays_directory_scoped(self, tmp_path):
-        warnings = self.collisions(tmp_path, (
-            "### Ana\n- **Status:** AI\n- **Rig:** solo\n- **Continue:** on\n\n"
-            "### Bob\n- **Status:** AI\n- **Rig:** solo\n"
-        ))
-        assert "per directory" in warnings[0]
-        assert "machine" not in warnings[0]
-
-    def test_global_scope_still_needs_a_same_cli_teammate(self, tmp_path):
-        # The lint sees one roster; a lone copilot member is all it can vouch for.
-        assert self.collisions(tmp_path, (
-            "### Ana\n- **Status:** AI\n- **Rig:** wide\n- **Continue:** on\n\n"
-            "### Bob\n- **Status:** AI\n- **Rig:** other\n"
-        )) == []
 
     def test_launcher_does_not_hide_a_shared_conversation(self, tmp_path):
         # One member reaches opencode through `ollama launch`, the other runs it

--- a/apps/r4t/tests/test_rig.py
+++ b/apps/r4t/tests/test_rig.py
@@ -313,6 +313,18 @@ class TestContinue:
         # claude founds a conversation silently, so it declares no pattern.
         assert not config.rigs["k"].had_no_prior_conversation("No previous chats found.")
 
+    def test_continue_scope_defaults_to_the_directory(self, tmp_path):
+        # copilot resumes the machine's most recent session whatever the cwd
+        # (verified live); every other CLI keys on the directory it runs from.
+        config = load_rig_config(write_config(tmp_path, {
+            "wide": {"preset": "copilot", "invoke": ["copilot", "-p", "{prompt}"]},
+            "here": {"preset": "claude", "invoke": ["claude", "-p", "{prompt}"]},
+            "none": {"invoke": ["run", "{prompt}"]},
+        }))
+        assert config.rigs["wide"].continue_scope == "global"
+        assert config.rigs["here"].continue_scope == "directory"
+        assert config.rigs["none"].continue_scope == "directory"
+
     def test_cli_key_sees_through_ollama_launch(self, tmp_path):
         config = load_rig_config(write_config(tmp_path, {
             "direct": {"preset": "claude", "invoke": ["claude", "-p", "{prompt}"]},
@@ -352,6 +364,7 @@ COLLISION_CONFIG = {
     "solo": {"preset": "claude", "invoke": ["claude", "-p", "{prompt}"]},
     "twin": {"preset": "claude", "invoke": ["claude", "--model", "x", "-p", "{prompt}"]},
     "other": {"preset": "cursor", "invoke": ["agent", "-p", "{prompt}"]},
+    "wide": {"preset": "copilot", "invoke": ["copilot", "-p", "{prompt}"]},
 }
 
 
@@ -389,6 +402,31 @@ class TestContinueCollisions:
             "### Bob\n- **Status:** AI\n- **Rig:** twin\n"
         ))
         assert len(warnings) == 1 and "Bob" in warnings[0]
+
+    def test_global_scope_warning_says_machine_wide(self, tmp_path):
+        warnings = self.collisions(tmp_path, (
+            "### Ana\n- **Status:** AI\n- **Rig:** wide\n- **Continue:** on\n\n"
+            "### Bob\n- **Status:** AI\n- **Rig:** wide\n"
+        ))
+        assert len(warnings) == 1
+        assert "machine's most recent session" in warnings[0]
+        assert "any other org" in warnings[0]
+        assert "no workdir can separate them" in warnings[0]
+
+    def test_directory_scope_warning_stays_directory_scoped(self, tmp_path):
+        warnings = self.collisions(tmp_path, (
+            "### Ana\n- **Status:** AI\n- **Rig:** solo\n- **Continue:** on\n\n"
+            "### Bob\n- **Status:** AI\n- **Rig:** solo\n"
+        ))
+        assert "per directory" in warnings[0]
+        assert "machine" not in warnings[0]
+
+    def test_global_scope_still_needs_a_same_cli_teammate(self, tmp_path):
+        # The lint sees one roster; a lone copilot member is all it can vouch for.
+        assert self.collisions(tmp_path, (
+            "### Ana\n- **Status:** AI\n- **Rig:** wide\n- **Continue:** on\n\n"
+            "### Bob\n- **Status:** AI\n- **Rig:** other\n"
+        )) == []
 
     def test_humans_and_broken_members_never_collide(self, tmp_path):
         assert self.collisions(tmp_path, (

--- a/apps/r4t/tests/test_rig.py
+++ b/apps/r4t/tests/test_rig.py
@@ -272,12 +272,11 @@ class TestArgv:
 class TestContinue:
     def test_only_verified_presets_declare_continue(self):
         # Each of these was verified against the installed CLI's own --help and
-        # then live. Two are absent on purpose: codex resumes with the
-        # `codex exec resume` subcommand, which no appended argv can express,
-        # and copilot resumes the machine's most recent session whatever the
-        # directory, which no working directory can keep apart (#256).
+        # then live. copilot is absent on purpose: it resumes the machine's most
+        # recent session whatever the directory, which no working directory can
+        # keep apart (#256).
         assert continue_presets() == [
-            "agy", "claude", "cursor", "opencode", "opencode-ollama",
+            "agy", "claude", "codex", "cursor", "opencode", "opencode-ollama",
         ]
 
     def test_continue_tokens_are_appended_to_the_argv(self, tmp_path):
@@ -353,7 +352,7 @@ class TestContinue:
 
     def test_continue_on_unsupported_rig_fails_closed(self, tmp_path):
         config = load_rig_config(write_config(tmp_path, {
-            "t": {"preset": "codex", "invoke": ["codex", "exec", "{prompt}"]},
+            "t": {"preset": "copilot", "invoke": ["copilot", "-p", "{prompt}"]},
         }))
         asker = member(name="Ana", rig="t")
         asker.continue_conversation = True
@@ -365,10 +364,51 @@ class TestContinue:
 
     def test_continue_off_runs_on_any_rig(self, tmp_path):
         config = load_rig_config(write_config(tmp_path, {
-            "t": {"preset": "codex", "invoke": ["codex", "exec", "{prompt}"]},
+            "t": {"preset": "copilot", "invoke": ["copilot", "-p", "{prompt}"]},
         }))
         rig, err, _pinned = config.rig_for(member(name="Ana", rig="t"))
         assert rig is not None and err is None
+
+    def test_codex_continue_is_anchored_after_exec(self, tmp_path):
+        # `resume --last` is a subcommand: it only reads immediately after
+        # `exec`, never appended to a finished argv.
+        path = tmp_path / "rigs.json"
+        add_preset_rig(path, "worker", "codex")
+        rig = load_rig_config(path).rigs["worker"]
+        assert rig.continue_anchor == "exec"
+        assert rig.argv("hi", continue_conversation=True) == [
+            "codex", "exec", "resume", "--last",
+            "--full-auto", "--skip-git-repo-check", "hi",
+        ]
+
+    def test_codex_continue_and_model_splice_in_the_right_order(self, tmp_path):
+        # Both anchor on `exec`; the model is spliced at add time and continue
+        # at turn time, which lands continue first — the order codex requires.
+        path = tmp_path / "rigs.json"
+        add_preset_rig(path, "worker", "codex", model="gpt-5")
+        rig = load_rig_config(path).rigs["worker"]
+        assert rig.argv("hi", continue_conversation=True) == [
+            "codex", "exec", "resume", "--last", "-m", "gpt-5",
+            "--full-auto", "--skip-git-repo-check", "hi",
+        ]
+
+    def test_codex_founds_cold_without_a_detection_pattern(self, tmp_path):
+        # `exec resume --last` in a virgin directory exits 0 and founds one,
+        # so there is no failure to retry (verified live).
+        path = tmp_path / "rigs.json"
+        add_preset_rig(path, "worker", "codex")
+        rig = load_rig_config(path).rigs["worker"]
+        assert not rig.had_no_prior_conversation("No previous chats found.")
+
+    def test_anchored_preset_without_its_anchor_fails_closed(self, tmp_path):
+        # A hand-edited invoke that lost `exec` has nowhere to put the tokens.
+        config = load_rig_config(write_config(tmp_path, {
+            "t": {"preset": "codex", "invoke": ["codex-wrapper", "{prompt}"]},
+        }))
+        assert config.rigs["t"].supports_continue is False
+        asker = member(name="Ana", rig="t")
+        asker.continue_conversation = True
+        assert config.rig_for(asker)[0] is None
 
 
 COLLISION_CONFIG = {

--- a/apps/r4t/tests/test_roster.py
+++ b/apps/r4t/tests/test_roster.py
@@ -12,6 +12,24 @@ from roster import (
     resolve_roster_path,
 )
 
+CONTINUE_TEXT = textwrap.dedent(
+    """\
+    ### Ana
+    - **Status:** AI
+    - **Rig:** r
+    - **Continue:** on
+
+    ### Bob
+    - **Status:** AI
+    - **Rig:** r
+
+    ### Cid
+    - **Status:** AI
+    - **Rig:** r
+    - **Continue:** off
+    """
+)
+
 
 def parse(text: str):
     return parse_roster(text, Path("ROSTER.md"))
@@ -70,6 +88,20 @@ class TestParsing:
     def test_cell_empty_when_absent(self, repo):
         phil = load_roster(repo / "ROSTER.md").find("phil")
         assert phil.cell == ""
+
+    def test_continue_on_is_read(self):
+        assert parse(CONTINUE_TEXT).find("ana").continue_conversation is True
+
+    def test_continue_defaults_off_when_absent(self):
+        assert parse(CONTINUE_TEXT).find("bob").continue_conversation is False
+
+    def test_continue_off_is_off(self):
+        assert parse(CONTINUE_TEXT).find("cid").continue_conversation is False
+
+    def test_continue_does_not_disturb_other_fields(self):
+        ana = parse(CONTINUE_TEXT).find("ana")
+        assert ana.rig == "r"
+        assert not ana.errors
 
     def test_lookup_is_case_insensitive(self, repo):
         roster = load_roster(repo / "ROSTER.md")


### PR DESCRIPTION
## What shipped

`- **Continue:** on` on a roster member runs that member's turns inside its CLI's
own conversation instead of a cold `-p` prompt every wake. Two reasons: an agent's
own conversation tracks its recent work better than the tells r4t replays into a
prompt, and the provider cache prices a continuation far below a fresh full prompt
— which is what makes an expensive rig affordable to wake often.

- **Presets** gained an optional `continue_argv` (argv tokens added to the
  invocation), an optional `continue_anchor` placing those tokens after a given
  token instead of at the end — the same mechanism `model_anchor` already uses,
  for CLIs whose continuation is a subcommand — and an optional
  `no_prior_conversation` regex matched case-insensitively against a failed
  turn's output.
- **Roster** gained the per-member `Continue:` field, default off (absent = off),
  parsed with the same truth words as `Leader:` (`on` added to the set).
- **Rigs** now carry their recorded `preset` on the `Rig` object, so dispatch can
  reach the preset's continue tokens and the lint can reach the CLI identity.
- **Fail closed:** `Continue: on` on a rig that cannot continue is a config error
  in `RigConfig.rig_for`, so `r4t roster check` and dispatch both report it from
  one place with a hint naming the presets that can.
- `r4t rig presets` marks the presets that support it.

## Per-preset continue support

Every entry was checked against the installed CLI's own `--help` and exercised end
to end in throwaway directories, then **independently live-verified by a second
party**: claude, cursor, agy and opencode all re-confirmed; cursor's cold-failure
text character-exact; an opencode transient failed and recovered on the retry,
validating the retry-once design; copilot's global session scope discovered;
opencode-ollama confirmed working with a local qwen3.6; and codex confirmed safe
and per-directory, which promoted it from unsupported to supported.

| preset | continue | verification |
| --- | --- | --- |
| `claude` | `--continue` | help: "Continue the most recent conversation in the current directory". No prior conversation → exits 0 and founds one, so no detection pattern needed. |
| `cursor` | `--continue` | help: "Continue previous session". No prior conversation → **fails to launch**: `No previous chats found.` exit 1. Pattern recorded; resumes correctly once founded. |
| `opencode` | `--continue` | `opencode run --help`: "-c, --continue — continue the last session". No prior session → exits 0. |
| `opencode-ollama` | `--continue` | `ollama launch` passes the appended flag through to opencode, whose per-directory session store then works normally. Verified live with a local qwen3.6: planted, resumed, and founded cold in a virgin dir. |
| `agy` | `--continue` | help: "Continue the most recent conversation". No prior conversation → exits 0. |
| `codex` | `resume --last`, anchored after `exec` | Not a flag, so it is inserted rather than appended. Verified live on codex-cli 0.144.6: a planted codeword came back through `exec resume --last`; the same invocation from **a different directory answered UNKNOWN**, so the scope is per-directory; a cold resume in a virgin dir exits 0 and founds one, so no detection pattern is needed. The shape is already what the operator's daily work agent runs. |
| `copilot` | **unsupported** | `--continue` resumes the machine's most recent session regardless of cwd: a run in a virgin directory returned a codeword planted in an unrelated one, both footers pinning the same session id. No workdir can keep two members apart, so it is left unsupported rather than shipped with a warning. Clean support = pinning `--resume=<session-id>` per member — **#256**. |
| `ollama`, other `*-ollama` | **unsupported** | Local-model presets; no continue. |

Unsupported is a fine v1 state; an unverified — or unsafe — flag would not be.
`copilot` is the only CLI left out for a behavioral reason, and `supports_continue`
also fails closed when an anchored preset's invoke has been hand-edited past its
anchor, rather than building an argv the CLI would misread.

## Retry design

A CLI keys its conversation on the directory it runs from, so a continuing member
necessarily starts with no conversation to continue — and cursor refuses to launch
in exactly that state. When a turn fails and its output matches the preset's
`no_prior_conversation` pattern, dispatch retries **once** without the continue
tokens; that turn founds the conversation every later turn resumes. The retry logs
a named event, `CONTINUE-COLD` (house style, alongside `STDOUT-REPLY` / `SILENT`)
— never silent. Any other failure keeps the normal requeue-and-breaker path
untouched.

The flag reaches `run_harness` through the turn env (`R4T_CONTINUE`), the same way
isolation and the container name already do, so the `run_fn` contract stays narrow
and every existing test double keeps working.

## Collision warning

Because conversation identity is (directory, CLI), two members driving the same CLI
from the same directory land in one conversation — and the other member does not
have to be continuing to clobber it, it only has to run the same CLI there.
`r4t roster check` warns (warn only, never blocks) when a `Continue: on` member has
same-CLI company, naming the teammates and the binary. The CLI key sees through
`ollama launch <tool>`, so a launched-opencode member and a direct-opencode member
are correctly treated as one CLI, and it falls back to the invoke's binary for rigs
with no preset. Today every member runs in the one workplace, so the CLI is the
whole key; a per-member `Workdir:` (a later PR) widens it to (directory, CLI) at
one call site. With copilot unsupported, every supported CLI is directory-scoped,
so this one rule covers all of them.

## Tests

- r4t: **585 passed** (554 before; 31 new — argv splicing appended and anchored,
  codex's exact combined argv with both model and continue active, `Continue:`
  parsing and default-off, the fail-closed config errors (unsupported preset, and
  an anchored preset whose invoke lost its anchor), `cli` key derivation through
  the ollama launcher, copilot's unsupported state, retry-once against a fake CLI
  that emits the real failure text, the logged retry event, no-retry for other
  failures, and collision fires / doesn't fire at both unit and `roster check`
  level).
- a8s: **778 passed**, no cross-breakage.

## Out of scope (deliberately)

`Workdir:`, idle flush / dump-state, echo-only rigs, and any session-id plumbing —
including copilot's `--resume=<id>` and codex's `resume [SESSION_ID]` positional,
both of which are #256 territory. Continue here is deliberately "a session was
there", keyed on cwd.

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)
