### PR TITLE
feat(ark): suite front-door CLI — greeter + doctor (#260)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,16 @@ jobs:
       - run: pip install pytest
       - run: python -m pytest apps/k7e/tests/ -x -q -m "not llm"
 
+  ark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install pytest
+      - run: python -m pytest apps/ark/tests/ -x -q
+
   r4t-isolation:
     runs-on: ubuntu-latest
     needs: changes

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ All bash scripts use `#!/usr/bin/env bash` instead of `#!/bin/bash`. This allows
 
 | Command | Description |
 |---------|-------------|
+| `ark` | Front door to the Ark Suite — suite status and `ark doctor` prereq probes ([docs](docs/ark.md)) |
 | `n0b` | Kitchen-sink utilities — `n0b json`, `n0b az tail`, `n0b ai video`, etc. ([apps/n0b/README.md](apps/n0b/README.md)) |
 | `h` | Highlight text patterns in color by piping ([docs](docs/h.md)) |
 | `install.sh` | Add ~/bin directory to PATH |

--- a/apps/ark/ark.py
+++ b/apps/ark/ark.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python3
+"""ark — the front door to the Ark Suite (a8s, r4t, k7e).
+
+ark orients and verifies. It reads state passively and probes prerequisites;
+it never mutates anything and never wraps another product's verbs. There is no
+`ark tell`, no `ark dispatch`, no passthrough: every action belongs to the CLI
+that owns it, and ark's job is to tell you which command that is.
+
+Home resolution mirrors each product exactly (A8S_HOME / R4T_HOME / K7E_HOME),
+so ark reports on the same state the products themselves would use.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Optional
+
+BIN_ROOT = Path(__file__).resolve().parent.parent.parent
+
+WORDMARK = ("A R K", "8 4 7", "S T E")
+
+TAGLINE = (
+    "The Ark Suite — a8s routes the messages, r4t governs the teams,",
+    "k7e keeps what they learn. ark reads; each product owns its own verbs.",
+)
+
+PATH_HINT = "source ~/bin/install.sh"
+
+Row = tuple[Optional[bool], str, str, Optional[str]]
+
+
+# ---------- panel rendering ----------
+
+def _mark(ok: bool | None) -> str:
+    return {True: "✓", False: "✗"}.get(ok, "-")
+
+
+def render_rows(rows: list[Row]) -> list[str]:
+    if not rows:
+        return ["  (none)"]
+    width = max(len(name) for _ok, name, _state, _hint in rows)
+    lines = []
+    for ok, name, state, hint in rows:
+        line = f"  {_mark(ok)} {name:<{width}}  {state}"
+        if hint:
+            line += f"   (try: {hint})"
+        lines.append(line.rstrip())
+    return lines
+
+
+def _print_rows(rows: list[Row]) -> None:
+    for line in render_rows(rows):
+        print(line)
+
+
+# ---------- shared probes ----------
+
+def _read_json(path: Path) -> dict | None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _locate(binary: str) -> tuple[Path | None, bool]:
+    """(path, on_PATH). A suite CLI sitting beside ark but absent from PATH is
+    found and reported, because that is the shape of a half-finished install."""
+    found = shutil.which(binary)
+    if found:
+        return Path(found), True
+    sibling = BIN_ROOT / binary
+    if sibling.is_file() and os.access(sibling, os.X_OK):
+        return sibling, False
+    return None, False
+
+
+def _cli_row(binary: str) -> Row:
+    path, on_path = _locate(binary)
+    if path is None:
+        return (False, "cli", f"{binary} not found", PATH_HINT)
+    if not on_path:
+        return (False, "cli", f"{binary} at {path}, not on PATH", PATH_HINT)
+    return (True, "cli", f"{binary} -> {path}", None)
+
+
+def _run(argv: list[str], timeout: float) -> tuple[int | None, str]:
+    """(exit code, combined output). None as the code means it never answered."""
+    try:
+        proc = subprocess.run(
+            argv,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None, ""
+    return proc.returncode, (proc.stdout or "") + (proc.stderr or "")
+
+
+def _first_line(text: str) -> str:
+    for line in text.splitlines():
+        if line.strip():
+            return line.strip()
+    return ""
+
+
+# ---------- a8s ----------
+
+def a8s_home() -> Path:
+    override = os.environ.get("A8S_HOME", "").strip()
+    if override:
+        return Path(override).expanduser()
+    config = Path.home() / ".config" / "a8s"
+    legacy = Path.home() / ".a8s"
+    if config.is_dir():
+        return config
+    if legacy.is_dir():
+        return legacy
+    return config
+
+
+def _live_pid(path: Path) -> int | None:
+    try:
+        pid = int(path.read_text(encoding="utf-8").strip())
+    except (OSError, ValueError):
+        return None
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return None
+    except OSError:
+        pass
+    return pid
+
+
+def a8s_rows() -> list[Row]:
+    home = a8s_home()
+    rows = [_cli_row("a8s")]
+    registry = home / "a8s.json"
+    if not registry.is_file():
+        rows.append((False, "registry", f"no registry at {registry}", "a8s discover <dir>"))
+        return rows
+    data = _read_json(registry)
+    if data is None:
+        rows.append((False, "registry", f"unreadable: {registry}", f"inspect {registry}"))
+        return rows
+    agents = data.get("agents") if isinstance(data.get("agents"), dict) else {}
+    aliases = data.get("aliases") if isinstance(data.get("aliases"), dict) else {}
+    namespaces = data.get("namespaces") if isinstance(data.get("namespaces"), dict) else {}
+    detail = f"{len(agents)} agent(s), {len(aliases)} alias(es), {len(namespaces)} namespace(s)"
+    rows.append((
+        bool(agents), "registry", detail,
+        None if agents else "a8s discover <dir>",
+    ))
+    running = [
+        name for name in sorted(agents)
+        if _live_pid(home / "agents" / re.sub(r"[^A-Za-z0-9_-]", "_", name) / "pid") is not None
+    ]
+    if running:
+        rows.append((True, "router", f"attached: {', '.join(running)}", None))
+    elif agents:
+        rows.append((False, "router", "no agent attached", "a8s start <agent>"))
+    return rows
+
+
+# ---------- r4t ----------
+
+def r4t_home() -> Path:
+    raw = os.environ.get("R4T_HOME", "").strip()
+    if raw:
+        return Path(raw).expanduser()
+    xdg = os.environ.get("XDG_CONFIG_HOME", "").strip()
+    base = Path(xdg).expanduser() if xdg else Path.home() / ".config"
+    return base / "r4t"
+
+
+def r4t_rows() -> list[Row]:
+    home = r4t_home()
+    rows = [_cli_row("r4t")]
+    rigs = home / "rigs.json"
+    if not rigs.is_file():
+        rows.append((False, "rigs", f"no rig config at {rigs}", "r4t init"))
+    else:
+        data = _read_json(rigs)
+        if data is None:
+            rows.append((False, "rigs", f"unreadable: {rigs}", f"inspect {rigs}"))
+        else:
+            names = sorted(
+                key for key, value in data.items()
+                if not key.startswith("_") and isinstance(value, dict) and "invoke" in value
+            )
+            rows.append((
+                bool(names),
+                "rigs",
+                f"{len(names)} rig(s): {', '.join(names)}" if names else "no rigs defined",
+                None if names else "r4t rig add <rig> <preset>",
+            ))
+    teams_dir = home / "teams"
+    teams = (
+        sorted(p.name for p in teams_dir.iterdir() if p.is_dir())
+        if teams_dir.is_dir() else []
+    )
+    rows.append((
+        bool(teams),
+        "teams",
+        f"{len(teams)} team(s): {', '.join(teams)}" if teams else f"none under {teams_dir}",
+        None if teams else "r4t init",
+    ))
+    return rows
+
+
+# ---------- k7e ----------
+
+def k7e_home() -> Path:
+    override = os.environ.get("K7E_HOME", "").strip()
+    return Path(override).expanduser() if override else Path.home() / ".k7e"
+
+
+def k7e_rows() -> list[Row]:
+    home = k7e_home()
+    rows = [_cli_row("k7e")]
+    nodes = home / "nodes"
+    if not nodes.is_dir():
+        rows.append((False, "store", f"no store at {home}", "k7e init"))
+        return rows
+    entries = sum(1 for p in nodes.rglob("*.md"))
+    rows.append((True, "store", f"{entries} entr(ies) under {nodes}", None))
+    index = home / ".index.db"
+    if index.is_file():
+        size = index.stat().st_size
+        rows.append((True, "index", f"{size // 1024} KiB at {index}", None))
+    else:
+        rows.append((False, "index", "no search index", "k7e reindex"))
+    return rows
+
+
+# ---------- greeter ----------
+
+PRODUCTS = (
+    ("a8s", "agent message router", a8s_home, a8s_rows),
+    ("r4t", "roster for teams", r4t_home, r4t_rows),
+    ("k7e", "knowledge engine", k7e_home, k7e_rows),
+)
+
+
+def cmd_default(_args: argparse.Namespace) -> int:
+    for line in WORDMARK:
+        print(line)
+    print()
+    for line in TAGLINE:
+        print(line)
+    for name, blurb, home, rows_fn in PRODUCTS:
+        print()
+        print(f"{name} — {blurb}  ({home()})")
+        _print_rows(rows_fn())
+    print()
+    print("next: ark doctor — probe the harnesses and tools the suite runs on")
+    return 0
+
+
+# ---------- doctor ----------
+
+HARNESS = "Harnesses"
+SERVICES = "Services"
+TOOLING = "Tooling"
+
+
+@dataclass(frozen=True)
+class Probe:
+    ok: bool
+    detail: str
+
+
+@dataclass(frozen=True)
+class Check:
+    name: str
+    group: str
+    probe: Callable[[], Probe]
+    hint: str
+    core: bool = False
+
+
+def _version_probe(binary: str, argv: tuple[str, ...] = ("--version",), timeout: float = 5.0):
+    def probe() -> Probe:
+        path = shutil.which(binary)
+        if path is None:
+            return Probe(False, "not on PATH")
+        code, out = _run([path, *argv], timeout)
+        if code is None:
+            return Probe(False, f"no answer in {timeout:g}s — {path}")
+        version = _first_line(out)
+        if code != 0:
+            return Probe(False, f"{' '.join(argv)} exited {code} — {version or path}")
+        return Probe(True, f"{version or 'ok'}  ({path})")
+    return probe
+
+
+def _ollama_probe() -> Probe:
+    path = shutil.which("ollama")
+    if path is None:
+        return Probe(False, "not on PATH")
+    code, out = _run([path, "list"], 5.0)
+    if code is None:
+        return Probe(False, "server did not answer in 5s")
+    if code != 0:
+        return Probe(False, f"server unreachable — {_first_line(out) or f'list exited {code}'}")
+    models = [
+        line.split()[0] for line in out.splitlines()[1:]
+        if line.strip() and not line.startswith("NAME")
+    ]
+    if not models:
+        return Probe(True, "reachable, no models pulled")
+    return Probe(True, f"{len(models)} model(s): {', '.join(models)}")
+
+
+def _docker_probe() -> Probe:
+    path = shutil.which("docker")
+    if path is None:
+        return Probe(False, "not on PATH")
+    code, out = _run([path, "info", "--format", "{{.ServerVersion}}"], 8.0)
+    if code is None:
+        return Probe(False, "daemon did not answer in 8s")
+    if code != 0:
+        return Probe(False, f"daemon unreachable — {_first_line(out) or f'info exited {code}'}")
+    return Probe(True, f"daemon {_first_line(out) or 'reachable'}")
+
+
+def _git_probe() -> Probe:
+    path = shutil.which("git")
+    if path is None:
+        return Probe(False, "not on PATH")
+    code, out = _run([path, "--version"], 5.0)
+    if code is None or code != 0:
+        return Probe(False, f"--version failed — {path}")
+    version = _first_line(out)
+    missing = [
+        key for key in ("user.name", "user.email")
+        if not _first_line(_run([path, "config", "--get", key], 5.0)[1])
+    ]
+    if missing:
+        return Probe(False, f"{version}, unset: {', '.join(missing)}")
+    return Probe(True, version)
+
+
+CHECKS: tuple[Check, ...] = (
+    Check("claude", HARNESS, _version_probe("claude"), "install Claude Code"),
+    Check("agent", HARNESS, _version_probe("agent"), "install the Cursor agent CLI"),
+    Check("codex", HARNESS, _version_probe("codex"), "install the Codex CLI"),
+    Check("copilot", HARNESS, _version_probe("copilot"), "install the GitHub Copilot CLI"),
+    Check("opencode", HARNESS, _version_probe("opencode"), "install OpenCode"),
+    Check("agy", HARNESS, _version_probe("agy"), "install Antigravity"),
+    Check("ollama", HARNESS, _version_probe("ollama"), "install ollama"),
+    Check("ollama serve", SERVICES, _ollama_probe, "ollama serve, then ollama pull <model>"),
+    Check("docker", SERVICES, _docker_probe, "start Docker Desktop or the docker daemon"),
+    Check("git", TOOLING, _git_probe, "git config --global user.name / user.email", core=True),
+)
+
+
+def doctor_results(checks: tuple[Check, ...]) -> list[tuple[Check, Probe]]:
+    return [(check, check.probe()) for check in checks]
+
+
+def doctor_rows(results: list[tuple[Check, Probe]], group: str) -> list[Row]:
+    return [
+        (probe.ok, check.name, probe.detail, None if probe.ok else check.hint)
+        for check, probe in results if check.group == group
+    ]
+
+
+def doctor_failures(results: list[tuple[Check, Probe]]) -> list[str]:
+    """Core prerequisites that are not satisfied. A suite with no agent harness
+    at all cannot run a roster turn, so that counts as core alongside the
+    checks flagged `core`."""
+    failed = [check.name for check, probe in results if check.core and not probe.ok]
+    harnesses = [probe.ok for check, probe in results if check.group == HARNESS]
+    if harnesses and not any(harnesses):
+        failed.append("at least one agent harness")
+    return failed
+
+
+def cmd_doctor(_args: argparse.Namespace) -> int:
+    results = doctor_results(CHECKS)
+    print("ark doctor — probes only; nothing here is installed, started, or changed")
+    for group in (HARNESS, SERVICES, TOOLING):
+        print()
+        print(group)
+        _print_rows(doctor_rows(results, group))
+    failed = doctor_failures(results)
+    green = sum(1 for _check, probe in results if probe.ok)
+    print()
+    if failed:
+        print(f"✗ core prerequisites missing: {', '.join(failed)}  ({green}/{len(results)} probes green)")
+        return 1
+    print(f"✓ core prerequisites satisfied  ({green}/{len(results)} probes green)")
+    return 0
+
+
+# ---------- cli ----------
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="ark",
+        description=(
+            "Front door to the Ark Suite. Bare `ark` reports where a8s, r4t and "
+            "k7e stand; `ark doctor` probes the tools they need. ark never runs "
+            "another product's commands for you."
+        ),
+    )
+    parser.set_defaults(func=cmd_default)
+    sub = parser.add_subparsers(dest="command")
+    doctor = sub.add_parser("doctor", help="Probe harness and tool prerequisites")
+    doctor.set_defaults(func=cmd_doctor)
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/ark/tests/conftest.py
+++ b/apps/ark/tests/conftest.py
@@ -1,0 +1,38 @@
+"""pytest scaffolding for ark."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_PKG = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PKG))
+
+import ark  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _no_real_subprocess(monkeypatch):
+    """No test may execute a real harness CLI. Probes that want to exercise
+    subprocess behaviour re-patch `ark.subprocess.run` themselves."""
+    def forbidden(*args, **kwargs):
+        raise AssertionError(f"tests must not spawn real processes: {args!r}")
+
+    monkeypatch.setattr(ark.subprocess, "run", forbidden)
+
+
+@pytest.fixture
+def homes(tmp_path, monkeypatch):
+    """Hermetic suite homes. Every probe path in the greeter resolves under
+    tmp_path, so no test can read or touch a real ~/.config/a8s, ~/.config/r4t
+    or ~/.k7e."""
+    roots = {}
+    for env, name in (("A8S_HOME", "a8s"), ("R4T_HOME", "r4t"), ("K7E_HOME", "k7e")):
+        root = tmp_path / name
+        root.mkdir()
+        monkeypatch.setenv(env, str(root))
+        roots[name] = root
+    monkeypatch.setattr(ark.shutil, "which", lambda _binary: None)
+    monkeypatch.setattr(ark, "BIN_ROOT", tmp_path / "absent-bin")
+    return roots

--- a/apps/ark/tests/test_ark.py
+++ b/apps/ark/tests/test_ark.py
@@ -1,0 +1,331 @@
+"""ark — greeter panel assembly and the doctor probe registry.
+
+Everything here is hermetic: suite state lives in tmp homes and every probe is
+stubbed, so no test reads real state or executes a real harness CLI.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+
+import pytest
+
+import ark
+
+
+def _row(rows, name):
+    for row in rows:
+        if row[1] == name:
+            return row
+    raise AssertionError(f"no {name!r} row in {[r[1] for r in rows]}")
+
+
+# ---------- rendering ----------
+
+def test_wordmark_is_the_suite_grid():
+    assert ark.WORDMARK == ("A R K", "8 4 7", "S T E")
+
+
+def test_render_rows_marks_aligns_and_appends_try_hints():
+    lines = ark.render_rows([
+        (True, "cli", "a8s -> /somewhere/a8s", None),
+        (False, "router", "no agent attached", "a8s start <agent>"),
+    ])
+    assert lines[0] == "  ✓ cli     a8s -> /somewhere/a8s"
+    assert lines[1] == "  ✗ router  no agent attached   (try: a8s start <agent>)"
+
+
+def test_render_rows_handles_an_empty_section():
+    assert ark.render_rows([]) == ["  (none)"]
+
+
+# ---------- home resolution matches each product ----------
+
+def test_homes_follow_the_product_env_overrides(homes):
+    assert ark.a8s_home() == homes["a8s"]
+    assert ark.r4t_home() == homes["r4t"]
+    assert ark.k7e_home() == homes["k7e"]
+
+
+def test_r4t_home_falls_back_to_xdg_config(tmp_path, monkeypatch):
+    monkeypatch.delenv("R4T_HOME", raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    assert ark.r4t_home() == tmp_path / "r4t"
+
+
+# ---------- a8s panel ----------
+
+def test_a8s_panel_is_all_misses_on_an_empty_home(homes):
+    rows = ark.a8s_rows()
+    assert _row(rows, "cli")[0] is False
+    ok, _name, state, hint = _row(rows, "registry")
+    assert ok is False
+    assert "no registry" in state
+    assert hint == "a8s discover <dir>"
+
+
+def test_a8s_panel_counts_registry_sections_and_reports_idle_router(homes):
+    (homes["a8s"] / "a8s.json").write_text(json.dumps({
+        "agents": {"one": {"root": "/x"}, "two": {"root": "/y"}},
+        "aliases": {"both": ["one", "two"]},
+        "namespaces": {},
+    }), encoding="utf-8")
+    rows = ark.a8s_rows()
+    ok, _name, state, hint = _row(rows, "registry")
+    assert ok is True
+    assert state == "2 agent(s), 1 alias(es), 0 namespace(s)"
+    assert hint is None
+    assert _row(rows, "router") == (False, "router", "no agent attached", "a8s start <agent>")
+
+
+def test_a8s_panel_reports_an_attached_router_from_a_live_pid(homes):
+    (homes["a8s"] / "a8s.json").write_text(
+        json.dumps({"agents": {"one": {"root": "/x"}}}), encoding="utf-8"
+    )
+    pid_dir = homes["a8s"] / "agents" / "one"
+    pid_dir.mkdir(parents=True)
+    (pid_dir / "pid").write_text(str(os.getpid()), encoding="utf-8")
+    assert _row(ark.a8s_rows(), "router") == (True, "router", "attached: one", None)
+
+
+def test_a8s_panel_ignores_a_stale_pid_file(homes):
+    (homes["a8s"] / "a8s.json").write_text(
+        json.dumps({"agents": {"one": {"root": "/x"}}}), encoding="utf-8"
+    )
+    pid_dir = homes["a8s"] / "agents" / "one"
+    pid_dir.mkdir(parents=True)
+    (pid_dir / "pid").write_text("not-a-pid", encoding="utf-8")
+    assert _row(ark.a8s_rows(), "router")[0] is False
+
+
+def test_a8s_panel_flags_an_unreadable_registry(homes):
+    (homes["a8s"] / "a8s.json").write_text("{ broken", encoding="utf-8")
+    ok, _name, state, _hint = _row(ark.a8s_rows(), "registry")
+    assert ok is False
+    assert "unreadable" in state
+
+
+# ---------- r4t panel ----------
+
+def test_r4t_panel_points_at_init_when_nothing_exists(homes):
+    rows = ark.r4t_rows()
+    assert _row(rows, "rigs")[3] == "r4t init"
+    assert _row(rows, "teams")[3] == "r4t init"
+
+
+def test_r4t_panel_counts_only_rig_entries_not_governance_knobs(homes):
+    (homes["r4t"] / "rigs.json").write_text(json.dumps({
+        "_notes": ["ignored"],
+        "throttle": {"max_concurrent": 1},
+        "cell_budget_max": 16,
+        "leader": {"invoke": ["claude", "-p", "{prompt}"]},
+        "worker": {"invoke": [["opencode", "run", "{prompt}"]]},
+    }), encoding="utf-8")
+    ok, _name, state, hint = _row(ark.r4t_rows(), "rigs")
+    assert ok is True
+    assert state == "2 rig(s): leader, worker"
+    assert hint is None
+
+
+def test_r4t_panel_lists_teams_under_the_home(homes):
+    for node in ("alpha", "beta"):
+        (homes["r4t"] / "teams" / node).mkdir(parents=True)
+    assert _row(ark.r4t_rows(), "teams")[:3] == (True, "teams", "2 team(s): alpha, beta")
+
+
+# ---------- k7e panel ----------
+
+def test_k7e_panel_asks_for_init_without_a_store(homes):
+    rows = ark.k7e_rows()
+    assert _row(rows, "store")[3] == "k7e init"
+    assert not [r for r in rows if r[1] == "index"]
+
+
+def test_k7e_panel_counts_entries_and_flags_a_missing_index(homes):
+    nodes = homes["k7e"] / "nodes"
+    nodes.mkdir()
+    (nodes / "a.md").write_text("x", encoding="utf-8")
+    (nodes / "b.md").write_text("y", encoding="utf-8")
+    rows = ark.k7e_rows()
+    assert rows[1][0] is True
+    assert "2 entr(ies)" in rows[1][2]
+    assert _row(rows, "index") == (False, "index", "no search index", "k7e reindex")
+
+
+def test_k7e_panel_reports_an_existing_index(homes):
+    (homes["k7e"] / "nodes").mkdir()
+    (homes["k7e"] / ".index.db").write_bytes(b"0" * 2048)
+    ok, _name, state, _hint = _row(ark.k7e_rows(), "index")
+    assert ok is True
+    assert state.startswith("2 KiB")
+
+
+# ---------- greeter ----------
+
+def test_greeter_prints_the_grid_and_one_section_per_product(homes, capsys):
+    assert ark.cmd_default(None) == 0
+    out = capsys.readouterr().out
+    assert out.startswith("A R K\n8 4 7\nS T E\n")
+    for name in ("a8s —", "r4t —", "k7e —"):
+        assert name in out
+    assert "ark doctor" in out
+
+
+def test_greeter_never_wraps_another_products_verbs():
+    """The boundary: ark's only subcommand is doctor. Suite verbs appear as
+    `(try: ...)` hints, never as ark subcommands."""
+    with pytest.raises(SystemExit):
+        ark.main(["tell", "someone", "hi"])
+
+
+# ---------- doctor registry ----------
+
+def test_every_check_is_grouped_into_a_rendered_section():
+    groups = {check.group for check in ark.CHECKS}
+    assert groups <= {ark.HARNESS, ark.SERVICES, ark.TOOLING}
+
+
+def test_registry_carries_a_hint_and_probe_for_every_check():
+    for check in ark.CHECKS:
+        assert check.hint
+        assert callable(check.probe)
+
+
+def test_registry_covers_the_known_harnesses_and_tools():
+    names = {check.name for check in ark.CHECKS}
+    assert {"claude", "agent", "codex", "copilot", "opencode", "agy", "ollama"} <= names
+    assert {"ollama serve", "docker", "git"} <= names
+
+
+def _fake(name, group, ok, core=False):
+    return ark.Check(name, group, lambda: ark.Probe(ok, "detail"), "do the thing", core=core)
+
+
+def test_doctor_rows_filter_by_group_and_attach_hints_to_failures():
+    checks = (_fake("one", ark.HARNESS, True), _fake("two", ark.TOOLING, False))
+    results = ark.doctor_results(checks)
+    assert ark.doctor_rows(results, ark.HARNESS) == [(True, "one", "detail", None)]
+    assert ark.doctor_rows(results, ark.TOOLING) == [(False, "two", "detail", "do the thing")]
+
+
+def test_doctor_failures_reports_core_checks():
+    results = ark.doctor_results((
+        _fake("harness", ark.HARNESS, True),
+        _fake("git", ark.TOOLING, False, core=True),
+    ))
+    assert ark.doctor_failures(results) == ["git"]
+
+
+def test_doctor_failures_requires_at_least_one_harness():
+    results = ark.doctor_results((
+        _fake("a", ark.HARNESS, False),
+        _fake("b", ark.HARNESS, False),
+        _fake("git", ark.TOOLING, True, core=True),
+    ))
+    assert ark.doctor_failures(results) == ["at least one agent harness"]
+
+
+def test_doctor_passes_when_core_and_one_harness_are_green():
+    results = ark.doctor_results((
+        _fake("a", ark.HARNESS, False),
+        _fake("b", ark.HARNESS, True),
+        _fake("git", ark.TOOLING, True, core=True),
+    ))
+    assert ark.doctor_failures(results) == []
+
+
+def test_doctor_exits_nonzero_when_a_core_check_fails(monkeypatch, capsys):
+    monkeypatch.setattr(ark, "CHECKS", (
+        _fake("b", ark.HARNESS, True),
+        _fake("git", ark.TOOLING, False, core=True),
+    ))
+    assert ark.cmd_doctor(None) == 1
+    out = capsys.readouterr().out
+    assert "core prerequisites missing: git" in out
+    assert "(try: do the thing)" in out
+
+
+def test_doctor_exits_zero_when_everything_core_is_green(monkeypatch, capsys):
+    monkeypatch.setattr(ark, "CHECKS", (
+        _fake("b", ark.HARNESS, True),
+        _fake("git", ark.TOOLING, True, core=True),
+    ))
+    assert ark.cmd_doctor(None) == 0
+    assert "core prerequisites satisfied  (2/2 probes green)" in capsys.readouterr().out
+
+
+# ---------- probes never hang, never fix ----------
+
+def test_version_probe_misses_when_the_binary_is_absent(monkeypatch):
+    monkeypatch.setattr(ark.shutil, "which", lambda _b: None)
+    assert ark._version_probe("nope")() == ark.Probe(False, "not on PATH")
+
+
+def test_version_probe_reports_the_first_output_line(monkeypatch):
+    monkeypatch.setattr(ark.shutil, "which", lambda _b: "/fake/claude")
+    monkeypatch.setattr(ark, "_run", lambda argv, timeout: (0, "\n1.2.3 (Some CLI)\nnoise\n"))
+    probe = ark._version_probe("claude")()
+    assert probe.ok is True
+    assert probe.detail == "1.2.3 (Some CLI)  (/fake/claude)"
+
+
+def test_version_probe_treats_a_timeout_as_a_miss(monkeypatch):
+    monkeypatch.setattr(ark.shutil, "which", lambda _b: "/fake/hangs")
+    monkeypatch.setattr(ark, "_run", lambda argv, timeout: (None, ""))
+    assert ark._version_probe("hangs")().ok is False
+
+
+def test_run_returns_none_when_the_command_times_out(monkeypatch):
+    def timeout(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired(cmd="slow", timeout=0.2)
+
+    monkeypatch.setattr(ark.subprocess, "run", timeout)
+    assert ark._run(["slow"], 0.2) == (None, "")
+
+
+def test_run_returns_none_when_the_binary_cannot_be_executed(monkeypatch):
+    def missing(*_args, **_kwargs):
+        raise OSError("no such file")
+
+    monkeypatch.setattr(ark.subprocess, "run", missing)
+    assert ark._run(["gone"], 1.0) == (None, "")
+
+
+def test_ollama_probe_parses_the_model_table(monkeypatch):
+    monkeypatch.setattr(ark.shutil, "which", lambda _b: "/fake/ollama")
+    table = "NAME    ID    SIZE\nsmall:latest  abc  1 GB\nbig:7b  def  4 GB\n"
+    monkeypatch.setattr(ark, "_run", lambda argv, timeout: (0, table))
+    probe = ark._ollama_probe()
+    assert probe.ok is True
+    assert probe.detail == "2 model(s): small:latest, big:7b"
+
+
+def test_ollama_probe_reports_an_unreachable_server(monkeypatch):
+    monkeypatch.setattr(ark.shutil, "which", lambda _b: "/fake/ollama")
+    monkeypatch.setattr(ark, "_run", lambda argv, timeout: (1, "connection refused"))
+    probe = ark._ollama_probe()
+    assert probe.ok is False
+    assert "unreachable" in probe.detail
+
+
+def test_docker_probe_separates_a_missing_binary_from_a_dead_daemon(monkeypatch):
+    monkeypatch.setattr(ark.shutil, "which", lambda _b: None)
+    assert ark._docker_probe().detail == "not on PATH"
+    monkeypatch.setattr(ark.shutil, "which", lambda _b: "/fake/docker")
+    monkeypatch.setattr(ark, "_run", lambda argv, timeout: (1, "cannot connect"))
+    assert "daemon unreachable" in ark._docker_probe().detail
+
+
+def test_git_probe_requires_identity_configuration(monkeypatch):
+    monkeypatch.setattr(ark.shutil, "which", lambda _b: "/fake/git")
+
+    def fake_run(argv, timeout):
+        if argv[1] == "--version":
+            return 0, "git version 2.0.0"
+        return 0, "" if argv[-1] == "user.email" else "someone"
+
+    monkeypatch.setattr(ark, "_run", fake_run)
+    probe = ark._git_probe()
+    assert probe.ok is False
+    assert probe.detail == "git version 2.0.0, unset: user.email"

--- a/ark
+++ b/ark
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+echo `# <#` >/dev/null
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$SCRIPT_DIR/apps/ark/ark.py" "$@"
+#> > $null
+
+$ScriptPath = $PSCommandPath
+if (-not $ScriptPath) { $ScriptPath = $MyInvocation.MyCommand.Path }
+if (-not $ScriptPath) { $ScriptPath = Join-Path (Get-Location) "ark" }
+
+$ScriptDir = Split-Path -Parent $ScriptPath
+$ArkPath = Join-Path $ScriptDir "apps/ark/ark.py"
+
+$Python = Get-Command python3 -ErrorAction SilentlyContinue
+if ($Python) { & $Python.Source $ArkPath @args; exit $LASTEXITCODE }
+$Python = Get-Command python -ErrorAction SilentlyContinue
+if ($Python) { & $Python.Source $ArkPath @args; exit $LASTEXITCODE }
+$Python = Get-Command py -ErrorAction SilentlyContinue
+if ($Python) { & $Python.Source -3 $ArkPath @args; exit $LASTEXITCODE }
+
+Write-Error "Could not find python3, python, or py on PATH."
+exit 127

--- a/docs/ark.md
+++ b/docs/ark.md
@@ -1,0 +1,74 @@
+---
+name: "ark"
+description: "Show whether the Ark Suite is set up and working on this machine."
+---
+
+# ark
+
+The front door to the Ark Suite: **a8s** (agent message router), **r4t**
+(roster for teams), **k7e** (knowledge engine).
+
+`ark` orients and verifies. It reads state and probes prerequisites — it never
+changes anything, and it never runs another product's commands for you. When
+something is missing, `ark` names the real command to fix it.
+
+```
+ark            # where the suite stands right now
+ark doctor     # are the harnesses and tools it runs on actually working?
+```
+
+## `ark` — the greeter
+
+```
+A R K
+8 4 7
+S T E
+```
+
+Then one panel per product, each line marked ✓ or ✗ with a short fact, and
+every ✗ followed by the command that fixes it:
+
+```
+a8s — agent message router  (~/.config/a8s)
+  ✓ cli       a8s -> /path/to/a8s
+  ✓ registry  3 agent(s), 1 alias(es), 0 namespace(s)
+  ✗ router    no agent attached   (try: a8s start <agent>)
+
+r4t — roster for teams  (~/.config/r4t)
+  ✓ cli    r4t -> /path/to/r4t
+  ✓ rigs   2 rig(s): leader, worker
+  ✗ teams  none under ~/.config/r4t/teams   (try: r4t init)
+
+k7e — knowledge engine  (~/.k7e)
+  ✓ cli    k7e -> /path/to/k7e
+  ✓ store  41 entr(ies) under ~/.k7e/nodes
+  ✗ index  no search index   (try: k7e reindex)
+```
+
+A product that is not installed at all degrades to its ✗ rows and hints; `ark`
+still prints the rest.
+
+State locations follow each product exactly, including the environment
+overrides: `A8S_HOME`, `R4T_HOME` (and `XDG_CONFIG_HOME`), `K7E_HOME`.
+
+## `ark doctor`
+
+Functional probes for the CLIs the suite runs on — every one is read-only and
+time-bounded, so `doctor` never hangs and never installs, starts, or
+configures anything.
+
+- **Harnesses** — `claude`, `agent` (Cursor), `codex`, `copilot`, `opencode`,
+  `agy`, `ollama`: on PATH, and does a version probe actually answer?
+- **Services** — the ollama server (reachable? which models are pulled?) and
+  docker (binary present *and* daemon reachable — they fail differently).
+- **Tooling** — git present with `user.name` and `user.email` configured.
+
+Exit code is 0 when the core prerequisites hold (git configured, and at least
+one agent harness answering), 1 otherwise — so it can gate a setup script.
+
+## What `ark` is not
+
+`ark` has exactly one subcommand. It does not wrap, alias, or pass through the
+products' own verbs: sending a message is still `tell`, running a team is still
+`r4t dispatch`, storing knowledge is still `k7e`. Those commands appear in
+`ark` output only as hints pointing you at the tool that owns them.


### PR DESCRIPTION
The suite has three products, three state trees and three sets of prerequisites, but no single place that answers "is any of this working?". `ark` is that place — the front door to the Ark Suite (a8s, r4t, k7e). It orients and verifies; it never mutates.

## The panel

Bare `ark` prints the wordmark grid, then one sectioned panel per product. Every row is ✓/✗ with a short fact, and every ✗ carries a `(try: ...)` naming the real command that fixes it — the p0o/`r4t status` style:

```
A R K
8 4 7
S T E

The Ark Suite — a8s routes the messages, r4t governs the teams,
k7e keeps what they learn. ark reads; each product owns its own verbs.

a8s — agent message router  (/tmp/demo/a8s)
  ✓ cli       a8s -> /path/to/a8s
  ✓ registry  3 agent(s), 1 alias(es), 0 namespace(s)
  ✗ router    no agent attached   (try: a8s start <agent>)

r4t — roster for teams  (/tmp/demo/r4t)
  ✓ cli    r4t -> /path/to/r4t
  ✓ rigs   2 rig(s): leader, worker
  ✓ teams  2 team(s): atlas, harbor

k7e — knowledge engine  (/tmp/demo/k7e)
  ✓ cli    k7e -> /path/to/k7e
  ✓ store  41 entr(ies) under /tmp/demo/k7e/nodes
  ✓ index  212 KiB at /tmp/demo/k7e/.index.db

next: ark doctor — probe the harnesses and tools the suite runs on
```

Home resolution duplicates each product's own logic rather than approximating it: `A8S_HOME` with the `~/.config/a8s` → legacy `~/.a8s` fallback, `R4T_HOME` over `XDG_CONFIG_HOME`, `K7E_HOME`. So ark reports on exactly the state the products themselves would read. Router liveness is a passive pid-file read plus `kill(pid, 0)` — stale pids read as not attached. A product that is absent entirely degrades to its ✗ rows and hints; the other panels still print.

## The probe registry

`ark doctor` is probe-only — it never installs, starts or configures anything. Checks live in a flat registry of `(name, group, probe, hint, core)`:

```
Harnesses
  ✗ claude    not on PATH   (try: install Claude Code)
  ✗ agent     not on PATH   (try: install the Cursor agent CLI)
  ✗ codex     not on PATH   (try: install the Codex CLI)
  ✗ copilot   not on PATH   (try: install the GitHub Copilot CLI)
  ✗ opencode  not on PATH   (try: install OpenCode)
  ✗ agy       not on PATH   (try: install Antigravity)
  ✗ ollama    not on PATH   (try: install ollama)

Services
  ✗ ollama serve  not on PATH   (try: ollama serve, then ollama pull <model>)
  ✗ docker        not on PATH   (try: start Docker Desktop or the docker daemon)

Tooling
  ✓ git  git version 2.50.1 (Apple Git-155)

✗ core prerequisites missing: at least one agent harness  (1/10 probes green)
```

On a fully provisioned machine the same command reports live versions, the ollama model list parsed from `ollama list`, and the docker daemon version — all ten green in ~2.5s.

Design notes:

- Every probe is time-bounded (`subprocess.run(timeout=…)`, stdin closed) and both `TimeoutExpired` and `OSError` degrade to a ✗ row, so `doctor` cannot hang.
- "Binary missing" is kept distinct from "binary present but broken": docker present vs daemon unreachable, ollama present vs server refusing, git present vs `user.name`/`user.email` unset.
- `group` drives the panel sections today and is the seam a future `--for <chapter>` filters on. Nothing speculative is built for it.
- Exit 0 when the core prerequisites hold (git configured, plus at least one harness answering), 1 otherwise — so it can gate a setup script.

## The boundary

ark has exactly one subcommand. There is no `ark tell`, no `ark dispatch`, no passthrough of any kind — a wrapper layer would just become a second, staler CLI for each product. Suite verbs appear in ark output only as `(try: ...)` hints pointing at the tool that owns them. A test pins this: `ark tell someone hi` exits non-zero as an unknown command.

## Layout

- `ark` — polyglot bash/PowerShell launcher at top level, same shape as `r4t`/`k7e`, delegating to `apps/ark/ark.py`
- `apps/ark/ark.py` — single stdlib-only module
- `apps/ark/tests/` — conftest + `test_ark.py`
- `docs/ark.md` — quoted-scalar frontmatter, picked up by `install.sh --skills`
- README command table gets one line; CI gets an `ark` job beside `k7e`

## Tests

36 new tests, all hermetic — tmp `A8S_HOME`/`R4T_HOME`/`K7E_HOME`, stubbed probes, and an autouse fixture that fails any test spawning a real process, so the suite can never read live state or execute a harness CLI.

Full run, all green:

- `apps/ark/tests/` — 36 passed
- `tests/test_pii.py` + `apps/a8s/tests/` + ark — 817 passed (the known-flaky `test_remote_e2e.py::test_remote_round_trip` passed first try)
- `apps/r4t/tests/` — 640 passed

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)
