### PR TITLE
feat(r4t): echo rigs — stdout-only members

### DIFF
--- a/apps/r4t/dispatch.py
+++ b/apps/r4t/dispatch.py
@@ -66,6 +66,7 @@ PROMPT_DEFAULTS: dict[str, str] = {
         "at {workplace} (your current directory). Write files here with "
         "relative paths only."
     ),
+    "echo_intro": "You are {name}, a member of the {node} team.",
     "mission_header": "## The mission (MISSION.md — outranks every other document)",
     "workdir_note": (
         "The team repo (org workplace) is at {workplace} — use that absolute "
@@ -492,6 +493,25 @@ def build_prompt(
         message_lines.append("")
         message_lines.append(body)
         message_lines.append("")
+    if rig.echo:
+        # An echo member has no tools and no concept of messages: no tell
+        # instructions, no teammate list, no how-to-work doctrine. It gets who
+        # it is, what has been said, and the new messages — its stdout IS the
+        # reply (_stage_echo_reply).
+        parts = [
+            ctx.prompt("echo_intro", name=member.name, node=ctx.node),
+            "",
+            *_mission_section(ctx, roster, member),
+            "## Who you are (from the team roster)",
+            member.persona or f"### {member.name}",
+            "",
+            "## Your conversation so far (messages you received and sent)",
+            history.strip() or "(no prior messages — this is your first recorded turn)",
+            "",
+            "## Messages since your last turn",
+            *(message_lines or ["(none)"]),
+        ]
+        return "\n".join(parts)
     workdir = resolve_workdir(ctx, member)
     workdir_lines: list[str] = []
     if workdir.resolve() != ctx.workplace.resolve():
@@ -1126,6 +1146,59 @@ def clean_transcript(output: str) -> str:
     return "\n".join(kept).strip()
 
 
+def _stage_echo_reply(
+    ctx: DispatchContext,
+    member: Member,
+    rig: Rig,
+    to: str,
+    output: str,
+) -> None:
+    """The echo rig's ONLY reply path: the turn's cleaned stdout becomes one
+    envelope to the newest inbound sender, staged pre-release so every gate
+    (quota, egress, attribution, hop) applies unchanged. Anything the model
+    somehow staged is noise — an echo member was never offered `tell` — and is
+    discarded. Output past `echo_max_chars` is truncated in the body with the
+    full text riding the same envelope as a markdown attachment (the a8s
+    bundle-dir mechanism `tell --attach` uses). Empty or chrome-only output
+    stays silent, SILENT logged."""
+    staging = state.staging_dir(ctx.node, member.name)
+    for stale in state.staged_envelopes(ctx.node, member.name):
+        stale.unlink(missing_ok=True)
+    reply = clean_transcript(output)
+    if not reply:
+        state.append_log(
+            ctx.node,
+            f"r4t: SILENT {member.name.lower()} (rig {rig.name}) exit 0 with "
+            f"{len(output.strip())} bytes of stdout but nothing worth "
+            "relaying survived transcript cleaning",
+        )
+        return
+    msg_id = tasks.new_thread_id()
+    body = reply
+    files: list[dict] = []
+    if len(reply) > rig.echo_max_chars:
+        name = "reply.md"
+        bundle = staging / msg_id
+        bundle.mkdir(parents=True, exist_ok=True)
+        (bundle / name).write_text(reply + "\n", encoding="utf-8")
+        body = (
+            reply[: rig.echo_max_chars]
+            + f"\n[truncated by r4t at {rig.echo_max_chars} chars — "
+            f"full reply attached as {name}]"
+        )
+        files = [{"filename": name}]
+    state.atomic_write_json(
+        staging / f"{msg_id}.json",
+        {"id": msg_id, "to": to, "content": body, "files": files},
+    )
+    state.append_log(
+        ctx.node,
+        f"r4t: ECHO-REPLY {member.name.lower()} (rig {rig.name}) "
+        f"{len(reply)} bytes of cleaned stdout staged as the reply to {to}"
+        + (" (full text attached)" if files else ""),
+    )
+
+
 def _capture_turn(
     ctx: DispatchContext,
     member: Member,
@@ -1325,7 +1398,9 @@ def _run_turn(
                 f"{_display_name(ctx.node, str(env_msg.get('from', '?')))}\n\n{entry_body}",
                 max_bytes=rig.history_max_bytes,
             )
-        if not state.staged_envelopes(ctx.node, member.name):
+        if rig.echo:
+            _stage_echo_reply(ctx, member, rig, newest_sender, output)
+        elif not state.staged_envelopes(ctx.node, member.name):
             # The classic weak-rig shape: the model answers on stdout instead
             # of running `tell`. `tell` always wins — a turn that staged
             # anything keeps its stdout as transcript — but a clean turn that

--- a/apps/r4t/dispatch.py
+++ b/apps/r4t/dispatch.py
@@ -343,14 +343,20 @@ def _park_seat(
     *,
     thread: str | None = None,
     roster: Roster | None = None,
+    files: list[dict] | None = None,
+    bundle: Path | None = None,
 ) -> None:
     """Deliver a message to a roster human: park it in the node's seat
-    mailbox, and ring the `Address:` doorbell (a forwarded copy over a8s)
-    only when no seat session is attached to read it live. When the org sets a
+    mailbox (attachments copied into seat storage alongside it), and ring the
+    `Address:` doorbell (a forwarded copy over a8s) only when no seat session
+    is attached to read it live. The doorbell forward is body-only —
+    attachments wait in the seat mailbox. When the org sets a
     `doorbell_check`, that command gates the ring — the message is always parked
     first (seat mail is never lost), and a failing gate suppresses only the
     ring and replies to the sender with an error."""
-    state.park_seat_message(ctx.node, member.name, sender, body)
+    state.park_seat_message(
+        ctx.node, member.name, sender, body, files=files, bundle=bundle
+    )
     if not (member.address and not state.seat_attached(ctx.node, member.name)):
         state.append_log(
             ctx.node, f"r4t: SEAT {member.name.lower()} <- {sender} (parked)"
@@ -704,6 +710,8 @@ def _ingest(
     hop: int = 0,
     roster: Roster | None = None,
     config: RigConfig | None = None,
+    files: list[dict] | None = None,
+    bundle: Path | None = None,
 ) -> str:
     """Resolve the recipient and enqueue a structured r4t-message. Humans park
     in the seat; undeliverable mail dead-letters with an audit record; a
@@ -766,7 +774,10 @@ def _ingest(
             return DEAD
 
     if member.is_human:
-        _park_seat(ctx, member, sender, body, thread=thread, roster=roster)
+        _park_seat(
+            ctx, member, sender, body, thread=thread, roster=roster,
+            files=files, bundle=bundle,
+        )
         return SKIPPED
 
     if member.errors:
@@ -848,19 +859,24 @@ def _release_one(
 ) -> None:
     to = str(envelope.get("to", "")).strip()
     if _is_internal(ctx.node, to):
+        bundle = staging / str(envelope.get("id", ""))
         _ingest(
             ctx, sender_addr, to, body,
             klass="auto", internal=True, thread=thread_id, hop=next_hop,
             roster=roster, config=config,
+            files=envelope.get("files") or [],
+            bundle=bundle if bundle.is_dir() else None,
         )
-        bundle = staging / str(envelope.get("id", ""))
         if bundle.is_dir():
             shutil.rmtree(bundle, ignore_errors=True)
-            state.append_log(
-                ctx.node,
-                f"r4t: WARN attachments dropped on intra-team route "
-                f"{sender_addr} -> {to}",
-            )
+            # A human recipient's park copied the files into seat storage;
+            # AI-member queues still carry no attachments.
+            if _human_member(ctx.node, roster, to) is None:
+                state.append_log(
+                    ctx.node,
+                    f"r4t: WARN attachments dropped on intra-team route "
+                    f"{sender_addr} -> {to}",
+                )
         state.append_log(
             ctx.node,
             f"r4t: RELEASED-internal {sender_addr} -> {to} thread={thread_id} "

--- a/apps/r4t/docs/operations.md
+++ b/apps/r4t/docs/operations.md
@@ -30,7 +30,8 @@ A human roster member is a first-class team address: teammates just
 disconnect. When the seat is unattended dispatch rings the `Address:`
 doorbell (a copy forwarded over a8s to the human's phone); a reply from that
 Address is the human speaking, so it re-enters through the seat path and
-routes like a chat send. Outsiders other than the human do not reach the
+routes like a chat send. The doorbell forward is body-only — attachments wait
+in the seat mailbox, where `r4t seat inbox` prints their stored paths. Outsiders other than the human do not reach the
 seat directly — like all external traffic they enter through the top lead.
 Two surfaces read and speak for it:
 

--- a/apps/r4t/docs/rigs.md
+++ b/apps/r4t/docs/rigs.md
@@ -88,7 +88,8 @@ other r4t preset, agy is trusted with normal filesystem permissions.
 
 Rig settings never need hand-edited JSON. The configurable keys are
 `concurrency`, `rig_budget_max`, `rig_budget_earn_per_hour`, the context knobs
-`history_max_bytes` / `history_body_max` / `prompt_body_max`, and `model`
+`history_max_bytes` / `history_body_max` / `prompt_body_max`, `model`, and the
+echo keys `echo` / `echo_max_chars`
 (each detailed in the [knob table](#governance-knobs) below).
 
 ```bash
@@ -117,6 +118,18 @@ recorded preset, exactly like `rig add --model` (agy keeps its live fuzzy match
 per turn). A rig with no recorded preset errors, pointing at
 `r4t rig swap <rig> <preset> --model ...`. Raw `invoke` arrays are never
 exposed through this surface; use `rig add`/`swap` to change the harness.
+
+## Echo rigs
+
+`r4t rig set <rig> echo true` makes the rig's members stdout-only: their turn
+prompt carries no `tell` instructions or messaging doctrine — just who they
+are, their history, and the new messages — and the turn's cleaned stdout is
+staged as the one reply to the sender (`ECHO-REPLY` in the log), through the
+same release gates every send passes. Use it for models that misuse `tell`
+(small models told to message via a shell tool can loop, while the same model
+simply asked a question just answers). A reply longer than `echo_max_chars`
+(default 1500) is truncated in the body with the full text attached to the
+same envelope as a markdown file; empty or chrome-only output stays silent.
 
 ## The economics: budgets, not cuts
 
@@ -155,6 +168,7 @@ invoke lines is a fully governed team. Rationale and prior art per layer:
 | `rig_budget_max` / `rig_budget_earn_per_hour` (rig) | unset (no rig gate) | Machine-global rig spend bucket for the subscription behind the rig. A turn also costs 1 rig unit; when empty, every member on that rig rests on every team. Set both together to bind a shared plan (e.g. 20 / 20 for ~20 prompts an hour) | A shared subscription outrunning its real quota across projects |
 | `max_sends_per_turn` (rig) | 6 | Envelopes released per turn; excess dead-letters | Runaway fan-out width |
 | `history_max_bytes` / `history_body_max` / `prompt_body_max` (rig) | by preset tier — big (agy/codex/claude) 50k/12k/24k · moderate (cursor/opencode/copilot) 25k/6k/12k · small (ollama variants, or no preset) 8192/2000/4000 | Context sizing on the rig: rolling-history budget, per-entry history clip, and per-message prompt clip. `rig add`/`swap` record the preset; explicit values override the tier | A weak rig drowning in context, or a strong one starved of it |
+| `echo` / `echo_max_chars` (rig) | false / 1500 | Stdout-only members (see [Echo rigs](#echo-rigs)): no messaging scaffolding in the prompt, cleaned stdout staged as the one reply, bodies past the cap truncated with the full text attached | A model that misuses `tell`, looping "I did it" messages instead of answering |
 | `timeout_seconds` (rig) | 900 | Harness wall clock; the process group is killed | Hung harnesses |
 | `concurrency` (rig) | 1 | Live turns within one rig | Rig-wide pile-ups |
 | `cell_budget_max` / `cell_budget_earn_per_hour` | 16 / 8 | Shared cell spend bucket; a turn also costs 1 cell unit. When empty, everyone rests | Whole-cell money burn |

--- a/apps/r4t/r4t.py
+++ b/apps/r4t/r4t.py
@@ -905,6 +905,11 @@ def cmd_seat(args: argparse.Namespace) -> int:
                     f" ({envelope.get('parked_at', '?')})"
                 )
                 print(envelope.get("content", ""))
+                for f in envelope.get("files") or []:
+                    print(
+                        f"(attachment: {f.get('filename', '?')} "
+                        f"at {f.get('path', '?')})"
+                    )
                 print()
             if not args.peek:
                 state.mark_seat_read(node, human.name, path)

--- a/apps/r4t/rig.py
+++ b/apps/r4t/rig.py
@@ -30,6 +30,12 @@ ceiling binds every team on the machine that shares the rig; a turn also costs
 `rig_budget_max` is set, `rig_budget_earn_per_hour` must be set too — a real
 plan always declares a refill rate.
 
+`echo` — the rig's members never see `tell` or any messaging instructions:
+they are simply prompted with the message content and their cleaned stdout is
+staged as the one reply, through the same release gates every send passes.
+`echo_max_chars` (default 1500) caps that reply's body; longer output is
+truncated with the full text attached as a markdown file on the same envelope.
+
 `preset` — the harness preset the rig was created from (`r4t rig add`/`swap`
 record it). It defaults the text knobs (`history_max_bytes` /
 `history_body_max` / `prompt_body_max`) by the preset's text tier (TEXT_TIERS);
@@ -342,6 +348,7 @@ def text_defaults(preset: str | None) -> dict[str, int]:
     return TEXT_TIERS.get(tier or "small", TEXT_TIERS["small"])
 DEFAULT_BUDGET_MAX = 8.0
 DEFAULT_BUDGET_EARN_PER_HOUR = 4.0
+DEFAULT_ECHO_MAX_CHARS = 1500
 DEFAULT_MAX_CONCURRENT = 1
 DEFAULT_MIN_SECONDS_BETWEEN_TURN_STARTS = 15.0
 DEFAULT_CELL_BUDGET_MAX = 16.0
@@ -382,6 +389,8 @@ class Rig:
     model: str | None = None
     model_resolver: str | None = None
     preset: str | None = None
+    echo: bool = False
+    echo_max_chars: int = DEFAULT_ECHO_MAX_CHARS
     error: str | None = None
 
     @property
@@ -826,8 +835,10 @@ CONFIGURABLE_INT_KEYS = (
     "history_max_bytes",
     "history_body_max",
     "prompt_body_max",
+    "echo_max_chars",
 )
 CONFIGURABLE_FLOAT_KEYS = ("rig_budget_max", "rig_budget_earn_per_hour")
+CONFIGURABLE_BOOL_KEYS = ("echo",)
 CONFIGURABLE_RIG_KEYS = (
     "concurrency",
     "rig_budget_max",
@@ -836,6 +847,8 @@ CONFIGURABLE_RIG_KEYS = (
     "history_body_max",
     "prompt_body_max",
     "model",
+    "echo",
+    "echo_max_chars",
 )
 
 
@@ -853,6 +866,8 @@ class RigSetting:
     def display(self) -> str:
         if self.value is None:
             return "unset"
+        if isinstance(self.value, bool):
+            return "true" if self.value else "false"
         if isinstance(self.value, float):
             return f"{self.value:g}"
         return str(self.value)
@@ -903,6 +918,14 @@ def _resolve_setting(entry: dict, key: str) -> RigSetting:
         if "concurrency" in entry:
             return RigSetting(key, int(entry["concurrency"]), "explicit", True)
         return RigSetting(key, DEFAULT_CONCURRENCY, "built-in default", False)
+    if key == "echo":
+        if "echo" in entry:
+            return RigSetting(key, bool(entry["echo"]), "explicit", True)
+        return RigSetting(key, False, "built-in default", False)
+    if key == "echo_max_chars":
+        if "echo_max_chars" in entry:
+            return RigSetting(key, int(entry["echo_max_chars"]), "explicit", True)
+        return RigSetting(key, DEFAULT_ECHO_MAX_CHARS, "built-in default", False)
     if key in CONFIGURABLE_FLOAT_KEYS:
         if key in entry:
             return RigSetting(key, float(entry[key]), "explicit", True)
@@ -977,6 +1000,18 @@ def set_rig_value(path: Path, rig_name: str, key: str, value: object) -> RigSett
         model = str(value).strip()
         set_rig_model(path, rig_key, model)
         return RigSetting("model", model, "explicit", True)
+    if key in CONFIGURABLE_BOOL_KEYS:
+        text = str(value).strip().lower()
+        if text not in ("true", "false"):
+            raise RigError(
+                f"{key} must be true or false, got {value!r} "
+                f"(try: r4t rig set <rig> {key} true)"
+            )
+        flag = text == "true"
+        _, entry, payload = _rig_entry(path, rig_name)
+        entry[key] = flag
+        atomic_write_json(path, payload)
+        return RigSetting(key, flag, "explicit", True)
     number = _parse_setting_number(key, value)
     _, entry, payload = _rig_entry(path, rig_name)
     entry[key] = number
@@ -1097,6 +1132,17 @@ def _parse_rig(name: str, raw: object) -> Rig:
         if err:
             problems.append(f"{knob}: {err}")
         setattr(rig, knob, int(value))
+
+    raw_echo = raw.get("echo")
+    if raw_echo is not None:
+        if not isinstance(raw_echo, bool):
+            problems.append(f"echo: expected true or false, got {raw_echo!r}")
+        else:
+            rig.echo = raw_echo
+    echo_max, err = _positive_number(raw.get("echo_max_chars"), DEFAULT_ECHO_MAX_CHARS)
+    if err:
+        problems.append(f"echo_max_chars: {err}")
+    rig.echo_max_chars = int(echo_max)
 
     # The rig spend bucket is opt-in: absent leaves both None and the rig gate
     # off. If present, both knobs are required — a real subscription always

--- a/apps/r4t/state.py
+++ b/apps/r4t/state.py
@@ -453,14 +453,37 @@ def seat_read_dir(node: str, name: str) -> Path:
     return seat_dir(node, name) / "read"
 
 
-def park_seat_message(node: str, name: str, sender: str, content: str) -> Path:
+def park_seat_message(
+    node: str,
+    name: str,
+    sender: str,
+    content: str,
+    *,
+    files: list[dict] | None = None,
+    bundle: Path | None = None,
+) -> Path:
+    """Park one message in the human's seat inbox. When the envelope carried
+    attachments (`files` entries + the staged `bundle` dir), copy them into the
+    seat's own storage so they outlive the per-turn staging dir; the parked
+    JSON records filename + stored path for each."""
     envelope = {
         "id": new_ulid(),
         "from": sender,
         "to": name.strip().lower(),
         "content": content,
+        "files": [],
         "parked_at": utc_now(),
     }
+    if files and bundle is not None:
+        store = seat_dir(node, name) / "files" / envelope["id"]
+        for entry in files:
+            src = bundle / str(entry.get("filename", ""))
+            if not src.is_file():
+                continue
+            store.mkdir(parents=True, exist_ok=True)
+            dest = store / src.name
+            shutil.copyfile(src, dest)
+            envelope["files"].append({"filename": src.name, "path": str(dest)})
     path = seat_inbox_dir(node, name) / f"{envelope['id']}.json"
     atomic_write_json(path, envelope)
     return path

--- a/apps/r4t/tests/test_dispatch.py
+++ b/apps/r4t/tests/test_dispatch.py
@@ -1082,6 +1082,167 @@ class TestStdoutFallback:
         assert "STDOUT-REPLY" not in read_log()
 
 
+def set_echo(config_path, rig_name="leader", **extra):
+    config = json.loads(Path(config_path).read_text(encoding="utf-8"))
+    config[rig_name]["echo"] = True
+    config[rig_name].update(extra)
+    Path(config_path).write_text(json.dumps(config), encoding="utf-8")
+
+
+class TestEchoRig:
+    def test_prompt_has_messages_but_no_messaging_scaffolding(self, ctx, fake_harness):
+        set_echo(ctx.config_path)
+        handle_message(ctx, "boss", "acme:gerry", "what is the plan?")
+        prompt = read_prompt(harness_calls(fake_harness)[0])
+        assert "You are Gerry, a member of the acme team." in prompt
+        assert "## Messages since your last turn" in prompt
+        assert "From: boss" in prompt
+        assert "what is the plan?" in prompt
+        assert "The Orchestrator" in prompt  # persona survives
+        assert "tell" not in prompt.lower()
+        assert "## How to work" not in prompt
+        assert "This is one turn" not in prompt
+        assert "Teammates" not in prompt
+
+    def test_stdout_staged_as_echo_reply_through_the_gates(self, ctx, repo, r4t_home):
+        set_echo(ctx.config_path)
+        handle_message(ctx, "boss", "acme:gerry", "question", run_fn=stdout_only)
+        envelopes = outbox_envelopes(repo)
+        assert [e["to"] for e in envelopes] == ["boss"]
+        assert envelopes[0]["content"] == ANSWER.strip()
+        assert envelopes[0]["files"] == []
+        assert "r4t: ECHO-REPLY gerry" in read_log()
+        assert "STDOUT-REPLY" not in read_log()
+        assert tasks.list_tasks(NODE)[0]["status"] == tasks.STATUS_CLOSED
+
+    def test_short_answer_still_replies(self, ctx, repo, r4t_home):
+        # No STDOUT_REPLY_MIN_CHARS floor: an echo member answering "4" to a
+        # question is a reply, not a quiet turn.
+        def terse(rig, prompt, cwd, *, env=None, variant=0):
+            return 0, "4\n", 1.0, False
+
+        set_echo(ctx.config_path)
+        handle_message(ctx, "boss", "acme:gerry", "2+2?", run_fn=terse)
+        assert outbox_envelopes(repo)[0]["content"] == "4"
+        assert "r4t: ECHO-REPLY gerry" in read_log()
+
+    def test_staged_tells_are_discarded(self, ctx, repo, r4t_home):
+        # An echo member was never offered tell; anything staged is noise and
+        # the stdout reply is the only envelope released.
+        def tell_and_chatter(rig, prompt, cwd, *, env=None, variant=0):
+            outbox = dispatch.Path(env["TELL_OUTBOX_DIR"])
+            msg_id = new_ulid()
+            (outbox / f"{msg_id}.json").write_text(
+                json.dumps({"id": msg_id, "to": "outsider", "content": "sneaky"}),
+                encoding="utf-8",
+            )
+            return 0, ANSWER, 1.0, False
+
+        set_echo(ctx.config_path)
+        handle_message(ctx, "boss", "acme:gerry", "question", run_fn=tell_and_chatter)
+        envelopes = outbox_envelopes(repo)
+        assert [e["to"] for e in envelopes] == ["boss"]
+        assert envelopes[0]["content"] == ANSWER.strip()
+
+    def test_empty_output_is_silent(self, ctx, repo, r4t_home):
+        def blank(rig, prompt, cwd, *, env=None, variant=0):
+            return 0, "", 1.0, False
+
+        set_echo(ctx.config_path)
+        handle_message(ctx, "boss", "acme:gerry", "question", run_fn=blank)
+        assert outbox_envelopes(repo) == []
+        text = read_log()
+        assert "r4t: SILENT gerry" in text
+        assert "ECHO-REPLY" not in text
+
+    def test_chrome_only_output_is_silent(self, ctx, repo, r4t_home):
+        def chrome_only(rig, prompt, cwd, *, env=None, variant=0):
+            return 0, "\x1b[0m\n> build · qwen3:0.6b\n\x1b[0m→ \x1b[0mRead x.txt\n", 1.0, False
+
+        set_echo(ctx.config_path)
+        handle_message(ctx, "boss", "acme:gerry", "question", run_fn=chrome_only)
+        assert outbox_envelopes(repo) == []
+        assert "r4t: SILENT gerry" in read_log()
+
+    def test_batch_composes_one_prompt_and_one_reply_to_newest_sender(
+        self, ctx, repo, r4t_home
+    ):
+        set_echo(ctx.config_path)
+        prompts = []
+
+        def capture(rig, prompt, cwd, *, env=None, variant=0):
+            prompts.append(prompt)
+            return 0, ANSWER, 1.0, False
+
+        handle_message(ctx, "acme:phil", "acme:gerry", "q one", drain_after=False)
+        handle_message(ctx, "acme:neil", "acme:gerry", "q two", drain_after=False)
+        assert drain(ctx, run_fn=capture) == 1
+        assert len(prompts) == 1
+        assert "q one" in prompts[0] and "q two" in prompts[0]
+        # Same resolution as the stdout fallback: ONE reply to the newest
+        # message's sender — here the human seat, so it parks there.
+        parked = seat_messages()
+        assert [m["from"] for m in parked] == ["acme:gerry"]
+        assert parked[0]["content"] == ANSWER.strip()
+        assert outbox_envelopes(repo) == []
+
+    def test_reply_to_internal_sender_wakes_them(self, ctx, fake_harness, r4t_home):
+        set_echo(ctx.config_path, rig_name="junior-dev")
+        handle_message(
+            ctx, f"{NODE}:gerry", "acme:phil", "question",
+            run_fn=stdout_only, drain_after=False,
+        )
+        assert drain(ctx, run_fn=stdout_only) == 1  # phil echoes back to gerry
+        drain(ctx)  # gerry's turn runs on the fake harness
+        prompts = [read_prompt(p) for p in harness_calls(fake_harness)]
+        assert any("From: phil" in p and ANSWER.strip() in p for p in prompts)
+
+    def test_long_output_truncates_body_and_attaches_full_text(
+        self, ctx, repo, r4t_home
+    ):
+        set_echo(ctx.config_path, echo_max_chars=100)
+        handle_message(ctx, "boss", "acme:gerry", "question", run_fn=stdout_only)
+        (envelope,) = outbox_envelopes(repo)
+        assert envelope["content"].startswith(ANSWER.strip()[:100])
+        assert "truncated by r4t at 100 chars" in envelope["content"]
+        assert envelope["files"] == [{"filename": "reply.md"}]
+        attached = repo / ".outbox" / envelope["id"] / "reply.md"
+        assert attached.read_text(encoding="utf-8").strip() == ANSWER.strip()
+        assert "(full text attached)" in read_log()
+
+    def test_under_threshold_carries_no_attachment(self, ctx, repo, r4t_home):
+        set_echo(ctx.config_path)  # default echo_max_chars 1500 > len(ANSWER)
+        handle_message(ctx, "boss", "acme:gerry", "question", run_fn=stdout_only)
+        (envelope,) = outbox_envelopes(repo)
+        assert envelope["files"] == []
+        assert "truncated" not in envelope["content"]
+        assert not (repo / ".outbox" / envelope["id"]).is_dir()
+
+    def test_failed_turn_stages_no_echo_reply(self, ctx, repo, r4t_home):
+        def crashed(rig, prompt, cwd, *, env=None, variant=0):
+            return 1, ANSWER, 1.0, False
+
+        set_echo(ctx.config_path)
+        handle_message(ctx, "boss", "acme:gerry", "question", run_fn=crashed)
+        assert outbox_envelopes(repo) == []
+        assert "ECHO-REPLY" not in read_log()
+
+    def test_echo_and_continue_coexist_in_one_turn(self, continue_ctx, repo):
+        # Echo shapes the prompt and reply; continue shapes the argv — they
+        # compose in a single turn without special cases.
+        ctx, calls = continue_ctx
+        set_echo(ctx.config_path, rig_name="resuming")
+        run_one(ctx, "boss", "acme:ana", "first task")  # founds the conversation
+        assert run_one(ctx, "boss", "acme:ana", "second task") == 1
+        argv = continue_argvs(calls)[-1]
+        assert argv[-1] == "--continue"
+        assert "tell" not in argv[0].lower()
+        assert "## Messages since your last turn" in argv[0]
+        assert "r4t: ECHO-REPLY ana" in read_log()
+        envelopes = outbox_envelopes(ctx.root)
+        assert envelopes and all(e["to"] == "boss" for e in envelopes)
+
+
 class TestCleanTranscript:
     def test_strips_ansi_and_chrome(self):
         raw = (

--- a/apps/r4t/tests/test_dispatch.py
+++ b/apps/r4t/tests/test_dispatch.py
@@ -1218,6 +1218,36 @@ class TestEchoRig:
         assert "truncated" not in envelope["content"]
         assert not (repo / ".outbox" / envelope["id"]).is_dir()
 
+    def test_long_reply_to_human_parks_with_attachment(
+        self, ctx, repo, r4t_home, capsys
+    ):
+        set_echo(ctx.config_path, echo_max_chars=100)
+        handle_message(ctx, "acme:neil", "acme:gerry", "question", run_fn=stdout_only)
+        assert r4t_main([
+            "seat", "inbox", "--peek", "--json", "--node", NODE,
+            "--root", str(repo), "--rig-config", str(ctx.config_path),
+            "--simulate-tell",
+        ]) == 0
+        envelope = json.loads(capsys.readouterr().out.strip())
+        assert "truncated by r4t at 100 chars" in envelope["content"]
+        (entry,) = envelope["files"]
+        assert entry["filename"] == "reply.md"
+        stored = Path(entry["path"])
+        assert stored.read_text(encoding="utf-8").strip() == ANSWER.strip()
+        assert "WARN attachments dropped" not in read_log()
+        assert r4t_main([
+            "seat", "inbox", "--node", NODE, "--root", str(repo),
+            "--rig-config", str(ctx.config_path), "--simulate-tell",
+        ]) == 0
+        assert f"(attachment: reply.md at {stored})" in capsys.readouterr().out
+
+    def test_short_reply_to_human_parks_without_files(self, ctx, r4t_home):
+        set_echo(ctx.config_path)
+        handle_message(ctx, "acme:neil", "acme:gerry", "question", run_fn=stdout_only)
+        (parked,) = seat_messages()
+        assert parked["content"] == ANSWER.strip()
+        assert parked["files"] == []
+
     def test_failed_turn_stages_no_echo_reply(self, ctx, repo, r4t_home):
         def crashed(rig, prompt, cwd, *, env=None, variant=0):
             return 1, ANSWER, 1.0, False

--- a/apps/r4t/tests/test_rig.py
+++ b/apps/r4t/tests/test_rig.py
@@ -8,6 +8,7 @@ import pytest
 from rig import (
     CONFIGURABLE_RIG_KEYS,
     DEFAULT_BUDGET_EARN_PER_HOUR,
+    DEFAULT_ECHO_MAX_CHARS,
     DEFAULT_BUDGET_MAX,
     DEFAULT_CONCURRENCY,
     DEFAULT_MAX_CONCURRENT,
@@ -1052,6 +1053,64 @@ class TestRigSettingsCore:
         path = write_config(tmp_path, {"other": {"invoke": ["x", "{prompt}"]}})
         with pytest.raises(RigError, match="no rig 'worker'"):
             set_rig_value(path, "worker", "concurrency", "2")
+
+
+class TestEchoSetting:
+    def test_default_off(self, tmp_path):
+        path = tmp_path / "rigs.json"
+        add_preset_rig(path, "worker", "ollama", model="tiny")
+        rig = load_rig_config(path).rigs["worker"]
+        assert rig.echo is False
+        assert rig.echo_max_chars == DEFAULT_ECHO_MAX_CHARS == 1500
+        s = rig_setting(path, "worker", "echo")
+        assert (s.value, s.explicit, s.source) == (False, False, "built-in default")
+        assert s.display() == "false"
+
+    def test_set_get_unset_round_trip(self, tmp_path):
+        path = tmp_path / "rigs.json"
+        add_preset_rig(path, "worker", "ollama", model="tiny")
+        set_rig_value(path, "worker", "echo", "true")
+        assert json.loads(path.read_text(encoding="utf-8"))["worker"]["echo"] is True
+        assert load_rig_config(path).rigs["worker"].echo is True
+        s = rig_setting(path, "worker", "echo")
+        assert (s.value, s.explicit, s.display()) == (True, True, "true")
+        set_rig_value(path, "worker", "echo", "false")
+        assert load_rig_config(path).rigs["worker"].echo is False
+        assert unset_rig_value(path, "worker", "echo") is True
+        assert "echo" not in json.loads(path.read_text(encoding="utf-8"))["worker"]
+
+    def test_set_rejects_non_boolean(self, tmp_path):
+        path = tmp_path / "rigs.json"
+        add_preset_rig(path, "worker", "ollama", model="tiny")
+        with pytest.raises(RigError, match="must be true or false"):
+            set_rig_value(path, "worker", "echo", "yes")
+
+    def test_parse_rejects_non_boolean_json(self, tmp_path):
+        path = write_config(
+            tmp_path, {"worker": {"invoke": ["x", "{prompt}"], "echo": "true"}}
+        )
+        rig = load_rig_config(path).rigs["worker"]
+        assert "echo: expected true or false" in rig.error
+
+    def test_max_chars_set_and_validation(self, tmp_path):
+        path = tmp_path / "rigs.json"
+        add_preset_rig(path, "worker", "ollama", model="tiny")
+        set_rig_value(path, "worker", "echo_max_chars", "400")
+        assert load_rig_config(path).rigs["worker"].echo_max_chars == 400
+        with pytest.raises(RigError, match="positive"):
+            set_rig_value(path, "worker", "echo_max_chars", "0")
+
+    def test_set_via_cli(self, tmp_path, capsys):
+        path = tmp_path / "rigs.json"
+        add_preset_rig(path, "worker", "ollama", model="tiny")
+        assert r4t_main(
+            ["rig", "set", "worker", "echo", "true", "--rig-config", str(path)]
+        ) == 0
+        assert "set worker echo = true" in capsys.readouterr().out
+        assert r4t_main(
+            ["rig", "get", "worker", "echo", "--rig-config", str(path)]
+        ) == 0
+        assert capsys.readouterr().out.strip() == "true"
 
 
 class TestRigModelSetting:

--- a/apps/r4t/tests/test_seat.py
+++ b/apps/r4t/tests/test_seat.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import os
+from pathlib import Path
 
 import state
 import tasks
@@ -56,6 +57,28 @@ def test_seat_inbox_peek_and_json(repo, rig_config, r4t_home, capsys):
     assert envelope["from"] == "acme:gerry"
     assert envelope["content"] == "hello"
     assert len(state.list_seat_messages(NODE, "neil")) == 1
+
+
+def test_park_without_files_records_empty_files(r4t_home):
+    path = state.park_seat_message(NODE, "Neil", "acme:gerry", "hello")
+    assert json.loads(path.read_text(encoding="utf-8"))["files"] == []
+
+
+def test_park_with_bundle_copies_into_seat_storage(r4t_home, tmp_path, capsys, repo, rig_config):
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "notes.md").write_text("full text", encoding="utf-8")
+    path = state.park_seat_message(
+        NODE, "Neil", "acme:gerry", "see attached",
+        files=[{"filename": "notes.md"}], bundle=bundle,
+    )
+    (entry,) = json.loads(path.read_text(encoding="utf-8"))["files"]
+    stored = Path(entry["path"])
+    assert entry["filename"] == "notes.md"
+    assert stored.read_text(encoding="utf-8") == "full text"
+    assert state.seat_dir(NODE, "neil") in stored.parents
+    assert _seat(repo, rig_config, "inbox") == 0
+    assert f"(attachment: notes.md at {stored})" in capsys.readouterr().out
 
 
 def test_seat_send_creates_task_as_human(repo, rig_config, r4t_home, fake_harness):


### PR DESCRIPTION
## What shipped

Per-rig `echo` flag: members on an echo rig never see `tell`. They are simply prompted with the message content and their cleaned stdout comes back as the reply. For models that misuse tell — small models told to message via a bash tool can loop a dozen "I did it" tells, while the same model asked a question through its CLI simply answers.

- `echo` boolean via the existing settings surface (`r4t rig set <rig> echo true`, get/unset/configure all work), default off; shown in `r4t rig get` with the other keys.
- `echo_max_chars` int (default 1500) caps the reply body.
- Docs: "Echo rigs" subsection + knob-table row in `apps/r4t/docs/rigs.md`.

## Prompt shape

For an echo member, `build_prompt` strips ALL messaging scaffolding — no tell instructions, no doctrine bullets ("How to work"), no teammate list, no "reply via tell" framing. The prompt is: identity line, mission section (leads only, unchanged rule), roster persona, conversation history, and the existing `From: SENDER (thread T)` message blocks. It reads coherently to a model with no tools concept and ends on the questions, so the model just answers.

## Reply path

The turn's cleaned stdout (`clean_transcript`) is staged as ONE envelope to the inbound sender at the same pre-release staging point the STDOUT-REPLY fallback uses, so every gate — send quota, egress redirect/block, thread attribution, hop, reroute — applies unchanged. Logged as **ECHO-REPLY**. This is the only reply path for echo members: anything the model somehow staged is discarded as noise. No minimum-length floor (an echo member answering "4" is a reply). Empty or chrome-only output stages nothing and logs **SILENT**, per the contract's explicit semantics (echo turns do not take the QUOTA-SUSPECT branch).

## Batch reply resolution

Same as the existing STDOUT-REPLY fallback: queued messages compose into one prompt and the single reply goes to `newest_sender` — the sender of the newest message in the claimed batch (`batch[-1]`). No new fan-out semantics.

## Threshold / attachment

When the cleaned stdout exceeds `echo_max_chars`, the envelope body is cut at the threshold with a one-line truncation notice, and the FULL text rides the same envelope as a `reply.md` attachment using the existing a8s bundle-dir mechanism (`staging/<msg_id>/reply.md`, moved to the outbox with the envelope). Under the threshold: no attachment.

## Seat attachment fix (second commit)

Live verification found the attachment died at the seat: `park_seat_message` took body only, so a roster human got a body promising "full reply attached" with no file. Pre-existing (`tell --attach` to a human dropped files too), but echo makes it routine. The park now copies the staged bundle's files into the seat's own storage (`seat/<name>/files/<id>/`) and records filename + stored path in the parked JSON's `files` field; `r4t seat inbox --json` carries the field and plain inbox prints one `(attachment: <name> at <path>)` line per file. The doorbell forward stays body-only — attachments wait in the seat mailbox (documented in operations.md). AI-member queues still carry no attachments; the dropped-attachments WARN now fires only on those routes. No a8s changes.

Live-verified: a short reply ("4") and a 1500-char truncation both round-tripped through `r4t seat send` with a local model.

## Orthogonality

Echo composes with `Continue:`/`Workdir:`/`Flush:` with no special cases (echo shapes prompt+reply, continue shapes argv, workdir shapes cwd); a test proves an echo+continue turn carries `--continue` with the echo prompt and stages an ECHO-REPLY.

## Tests

- r4t: **640 passed** (was 618; +18 echo feature, +4 seat attachment)
- a8s: **778 passed** (untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)