### PR TITLE
feat(guides): The Ark Raising — skeleton, chapters 1-2, solo templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 These are my common command-line utilities. Install by `source`'ing `install.sh` after cloning.
 
+New to the Ark Suite (a8s + r4t + k7e)? Start with **[The Ark Raising](guides/README.md)** — a chapter-by-chapter build-along that raises a crew of AI agents from nothing.
+
 ## Note on Shebangs
 
 All bash scripts use `#!/usr/bin/env bash` instead of `#!/bin/bash`. This allows the scripts to use a newer version of bash if installed (e.g., via Homebrew on macOS) rather than being forced to use the system's outdated bash 3.2.57.

--- a/apps/r4t/README.md
+++ b/apps/r4t/README.md
@@ -81,6 +81,7 @@ in production too. Full flow: [docs/message-flow.md](docs/message-flow.md).
 
 ## Learn more
 
+- [The Ark Raising](../../guides/README.md) — the suite build-along; [chapter 2](../../guides/02-the-solo-agent.md) raises a governed roster of one
 - [Tutorial](docs/tutorial.md) — first team, step by step, fail-closed rules
 - [Rigs](docs/rigs.md) — presets, `--model`, settings, the governance knob table
 - [Message flow](docs/message-flow.md) — threads, queues, the stdout fallback

--- a/guides/01-hello-agent.md
+++ b/guides/01-hello-agent.md
@@ -1,0 +1,355 @@
+# Chapter 1 — Hello, Agent
+
+## 1. Capability
+
+At the end of this chapter you will have a registered a8s agent running on
+your machine that you can message with `tell` and that messages you back.
+You will have seen the whole loop — outbox, router, inbox, wake, reply —
+and broken it once on purpose. No LLM is involved: your first agent is a
+shell script, which is the point. An a8s agent is anything that can read a
+message and send one.
+
+## 2. Time
+
+About 20 minutes.
+
+## 3. Starting state
+
+- The bin repo cloned at `~/bin` and on your PATH:
+
+**Run**
+
+```bash
+git clone <YOUR_FORK_OR_CLONE_URL> ~/bin
+source ~/bin/install.sh
+```
+
+- Python 3 installed (`python3 --version` answers).
+
+Now type the suite's front door command:
+
+**Run**
+
+```bash
+ark
+```
+
+You should see:
+
+```
+A R K
+8 4 7
+S T E
+
+The Ark Suite — a8s routes the messages, r4t governs the teams,
+k7e keeps what they learn. ark reads; each product owns its own verbs.
+
+a8s — agent message router  (/home/you/.config/a8s)
+  ✓ cli       a8s -> /home/you/bin/a8s
+  ✗ registry  no registry at /home/you/.config/a8s/a8s.json   (try: a8s discover <dir>)
+
+r4t — roster for teams  (/home/you/.config/r4t)
+  ✓ cli    r4t -> /home/you/bin/r4t
+  ✗ rigs   no rig config at /home/you/.config/r4t/rigs.json   (try: r4t init)
+  ✗ teams  none under /home/you/.config/r4t/teams   (try: r4t init)
+
+k7e — knowledge engine  (/home/you/.k7e)
+  ✓ cli    k7e -> /home/you/bin/k7e
+  ✗ store  no store at /home/you/.k7e   (try: k7e init)
+
+next: ark doctor — probe the harnesses and tools the suite runs on
+```
+
+Three CLIs found, nothing configured — the correct fresh-machine state.
+`ark` never changes anything; it reads and tells you which command owns the
+next move. Take its suggestion:
+
+**Run**
+
+```bash
+ark doctor
+```
+
+You should see:
+
+```
+ark doctor — probes only; nothing here is installed, started, or changed
+
+Harnesses
+  ✓ claude    2.1.220 (Claude Code)  (/home/you/.local/bin/claude)
+  ✓ agent     2026.07.23-e383d2b  (/home/you/.local/bin/agent)
+  ✓ codex     codex-cli 0.144.6  (/home/you/bin/codex)
+  ✓ copilot   GitHub Copilot CLI 1.0.75.  (/home/you/bin/copilot)
+  ✓ opencode  1.18.3  (/home/you/bin/opencode)
+  ✓ agy       1.1.8  (/home/you/.local/bin/agy)
+  ✓ ollama    ollama version is 0.32.5  (/home/you/bin/ollama)
+
+Services
+  ✓ ollama serve  3 model(s): qwen3.6:latest, qwen3:1.7b, qwen3:0.6b
+  ✓ docker        daemon 29.6.2
+
+Tooling
+  ✓ git  git version 2.50.1 (Apple Git-155)
+
+✓ core prerequisites satisfied  (10/10 probes green)
+```
+
+Your panel will show ✗ for harnesses you haven't installed — that is fine.
+This chapter needs **none** of them. Chapter 2 needs exactly one: `ollama`
+with a model pulled (free path) or `agent` (subscription path). If you want
+to get ahead, install that one now; otherwise keep going.
+
+## 4. The change
+
+Two directories: one agent that replies, and one seat for you to speak
+from.
+
+The agent is a script. When a message arrives, a8s wakes the agent by
+running the command in its *definition* — a small JSON file — substituting
+`$SENDER` and `$MESSAGE`. Our script replies with the one verb every agent
+gets: `tell`.
+
+**Run**
+
+```bash
+mkdir -p ~/ark/hello ~/ark/me
+```
+
+**Create** `~/ark/hello/reply.sh`
+
+```bash
+#!/usr/bin/env bash
+sender="$1"
+message="$2"
+tell "$sender" "hello received: $message"
+```
+
+**Create** `~/ark/hello/hello.json`
+
+```json
+{
+  "description": "hello agent — replies to every tell with a script",
+  "invoke": ["bash", "reply.sh", "$SENDER", "$MESSAGE"]
+}
+```
+
+**Run**
+
+```bash
+chmod +x ~/ark/hello/reply.sh
+```
+
+`~/ark/me` is your **filedrop seat**: a directory a8s delivers your mail
+into, with no CLI to wake — you read it with `tells`. Register both, then
+look at the roster:
+
+**Run**
+
+```bash
+a8s add me ~/ark/me filedrop
+a8s add hello ~/ark/hello ~/ark/hello/hello.json
+a8s ls
+```
+
+You should see:
+
+```
+added me -> /home/you/ark/me
+definition: /home/you/bin/apps/a8s/definitions/filedrop.json  (explicit)
+added hello -> /home/you/ark/hello
+definition: /home/you/ark/hello/hello.json  (explicit)
+NAME    STATUS    DEFINITION   ROOT
+hello   stopped   hello        /home/you/ark/hello
+me      stopped   filedrop     /home/you/ark/me
+```
+
+Registered but stopped: nothing routes until a handler process is attached.
+Start one for each:
+
+**Run**
+
+```bash
+a8s start hello
+a8s start me
+```
+
+You should see:
+
+```
+started hello as PID 14186
+started me as PID 14191
+```
+
+## 5. Run it
+
+Speak from your seat. `tell` figures out who you are from the directory you
+stand in, and `tells` waits by your inbox for what comes back:
+
+**Run**
+
+```bash
+cd ~/ark/me
+tell hello "are you alive?" && tells --timeout 30
+```
+
+## 6. Expected receipt
+
+You should see:
+
+```
+tell -> hello: are you alive?
+hello: hello received: are you alive?
+```
+
+The reply lands in a few seconds; `tells` prints it as it arrives and exits
+when its window closes. That round trip crossed the full machinery: your
+envelope was written to `~/ark/me/.outbox/`, the router stamped you as the
+sender and moved it to hello's inbox, hello's handler woke `reply.sh`, and
+the reply rode the same road back into `~/ark/me/.inbox/`.
+
+## 7. Break it
+
+Message an agent that does not exist:
+
+**Run**
+
+```bash
+tell gost "are you alive?"
+```
+
+You should see:
+
+```
+tell: no agent or alias named 'gost'
+```
+
+The command exits nonzero and **nothing is written anywhere** — no
+envelope, no dead letter, no queued retry. a8s validates the recipient
+against the registry before accepting the message, so a typo fails at your
+prompt instead of vanishing into a mailbox.
+
+## 8. Diagnose
+
+Two reads settle any "where did my message go?" question. The registry
+tells you which names exist:
+
+**Run**
+
+```bash
+a8s ls -q
+```
+
+You should see:
+
+```
+hello
+me
+```
+
+And the per-agent log tells you what actually moved. Every accepted send,
+route, and wake leaves a line:
+
+**Run**
+
+```bash
+a8s logs hello --tail 5
+```
+
+You should see:
+
+```
+2026-07-29T04:45:58.330587Z received from me: are you alive?
+2026-07-29T04:45:58.360655Z [hello] waking from 01ABC....json: are you alive?
+2026-07-29T04:45:58.361043Z [hello] exec: bash reply.sh me 'are you alive?'
+2026-07-29T04:45:58.439346Z tell -> me: hello received: are you alive?
+2026-07-29T04:45:59.377730Z routed: hello -> me: hello received: are you alive?
+```
+
+The `gost` attempt appears in neither place — it was refused at the
+boundary, so there is nothing to clean up.
+
+## 9. Fix
+
+Spell the name right and send again:
+
+**Run**
+
+```bash
+tell hello "are you alive?" && tells --timeout 30
+```
+
+You should see:
+
+```
+tell -> hello: are you alive?
+hello: hello received: are you alive?
+```
+
+## 10. Check
+
+Ask the front door where the suite stands now:
+
+**Run**
+
+```bash
+ark
+```
+
+You should see (a8s section):
+
+```
+a8s — agent message router  (/home/you/.config/a8s)
+  ✓ cli       a8s -> /home/you/bin/a8s
+  ✓ registry  2 agent(s), 0 alias(es), 0 namespace(s)
+  ✓ router    attached: hello, me
+```
+
+The registry has your two agents and both handlers are attached. The r4t
+and k7e sections still show ✗ — those are chapters 2 and 3.
+
+## 11. Customize
+
+Make the reply yours. One bounded edit — the agent's behavior is exactly
+its script:
+
+**Replace** `~/ark/hello/reply.sh` (whole file)
+
+```bash
+#!/usr/bin/env bash
+sender="$1"
+message="$2"
+tell "$sender" "hello heard you loud and clear: ${message} (word count: $(echo "$message" | wc -w | tr -d ' '))"
+```
+
+No restart needed — the definition runs the script fresh on every wake:
+
+**Run**
+
+```bash
+cd ~/ark/me
+tell hello "one small step" && tells --timeout 30
+```
+
+You should see:
+
+```
+tell -> hello: one small step
+hello: hello heard you loud and clear: one small step (word count: 3)
+```
+
+## 12. Commit point
+
+Your agent is two files; keep them under version control like anything
+else you built:
+
+**Run**
+
+```bash
+cd ~/ark/hello
+git init -q
+git add reply.sh hello.json
+git commit -q -m "hello agent: script + a8s definition"
+```
+
+Leave `hello` and `me` running — chapter 2 registers a third node beside
+them and gives it something none of your agents have yet: a mind.

--- a/guides/02-the-solo-agent.md
+++ b/guides/02-the-solo-agent.md
@@ -1,0 +1,362 @@
+# Chapter 2 — The Solo Agent
+
+## 1. Capability
+
+At the end of this chapter you will have **Sol**: a roster of one — a
+single AI member behind r4t, with spend budgets, a swappable rig, and a
+conversation that persists across turns. You will prove the persistence
+with a codeword, break the configuration on purpose, and read the
+fail-closed error that stops it from ever half-running.
+
+## 2. Time
+
+About 30 minutes, plus a one-time model download on the free path.
+
+## 3. Starting state
+
+- Chapter 1 complete: `hello` and `me` registered, `ark` shows the a8s
+  section green.
+- One harness, depending on your path:
+  - **Free path** — `ollama` installed and serving, with the model pulled:
+
+**Run**
+
+```bash
+ollama pull qwen3.6
+```
+
+  - **Subscription path** — the Cursor agent CLI (`agent`) installed and
+    logged in.
+
+`ark doctor` should show your chosen harness green before you continue.
+
+## 4. The change
+
+A team is two files with two jobs: `ROSTER.md` in the team repo says *who*
+exists, and `~/.config/r4t/rigs.json` — outside the repo, where a repo
+edit can't reach it — says what each member's **rig** actually runs. Make
+the team directory and let r4t write the starters:
+
+**Run**
+
+```bash
+mkdir -p ~/ark/solo
+cd ~/ark/solo
+r4t init
+```
+
+You should see:
+
+```
+roster: wrote starter /home/you/ark/solo/ROSTER.md
+rig config: wrote starter /home/you/.config/r4t/rigs.json
+
+Register and start the team (a namespace prefix cannot share a
+name with its agent, so the node is registered as <team>-node):
+
+  a8s add solo-node /home/you/ark/solo /home/you/bin/apps/r4t/example-definition.json
+  a8s namespace solo solo-node
+  a8s start solo-node
+  tell solo "hello"            # bare namespace -> roster leader
+  tell solo:dev "hello"        # namespace:member -> specific member
+```
+
+The starter roster is a three-member team. Ours is smaller. Replace it
+with a roster of one AI and one human — you:
+
+**Replace** `~/ark/solo/ROSTER.md` (whole file)
+
+```markdown
+# Team Roster
+
+### You
+- **Status:** Human
+- **Role:** Owner
+
+### Sol
+- **Status:** AI
+- **Rig:** solo
+- **Leader:** yes
+- **Continue:** on
+- **Workdir:** agents/sol
+- **Role:** The solo agent — does the work and answers the owner
+
+Sol is a roster of one: leader, developer, and correspondent in a single
+seat. Keep answers short and concrete.
+```
+
+Four lines carry the weight. `Leader: yes` — external mail enters at Sol.
+`Rig: solo` — a symbolic name; what it runs comes next, from outside the
+repo. `Continue: on` — Sol's turns resume its CLI's own conversation
+instead of starting cold every wake. `Workdir: agents/sol` — Sol gets its
+own subfolder, so its conversation and files never collide with a future
+teammate's.
+
+Now define the `solo` rig. Pick your path:
+
+**Run** (free path)
+
+```bash
+r4t rig add solo opencode-ollama --model qwen3.6
+r4t rig set solo echo true
+```
+
+You should see:
+
+```
+added rig 'solo' (opencode-ollama) to /home/you/.config/r4t/rigs.json
+  invoke: ollama launch opencode --model qwen3.6 -- run --auto --dir . {prompt}
+Reference it from ROSTER.md: `- **Rig:** solo`
+set solo echo = true in /home/you/.config/r4t/rigs.json
+```
+
+**Run** (subscription path)
+
+```bash
+r4t rig add solo cursor --model claude-fable-5-medium
+r4t rig set solo echo true
+```
+
+You should see:
+
+```
+added rig 'solo' (cursor) to /home/you/.config/r4t/rigs.json
+  invoke: agent --model claude-fable-5-medium -p --trust --force --approve-mcps {prompt}
+Reference it from ROSTER.md: `- **Rig:** solo`
+set solo echo = true in /home/you/.config/r4t/rigs.json
+```
+
+(`agent models` lists what your account can run; any Fable-class model
+slug works in place of `claude-fable-5-medium`.)
+
+`echo true` makes Sol **stdout-only**: its turn prompt carries no
+messaging doctrine, and whatever it prints becomes its one reply to you.
+That is the right shape for a roster of one — Sol has nobody to message
+but you — and it sidesteps a real failure mode: without echo, a member
+must send its reply with `tell`, and prose answers under ~80 characters
+are discarded as terminal chrome. Chapter 3 lifts echo when the team
+grows.
+
+Lint before going live — r4t fails closed on any roster/rig disagreement:
+
+**Run**
+
+```bash
+cd ~/ark/solo
+r4t roster check
+```
+
+You should see:
+
+```
+You: note — Human without an Address (team cannot tell them)
+/home/you/ark/solo/ROSTER.md: OK (2 member(s), leader Sol)
+```
+
+The note is expected: you have no a8s doorbell address yet, so the team
+can't ring you when you're away. You'll read your mail at the seat
+instead. Finally, register the node on a8s exactly as `r4t init` printed:
+
+**Run**
+
+```bash
+a8s add solo-node ~/ark/solo ~/bin/apps/r4t/example-definition.json
+a8s namespace solo solo-node
+a8s start solo-node
+```
+
+You should see:
+
+```
+added solo-node -> /home/you/ark/solo
+definition: /home/you/bin/apps/r4t/example-definition.json  (explicit)
+bound solo: -> solo-node
+started solo-node as PID 23851
+```
+
+## 5. Run it
+
+You are the roster's Human, and r4t gives you a **seat**: send as
+yourself, and read what parks for you. `seat send` runs Sol's turn
+synchronously — the first turn takes a minute on the free path while the
+model loads; later turns take seconds.
+
+**Run**
+
+```bash
+cd ~/ark/solo
+r4t seat send --node solo "In one sentence: what is your job on this team?"
+r4t seat inbox --node solo
+```
+
+(`--node solo` is needed the first time; once the team has dispatched a
+turn, r4t finds the node from inside the repo on its own.)
+
+## 6. Expected receipt
+
+You should see:
+
+```
+── from solo:sol (2026-07-29T04:55:04.121285Z)
+My job is to do the work and answer to the owner — handling everything from leadership to development as the sole member of the solo team.
+```
+
+Sol read its own roster block and answered in character. Now the proof
+that `Continue: on` means what it says — plant a codeword in one turn:
+
+**Run**
+
+```bash
+r4t seat send --node solo "Remember this codeword: TIDEPOOL. Confirm you have it."
+r4t seat inbox --node solo
+```
+
+You should see:
+
+```
+── from solo:sol (2026-07-29T04:55:15.702909Z)
+Codeword confirmed: TIDEPOOL.
+```
+
+And ask for it back in a second, separate turn:
+
+**Run**
+
+```bash
+r4t seat send --node solo "What was the codeword?"
+r4t seat inbox --node solo
+```
+
+You should see:
+
+```
+── from solo:sol (2026-07-29T04:55:30.722365Z)
+TIDEPOOL.
+```
+
+Two processes, two wakes, one conversation. That continuity is what
+`Continue: on` buys.
+
+## 7. Break it
+
+`Continue: on` needs a rig whose CLI can actually resume a conversation.
+Swap Sol's rig to the bare `ollama` preset — a raw model prompt, no
+session store, no continue support:
+
+**Run**
+
+```bash
+r4t rig swap solo ollama --model qwen3.6
+r4t roster check
+```
+
+You should see:
+
+```
+swapped rig 'solo' to ollama in /home/you/.config/r4t/rigs.json
+  invoke: ollama run qwen3.6 {prompt}
+You: note — Human without an Address (team cannot tell them)
+Sol: Sol has Continue: on but rig 'solo' does not support it (preset ollama; presets that continue: agy, claude, codex, cursor, opencode, opencode-ollama) — try: r4t rig swap solo <preset>
+1 problem(s)
+```
+
+## 8. Diagnose
+
+Read the error end to end — it names the member, the rig, the reason, the
+presets that would work, and the exact command to run. Exit code is 1, and
+the same check runs at dispatch: a member in this state **does not run**,
+and whoever messages it is told why. r4t never silently downgrades
+`Continue: on` to cold prompts — that would look like working while
+quietly lobotomizing your agent every turn.
+
+## 9. Fix
+
+Take the error's suggestion:
+
+**Run**
+
+```bash
+r4t rig swap solo opencode-ollama --model qwen3.6
+r4t roster check
+```
+
+(Subscription path: swap back to `cursor --model claude-fable-5-medium`
+instead.)
+
+You should see:
+
+```
+swapped rig 'solo' to opencode-ollama in /home/you/.config/r4t/rigs.json
+  invoke: ollama launch opencode --model qwen3.6 -- run --auto --dir . {prompt}
+You: note — Human without an Address (team cannot tell them)
+/home/you/ark/solo/ROSTER.md: OK (2 member(s), leader Sol)
+```
+
+## 10. Check
+
+The codeword is the health check. Ask again:
+
+**Run**
+
+```bash
+r4t seat send --node solo "What was the codeword?"
+r4t seat inbox --node solo
+```
+
+You should see:
+
+```
+── from solo:sol (2026-07-29T04:55:49.122781Z)
+TIDEPOOL.
+```
+
+Sol still knows. The team is whole.
+
+## 11. Customize
+
+One line in the roster: bound how long Sol's conversation may sit idle.
+
+**Replace** `~/ark/solo/ROSTER.md` — in Sol's block, directly under
+`- **Continue:** on`, add:
+
+```markdown
+- **Flush:** 4h
+```
+
+A conversation idle past four hours is retired — Sol is prompted once to
+write its state to disk, and the next real message founds a fresh
+conversation from that saved state. It keeps a long-lived agent from
+dragging weeks of stale context into every turn; the full mechanics are
+chapter 3's subject.
+
+**Run**
+
+```bash
+r4t roster check
+```
+
+You should see:
+
+```
+You: note — Human without an Address (team cannot tell them)
+/home/you/ark/solo/ROSTER.md: OK (2 member(s), leader Sol)
+```
+
+## 12. Commit point
+
+The roster is repo state; commit it. (The rig config stays outside the
+repo by design — that split is what makes a roster edit unable to smuggle
+in commands.)
+
+**Run**
+
+```bash
+cd ~/ark/solo
+git init -q
+git add ROSTER.md
+git commit -q -m "solo roster: Sol, continue on, flush 4h"
+```
+
+Copy-paste templates for this chapter's final state live in
+[templates/02-solo-opencode-ollama/](templates/02-solo-opencode-ollama/)
+and [templates/02-solo-cursor/](templates/02-solo-cursor/).

--- a/guides/README.md
+++ b/guides/README.md
@@ -1,0 +1,93 @@
+# The Ark Raising
+
+```
+A R K
+8 4 7
+S T E
+```
+
+You will raise a small crew of AI agents from nothing, chapter by chapter,
+on machinery you own. Each chapter builds one working thing — an agent you
+can message, a governed roster of one, a team that remembers — on top of
+the previous chapter's state, and every chapter ends with something you can
+break, fix, and commit. The suite underneath is three tools:
+[a8s](../apps/a8s/README.md) routes the messages, [r4t](../apps/r4t/README.md)
+governs the teams, [k7e](../apps/k7e/README.md) keeps what they learn.
+
+## The name
+
+Read the wordmark by columns: `A-8-S`, `R-4-T`, `K-7-E` — the three product
+names. Read it by rows: `ARK / 847 / STE` — the suite's initials spell ARK,
+and the rows give it an address: **ARK, STE 847**. The name was there all
+along; the wordmark just files the paperwork.
+
+## Chapters
+
+| # | Chapter | What you raise |
+|---|---------|----------------|
+| 01 | [Hello, Agent](01-hello-agent.md) | Your first a8s agent — tell it something, get a reply. No LLM required. |
+| 02 | [The Solo Agent](02-the-solo-agent.md) | A governed roster of one: Sol, on r4t, with a conversation that persists. |
+| 03 | The Long Memory *(coming)* | Flush, refound, and k7e — what Sol keeps when the conversation ends. |
+| 04+ | *(coming)* | More seats, cells, missions, and the machinery of a real crew. |
+
+## Two blessed paths
+
+Every chapter is completable with **zero subscriptions** — that is the
+default path and the one every pasted output in these guides was captured
+on:
+
+- **Free path** — [OpenCode](https://opencode.ai/) driven through
+  `ollama launch`, running a local model (`qwen3.6` in these guides). Your
+  hardware, your weights, no meter.
+- **Subscription path** — the Cursor agent CLI (`agent`), the one blessed
+  paid harness. Same chapters, same commands, different rig preset.
+
+Choose by answering one question: do you have a machine that can hold a
+capable local model (roughly 16 GB+ of RAM/VRAM for `qwen3.6`-class)? If
+yes, take the free path. If not — or you already pay for Cursor — take the
+subscription path. Chapters mark the fork with a "pick your path" block;
+everything outside those blocks is identical.
+
+## Conventions
+
+Every code block in a chapter is one of four declared types, marked with a
+bold label line directly above the fence:
+
+- **Run** — paste into a shell exactly as written.
+- **Create** — the complete contents of a new file; the path is given in
+  the label line.
+- **Replace** — replaces an existing file (or a named section of one); the
+  exact file and anchor are given in the label line.
+- **Patch** — a unified diff to apply.
+
+Rules the blocks obey, so you can trust your clipboard:
+
+- No unexplained `...` inside a copyable block.
+- No `$` prompts mixed into commands.
+- Anything you must substitute yourself looks `<LIKE_THIS>`.
+- Expected output appears in its own fence directly after a Run block,
+  introduced by "You should see:".
+
+**Normalization, stated once:** every "You should see:" block comes from a
+real run captured on a real machine. Where that output contained absolute
+paths, they are normalized to `/home/you/...` (your own home and repo paths
+appear instead); ULIDs are shortened to `01ABC...`; timestamps and PIDs are
+from the capture runs — treat them as placeholders, yours will differ.
+Everything else is verbatim.
+
+### The 12-step contract
+
+Every chapter walks the same twelve steps, in order:
+
+1. **Capability** — what you can do at the end that you couldn't before.
+2. **Time** — how long it takes.
+3. **Starting state** — what must already be true.
+4. **The change** — the files you create or edit.
+5. **Run it** — the commands.
+6. **Expected receipt** — the real output that proves it worked.
+7. **Break it** — a deliberate failure.
+8. **Diagnose** — reading the error and the logs.
+9. **Fix** — the repair.
+10. **Check** — independent confirmation the system is healthy again.
+11. **Customize** — one bounded edit to make it yours.
+12. **Commit point** — what to commit before moving on.

--- a/guides/templates/02-solo-cursor/README.md
+++ b/guides/templates/02-solo-cursor/README.md
@@ -1,0 +1,3 @@
+Chapter 2's final state on the subscription path (Cursor agent CLI, Fable-class model).
+Copy ROSTER.md into your team repo (e.g. `~/ark/solo/`), then run rig-setup.sh.
+Used by [guides/02-the-solo-agent.md](../../02-the-solo-agent.md).

--- a/guides/templates/02-solo-cursor/ROSTER.md
+++ b/guides/templates/02-solo-cursor/ROSTER.md
@@ -1,0 +1,17 @@
+# Team Roster
+
+### You
+- **Status:** Human
+- **Role:** Owner
+
+### Sol
+- **Status:** AI
+- **Rig:** solo
+- **Leader:** yes
+- **Continue:** on
+- **Flush:** 4h
+- **Workdir:** agents/sol
+- **Role:** The solo agent — does the work and answers the owner
+
+Sol is a roster of one: leader, developer, and correspondent in a single
+seat. Keep answers short and concrete.

--- a/guides/templates/02-solo-cursor/rig-setup.sh
+++ b/guides/templates/02-solo-cursor/rig-setup.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+r4t rig add solo cursor --model claude-fable-5-medium
+r4t rig set solo echo true

--- a/guides/templates/02-solo-opencode-ollama/README.md
+++ b/guides/templates/02-solo-opencode-ollama/README.md
@@ -1,0 +1,3 @@
+Chapter 2's final state on the free path (OpenCode via ollama, qwen3.6).
+Copy ROSTER.md into your team repo (e.g. `~/ark/solo/`), then run rig-setup.sh.
+Used by [guides/02-the-solo-agent.md](../../02-the-solo-agent.md).

--- a/guides/templates/02-solo-opencode-ollama/ROSTER.md
+++ b/guides/templates/02-solo-opencode-ollama/ROSTER.md
@@ -1,0 +1,17 @@
+# Team Roster
+
+### You
+- **Status:** Human
+- **Role:** Owner
+
+### Sol
+- **Status:** AI
+- **Rig:** solo
+- **Leader:** yes
+- **Continue:** on
+- **Flush:** 4h
+- **Workdir:** agents/sol
+- **Role:** The solo agent — does the work and answers the owner
+
+Sol is a roster of one: leader, developer, and correspondent in a single
+seat. Keep answers short and concrete.

--- a/guides/templates/02-solo-opencode-ollama/rig-setup.sh
+++ b/guides/templates/02-solo-opencode-ollama/rig-setup.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+r4t rig add solo opencode-ollama --model qwen3.6
+r4t rig set solo echo true


### PR DESCRIPTION
## What shipped

- **guides/README.md** — course index: the ARK/847/STE wordmark, the pitch, the chapter list (01–02 live, 03+ coming), the two blessed paths and how to choose, the conventions, and the brand story (a8s/r4t/k7e initials → ARK, rows → the address ARK, STE 847).
- **guides/01-hello-agent.md** — chapter 1: the 20-minute a8s vertical slice. `ark` and `ark doctor`, a script agent (`reply.sh` + a two-key definition JSON), a filedrop seat, `tell`/`tells` round trip, break/diagnose/fix, `ark` re-check, one bounded customize, commit point. No LLM required.
- **guides/02-the-solo-agent.md** — chapter 2: r4t roster of one. `r4t init`, SOLO ROSTER.md (Sol: Leader/Continue/Workdir), pick-your-path rig add (`opencode-ollama --model qwen3.6` free / `cursor --model claude-fable-5-medium` subscription), `roster check`, a8s registration, `seat send`/`seat inbox`, the TIDEPOOL codeword continuity proof across turns, break it on the bare `ollama` preset (fail-closed continue error with its try: hint), fix, re-check, `Flush: 4h` customize, commit point.
- **guides/templates/02-solo-{opencode-ollama,cursor}/** — ROSTER.md (chapter final state), 3-line README, rig-setup.sh matching the chapter's exact Run lines.
- One-line links from the root README.md and apps/r4t/README.md's Learn-more list.

## Conventions chosen

Four declared block types (**Run** / **Create** / **Replace** / **Patch**) as a bold label line above each fence; no bare `...` in copyable blocks, no `$` prompts, substitutions `<LIKE_THIS>`; expected output in its own fence introduced by "You should see:"; the 12-step chapter contract listed in the index.

## Captured live vs normalized

All free-path outputs in both chapters were captured from real runs under scratch homes (`A8S_HOME`/`R4T_HOME`/`K7E_HOME` in a temp dir) on this machine, including the qwen3.6 seat turns and the TIDEPOOL two-turn round trip. The cursor path's `rig add`/`rig set` were captured for real in an isolated `R4T_HOME`; the rest of that path is marked identical-shape. Normalization (stated once in the conventions): absolute paths → `/home/you/...`, ULIDs → `01ABC...`, timestamps/PIDs are capture-run values.

Two code-vs-plan deviations, both written to reality: a typo'd `tell` fails closed at recipient validation (nothing is queued — no dead letter to show), and the solo rig is set `echo true` because a local model's short prose reply falls under dispatch's 80-char stdout-fallback floor and is silently dropped otherwise.

## Tests

- r4t: 640 passed (full suite, repo venv python).
- a8s: 776 passed, 2 failed — `test_remote_e2e.py` MQTT round-trip tests, environmental (no reachable broker), pre-existing; no a8s source touched in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)