### PR TITLE
feat(r4t): per-member Workdir: roster field

### DIFF
--- a/apps/r4t/dispatch.py
+++ b/apps/r4t/dispatch.py
@@ -66,6 +66,10 @@ PROMPT_DEFAULTS: dict[str, str] = {
         "relative paths only."
     ),
     "mission_header": "## The mission (MISSION.md — outranks every other document)",
+    "workdir_note": (
+        "The team repo (org workplace) is at {workplace} — use that absolute "
+        "path to reach shared team files."
+    ),
     "work_batch": (
         "- This is one turn: you were woken with every message above at once. "
         "Read them together and act on the current state, not each message in "
@@ -446,6 +450,18 @@ def _mission_section(ctx: DispatchContext, roster: Roster, member: Member) -> li
     ]
 
 
+def resolve_workdir(ctx: DispatchContext, member: Member) -> Path:
+    """The directory a member's turn runs from: its `Workdir:` when set
+    (relative paths against the workplace; absolute and `~` paths as given),
+    else the workplace itself."""
+    if not member.workdir:
+        return ctx.workplace
+    p = Path(member.workdir).expanduser()
+    if p.is_absolute():
+        return p
+    return ctx.workplace / p
+
+
 def build_prompt(
     ctx: DispatchContext,
     roster: Roster,
@@ -473,13 +489,20 @@ def build_prompt(
         message_lines.append("")
         message_lines.append(body)
         message_lines.append("")
+    workdir = resolve_workdir(ctx, member)
+    workdir_lines: list[str] = []
+    if workdir.resolve() != ctx.workplace.resolve():
+        workdir_lines = [
+            ctx.prompt("workdir_note", workplace=ctx.workplace.resolve())
+        ]
     parts = [
         ctx.prompt(
             "intro",
             name=member.name,
             node=ctx.node,
-            workplace=ctx.workplace.resolve(),
+            workplace=workdir.resolve(),
         ),
+        *workdir_lines,
         "",
         *_mission_section(ctx, roster, member),
         "## Who you are (from the team roster)",
@@ -1198,8 +1221,10 @@ def _run_turn(
         + f")\n\n### Prompt\n\n{prompt}",
     )
 
+    workdir = resolve_workdir(ctx, member)
+    workdir.mkdir(parents=True, exist_ok=True)
     exit_code, output, duration, timed_out = run_fn(
-        rig, prompt, ctx.workplace, env=env, variant=variant
+        rig, prompt, workdir, env=env, variant=variant
     )
 
     # Some CLIs (cursor) refuse to launch at all when asked to continue a

--- a/apps/r4t/roster.py
+++ b/apps/r4t/roster.py
@@ -21,6 +21,12 @@ Humans (`- **Status:** Human`) are never dispatched; an optional
 value is a SYMBOLIC rig name resolved against the out-of-repo rig
 config — never a command. Parsing is defensive: a malformed block disables
 that one member (Member.error set) without crashing dispatch.
+
+An optional `- **Workdir:** <path>` gives the member its own working
+directory for turns. Relative paths resolve against the org workplace
+(`agents/bob/`, `.bob/`); absolute and `~` paths are allowed and may live
+outside the repo entirely. Absent means the member runs from the workplace
+root, as before. The directory is created on demand at the start of a turn.
 """
 from __future__ import annotations
 
@@ -51,6 +57,7 @@ class Member:
     continue_conversation: bool = False
     cell: str = ""
     lead: str = ""
+    workdir: str = ""
     persona: str = ""
     errors: list[str] = field(default_factory=list)
 
@@ -226,6 +233,7 @@ def _member_from_block(name: str, lines: list[str]) -> Member:
     m.continue_conversation = _is_true(fields.get("continue", ""))
     m.cell = fields.get("cell", "")
     m.lead = fields.get("lead", "")
+    m.workdir = fields.get("workdir", "")
 
     rig = fields.get("rig", "")
     if rig:

--- a/apps/r4t/tests/test_dispatch.py
+++ b/apps/r4t/tests/test_dispatch.py
@@ -7,6 +7,7 @@ import sys
 import textwrap
 import time
 from dataclasses import replace
+from pathlib import Path
 
 import pytest
 
@@ -2025,3 +2026,118 @@ class TestDoorbellGate:
         handle_message(gated, "acme:gerry", "acme:neil", "hi")
         assert not sent
         assert "GATE" not in read_log()
+
+
+WORKDIR_ROSTER = textwrap.dedent(
+    """\
+    ### Gerry
+    - **Status:** AI
+    - **Rig:** leader
+    - **Leader:** yes
+
+    ### Bob
+    - **Status:** AI
+    - **Rig:** junior-dev
+    - **Workdir:** {workdir}
+    """
+)
+
+
+class TestWorkdir:
+    def make_ctx(self, tmp_path, rig_config, tells, workdir):
+        from dispatch import DispatchContext
+
+        root = tmp_path / "workdir-repo"
+        root.mkdir(exist_ok=True)
+        (root / "ROSTER.md").write_text(
+            WORKDIR_ROSTER.format(workdir=workdir), encoding="utf-8"
+        )
+        _sent, capture = tells
+        return DispatchContext(
+            root=root,
+            node=NODE,
+            roster_path=root / "ROSTER.md",
+            config_path=rig_config,
+            tell_fn=capture,
+        )
+
+    @staticmethod
+    def recording_run(turns):
+        def run(rig, prompt, cwd, *, env=None, variant=0):
+            turns.append((prompt, Path(cwd)))
+            return 0, "fake harness ran", 0.0, False
+
+        return run
+
+    def test_absent_workdir_runs_from_workplace(
+        self, r4t_home, tmp_path, rig_config, tells
+    ):
+        ctx = self.make_ctx(tmp_path, rig_config, tells, "agents/bob")
+        turns = []
+        assert run_one(ctx, "acme:bob", "acme:gerry", "hi", run_fn=self.recording_run(turns)) == 1
+        _prompt, cwd = turns[0]
+        assert cwd == ctx.root
+
+    def test_relative_workdir_resolves_against_workplace(
+        self, r4t_home, tmp_path, rig_config, tells
+    ):
+        ctx = self.make_ctx(tmp_path, rig_config, tells, "agents/bob")
+        turns = []
+        assert run_one(ctx, "acme:gerry", "acme:bob", "hi", run_fn=self.recording_run(turns)) == 1
+        _prompt, cwd = turns[0]
+        assert cwd == ctx.root / "agents" / "bob"
+        assert cwd.is_dir()
+
+    def test_absolute_workdir_outside_workplace(
+        self, r4t_home, tmp_path, rig_config, tells
+    ):
+        target = tmp_path / "elsewhere" / "bob-home"
+        ctx = self.make_ctx(tmp_path, rig_config, tells, str(target))
+        turns = []
+        assert run_one(ctx, "acme:gerry", "acme:bob", "hi", run_fn=self.recording_run(turns)) == 1
+        _prompt, cwd = turns[0]
+        assert cwd == target
+        assert cwd.is_dir()
+
+    def test_tilde_workdir_expands_to_home(
+        self, r4t_home, tmp_path, rig_config, tells, monkeypatch
+    ):
+        home = tmp_path / "fake-home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+        ctx = self.make_ctx(tmp_path, rig_config, tells, "~/bob-space")
+        turns = []
+        assert run_one(ctx, "acme:gerry", "acme:bob", "hi", run_fn=self.recording_run(turns)) == 1
+        _prompt, cwd = turns[0]
+        assert cwd == home / "bob-space"
+        assert cwd.is_dir()
+
+    def test_preexisting_workdir_untouched(
+        self, r4t_home, tmp_path, rig_config, tells
+    ):
+        ctx = self.make_ctx(tmp_path, rig_config, tells, ".bob")
+        existing = ctx.root / ".bob"
+        existing.mkdir()
+        (existing / "notes.md").write_text("keep me", encoding="utf-8")
+        turns = []
+        assert run_one(ctx, "acme:gerry", "acme:bob", "hi", run_fn=self.recording_run(turns)) == 1
+        assert (existing / "notes.md").read_text(encoding="utf-8") == "keep me"
+
+    def test_prompt_addendum_when_workdir_differs(
+        self, r4t_home, tmp_path, rig_config, tells
+    ):
+        ctx = self.make_ctx(tmp_path, rig_config, tells, "agents/bob")
+        turns = []
+        run_one(ctx, "acme:gerry", "acme:bob", "hi", run_fn=self.recording_run(turns))
+        prompt, _cwd = turns[0]
+        assert str(ctx.root.resolve()) in prompt
+        assert "org workplace" in prompt
+
+    def test_no_addendum_without_workdir(
+        self, r4t_home, tmp_path, rig_config, tells
+    ):
+        ctx = self.make_ctx(tmp_path, rig_config, tells, "agents/bob")
+        turns = []
+        run_one(ctx, "acme:bob", "acme:gerry", "hi", run_fn=self.recording_run(turns))
+        prompt, _cwd = turns[0]
+        assert "org workplace" not in prompt

--- a/apps/r4t/tests/test_roster.py
+++ b/apps/r4t/tests/test_roster.py
@@ -145,6 +145,15 @@ class TestParsing:
         roster = parse("### A\n- **Status:** AI\n- **Rig:** Leader\n")
         assert roster.find("a").rig == "leader"
 
+    def test_workdir_captured(self):
+        roster = parse(
+            "### A\n- **Status:** AI\n- **Rig:** t\n- **Workdir:** agents/bob\n"
+        )
+        assert roster.find("a").workdir == "agents/bob"
+
+    def test_workdir_empty_when_absent(self, repo):
+        assert load_roster(repo / "ROSTER.md").find("phil").workdir == ""
+
     def test_mandate_accepted_as_role(self):
         roster = parse(
             "### A\n- **Status:** AI\n- **Rig:** t\n- **Mandate:** The Server\n"


### PR DESCRIPTION
## What shipped

Optional per-member `Workdir: <path>` roster field. A member with a workdir runs its CLI subprocess with cwd = the resolved workdir instead of the shared org workplace, giving each member its own data space and a distinct CLI conversation identity per directory. Absent field = existing behavior, unchanged.

## Resolution rules

- Relative paths (`agents/bob/`, `.bob/`) resolve against the org workplace.
- Absolute paths and `~` paths are allowed and may live entirely outside the repo/workplace — deliberate, so an org repo can hold only roster + helper scripts while members work from pre-existing homes elsewhere. `~` expands via `Path.expanduser()`.

## Creation on demand

At the start of a member's turn, the resolved workdir is created if missing (parents included) — no error, no prompt; it is the member's data space. Pre-existing directories are untouched.

## Prompt addendum

When a member's workdir differs from the workplace, the intro names the workdir as the current directory and one added line (`workdir_note`, overridable like every prompt key) states the absolute path of the org workplace so the member can reach shared team files.

## Tests

- r4t: 563 passed (7 new dispatch tests covering resolution, on-demand creation, subprocess cwd, and the prompt addendum; 2 new roster parsing tests)
- a8s: 778 passed (no cross-breakage)

## Note

Collision lint/warning integration deliberately not built here — it lands with the continue-core line (`feat/r4t-continue-core`), which owns roster lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)