### PR TITLE
fix(k7e): default home to ~/.config/k7e (XDG)

### DIFF
--- a/apps/ark/ark.py
+++ b/apps/ark/ark.py
@@ -221,8 +221,12 @@ def r4t_rows() -> list[Row]:
 # ---------- k7e ----------
 
 def k7e_home() -> Path:
-    override = os.environ.get("K7E_HOME", "").strip()
-    return Path(override).expanduser() if override else Path.home() / ".k7e"
+    raw = os.environ.get("K7E_HOME", "").strip()
+    if raw:
+        return Path(raw).expanduser()
+    xdg = os.environ.get("XDG_CONFIG_HOME", "").strip()
+    base = Path(xdg).expanduser() if xdg else Path.home() / ".config"
+    return base / "k7e"
 
 
 def k7e_rows() -> list[Row]:

--- a/apps/ark/tests/conftest.py
+++ b/apps/ark/tests/conftest.py
@@ -26,7 +26,7 @@ def _no_real_subprocess(monkeypatch):
 def homes(tmp_path, monkeypatch):
     """Hermetic suite homes. Every probe path in the greeter resolves under
     tmp_path, so no test can read or touch a real ~/.config/a8s, ~/.config/r4t
-    or ~/.k7e."""
+    or ~/.config/k7e."""
     roots = {}
     for env, name in (("A8S_HOME", "a8s"), ("R4T_HOME", "r4t"), ("K7E_HOME", "k7e")):
         root = tmp_path / name

--- a/apps/ark/tests/test_ark.py
+++ b/apps/ark/tests/test_ark.py
@@ -54,6 +54,12 @@ def test_r4t_home_falls_back_to_xdg_config(tmp_path, monkeypatch):
     assert ark.r4t_home() == tmp_path / "r4t"
 
 
+def test_k7e_home_falls_back_to_xdg_config(tmp_path, monkeypatch):
+    monkeypatch.delenv("K7E_HOME", raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    assert ark.k7e_home() == tmp_path / "k7e"
+
+
 # ---------- a8s panel ----------
 
 def test_a8s_panel_is_all_misses_on_an_empty_home(homes):

--- a/apps/k7e/README.md
+++ b/apps/k7e/README.md
@@ -71,7 +71,7 @@ embeddings; an **LLM CLI** you configure via `llm_command` for distill/recall/co
 
 ## How it works (30 seconds)
 
-- Every fact is a markdown file under `$K7E_HOME/nodes/` (default `~/.k7e`).
+- Every fact is a markdown file under `$K7E_HOME/nodes/` (default `~/.config/k7e`).
   `.index.db` is a derived cache — delete it and `k7e reindex` rebuilds.
 - **Search** fuses BM25 + metadata + embeddings (RRF), then weights by
   confidence, recency decay, and use-count, with an optional LLM reranker.

--- a/apps/k7e/config.py
+++ b/apps/k7e/config.py
@@ -44,8 +44,12 @@ LLM_PURPOSES = {
 
 
 def _k7e_home():
-    override = os.environ.get("K7E_HOME")
-    return Path(override) if override else Path.home() / ".k7e"
+    override = os.environ.get("K7E_HOME", "").strip()
+    if override:
+        return Path(override).expanduser()
+    xdg = os.environ.get("XDG_CONFIG_HOME", "").strip()
+    base = Path(xdg).expanduser() if xdg else Path.home() / ".config"
+    return base / "k7e"
 
 
 def config_path():

--- a/apps/k7e/docs/architecture.md
+++ b/apps/k7e/docs/architecture.md
@@ -9,7 +9,7 @@ database.
 
 ## Storage layout
 
-`K7E_HOME` (default `~/.k7e`):
+`K7E_HOME` (default `~/.config/k7e`, honoring `XDG_CONFIG_HOME`):
 
 ```
 $K7E_HOME/

--- a/apps/k7e/engine.py
+++ b/apps/k7e/engine.py
@@ -7,7 +7,8 @@ Binary assets stored content-addressed (SHA256 hash + extension).
 Same content = same hash = one file.
 
 Zero non-stdlib dependencies. Embeddings use ollama HTTP API (urllib).
-Configurable root via K7E_HOME env var (defaults to ~/.k7e).
+Configurable root via K7E_HOME env var (defaults to ~/.config/k7e, honoring
+XDG_CONFIG_HOME).
 """
 
 import hashlib
@@ -26,8 +27,12 @@ from pathlib import Path
 
 
 def _k7e_home():
-    override = os.environ.get("K7E_HOME")
-    return Path(override) if override else Path.home() / ".k7e"
+    override = os.environ.get("K7E_HOME", "").strip()
+    if override:
+        return Path(override).expanduser()
+    xdg = os.environ.get("XDG_CONFIG_HOME", "").strip()
+    base = Path(xdg).expanduser() if xdg else Path.home() / ".config"
+    return base / "k7e"
 
 
 NODES_DIR = None

--- a/apps/k7e/k7e.py
+++ b/apps/k7e/k7e.py
@@ -22,7 +22,7 @@ Surface (CLI):
   check [--fix]               structural integrity audit
 
 State:
-  K7E_HOME (env) or ~/.k7e    base directory for the knowledge store
+  K7E_HOME (env) or ~/.config/k7e   base directory for the knowledge store
   $K7E_HOME/nodes/            atomic markdown entries (source of truth)
   $K7E_HOME/mocs/             Maps of Content (mutable indexes)
   $K7E_HOME/assets/           content-addressed binaries

--- a/docs/ark.md
+++ b/docs/ark.md
@@ -39,9 +39,9 @@ r4t — roster for teams  (~/.config/r4t)
   ✓ rigs   2 rig(s): leader, worker
   ✗ teams  none under ~/.config/r4t/teams   (try: r4t init)
 
-k7e — knowledge engine  (~/.k7e)
+k7e — knowledge engine  (~/.config/k7e)
   ✓ cli    k7e -> /path/to/k7e
-  ✓ store  41 entr(ies) under ~/.k7e/nodes
+  ✓ store  41 entr(ies) under ~/.config/k7e/nodes
   ✗ index  no search index   (try: k7e reindex)
 ```
 

--- a/guides/01-hello-agent.md
+++ b/guides/01-hello-agent.md
@@ -53,9 +53,9 @@ r4t — roster for teams  (/home/you/.config/r4t)
   ✗ rigs   no rig config at /home/you/.config/r4t/rigs.json   (try: r4t init)
   ✗ teams  none under /home/you/.config/r4t/teams   (try: r4t init)
 
-k7e — knowledge engine  (/home/you/.k7e)
+k7e — knowledge engine  (/home/you/.config/k7e)
   ✓ cli    k7e -> /home/you/bin/k7e
-  ✗ store  no store at /home/you/.k7e   (try: k7e init)
+  ✗ store  no store at /home/you/.config/k7e   (try: k7e init)
 
 next: ark doctor — probe the harnesses and tools the suite runs on
 ```


### PR DESCRIPTION
Closes #264

## Migration — one command, once

Existing installs must move the store by hand; there is no fallback code:

```
mv ~/.k7e ~/.config/k7e
```

That directory holds `nodes/`, `mocs/`, `assets/`, and `config.json`. The
`.index.db` inside it is a derived cache — if you'd rather not carry it, drop
it and run `k7e reindex`.

## What changed

k7e's home resolution is now `K7E_HOME` -> `$XDG_CONFIG_HOME/k7e` ->
`~/.config/k7e`, in both `apps/k7e/config.py` and `apps/k7e/engine.py` (they
each carry their own resolver). `apps/ark/ark.py` resolved the k7e home
independently for its greeter panel, so it gets the same three-step lookup —
identical in shape to the `r4t_home()` sitting a few lines above it.

Docs and help text that printed the old path move with it: `k7e --help`'s
State block, `apps/k7e/README.md`, `apps/k7e/docs/architecture.md`,
`docs/ark.md`, and the fresh-machine panel in `guides/01-hello-agent.md`.

## Why

Repo convention is that tool state lives under `~/.config/<tool>`, never a new
`$HOME` dot-dir. r4t already followed it; k7e predates it, which left the suite
telling two different stories — visible in the ark guide, where the a8s and r4t
rows point at `~/.config/...` and the k7e row points at `~/.k7e`.

No compatibility shim and no auto-migration: pre-v1 doctrine is
scorch-the-earth, and the store is a plain directory.

## Tests

- k7e: `cd apps/k7e && tests/run` — **108 passed**
- ark: `pytest apps/ark/tests` — **37 passed** (adds
  `test_k7e_home_falls_back_to_xdg_config`, mirroring the existing r4t case)

Neither suite touched a real home before or after: k7e's tests set `K7E_HOME`
to a tmpdir in `conftest.py`, and ark's `homes` fixture does the same for all
three products.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
