### PR TITLE
feat(guides): The Ark Raising — chapters 3-4 (memory + second hands)

### DIFF
--- a/guides/02-the-solo-agent.md
+++ b/guides/02-the-solo-agent.md
@@ -134,7 +134,7 @@ messaging doctrine, and whatever it prints becomes its one reply to you.
 That is the right shape for a roster of one — Sol has nobody to message
 but you — and it sidesteps a real failure mode: without echo, a member
 must send its reply with `tell`, and prose answers under ~80 characters
-are discarded as terminal chrome. Chapter 3 lifts echo when the team
+are discarded as terminal chrome. Chapter 4 lifts echo when the team
 grows.
 
 Lint before going live — r4t fails closed on any roster/rig disagreement:

--- a/guides/03-the-long-memory.md
+++ b/guides/03-the-long-memory.md
@@ -1,0 +1,404 @@
+# Chapter 3 — The Long Memory
+
+## 1. Capability
+
+At the end of this chapter Sol survives conversation death. You will watch
+the **flush cycle** end an idle conversation on purpose — Sol is prompted
+once to write his state to `STATUS.md`, the conversation is retired, and
+the next real message **refounds** him from that file. Then you will do
+something harsher: swap Sol's rig to a different CLI mid-life and watch him
+come back coherent on the other side. The conversation is disposable; the
+agent is not.
+
+## 2. Time
+
+About 30 minutes, most of it deliberate waiting.
+
+## 3. Starting state
+
+- Chapter 2 complete: Sol answers at the seat, `Continue: on`, and the
+  customize step left `Flush: 4h` in his roster block.
+- Sol's conversation is live — if you just restarted the machine, send one
+  seat message so there is a conversation to flush.
+
+## 4. The change
+
+`Flush: 4h` is a promise you made in chapter 2 without seeing it kept: a
+conversation idle past four hours is retired. Four hours is the right
+setting and the wrong demo — you are not going to sit here for four hours.
+The value takes bare seconds or an `s`/`m`/`h`/`d` suffix, so shrink the
+window for one session:
+
+**Replace** `~/ark/solo/ROSTER.md` — in Sol's block, the `Flush:` line
+becomes:
+
+```markdown
+- **Flush:** 60
+```
+
+**Run**
+
+```bash
+cd ~/ark/solo
+r4t roster check
+```
+
+You should see:
+
+```
+You: note — Human without an Address (team cannot tell them)
+/home/you/ark/solo/ROSTER.md: OK (2 member(s), leader Sol)
+```
+
+One rule worth knowing before you rely on this line: `Flush:` only means
+something next to `Continue: on` — flush retires a *continuing*
+conversation. Set it on a member without `Continue: on` and the lint warns
+instead of blocking:
+
+```
+warning: Sol: Flush: set but Continue: is off — flush retires a continuing
+conversation, so it is ignored here
+/home/you/ark/solo/ROSTER.md: OK (2 member(s), leader Sol, 1 warning(s))
+```
+
+Harmless, but it means the field is doing nothing. Yours says OK — keep
+going.
+
+## 5. Run it
+
+Give Sol a fact to hold, and prove he has it:
+
+**Run**
+
+```bash
+r4t seat send --node solo "Hold this fact for later: the supply cache is at grid square K-19. Confirm."
+r4t seat inbox --node solo
+```
+
+You should see:
+
+```
+── from solo:sol (2026-07-29T05:19:47.051352Z)
+Supply cache at grid square K-19 recorded. Confirming storage complete.
+```
+
+Now leave the team alone for a bit over a minute — the window is 60
+seconds of *idle*, measured from Sol's last completed turn. Then run the
+idle sweep. `r4t idle` is the janitor pass a running node performs on its
+own; invoking it by hand lets you watch it work:
+
+**Run**
+
+```bash
+r4t idle --node solo
+```
+
+You should see:
+
+```
+drained 0 queued turn(s); nudged the leader on 0 quiet thread(s)
+pruned 0 stale lock(s); expired 0 thread(s); drained 0 more queued turn(s)
+```
+
+The summary doesn't mention the flush — the receipt lives in the team log
+and on disk, which is where the next section takes you.
+
+## 6. Expected receipt
+
+**Run**
+
+```bash
+r4t logs --node solo -n 6
+```
+
+You should see:
+
+```
+r4t: FLUSH dump turn -> sol (conversation idle > 60s)
+turn: 1 message(s) -> Sol (threads 01ABC..., rig solo)
+done: Sol, exit 0 in 28.8s
+r4t: ECHO-REPLY sol (rig solo) 674 bytes of cleaned stdout staged as the reply to r4t:solo
+r4t: RELEASED solo:sol -> r4t:solo thread=01ABC... hop=1
+r4t: FLUSH retired sol's conversation — the next real message refounds it from state on disk
+```
+
+Two `FLUSH` events bracket a real turn. The **dump turn** is an ordinary
+continuing turn whose prompt asks one thing: "Save your current state and
+progress to STATUS.md." It is logged, captured, and budgeted like any
+other turn, and only if it exits cleanly is the conversation retired. Look
+at what Sol wrote:
+
+**Run**
+
+```bash
+cat STATUS.md
+```
+
+You should see:
+
+```
+# STATUS.md — Sol
+
+## Codeword
+TIDEPOOL (confirmed)
+
+## Supplied Facts
+- Supply cache location: grid square K-19
+
+## Current State
+Active. No open tasks. Waiting for instructions.
+
+## Progress
+Session initialized. Stored codeword and supply cache location.
+```
+
+Sol chose that structure himself — the dump prompt names the file, not the
+format. (Where the file lands depends on the harness: OpenCode anchors
+relative paths at the repo root, so on the free path it appears at
+`~/ark/solo/STATUS.md`; a harness that stays in Sol's `Workdir:` writes
+`agents/sol/STATUS.md` instead. Either way it is inside the team repo,
+which matters at the commit point.)
+
+The conversation is now retired. Ask for the fact back:
+
+**Run**
+
+```bash
+r4t seat send --node solo "What was the codeword, and where is the supply cache?"
+r4t seat inbox --node solo
+```
+
+You should see:
+
+```
+── from solo:sol (2026-07-29T05:23:14.719675Z)
+The codeword was **TIDEPOOL** and the supply cache is located at **grid square K-19**.
+```
+
+That turn was a **refound**: no continue flag on the CLI (there is no
+conversation left to continue), and the prompt opens with a preamble —
+"Check your STATUS.md to refresh your memory." A fresh conversation,
+founded from saved state, holding facts learned in a conversation that no
+longer exists.
+
+### The rig swap
+
+Flush is scheduled death. A rig swap is sudden death: the conversation is
+keyed on the CLI that holds it, so a rig that now drives a *different* CLI
+cannot resume it — and r4t does not try, because the old CLI may be
+quota-dead and unable to run a dump turn. State on disk is whatever the
+last flush left. Swap Sol to the other path's harness (this beat needs a
+second continue-capable CLI installed — `agent` here; free-path readers
+with only ollama can read along, the machinery is identical):
+
+**Run**
+
+```bash
+r4t rig swap solo cursor --model claude-fable-5-medium
+r4t seat send --node solo "New rig, same Sol? Tell me the codeword and the cache location."
+r4t seat inbox --node solo
+```
+
+You should see:
+
+```
+swapped rig 'solo' to cursor in /home/you/.config/r4t/rigs.json
+  invoke: agent --model claude-fable-5-medium -p --trust --force --approve-mcps {prompt}
+── from solo:sol (2026-07-29T05:26:27.150992Z)
+Same Sol. Codeword: **TIDEPOOL**. Supply cache: **grid square K-19**. Both verified against STATUS.md.
+```
+
+And the log names what happened:
+
+**Run**
+
+```bash
+r4t logs --node solo -n 8
+```
+
+You should see:
+
+```
+r4t: QUEUED solo:you -> sol thread=01ABC... hop=0 "New rig, same Sol? Tell me the codeword and the cache location." (depth 1)
+r4t: CONTINUE-SWAP sol (rig solo) drives 'agent' but the conversation lives on 'opencode' — retired; this turn refounds from state on disk
+turn: 1 message(s) -> Sol (threads 01ABC..., rig solo)
+done: Sol, exit 0 in 12.4s
+r4t: ECHO-REPLY sol (rig solo) 102 bytes of cleaned stdout staged as the reply to solo:you
+r4t: SEAT you <- solo:sol (parked)
+r4t: RELEASED-internal solo:sol -> solo:you thread=01ABC... hop=1
+r4t: ANSWERED thread=01ABC... solo:sol -> solo:you (originator answered, thread closed)
+```
+
+`CONTINUE-SWAP`: the conversation lived on `opencode`, the rig now drives
+`agent`, so the old conversation is retired and this turn refounds — same
+mechanics as after a flush, minus the dump. Sol's identity crossed a CLI
+boundary on the strength of a markdown file. Swap back:
+
+**Run**
+
+```bash
+r4t rig swap solo opencode-ollama --model qwen3.6
+r4t seat send --node solo "Back on the local rig. Codeword and cache location, one line."
+r4t seat inbox --node solo
+```
+
+You should see:
+
+```
+swapped rig 'solo' to opencode-ollama in /home/you/.config/r4t/rigs.json
+  invoke: ollama launch opencode --model qwen3.6 -- run --auto --dir . {prompt}
+── from solo:sol (2026-07-29T05:27:48.329830Z)
+Codeword: TIDEPOOL — Cache: grid square K-19
+```
+
+The log shows the same `CONTINUE-SWAP` event with the CLIs reversed. One
+subtlety the event teaches: a swap that keeps the CLI (a model change, or
+`opencode` ↔ `opencode-ollama`, which both drive `opencode`) keeps the
+conversation — only a real CLI change retires it.
+
+(If a send comes back with `queued — Sol is resting (member budget ...)`,
+you have simply outrun Sol's spend budget with all this demo traffic. The
+message is queued, not lost; wait the minutes it names and run
+`r4t clear --node solo`. Chapter 4 makes that machinery the main event.)
+
+## 7. Break it
+
+`STATUS.md` looks like a single point of failure, so attack it. Retire the
+conversation again — wait a bit over a minute, flush, then delete the
+state file before sending the recall:
+
+**Run**
+
+```bash
+r4t idle --node solo
+rm STATUS.md
+r4t seat send --node solo "What was the codeword?"
+r4t seat inbox --node solo
+```
+
+You should see:
+
+```
+── from solo:sol (2026-07-29T05:34:01.509705Z)
+Codeword: TIDEPOOL
+```
+
+The lobotomy failed. Honest result, worth understanding rather than
+celebrating.
+
+## 8. Diagnose
+
+The refound turn told Sol to check a file that did not exist — so why does
+he still know? Because `STATUS.md` was never the only layer. Every turn's
+prompt carries a section r4t maintains itself:
+
+```
+## Your conversation so far (messages you received and sent)
+```
+
+— the member's rolling message history, machinery-kept, capped by the
+rig's history budget. The codeword rode in on that. So refound memory is
+belt and braces: `STATUS.md` holds what the *member* chose to write down
+(judgments, progress, structure), the rolling history holds what was
+*said* recently (until it scrolls off the cap). Delete one and the other
+covers — for a while. A fact old enough to have scrolled out of history
+survives only if Sol wrote it to `STATUS.md`. That is the layer you just
+deleted, and on a longer-lived agent the loss would have been real.
+
+## 9. Fix
+
+Nothing is broken in the machinery — what's missing is the file, and the
+machinery that wrote it once will write it again. Wait past the window and
+run another sweep:
+
+**Run**
+
+```bash
+r4t idle --node solo
+ls STATUS.md
+head -8 STATUS.md
+```
+
+You should see:
+
+```
+STATUS.md
+# STATUS.md — Sol
+
+## Codeword
+TIDEPOOL (confirmed)
+
+## Supplied Facts
+- Supply cache location: grid square K-19
+```
+
+The dump turn regenerated it from the live conversation.
+
+## 10. Check
+
+One full recall-after-flush round trip — the same health check the whole
+chapter has been circling:
+
+**Run**
+
+```bash
+r4t seat send --node solo "Codeword and cache location, one line."
+r4t seat inbox --node solo
+```
+
+You should see:
+
+```
+── from solo:sol (2026-07-29T05:38:30.929831Z)
+Codeword: TIDEPOOL — Cache: grid square K-19
+```
+
+Flushed, refounded, swapped, swapped back, state file deleted and
+regrown — and Sol still answers. The team is whole.
+
+## 11. Customize
+
+Put the window back where it belongs:
+
+**Replace** `~/ark/solo/ROSTER.md` — Sol's `Flush:` line becomes:
+
+```markdown
+- **Flush:** 4h
+```
+
+**Run**
+
+```bash
+r4t roster check
+```
+
+You should see:
+
+```
+You: note — Human without an Address (team cannot tell them)
+/home/you/ark/solo/ROSTER.md: OK (2 member(s), leader Sol)
+```
+
+Choosing a window is cache economics: a conversation left idle falls out
+of the provider's prompt cache, and re-caching weeks of stale context at
+frontier prices is real money spent on messages nobody needed — flush
+early enough to avoid that, late enough that normal working pauses don't
+cost Sol his short-term memory. Four hours suits a daily-driver agent; on
+the free path the meter is zero and the window is purely about context
+hygiene.
+
+## 12. Commit point
+
+`STATUS.md` is Sol's own writing and it lives in the repo — version it.
+The snapshot you commit is the state Sol would refound from if the
+machine died right now:
+
+**Run**
+
+```bash
+cd ~/ark/solo
+git add ROSTER.md STATUS.md
+git commit -q -m "solo: Sol's first memory dump"
+```
+
+Chapter 4 gives Sol something no amount of memory provides: a teammate.

--- a/guides/04-a-second-pair-of-hands.md
+++ b/guides/04-a-second-pair-of-hands.md
@@ -1,0 +1,388 @@
+# Chapter 4 — A Second Pair of Hands
+
+## 1. Capability
+
+At the end of this chapter the roster is two: Sol leads, and **Pip** — a
+zero-cost helper on the same local model — answers his questions. You will
+send Sol a task, watch him delegate to Pip with `tell`, watch Pip's answer
+come back, and read the whole exchange in the team log. You will also see,
+honestly, where a small free model fumbles the last step — and why the
+machinery guarantees the *messages* even when it cannot guarantee the
+model. Then you will starve Pip's budget and watch a message wait, unharmed,
+for the refill.
+
+This chapter also keeps chapter 2's promise: echo comes off Sol here. An
+echo member never sees `tell`, and a leader who cannot `tell` cannot
+delegate.
+
+## 2. Time
+
+About 30 minutes.
+
+## 3. Starting state
+
+- Chapter 3 complete: Sol on `Continue: on` / `Flush: 4h`, answering at
+  the seat.
+- The free path runs both members on one `qwen3.6` — no second model, no
+  extra download. (Subscription path: Pip still runs local and free; only
+  Sol's rig differs, exactly as in chapters 2–3.)
+
+## 4. The change
+
+Two edits: the roster grows a member, and the rig config grows a rig.
+
+**Replace** `~/ark/solo/ROSTER.md` (whole file)
+
+```markdown
+# Team Roster
+
+### You
+- **Status:** Human
+- **Role:** Owner
+
+### Sol
+- **Status:** AI
+- **Rig:** solo
+- **Leader:** yes
+- **Continue:** on
+- **Flush:** 4h
+- **Workdir:** agents/sol
+- **Role:** The solo agent — does the work and answers the owner
+
+Sol is a roster of one: leader, developer, and correspondent in a single
+seat. Keep answers short and concrete.
+
+### Pip
+- **Status:** AI
+- **Rig:** helper
+- **Workdir:** agents/pip
+- **Role:** Helper — quick lookups and drafts for Sol
+
+Pip answers fast and short: facts, lists, first drafts. No long essays.
+```
+
+Pip gets no `Leader:`, no `Continue:` — external mail still enters at Sol,
+and a helper that starts cold every turn is fine for quick lookups. The
+separate `Workdir:` keeps Pip's conversation and files out of Sol's
+directory (two members driving the same CLI in one directory would share
+one conversation — `r4t roster check` warns about exactly that). Sol's
+persona line still says "a roster of one" — as of this chapter that is a
+lie he tells himself; persona is free prose, edit it whenever you like.
+
+Now the rig. Pip is an **echo** member — stdout-only, no messaging
+doctrine, the right shape for a small model that answers questions. Sol
+loses echo in the same breath, because the leader now has somebody to
+message:
+
+**Run**
+
+```bash
+r4t rig add helper opencode-ollama --model qwen3.6
+r4t rig set helper echo true
+r4t rig unset solo echo
+cd ~/ark/solo
+r4t roster check
+```
+
+You should see:
+
+```
+added rig 'helper' (opencode-ollama) to /home/you/.config/r4t/rigs.json
+  invoke: ollama launch opencode --model qwen3.6 -- run --auto --dir . {prompt}
+Reference it from ROSTER.md: `- **Rig:** helper`
+set helper echo = true in /home/you/.config/r4t/rigs.json
+unset solo echo in /home/you/.config/r4t/rigs.json
+You: note — Human without an Address (team cannot tell them)
+/home/you/ark/solo/ROSTER.md: OK (3 member(s), leader Sol)
+```
+
+From this turn on, Sol's prompt carries the messaging doctrine — the
+`tell` command, and a teammate list naming You and Pip.
+
+## 5. Run it
+
+Give Sol a task that names Pip:
+
+**Run**
+
+```bash
+r4t seat send --node solo "Ask Pip for three name ideas for our team mascot, an octopus. Pick your favorite and tell me."
+r4t seat inbox --node solo
+```
+
+## 6. Expected receipt
+
+You should see:
+
+```
+(no unread messages)
+```
+
+Not a typo. On the free path this is the *real* result, and it is worth
+more than a staged success. The work happened — read the thread's spine in
+the team log (`r4t logs --node solo` shows these events; turn boundaries
+between them omitted here):
+
+```
+r4t: QUEUED solo:you -> sol thread=01ABC... hop=0 "Ask Pip for three name ideas for our team mascot, an octopus. Pick your favorite" (depth 1)
+r4t: QUEUED solo:sol -> pip thread=01ABC... hop=1 "I need three name ideas for our team mascot — an octopus. Keep them punchy, memo" (depth 1)
+r4t: ECHO-REPLY pip (rig helper) 232 bytes of cleaned stdout staged as the reply to solo:sol
+r4t: QUEUED solo:pip -> sol thread=01ABC... hop=2 "1. **Inkwell** — evokes the octopus "pen" while sounding sharp and professional " (depth 1)
+r4t: STDOUT-REPLY sol (rig solo) released nothing; 156 bytes of cleaned stdout staged as a reply to solo:pip
+r4t: QUEUED solo:sol -> pip thread=01ABC... hop=3 "**Inkwell** is the pick. Sharp, professional, and the octopus pun lands without " (depth 1)
+r4t: ECHO-REPLY pip (rig helper) 22 bytes of cleaned stdout staged as the reply to solo:sol
+r4t: QUEUED solo:pip -> sol thread=01ABC... hop=4 "Noted. Inkwell it is 🐙" (depth 1)
+```
+
+Read it hop by hop. **Hop 1** is the delegation working: Sol ran `tell pip`
+himself — a real shell command, composed and executed by a small local
+model. **Hop 2** is Pip's echo: no tools, no doctrine, just three names
+staged straight back as the reply. **Hop 3** is the fumble: Sol *decided*
+("Inkwell is the pick") but printed his answer instead of telling you, so
+the `STDOUT-REPLY` fallback staged his stdout as a reply to the newest
+sender — which was Pip, not you. Pip politely acknowledged (hop 4), the
+two drifted into housekeeping for a few more hops, and r4t ended the loop
+the boring way:
+
+```
+r4t: SILENT sol (rig solo) exit 0 with 85 bytes of stdout but nothing worth relaying survived transcript cleaning
+```
+
+Nothing crashed, nothing looped forever, nobody spent money — but you
+never got your answer, because the last mile (Sol messaging *you*) is the
+one step that needs the model to follow instructions, and small local
+models follow them intermittently. Watch it happen in miniature — ask
+again and demand the `tell`:
+
+**Run**
+
+```bash
+r4t seat send --node solo "Which mascot name did you pick? Send me the answer with the tell command."
+r4t seat inbox --node solo
+r4t logs --node solo --full -n 8
+```
+
+You should see:
+
+```
+(no unread messages)
+### Output (Sol, exit 0 in 13.2s)
+
+[0m
+> build · qwen3.6:latest
+[0m
+tell you "Inkwell 🐙"
+```
+
+Sol *printed* `tell you "Inkwell 🐙"` as text — the exact mistake the
+doctrine warns about ("printing it as text sends nothing"). Twelve
+characters of perfect answer, discarded as terminal chrome by the sub-80
+threshold you met in chapter 2. This is why chapter 2 shipped Sol with
+echo on, and it is the honest cost of lifting it.
+
+Now the two ways you actually get answers out of this team. First: the
+stdout fallback *does* reach you whenever Sol's answer has substance,
+because a fresh question from you makes you the newest sender:
+
+**Run**
+
+```bash
+r4t seat send --node solo "Report in two or three full sentences: what did you ask Pip, what did Pip offer, and which mascot name won?"
+r4t seat inbox --node solo
+```
+
+You should see:
+
+```
+── from solo:sol (2026-07-29T05:47:12.961106Z)
+I asked Pip for three octopus name ideas. Pip offered Inkwell, Blotz, and Eight. Inkwell won — sharp, professional, with a subtle ink pun that lands cleanly.
+```
+
+There is the delegated round trip, synthesized and delivered — Sol never
+ran `tell`, and the machinery covered for him: the log shows
+`r4t: STDOUT-REPLY sol (rig solo) released nothing; 157 bytes of cleaned
+stdout staged as a reply to solo:you`. Second: the direct route. The seat
+can address any member, so for quick lookups skip the middleman:
+
+**Run**
+
+```bash
+r4t seat send --node solo --to pip "Three verbs that describe what an octopus does. Just the list."
+r4t seat inbox --node solo
+```
+
+You should see:
+
+```
+── from solo:pip (2026-07-29T05:47:58.265173Z)
+1. Jet
+2. Camouflage
+3. Grasp
+```
+
+(On the subscription path Sol runs `tell` reliably and the first send
+comes back synthesized on hop 3 — the machinery is identical, the model
+discipline is what you are paying for.) Now look at the team as a whole:
+
+**Run**
+
+```bash
+r4t status --node solo
+```
+
+You should see (roster section):
+
+```
+Roster  (repo settings: /home/you/ark/solo/ROSTER.md)
+    You  Human  address=(none)   (try: add an **Address:** line so the team can reach them)
+  ✓ Sol  rig=solo  budget=5.2/8  [leader]
+  ✓ Pip  rig=helper  budget=7/8
+```
+
+Two members, two spend buckets, every turn above accounted for.
+
+## 7. Break it
+
+Budgets have been sitting in that status line since chapter 2 without ever
+biting. Make one bite. Each rig can carry a machine-global spend bucket —
+`rig_budget_max` units, refilled at `rig_budget_earn_per_hour` — sized for
+the real subscription behind it. Give Pip's rig a bucket of one:
+
+**Run**
+
+```bash
+r4t rig set helper rig_budget_max 1
+r4t rig set helper rig_budget_earn_per_hour 1
+r4t seat send --node solo --to pip "One fun fact about octopus arms."
+r4t seat inbox --node solo
+r4t seat send --node solo --to pip "And one about octopus hearts."
+```
+
+You should see:
+
+```
+set helper rig_budget_max = 1 in /home/you/.config/r4t/rigs.json
+set helper rig_budget_earn_per_hour = 1 in /home/you/.config/r4t/rigs.json
+── from solo:pip (2026-07-29T05:48:56.279303Z)
+Each of an octopus's eight arms can taste, touch, and move independently—thanks to most of its neurons residing in the arms rather than the brain.
+
+queued — Pip is resting — rig helper exhausted (0), ready in ~59 min
+```
+
+The first question ran — and spent the bucket's single unit. The second
+came back with a receipt instead of an answer.
+
+## 8. Diagnose
+
+Read the receipt, then confirm it from the other two surfaces:
+
+**Run**
+
+```bash
+r4t status --node solo
+r4t logs --node solo -n 1
+```
+
+You should see (roster section, and the log line):
+
+```
+  ✓ Pip  rig=helper  budget=6.1/8  rig=0/1  1 queued  RESTING (rig helper, ready in ~59 min)
+r4t: RESTING pip — resting — rig helper exhausted (0), ready in ~59 min (1 queued)
+```
+
+Nothing was refused and nothing was dropped: the message is **queued**,
+durably, in Pip's queue on disk. An empty bucket means *resting*, not
+*muted* — the queue simply holds until the bucket refills, and then the
+turn runs with every queued message in one batch. This is the doctrine the
+whole dispatcher is built on: gates govern *when* a member runs, never
+*whether* a message survives. Messages never die.
+
+## 9. Fix
+
+You could wait the ~59 minutes and the machinery would fire on its own.
+Or lift the ceiling you just installed:
+
+**Run**
+
+```bash
+r4t rig unset helper rig_budget_max
+r4t rig unset helper rig_budget_earn_per_hour
+r4t idle --node solo
+r4t seat inbox --node solo
+```
+
+You should see:
+
+```
+unset helper rig_budget_max in /home/you/.config/r4t/rigs.json
+unset helper rig_budget_earn_per_hour in /home/you/.config/r4t/rigs.json
+drained 1 queued turn(s); nudged the leader on 0 quiet thread(s)
+pruned 0 stale lock(s); expired 0 thread(s); drained 0 more queued turn(s)
+── from solo:pip (2026-07-29T05:50:20.969451Z)
+An octopus has three hearts. Two pump blood to the gills, one to the body. The main heart stops when swimming, which is why they prefer crawling.
+```
+
+`drained 1 queued turn(s)` — the held message fired the moment the gate
+opened, and the answer landed as if nothing had happened. Because, from
+the message's point of view, nothing did.
+
+## 10. Check
+
+One full round trip through the leader, end to end:
+
+**Run**
+
+```bash
+r4t seat send --node solo "In two or three full sentences: what has Pip contributed to this team so far?"
+r4t seat inbox --node solo
+```
+
+You should see:
+
+```
+── from solo:sol (2026-07-29T05:56:13.232267Z)
+Two things, both concrete: Pip drafted three octopus name options for our mascot (we landed on Inkwell), then committed ROSTER.md with Pip added to the team at `0a80bcf`. That's it — two small, done items.
+```
+
+Sol knows what his helper has done. (That commit hash is real: the
+"housekeeping drift" in section 6 was the pair committing the roster on
+their own initiative — `git log` in the team repo will show it.) The team
+is whole — and it is a team now.
+
+## 11. Customize
+
+Pip's model is one setting. Any model in `ollama ls` slots in:
+
+**Run**
+
+```bash
+r4t rig set helper model qwen3:1.7b
+```
+
+You should see:
+
+```
+set helper model = qwen3:1.7b in /home/you/.config/r4t/rigs.json
+```
+
+A 1.7B Pip answers in a fraction of the time and a fraction of the
+quality — try one `--to pip` lookup and judge the trade; set it back the
+same way. One more knob while you are here: `echo_max_chars` (default
+1500) caps an echo member's reply body — anything longer is truncated
+with the full text attached to the same envelope as a markdown file.
+
+## 12. Commit point
+
+The roster is the team; commit it. (The `helper` rig lives outside the
+repo with `solo`, by design.)
+
+**Run**
+
+```bash
+cd ~/ark/solo
+git add ROSTER.md
+git commit -q -m "solo roster: Pip joins — helper rig, echo lifted from Sol"
+```
+
+Copy-paste templates for this chapter's final state live in
+[templates/04-two-member/](templates/04-two-member/).

--- a/guides/README.md
+++ b/guides/README.md
@@ -27,8 +27,9 @@ along; the wordmark just files the paperwork.
 |---|---------|----------------|
 | 01 | [Hello, Agent](01-hello-agent.md) | Your first a8s agent — tell it something, get a reply. No LLM required. |
 | 02 | [The Solo Agent](02-the-solo-agent.md) | A governed roster of one: Sol, on r4t, with a conversation that persists. |
-| 03 | The Long Memory *(coming)* | Flush, refound, and k7e — what Sol keeps when the conversation ends. |
-| 04+ | *(coming)* | More seats, cells, missions, and the machinery of a real crew. |
+| 03 | [The Long Memory](03-the-long-memory.md) | Flush, refound, and rig portability — what Sol keeps when the conversation ends. |
+| 04 | [A Second Pair of Hands](04-a-second-pair-of-hands.md) | The roster grows to two: Sol delegates, Pip answers for free, budgets bite. |
+| 05+ | *(coming)* | k7e, more seats, cells, missions, and the machinery of a real crew. |
 
 ## Two blessed paths
 

--- a/guides/templates/04-two-member/README.md
+++ b/guides/templates/04-two-member/README.md
@@ -1,0 +1,4 @@
+Chapter 4's final state on the free path (Sol + Pip, both OpenCode via
+ollama, qwen3.6; echo lifted from Sol, echo on Pip).
+Copy ROSTER.md into your team repo (e.g. `~/ark/solo/`), then run rig-setup.sh.
+Used by [guides/04-a-second-pair-of-hands.md](../../04-a-second-pair-of-hands.md).

--- a/guides/templates/04-two-member/ROSTER.md
+++ b/guides/templates/04-two-member/ROSTER.md
@@ -1,0 +1,25 @@
+# Team Roster
+
+### You
+- **Status:** Human
+- **Role:** Owner
+
+### Sol
+- **Status:** AI
+- **Rig:** solo
+- **Leader:** yes
+- **Continue:** on
+- **Flush:** 4h
+- **Workdir:** agents/sol
+- **Role:** The solo agent — does the work and answers the owner
+
+Sol is a roster of one: leader, developer, and correspondent in a single
+seat. Keep answers short and concrete.
+
+### Pip
+- **Status:** AI
+- **Rig:** helper
+- **Workdir:** agents/pip
+- **Role:** Helper — quick lookups and drafts for Sol
+
+Pip answers fast and short: facts, lists, first drafts. No long essays.

--- a/guides/templates/04-two-member/rig-setup.sh
+++ b/guides/templates/04-two-member/rig-setup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+r4t rig add solo opencode-ollama --model qwen3.6
+r4t rig add helper opencode-ollama --model qwen3.6
+r4t rig set helper echo true


### PR DESCRIPTION
## What shipped

- **guides/03-the-long-memory.md** — the flush cycle made visible: `Flush: 60` demo, the dump turn writing STATUS.md, retirement, refound-with-preamble recall, and rig portability via `r4t rig swap` across a real CLI boundary (opencode → agent → opencode). Break-it deletes STATUS.md before a refound and honestly shows Sol coping — the rolling history is the second memory layer, and the diagnose step teaches the belt-and-braces design instead of staging a loss.
- **guides/04-a-second-pair-of-hands.md** — the roster grows to two. Pip on a `helper` echo rig (opencode-ollama qwen3.6), echo lifted from Sol (`r4t rig unset solo echo`) so he can `tell`, keeping chapter 2's promise (its forward reference now correctly points at chapter 4). Break-it is budget starvation on the real rig-bucket surface with the QUEUED → RESTING → refill → fire cycle shown end to end.
- **guides/README.md** — chapter table: 03 row re-blurbed (flush/refound/portability, no k7e), 04 row added, k7e moved to the 05+ line.
- **guides/templates/04-two-member/** — final ROSTER.md + rig-setup.sh for the free path, matching the 02 template shape.

## Live-captured runs

All "You should see" blocks come from real runs on the free path (opencode-ollama + qwen3.6) under scratch `A8S_HOME`/`R4T_HOME`, normalized per the README rules. Real event names observed and taught: `r4t: FLUSH dump turn -> sol (conversation idle > 60s)`, `r4t: FLUSH retired sol's conversation`, `r4t: CONTINUE-SWAP sol (rig solo) drives 'agent' but the conversation lives on 'opencode'`, `ECHO-REPLY`, `STDOUT-REPLY`, `SILENT`, `RESTING`, `QUEUED`, `ANSWERED`.

The chapter-4 delegation demo is captured exactly as it went: Sol really ran `tell pip` (hop 1), Pip echoed three mascot names (hop 2), then Sol printed his synthesis instead of telling the human — the STDOUT-REPLY fallback sent it to Pip, the pair looped politely until the SILENT gate ended it. The chapter teaches that anatomy, then the two honest recovery routes (substantive question → fallback delivers to the seat; `seat send --to pip` direct route).

## Deviations from the work order

- **STATUS.md lands at the team repo root on the free path**, not `agents/sol/` — OpenCode anchors relative paths at the git root. The chapter states both possibilities; the receipts show the root.
- **The free path cannot demo CONTINUE-SWAP by itself**: `opencode` and `opencode-ollama` share the CLI key (`ollama launch opencode` drives `opencode`), so swapping between them keeps the conversation, and no other free preset supports continue. The swap was captured opencode-ollama → cursor → back, and the chapter marks the beat as needing a second continue-capable CLI (free-path readers read along). The shared-key subtlety is taught explicitly.
- **"Member budget to 0" is impossible by design** — `budget_max` has no CLI surface and 0 is rejected as a value. The starvation demo uses the real surface: `r4t rig set helper rig_budget_max 1` / `rig_budget_earn_per_hour 1`, spend the single unit, watch the queue hold, `rig unset` both to refill.
- **`r4t idle` stdout does not mention the flush** — the receipt lives in `r4t logs`; the chapter says so.
- The deleted-STATUS.md break-it produced a *non-failure* (rolling history covered); chosen over the Flush-without-Continue lint warning as the more instructive real output, with the warning still shown in chapter 3 §4.

## Verification

- Full r4t suite green from the worktree root: **640 passed** (`/Users/neilo/bin/venv/bin/python3 -m pytest apps/r4t/tests/`).
- Fresh-eyes read of both chapters for order-of-operations (caught and fixed a `logs -n` backfill slice that showed the wrong window).
- PII sweep over guides/ clean; no scratch paths leaked.

Part of the Ark Raising series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)