### PR TITLE
feat(r4t): conversation flush — retire, dump, refound

### DIFF
--- a/apps/r4t/dispatch.py
+++ b/apps/r4t/dispatch.py
@@ -45,6 +45,7 @@ import subprocess
 import threading
 import time
 from dataclasses import dataclass, field
+from datetime import datetime
 from pathlib import Path
 
 import isolate
@@ -106,6 +107,8 @@ PROMPT_DEFAULTS: dict[str, str] = {
         "Reply to them with where things stand — what is done and what remains. "
         "You do not have to finish the work, just report current state."
     ),
+    "flush_dump": "Save your current state and progress to STATUS.md.",
+    "refound_preamble": "Check your STATUS.md to refresh your memory.",
     "mission_review": (
         "The team's queues are empty and no thread is open, but the mission "
         "may not be met. Review MISSION.md against where things stand and "
@@ -1181,6 +1184,28 @@ def _run_turn(
     newest_hop = int(batch[-1].get("hop", 0) or 0)
     newest_sender = str(batch[-1].get("from", "")) or f"{ctx.node}"
 
+    # Rig-swap retirement: the conversation is keyed on the CLI, so a rig that
+    # now drives a different CLI cannot resume it — the old CLI may be
+    # quota-dead, so no dump turn; state on disk is whatever the last flush or
+    # the member's own writing left. A swap that keeps the CLI key (model-only,
+    # launcher variant) keeps the conversation. A retired or absent record
+    # makes this turn a refound: no continue argv, and a read-your-state
+    # preamble tops the prompt.
+    refound = False
+    if member.continue_conversation:
+        convo = state.read_conversation(ctx.node, member.name)
+        if convo and not convo.get("retired") and convo.get("cli") != rig.cli:
+            state.retire_conversation(ctx.node, member.name)
+            state.append_log(
+                ctx.node,
+                f"r4t: CONTINUE-SWAP {member.name.lower()} (rig {rig.name}) "
+                f"drives {rig.cli!r} but the conversation lives on "
+                f"{convo.get('cli')!r} — retired; this turn refounds from "
+                "state on disk",
+            )
+            convo = {}
+        refound = not convo or bool(convo.get("retired"))
+
     variant = state.take_rotation(ctx.node, rig.name, rig.pool_size)
     staging = state.prepare_staging(ctx.node, member.name)
     state.write_turn(
@@ -1195,6 +1220,8 @@ def _run_turn(
         },
     )
     prompt = build_prompt(ctx, roster, member, batch, rig)
+    if refound:
+        prompt = ctx.prompt("refound_preamble") + "\n\n" + prompt
 
     env = dict(os.environ)
     env["TELL_OUTBOX_DIR"] = str(staging)
@@ -1207,7 +1234,7 @@ def _run_turn(
     # forward and the provider cache prices the wake as a continuation rather
     # than a fresh full prompt. rig_for has already refused any member whose rig
     # cannot continue, so no second check is needed here.
-    if member.continue_conversation:
+    if member.continue_conversation and not refound:
         env["R4T_CONTINUE"] = "1"
     # The org's OS-level boundary (org.py) rides in the same way — one setting
     # wraps every member turn regardless of rig (machinery outside, hands inside).
@@ -1233,19 +1260,19 @@ def _run_turn(
     # every later turn continues. Any other failure falls through to the normal
     # requeue-and-breaker path.
     if (
-        member.continue_conversation
+        "R4T_CONTINUE" in env
         and (timed_out or exit_code != 0)
         and rig.had_no_prior_conversation(output)
     ):
         state.append_log(
             ctx.node,
             f"r4t: CONTINUE-COLD {member.name.lower()} (rig {rig.name}) exit "
-            f"{exit_code}: no conversation to continue in {ctx.workplace} — "
+            f"{exit_code}: no conversation to continue in {workdir} — "
             "retrying once without it to found one",
         )
         del env["R4T_CONTINUE"]
         exit_code, output, duration, timed_out = run_fn(
-            rig, prompt, ctx.workplace, env=env, variant=variant
+            rig, prompt, workdir, env=env, variant=variant
         )
 
     outcome = f"exit {exit_code} in {duration:.1f}s"
@@ -1269,6 +1296,11 @@ def _run_turn(
     )
 
     failed = timed_out or exit_code != 0
+    if not failed and member.continue_conversation:
+        # One recording path for every way a conversation comes to exist —
+        # a refound, the CONTINUE-COLD founding retry, and a normal continue
+        # all land here: the current CLI key, retired cleared.
+        state.record_conversation(ctx.node, member.name, rig.cli)
     if failed:
         # A failed turn releases nothing and returns its whole batch to the
         # queue: the messages are never lost, and the breaker accumulates
@@ -1658,6 +1690,87 @@ def _quiet_task_sweep(
     return nudged
 
 
+# ---------- idle conversation flush (retire, dump, refound) ----------
+#
+# A continuing conversation left idle eventually goes stale or falls out of
+# the provider cache — re-caching a huge context at frontier prices costs real
+# money for one message. `Flush: <duration>` bounds that: once the member's
+# last turn is older than the duration, a DUMP TURN (a normal continuing turn
+# whose prompt asks the member to write its state to disk) runs and the
+# conversation is retired; the next real message refounds cold from that state.
+
+
+def _last_completed(node: str, name: str) -> float | None:
+    raw = str(state.read_meta(node, name).get("last_completed_at", ""))
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return None
+
+
+def _flush_sweep(
+    ctx: DispatchContext, config: RigConfig, roster: Roster, run_fn
+) -> list[str]:
+    """Retire idle continuing conversations. Budget-gated exactly like
+    mission-review: no budget skips the member this sweep and retries when it
+    refills. The dump turn is a real turn — logged, captured, counted — and
+    retirement is marked only when it succeeds. Returns members retired."""
+    flushed: list[str] = []
+    now = time.time()
+    for member in roster.members:
+        if member.is_human or member.errors:
+            continue
+        if not member.continue_conversation or member.flush_seconds is None:
+            continue
+        convo = state.read_conversation(ctx.node, member.name)
+        if not convo or convo.get("retired"):
+            continue
+        if state.queue_depth(ctx.node, member.name):
+            continue  # queued work will run a real continuing turn anyway
+        last = _last_completed(ctx.node, member.name)
+        if last is None or now - last < member.flush_seconds:
+            continue
+        rig, _err, _pinned = config.rig_for(member)
+        if rig is None:
+            continue
+        runnable, reason = _runnable(ctx, config, member, rig)
+        if not runnable:
+            state.append_log(
+                ctx.node,
+                f"r4t: FLUSH deferred — {member.name.lower()} {reason}",
+            )
+            continue
+        state.enqueue(
+            ctx.node,
+            member.name,
+            {
+                "from": f"r4t:{ctx.node}",
+                "to": f"{ctx.node}:{member.name.lower()}",
+                "thread": tasks.new_thread_id(),
+                "hop": 0,
+                "class": "auto",
+                "body": ctx.prompt("flush_dump"),
+            },
+        )
+        state.append_log(
+            ctx.node,
+            f"r4t: FLUSH dump turn -> {member.name.lower()} (conversation idle "
+            f"> {member.flush_seconds:g}s)",
+        )
+        if _run_member_turn(ctx, config, roster, member, rig, run_fn) != RAN:
+            continue
+        last_turn = state.read_meta(ctx.node, member.name).get("last_turn") or {}
+        if last_turn.get("exit") == 0 and not last_turn.get("timed_out"):
+            state.retire_conversation(ctx.node, member.name)
+            state.append_log(
+                ctx.node,
+                f"r4t: FLUSH retired {member.name.lower()}'s conversation — "
+                "the next real message refounds it from state on disk",
+            )
+            flushed.append(member.name)
+    return flushed
+
+
 # ---------- mission-review idle turn (the furnace burns on its own) ----------
 
 MISSION_REVIEW_BACKOFF_BASE = 2
@@ -1786,7 +1899,8 @@ def _mission_review(
 
 def run_idle(ctx: DispatchContext, *, run_fn=run_harness) -> dict:
     """One idle pass: nudge the leader about quiet unanswered threads, drain
-    every runnable member's queue, then — if the org is structurally stalled —
+    every runnable member's queue, retire idle continuing conversations
+    (_flush_sweep), then — if the org is structurally stalled —
     hand the top leader a budget-gated mission-review turn. Crash recovery needs
     no special path — a turn that never completed left its messages in the queue
     (they were claimed only at a turn that ran), so the next runnable turn picks
@@ -1796,10 +1910,17 @@ def run_idle(ctx: DispatchContext, *, run_fn=run_harness) -> dict:
         config = load_rig_config(ctx.config_path)
     except (RosterError, RigError) as e:
         state.append_log(ctx.node, f"r4t: IDLE-SKIPPED {e}")
-        return {"quiet_nudged": [], "drained": 0, "mission_review": {"fired": False}, "error": str(e)}
+        return {
+            "quiet_nudged": [], "drained": 0, "flushed": [],
+            "mission_review": {"fired": False}, "error": str(e),
+        }
     nudged = _quiet_task_sweep(ctx, config, roster)
     drained = drain_until_quiet(ctx, run_fn=run_fn)
+    flushed = _flush_sweep(ctx, config, roster, run_fn)
     review = _mission_review(ctx, config, roster, drained, run_fn)
     if review.get("fired"):
         drained += drain_until_quiet(ctx, run_fn=run_fn)
-    return {"quiet_nudged": nudged, "drained": drained, "mission_review": review}
+    return {
+        "quiet_nudged": nudged, "drained": drained, "flushed": flushed,
+        "mission_review": review,
+    }

--- a/apps/r4t/docs/rigs.md
+++ b/apps/r4t/docs/rigs.md
@@ -42,8 +42,20 @@ whatever the directory, so members cannot be kept apart, and supporting it
 cleanly means pinning a session id per member (issue #256).
 
 A CLI keeps ONE conversation per directory, so two members running the same
-CLI in the team workplace land in the same one. `r4t roster check` warns when
-that happens — it never blocks, but the fix is to put them on different CLIs.
+CLI from the same effective directory (the workplace root, or their resolved
+`Workdir:`) land in the same one. `r4t roster check` warns when that happens —
+it never blocks, but the fix is another CLI or distinct `Workdir:` lines.
+
+An optional `- **Flush:** 4h` (bare seconds or an s/m/h/d suffix) bounds how
+long a continuing conversation may sit idle before it is retired — dumped to
+disk, then refounded from that state on the next real message. The `r4t idle`
+sweep retires a conversation idle past the duration by running a budget-gated
+dump turn (a normal continuing turn prompting the member to save its state to
+STATUS.md). A rig swap that changes the CLI retires the conversation
+immediately, with no dump turn — the old CLI may be quota-dead. A retired
+member's next turn runs cold with a read-your-state preamble; the dump prompt
+and preamble are overridable via the node definition's `prompts` object (keys
+`flush_dump` and `refound_preamble`).
 
 ## Picking a model (`--model`)
 

--- a/apps/r4t/r4t.py
+++ b/apps/r4t/r4t.py
@@ -48,7 +48,14 @@ from rig import (
 )
 from notify import resolve_tell_fn, simulate_enabled
 from org import check_org, load_org
-from roster import Member, Roster, RosterError, load_roster, resolve_roster_path
+from roster import (
+    Member,
+    Roster,
+    RosterError,
+    flush_warnings,
+    load_roster,
+    resolve_roster_path,
+)
 
 DEFAULT_TASK_TTL_SECONDS = 7 * 86400
 R4T_DIR = Path(__file__).resolve().parent
@@ -1254,9 +1261,12 @@ def cmd_roster_check(args: argparse.Namespace) -> int:
         problems += 1
     warnings = 0
     if config is not None:
-        for message in continue_collisions(roster, config):
+        for message in continue_collisions(roster, config, org.workplace):
             print(f"warning: {message}")
             warnings += 1
+    for message in flush_warnings(roster):
+        print(f"warning: {message}")
+        warnings += 1
     for severity, message in roster.tree_problems():
         if severity == "error":
             print(message)

--- a/apps/r4t/rig.py
+++ b/apps/r4t/rig.py
@@ -514,34 +514,48 @@ def continue_presets() -> list[str]:
     return [n for n in preset_names() if HARNESS_PRESETS[n].get("continue_argv")]
 
 
-def continue_collisions(roster: Roster, config: RigConfig) -> list[str]:
+def _effective_cwd(member: Member, workplace: Path) -> Path:
+    """The directory the member's turns run from, mirroring
+    dispatch.resolve_workdir: the resolved `Workdir:` when set, else the
+    workplace root."""
+    if not member.workdir:
+        return workplace.resolve()
+    p = Path(member.workdir).expanduser()
+    if not p.is_absolute():
+        p = workplace / p
+    return p.resolve()
+
+
+def continue_collisions(roster: Roster, config: RigConfig, workplace: Path) -> list[str]:
     """Warn (never block) where `Continue: on` will cross wires with a teammate.
 
     A CLI keys its conversation on the directory it runs from, so two members
-    driving the SAME CLI from the same directory land in one conversation —
-    reading each other's turns and overwriting each other's tail. The other
-    member does not have to be continuing to clobber it; it only has to run the
-    same CLI there. Today every member works in the one team workplace, so the
-    CLI alone identifies the conversation; a per-member workdir would widen the
-    key to (directory, CLI)."""
-    seats: list[tuple[Member, Rig]] = []
+    driving the SAME CLI from the SAME effective directory (the workplace root,
+    or the resolved `Workdir:` when set) land in one conversation — reading
+    each other's turns and overwriting each other's tail. The other member does
+    not have to be continuing to clobber it; it only has to run the same CLI
+    there. Distinct workdirs keep members on one CLI apart."""
+    seats: list[tuple[Member, Rig, Path]] = []
     for m in roster.members:
         if m.is_human or m.errors:
             continue
         rig, _err, _pinned = config.rig_for(m)
         if rig is not None:
-            seats.append((m, rig))
+            seats.append((m, rig, _effective_cwd(m, workplace)))
     out: list[str] = []
-    for member, rig in seats:
+    for member, rig, cwd in seats:
         if not member.continue_conversation:
             continue
-        others = [o.name for o, r in seats if o is not member and r.cli == rig.cli]
+        others = [
+            o.name for o, r, c in seats
+            if o is not member and r.cli == rig.cli and c == cwd
+        ]
         if others:
             out.append(
                 f"{member.name}: Continue: on, but {', '.join(others)} also run "
-                f"{rig.cli!r} in the same directory — one CLI keeps one "
-                f"conversation per directory, so their turns will land in "
-                f"{member.name}'s (try: move one of them to a rig on another CLI)"
+                f"{rig.cli!r} in {cwd} — one CLI keeps one conversation per "
+                f"directory, so their turns will land in {member.name}'s "
+                f"(try: another CLI, or a distinct Workdir:)"
             )
     return out
 

--- a/apps/r4t/roster.py
+++ b/apps/r4t/roster.py
@@ -16,6 +16,12 @@ work, and the provider cache makes an expensive rig affordable. It needs a rig
 whose preset supports it (rig.py), and members sharing a CLI in one directory
 share that conversation, so `r4t roster check` warns about the overlap.
 
+`Flush:` (optional, only meaningful with `Continue: on`) is how long the
+member's conversation may sit idle before the `r4t idle` sweep retires it —
+dump state to disk, then refound on the next real message. Bare seconds or an
+s/m/h/d suffix (`Flush: 4h`). Without `Continue: on` it is ignored;
+`r4t roster check` warns.
+
 Humans (`- **Status:** Human`) are never dispatched; an optional
 `- **Address:** <a8s-name>` tells teammates how to reach them. The Rig
 value is a SYMBOLIC rig name resolved against the out-of-repo rig
@@ -40,6 +46,19 @@ HEADING_RE = re.compile(r"^###\s+(.+?)\s*$")
 STOP_RE = re.compile(r"^#{1,3}\s")
 FIELD_RE = re.compile(r"^-\s+\*\*([A-Za-z]+):\*\*\s*(.*?)\s*$")
 RIG_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
+FLUSH_RE = re.compile(r"^(\d+(?:\.\d+)?)\s*([smhd]?)$", re.IGNORECASE)
+
+FLUSH_UNIT_SECONDS = {"": 1, "s": 1, "m": 60, "h": 3600, "d": 86400}
+
+
+def parse_flush(value: str) -> float:
+    match = FLUSH_RE.match(value.strip())
+    if not match:
+        raise ValueError(
+            f"Flush must be seconds or a duration with an s/m/h/d suffix "
+            f"(got {value!r})"
+        )
+    return float(match.group(1)) * FLUSH_UNIT_SECONDS[match.group(2).lower()]
 
 
 class RosterError(Exception):
@@ -55,6 +74,7 @@ class Member:
     leader: bool = False
     address: str | None = None
     continue_conversation: bool = False
+    flush_seconds: float | None = None
     cell: str = ""
     lead: str = ""
     workdir: str = ""
@@ -192,6 +212,20 @@ class Roster:
         return out
 
 
+def flush_warnings(roster: Roster) -> list[str]:
+    """Warn (never block) where `Flush:` is set without `Continue: on` — flush
+    only retires a continuing conversation, so the field does nothing there."""
+    return [
+        f"{m.name}: Flush: set but Continue: is off — flush retires a "
+        f"continuing conversation, so it is ignored here"
+        for m in roster.members
+        if not m.is_human
+        and not m.errors
+        and m.flush_seconds is not None
+        and not m.continue_conversation
+    ]
+
+
 def resolve_roster_path(root: Path, raw: str | None) -> Path:
     if not raw:
         return root / DEFAULT_ROSTER_NAME
@@ -231,6 +265,12 @@ def _member_from_block(name: str, lines: list[str]) -> Member:
     m.leader = _is_true(fields.get("leader", ""))
     m.address = fields.get("address") or None
     m.continue_conversation = _is_true(fields.get("continue", ""))
+    flush = fields.get("flush", "")
+    if flush:
+        try:
+            m.flush_seconds = parse_flush(flush)
+        except ValueError as e:
+            m.errors.append(str(e))
     m.cell = fields.get("cell", "")
     m.lead = fields.get("lead", "")
     m.workdir = fields.get("workdir", "")

--- a/apps/r4t/state.py
+++ b/apps/r4t/state.py
@@ -1006,6 +1006,32 @@ def update_meta(node: str, name: str, **fields) -> dict:
     return meta
 
 
+# ---------- continue conversation record (founded / retired per member) ----------
+#
+# A continuing member's CLI conversation is keyed on the CLI binary in the turn
+# directory. The record says which CLI the current conversation lives on and
+# whether it has been retired (by an idle flush or a rig swap); a retired or
+# absent record makes the next turn refound cold from state on disk.
+
+def read_conversation(node: str, name: str) -> dict:
+    data = read_meta(node, name).get("conversation")
+    return data if isinstance(data, dict) else {}
+
+
+def record_conversation(node: str, name: str, cli: str) -> dict:
+    return update_meta(
+        node, name,
+        conversation={"cli": cli, "retired": False, "recorded_at": utc_now()},
+    )
+
+
+def retire_conversation(node: str, name: str) -> None:
+    convo = read_conversation(node, name)
+    if convo and not convo.get("retired"):
+        convo["retired"] = True
+        update_meta(node, name, conversation=convo)
+
+
 # ---------- harness pool rotation ----------
 
 def take_rotation(node: str, rig: str, pool_size: int) -> int:

--- a/apps/r4t/tests/test_dispatch.py
+++ b/apps/r4t/tests/test_dispatch.py
@@ -673,10 +673,12 @@ CONTINUE_ROSTER = textwrap.dedent(
     - **Rig:** resuming
     - **Leader:** yes
     - **Continue:** on
+    - **Flush:** 1h
 
     ### Bob
     - **Status:** AI
     - **Rig:** cold
+    - **Flush:** 1h
     """
 )
 
@@ -743,37 +745,67 @@ def continue_argvs(calls):
     return [json.loads(p.read_text(encoding="utf-8")) for p in sorted(calls.iterdir())]
 
 
-class TestContinueTurns:
-    def test_founding_turn_retries_once_without_continue(self, continue_ctx):
-        ctx, calls = continue_ctx
-        assert run_one(ctx, "boss", "acme:ana", "first task") == 1
-        first, second = continue_argvs(calls)
-        assert first[-1] == "--continue"  # asked to resume; the CLI refused
-        assert "--continue" not in second  # founded the conversation instead
-        assert "CONTINUE-COLD ana" in read_log()
+REFOUND_PREAMBLE = "Check your STATUS.md to refresh your memory."
+DUMP_PROMPT = "Save your current state and progress to STATUS.md."
 
-    def test_founding_turn_is_not_a_failure(self, continue_ctx):
+
+def continue_cli(ctx, name="ana"):
+    config = load_rig_config(ctx.config_path)
+    member = load_roster(ctx.roster_path).find(name)
+    rig, _e, _p = config.rig_for(member)
+    return rig.cli
+
+
+class TestContinueTurns:
+    def test_first_turn_refounds_cold_with_the_preamble(self, continue_ctx):
+        # No recorded conversation: the turn founds one — no continue argv,
+        # read-your-state preamble on top of the prompt.
         ctx, calls = continue_ctx
         assert run_one(ctx, "boss", "acme:ana", "first task") == 1
-        assert state.queue_depth(NODE, "ana") == 0  # batch released, not requeued
-        assert state.read_meta(NODE, "ana")["consecutive_failures"] == 0
+        (argv,) = continue_argvs(calls)
+        assert "--continue" not in argv
+        assert argv[0].startswith(REFOUND_PREAMBLE)
+
+    def test_successful_refound_records_the_conversation(self, continue_ctx):
+        ctx, calls = continue_ctx
+        assert run_one(ctx, "boss", "acme:ana", "first task") == 1
+        convo = state.read_conversation(NODE, "ana")
+        assert convo["cli"] == continue_cli(ctx)
+        assert convo["retired"] is False
 
     def test_later_turns_continue_the_conversation(self, continue_ctx):
         ctx, calls = continue_ctx
         run_one(ctx, "boss", "acme:ana", "first task")
         assert run_one(ctx, "boss", "acme:ana", "second task") == 1
-        assert len(continue_argvs(calls)) == 3  # 2 to found, 1 continuing
-        assert continue_argvs(calls)[2][-1] == "--continue"
-        assert read_log().count("CONTINUE-COLD") == 1  # retried once, ever
+        argvs = continue_argvs(calls)
+        assert len(argvs) == 2
+        assert argvs[1][-1] == "--continue"
+        assert REFOUND_PREAMBLE not in argvs[1][0]
+
+    def test_lost_conversation_retries_once_cold(self, continue_ctx):
+        # A conversation is recorded but the CLI store lost it (the fake CLI's
+        # marker is absent) — the CONTINUE-COLD retry founds a new one.
+        ctx, calls = continue_ctx
+        state.record_conversation(NODE, "ana", continue_cli(ctx))
+        assert run_one(ctx, "boss", "acme:ana", "task") == 1
+        first, second = continue_argvs(calls)
+        assert first[-1] == "--continue"  # asked to resume; the CLI refused
+        assert "--continue" not in second  # founded the conversation instead
+        assert "CONTINUE-COLD ana" in read_log()
+        assert state.queue_depth(NODE, "ana") == 0  # not a failure
+        assert state.read_meta(NODE, "ana")["consecutive_failures"] == 0
+        assert state.read_conversation(NODE, "ana")["retired"] is False
 
     def test_member_without_continue_never_gets_the_flag(self, continue_ctx):
         ctx, calls = continue_ctx
         assert run_one(ctx, "acme:ana", "acme:bob", "task") == 1
         argvs = continue_argvs(calls)
         assert len(argvs) == 1 and "--continue" not in argvs[0]
+        assert state.read_conversation(NODE, "bob") == {}
 
     def test_other_failures_are_not_retried(self, continue_ctx):
         ctx, _calls = continue_ctx
+        state.record_conversation(NODE, "ana", continue_cli(ctx))
         seen = []
 
         def broken(rig, prompt, cwd, *, env=None, variant=0):
@@ -783,6 +815,161 @@ class TestContinueTurns:
         assert run_one(ctx, "boss", "acme:ana", "task", run_fn=broken) == 1
         assert seen == ["1"]  # one attempt only
         assert state.queue_depth(NODE, "ana") == 1  # normal requeue path
+
+
+class TestConversationRetirement:
+    def test_rig_swap_retires_and_refounds(self, continue_ctx):
+        # The recorded conversation lives on another CLI: retire it (no dump
+        # turn — the old CLI may be quota-dead) and refound on the new one.
+        ctx, calls = continue_ctx
+        state.record_conversation(NODE, "ana", "claude")
+        assert run_one(ctx, "boss", "acme:ana", "task") == 1
+        (argv,) = continue_argvs(calls)
+        assert "--continue" not in argv
+        assert argv[0].startswith(REFOUND_PREAMBLE)
+        assert "CONTINUE-SWAP ana" in read_log()
+        convo = state.read_conversation(NODE, "ana")
+        assert convo["cli"] == continue_cli(ctx) and convo["retired"] is False
+
+    def test_same_cli_swap_keeps_the_conversation(self, continue_ctx):
+        # Ana moves from rig "resuming" to rig "cold" — same CLI, same store,
+        # same cwd — so the conversation survives the swap.
+        ctx, calls = continue_ctx
+        run_one(ctx, "boss", "acme:ana", "first task")
+        (ctx.roster_path).write_text(
+            CONTINUE_ROSTER.replace("**Rig:** resuming", "**Rig:** cold"),
+            encoding="utf-8",
+        )
+        assert run_one(ctx, "boss", "acme:ana", "second task") == 1
+        assert continue_argvs(calls)[-1][-1] == "--continue"
+        assert "CONTINUE-SWAP" not in read_log()
+
+    def test_retired_conversation_refounds_with_preamble(self, continue_ctx):
+        ctx, calls = continue_ctx
+        run_one(ctx, "boss", "acme:ana", "first task")
+        state.retire_conversation(NODE, "ana")
+        assert run_one(ctx, "boss", "acme:ana", "second task") == 1
+        argv = continue_argvs(calls)[-1]
+        assert "--continue" not in argv
+        assert argv[0].startswith(REFOUND_PREAMBLE)
+        assert state.read_conversation(NODE, "ana")["retired"] is False
+
+
+def age_last_turn(name):
+    state.update_meta(NODE, name, last_completed_at="2020-01-01T00:00:00Z")
+
+
+class TestIdleFlush:
+    def found(self, ctx):
+        assert run_one(ctx, "boss", "acme:ana", "first task") == 1
+
+    def test_no_flush_before_the_threshold(self, continue_ctx):
+        ctx, calls = continue_ctx
+        self.found(ctx)
+        summary = run_idle(ctx)
+        assert summary["flushed"] == []
+        assert len(continue_argvs(calls)) == 1  # no dump turn ran
+        assert state.read_conversation(NODE, "ana")["retired"] is False
+
+    def test_flush_dump_turn_then_retirement(self, continue_ctx):
+        ctx, calls = continue_ctx
+        self.found(ctx)
+        age_last_turn("ana")
+        summary = run_idle(ctx)
+        assert summary["flushed"] == ["Ana"]
+        dump = continue_argvs(calls)[-1]
+        assert dump[-1] == "--continue"  # the dump rides the conversation
+        assert DUMP_PROMPT in dump[0]
+        assert state.read_conversation(NODE, "ana")["retired"] is True
+        assert "FLUSH retired ana" in read_log()
+
+    def test_retired_conversation_not_flushed_again(self, continue_ctx):
+        ctx, calls = continue_ctx
+        self.found(ctx)
+        age_last_turn("ana")
+        run_idle(ctx)
+        before = len(continue_argvs(calls))
+        age_last_turn("ana")
+        assert run_idle(ctx)["flushed"] == []
+        assert len(continue_argvs(calls)) == before
+
+    def test_flush_ignored_without_continue(self, continue_ctx):
+        # Bob carries Flush: without Continue: on — lint warns; dispatch ignores.
+        ctx, calls = continue_ctx
+        assert run_one(ctx, "acme:ana", "acme:bob", "task") == 1
+        age_last_turn("bob")
+        assert run_idle(ctx)["flushed"] == []
+        assert len(continue_argvs(calls)) == 1
+
+    def test_flush_is_budget_gated_like_mission_review(self, continue_ctx):
+        ctx, calls = continue_ctx
+        self.found(ctx)
+        age_last_turn("ana")
+        empty_member_budget(ctx, "ana")
+        assert run_idle(ctx)["flushed"] == []
+        assert "FLUSH deferred — ana" in read_log()
+        assert state.read_conversation(NODE, "ana")["retired"] is False
+        # The bucket refills: the next sweep runs the dump and retires.
+        state.atomic_write_json(
+            state.buckets_path(NODE), {"ana": {"level": 100, "at": time.time()}}
+        )
+        assert run_idle(ctx)["flushed"] == ["Ana"]
+        assert state.read_conversation(NODE, "ana")["retired"] is True
+
+    def test_dump_and_refound_templates_override_via_definition(
+        self, continue_ctx, tmp_path
+    ):
+        ctx, calls = continue_ctx
+        p = tmp_path / "defn.json"
+        p.write_text(
+            json.dumps({"invoke": ["x"], "prompts": {
+                "flush_dump": "DUMP EVERYTHING NOW",
+                "refound_preamble": "READ THE LOG FIRST",
+            }}),
+            encoding="utf-8",
+        )
+        ctx = replace(ctx, definition_path=p)
+        assert run_one(ctx, "boss", "acme:ana", "first task") == 1
+        assert continue_argvs(calls)[0][0].startswith("READ THE LOG FIRST")
+        age_last_turn("ana")
+        assert run_idle(ctx)["flushed"] == ["Ana"]
+        assert "DUMP EVERYTHING NOW" in continue_argvs(calls)[-1][0]
+
+    def test_real_message_after_flush_refounds(self, continue_ctx):
+        ctx, calls = continue_ctx
+        self.found(ctx)
+        age_last_turn("ana")
+        run_idle(ctx)
+        assert run_one(ctx, "boss", "acme:ana", "new work") == 1
+        argv = continue_argvs(calls)[-1]
+        assert "--continue" not in argv
+        assert argv[0].startswith(REFOUND_PREAMBLE)
+        convo = state.read_conversation(NODE, "ana")
+        assert convo["retired"] is False
+
+
+class TestTurnSerialization:
+    def test_message_arriving_mid_turn_never_spawns_a_second_turn(self, ctx):
+        """Pins the guarantee continue depends on: one turn at a time per
+        member. The agent .lock is held for the whole turn and claim_queue
+        snapshots under it, so a mid-turn arrival queues for the NEXT turn —
+        it must never start a second CLI on the same conversation."""
+        turns = []
+
+        def run_fn(rig, prompt, cwd, *, env=None, variant=0):
+            turns.append(prompt)
+            state.enqueue(NODE, "phil", {
+                "from": "acme:gerry", "to": "acme:phil",
+                "thread": "T", "hop": 0, "class": "auto", "body": "mid-turn",
+            })
+            assert drain(ctx, run_fn=run_fn) == 0  # lock held: no nested turn
+            return 0, "ok", 0.1, False
+
+        assert run_one(ctx, "acme:gerry", "acme:phil", "first", run_fn=run_fn) == 1
+        assert len(turns) == 1
+        assert state.queue_depth(NODE, "phil") == 1  # mid-turn message held
+        assert drain(ctx, run_fn=ok_run) == 1  # ...and rides the next turn
+        assert state.queue_depth(NODE, "phil") == 0
 
 
 ANSWER = "Here is my long detailed answer about the payload format. " * 3

--- a/apps/r4t/tests/test_rig.py
+++ b/apps/r4t/tests/test_rig.py
@@ -427,7 +427,7 @@ class TestContinueCollisions:
     def collisions(self, tmp_path, roster_text):
         config = load_rig_config(write_config(tmp_path, COLLISION_CONFIG))
         roster = parse_roster(roster_text, Path("ROSTER.md"))
-        return continue_collisions(roster, config)
+        return continue_collisions(roster, config, tmp_path)
 
     def test_no_warning_when_clis_differ(self, tmp_path):
         assert self.collisions(tmp_path, (
@@ -475,6 +475,29 @@ class TestContinueCollisions:
             "### Cid\n- **Status:** Human\n- **Address:** cid\n\n"
             "### Dot\n- **Status:** AI\n"
         )) == []
+
+    def test_distinct_workdirs_on_one_cli_do_not_collide(self, tmp_path):
+        # The conversation is keyed on (CLI, directory): a member with its own
+        # Workdir: runs the shared CLI somewhere else entirely.
+        assert self.collisions(tmp_path, (
+            "### Ana\n- **Status:** AI\n- **Rig:** solo\n- **Continue:** on\n\n"
+            "### Bob\n- **Status:** AI\n- **Rig:** solo\n- **Workdir:** agents/bob\n"
+        )) == []
+
+    def test_same_explicit_workdir_still_collides(self, tmp_path):
+        warnings = self.collisions(tmp_path, (
+            "### Ana\n- **Status:** AI\n- **Rig:** solo\n- **Continue:** on\n"
+            "- **Workdir:** shared\n\n"
+            "### Bob\n- **Status:** AI\n- **Rig:** solo\n- **Workdir:** shared\n"
+        ))
+        assert len(warnings) == 1 and "Bob" in warnings[0]
+
+    def test_workdir_resolving_to_the_workplace_collides(self, tmp_path):
+        warnings = self.collisions(tmp_path, (
+            "### Ana\n- **Status:** AI\n- **Rig:** solo\n- **Continue:** on\n\n"
+            "### Bob\n- **Status:** AI\n- **Rig:** solo\n- **Workdir:** .\n"
+        ))
+        assert len(warnings) == 1 and "Bob" in warnings[0]
 
 
 class TestDefaultPayload:

--- a/apps/r4t/tests/test_roster.py
+++ b/apps/r4t/tests/test_roster.py
@@ -7,6 +7,7 @@ import pytest
 
 from roster import (
     RosterError,
+    flush_warnings,
     load_roster,
     parse_roster,
     resolve_roster_path,
@@ -102,6 +103,48 @@ class TestParsing:
         ana = parse(CONTINUE_TEXT).find("ana")
         assert ana.rig == "r"
         assert not ana.errors
+
+    def test_flush_bare_seconds(self):
+        roster = parse(
+            "### A\n- **Status:** AI\n- **Rig:** r\n- **Continue:** on\n"
+            "- **Flush:** 90\n"
+        )
+        assert roster.find("a").flush_seconds == 90.0
+
+    @pytest.mark.parametrize(
+        "value,seconds",
+        [("30s", 30.0), ("5m", 300.0), ("4h", 14400.0), ("2d", 172800.0)],
+    )
+    def test_flush_suffixes(self, value, seconds):
+        roster = parse(
+            f"### A\n- **Status:** AI\n- **Rig:** r\n- **Continue:** on\n"
+            f"- **Flush:** {value}\n"
+        )
+        assert roster.find("a").flush_seconds == seconds
+
+    def test_flush_absent_is_none(self):
+        assert parse(CONTINUE_TEXT).find("ana").flush_seconds is None
+
+    def test_flush_malformed_disables_member(self):
+        roster = parse(
+            "### A\n- **Status:** AI\n- **Rig:** r\n- **Continue:** on\n"
+            "- **Flush:** soon\n"
+        )
+        assert "Flush" in roster.find("a").error
+
+    def test_flush_without_continue_warns(self):
+        roster = parse(
+            "### A\n- **Status:** AI\n- **Rig:** r\n- **Flush:** 4h\n"
+        )
+        warnings = flush_warnings(roster)
+        assert len(warnings) == 1 and warnings[0].startswith("A: Flush")
+
+    def test_flush_with_continue_does_not_warn(self):
+        roster = parse(
+            "### A\n- **Status:** AI\n- **Rig:** r\n- **Continue:** on\n"
+            "- **Flush:** 4h\n"
+        )
+        assert flush_warnings(roster) == []
 
     def test_lookup_is_case_insensitive(self, repo):
         roster = load_roster(repo / "ROSTER.md")


### PR DESCRIPTION
## What shipped

One mechanism to keep continuing conversations affordable and portable: retire the CLI conversation, dump state to disk first when possible, and refound from that state on the next real message. Why: an idle conversation cache-expires (re-caching a huge context at frontier prices is ~$10 for one message), and a rig swap strands the conversation entirely — CLI conversations don't cross CLIs.

- **`Flush:` roster field** — optional, per member, beside `Continue:` (`Flush: 4h`; bare seconds or s/m/h/d). Default: no flush.
- **Continue state** — per-member record in `meta.json` (`conversation`: current CLI key + retired flag), written on every successful continuing turn.

## The two triggers

1. **Idle flush** — the `r4t idle` sweep finds continuing members whose conversation is founded, not retired, and older than `Flush:`, runs a DUMP TURN (normal turn machinery, WITH continue, dump-template prompt — logged, captured, counted, budget-gated exactly like mission-review; no budget skips the sweep and retries on refill), then retires the conversation.
2. **Rig swap** — at turn start, a rig resolving to a different CLI key than the recorded conversation retires it immediately, no dump turn (the old CLI may be quota-dead); logged as `CONTINUE-SWAP`. A same-CLI swap (model-only, `opencode`↔`opencode-ollama`) keeps the conversation.

A retired or unrecorded conversation refounds: no continue argv, a read-your-state preamble tops the prompt, and success records the new CLI key through the same path the CONTINUE-COLD founding retry uses.

## Template override keys

`flush_dump` (default "Save your current state and progress to STATUS.md.") and `refound_preamble` (default "Check your STATUS.md to refresh your memory.") — via the existing definition `prompts` object.

## Serialization pin

Continue makes one-turn-at-a-time per member mandatory. The existing guarantee — the per-member agent `.lock` held for the whole turn, with `claim_queue` snapshotting under it so mid-turn arrivals ride the next turn — holds; `TestTurnSerialization` pins it (a nested drain during a live turn runs nothing, and the mid-turn message queues).

## Lint upgrade (deferred from #255)

Continue collisions now key on (CLI key, effective cwd): members on the same CLI with distinct `Workdir:`s no longer warn; same CLI + same directory still does, and launcher variants still share a CLI key. `Flush:` without `Continue: on` is a new harmless lint warning.

## Tests

- r4t: 618 passed (594 on main; +24 net, and the 5 continue-founding tests reworked for the refound flow)
- a8s: 778 passed (no cross-breakage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)