### PR TITLE
docs(guides): rename tutorial agents Sol→Wren, Pip→Moss; cursor rig defaults to subscription model

### DIFF
--- a/guides/02-the-solo-agent.md
+++ b/guides/02-the-solo-agent.md
@@ -2,7 +2,7 @@
 
 ## 1. Capability
 
-At the end of this chapter you will have **Sol**: a roster of one — a
+At the end of this chapter you will have **Wren**: a roster of one — a
 single AI member behind r4t, with spend budgets, a swappable rig, and a
 conversation that persists across turns. You will prove the persistence
 with a codeword, break the configuration on purpose, and read the
@@ -73,26 +73,29 @@ with a roster of one AI and one human — you:
 - **Status:** Human
 - **Role:** Owner
 
-### Sol
+### Wren
 - **Status:** AI
 - **Rig:** solo
 - **Leader:** yes
 - **Continue:** on
-- **Workdir:** agents/sol
+- **Workdir:** agents/wren
 - **Role:** The solo agent — does the work and answers the owner
 
-Sol is a roster of one: leader, developer, and correspondent in a single
+Wren is a roster of one: leader, developer, and correspondent in a single
 seat. Keep answers short and concrete.
 ```
 
-Four lines carry the weight. `Leader: yes` — external mail enters at Sol.
+Four lines carry the weight. `Leader: yes` — external mail enters at Wren.
 `Rig: solo` — a symbolic name; what it runs comes next, from outside the
-repo. `Continue: on` — Sol's turns resume its CLI's own conversation
-instead of starting cold every wake. `Workdir: agents/sol` — Sol gets its
+repo. `Continue: on` — Wren's turns resume its CLI's own conversation
+instead of starting cold every wake. `Workdir: agents/wren` — Wren gets its
 own subfolder, so its conversation and files never collide with a future
 teammate's.
 
-Now define the `solo` rig. Pick your path:
+Now define the `solo` rig. Pick your path — and note that these two
+presets are only the blessed pair: the other popular harness CLIs are
+presets too (`r4t rig presets` lists them, and later guide branches may
+walk through more of them), added by the same one-line command.
 
 **Run** (free path)
 
@@ -113,7 +116,7 @@ set solo echo = true in /home/you/.config/r4t/rigs.json
 **Run** (subscription path)
 
 ```bash
-r4t rig add solo cursor --model claude-fable-5-medium
+r4t rig add solo cursor
 r4t rig set solo echo true
 ```
 
@@ -121,17 +124,21 @@ You should see:
 
 ```
 added rig 'solo' (cursor) to /home/you/.config/r4t/rigs.json
-  invoke: agent --model claude-fable-5-medium -p --trust --force --approve-mcps {prompt}
+  invoke: agent -p --trust --force --approve-mcps {prompt}
 Reference it from ROSTER.md: `- **Rig:** solo`
 set solo echo = true in /home/you/.config/r4t/rigs.json
 ```
 
-(`agent models` lists what your account can run; any Fable-class model
-slug works in place of `claude-fable-5-medium`.)
+No `--model` is the deliberate part: the invoke line carries no model
+flag, so the harness runs whatever your Cursor subscription defaults to —
+covered by what you already pay. Pin one with `--model <name>` and you
+can land on a frontier model billed as usage-based credits, which a
+chatty agent burns through fast; add the flag only when you mean to.
+(`agent models` lists what your account can run.)
 
-`echo true` makes Sol **stdout-only**: its turn prompt carries no
+`echo true` makes Wren **stdout-only**: its turn prompt carries no
 messaging doctrine, and whatever it prints becomes its one reply to you.
-That is the right shape for a roster of one — Sol has nobody to message
+That is the right shape for a roster of one — Wren has nobody to message
 but you — and it sidesteps a real failure mode: without echo, a member
 must send its reply with `tell`, and prose answers under ~80 characters
 are discarded as terminal chrome. Chapter 4 lifts echo when the team
@@ -150,7 +157,7 @@ You should see:
 
 ```
 You: note — Human without an Address (team cannot tell them)
-/home/you/ark/solo/ROSTER.md: OK (2 member(s), leader Sol)
+/home/you/ark/solo/ROSTER.md: OK (2 member(s), leader Wren)
 ```
 
 The note is expected: you have no a8s doorbell address yet, so the team
@@ -177,7 +184,7 @@ started solo-node as PID 23851
 ## 5. Run it
 
 You are the roster's Human, and r4t gives you a **seat**: send as
-yourself, and read what parks for you. `seat send` runs Sol's turn
+yourself, and read what parks for you. `seat send` runs Wren's turn
 synchronously — the first turn takes a minute on the free path while the
 model loads; later turns take seconds.
 
@@ -197,11 +204,11 @@ turn, r4t finds the node from inside the repo on its own.)
 You should see:
 
 ```
-── from solo:sol (2026-07-29T04:55:04.121285Z)
+── from solo:wren (2026-07-29T04:55:04.121285Z)
 My job is to do the work and answer to the owner — handling everything from leadership to development as the sole member of the solo team.
 ```
 
-Sol read its own roster block and answered in character. Now the proof
+Wren read its own roster block and answered in character. Now the proof
 that `Continue: on` means what it says — plant a codeword in one turn:
 
 **Run**
@@ -214,7 +221,7 @@ r4t seat inbox --node solo
 You should see:
 
 ```
-── from solo:sol (2026-07-29T04:55:15.702909Z)
+── from solo:wren (2026-07-29T04:55:15.702909Z)
 Codeword confirmed: TIDEPOOL.
 ```
 
@@ -230,7 +237,7 @@ r4t seat inbox --node solo
 You should see:
 
 ```
-── from solo:sol (2026-07-29T04:55:30.722365Z)
+── from solo:wren (2026-07-29T04:55:30.722365Z)
 TIDEPOOL.
 ```
 
@@ -240,7 +247,7 @@ Two processes, two wakes, one conversation. That continuity is what
 ## 7. Break it
 
 `Continue: on` needs a rig whose CLI can actually resume a conversation.
-Swap Sol's rig to the bare `ollama` preset — a raw model prompt, no
+Swap Wren's rig to the bare `ollama` preset — a raw model prompt, no
 session store, no continue support:
 
 **Run**
@@ -256,7 +263,7 @@ You should see:
 swapped rig 'solo' to ollama in /home/you/.config/r4t/rigs.json
   invoke: ollama run qwen3.6 {prompt}
 You: note — Human without an Address (team cannot tell them)
-Sol: Sol has Continue: on but rig 'solo' does not support it (preset ollama; presets that continue: agy, claude, codex, cursor, opencode, opencode-ollama) — try: r4t rig swap solo <preset>
+Wren: Wren has Continue: on but rig 'solo' does not support it (preset ollama; presets that continue: agy, claude, codex, cursor, opencode, opencode-ollama) — try: r4t rig swap solo <preset>
 1 problem(s)
 ```
 
@@ -280,8 +287,7 @@ r4t rig swap solo opencode-ollama --model qwen3.6
 r4t roster check
 ```
 
-(Subscription path: swap back to `cursor --model claude-fable-5-medium`
-instead.)
+(Subscription path: swap back to `cursor` instead.)
 
 You should see:
 
@@ -289,7 +295,7 @@ You should see:
 swapped rig 'solo' to opencode-ollama in /home/you/.config/r4t/rigs.json
   invoke: ollama launch opencode --model qwen3.6 -- run --auto --dir . {prompt}
 You: note — Human without an Address (team cannot tell them)
-/home/you/ark/solo/ROSTER.md: OK (2 member(s), leader Sol)
+/home/you/ark/solo/ROSTER.md: OK (2 member(s), leader Wren)
 ```
 
 ## 10. Check
@@ -306,24 +312,24 @@ r4t seat inbox --node solo
 You should see:
 
 ```
-── from solo:sol (2026-07-29T04:55:49.122781Z)
+── from solo:wren (2026-07-29T04:55:49.122781Z)
 TIDEPOOL.
 ```
 
-Sol still knows. The team is whole.
+Wren still knows. The team is whole.
 
 ## 11. Customize
 
-One line in the roster: bound how long Sol's conversation may sit idle.
+One line in the roster: bound how long Wren's conversation may sit idle.
 
-**Replace** `~/ark/solo/ROSTER.md` — in Sol's block, directly under
+**Replace** `~/ark/solo/ROSTER.md` — in Wren's block, directly under
 `- **Continue:** on`, add:
 
 ```markdown
 - **Flush:** 4h
 ```
 
-A conversation idle past four hours is retired — Sol is prompted once to
+A conversation idle past four hours is retired — Wren is prompted once to
 write its state to disk, and the next real message founds a fresh
 conversation from that saved state. It keeps a long-lived agent from
 dragging weeks of stale context into every turn; the full mechanics are
@@ -339,7 +345,7 @@ You should see:
 
 ```
 You: note — Human without an Address (team cannot tell them)
-/home/you/ark/solo/ROSTER.md: OK (2 member(s), leader Sol)
+/home/you/ark/solo/ROSTER.md: OK (2 member(s), leader Wren)
 ```
 
 ## 12. Commit point
@@ -354,7 +360,7 @@ in commands.)
 cd ~/ark/solo
 git init -q
 git add ROSTER.md
-git commit -q -m "solo roster: Sol, continue on, flush 4h"
+git commit -q -m "solo roster: Wren, continue on, flush 4h"
 ```
 
 Copy-paste templates for this chapter's final state live in

--- a/guides/03-the-long-memory.md
+++ b/guides/03-the-long-memory.md
@@ -2,11 +2,11 @@
 
 ## 1. Capability
 
-At the end of this chapter Sol survives conversation death. You will watch
-the **flush cycle** end an idle conversation on purpose — Sol is prompted
+At the end of this chapter Wren survives conversation death. You will watch
+the **flush cycle** end an idle conversation on purpose — Wren is prompted
 once to write his state to `STATUS.md`, the conversation is retired, and
 the next real message **refounds** him from that file. Then you will do
-something harsher: swap Sol's rig to a different CLI mid-life and watch him
+something harsher: swap Wren's rig to a different CLI mid-life and watch him
 come back coherent on the other side. The conversation is disposable; the
 agent is not.
 
@@ -16,9 +16,9 @@ About 30 minutes, most of it deliberate waiting.
 
 ## 3. Starting state
 
-- Chapter 2 complete: Sol answers at the seat, `Continue: on`, and the
+- Chapter 2 complete: Wren answers at the seat, `Continue: on`, and the
   customize step left `Flush: 4h` in his roster block.
-- Sol's conversation is live — if you just restarted the machine, send one
+- Wren's conversation is live — if you just restarted the machine, send one
   seat message so there is a conversation to flush.
 
 ## 4. The change
@@ -29,7 +29,7 @@ setting and the wrong demo — you are not going to sit here for four hours.
 The value takes bare seconds or an `s`/`m`/`h`/`d` suffix, so shrink the
 window for one session:
 
-**Replace** `~/ark/solo/ROSTER.md` — in Sol's block, the `Flush:` line
+**Replace** `~/ark/solo/ROSTER.md` — in Wren's block, the `Flush:` line
 becomes:
 
 ```markdown
@@ -47,7 +47,7 @@ You should see:
 
 ```
 You: note — Human without an Address (team cannot tell them)
-/home/you/ark/solo/ROSTER.md: OK (2 member(s), leader Sol)
+/home/you/ark/solo/ROSTER.md: OK (2 member(s), leader Wren)
 ```
 
 One rule worth knowing before you rely on this line: `Flush:` only means
@@ -56,9 +56,9 @@ conversation. Set it on a member without `Continue: on` and the lint warns
 instead of blocking:
 
 ```
-warning: Sol: Flush: set but Continue: is off — flush retires a continuing
+warning: Wren: Flush: set but Continue: is off — flush retires a continuing
 conversation, so it is ignored here
-/home/you/ark/solo/ROSTER.md: OK (2 member(s), leader Sol, 1 warning(s))
+/home/you/ark/solo/ROSTER.md: OK (2 member(s), leader Wren, 1 warning(s))
 ```
 
 Harmless, but it means the field is doing nothing. Yours says OK — keep
@@ -66,7 +66,7 @@ going.
 
 ## 5. Run it
 
-Give Sol a fact to hold, and prove he has it:
+Give Wren a fact to hold, and prove he has it:
 
 **Run**
 
@@ -78,12 +78,12 @@ r4t seat inbox --node solo
 You should see:
 
 ```
-── from solo:sol (2026-07-29T05:19:47.051352Z)
+── from solo:wren (2026-07-29T05:19:47.051352Z)
 Supply cache at grid square K-19 recorded. Confirming storage complete.
 ```
 
 Now leave the team alone for a bit over a minute — the window is 60
-seconds of *idle*, measured from Sol's last completed turn. Then run the
+seconds of *idle*, measured from Wren's last completed turn. Then run the
 idle sweep. `r4t idle` is the janitor pass a running node performs on its
 own; invoking it by hand lets you watch it work:
 
@@ -114,19 +114,19 @@ r4t logs --node solo -n 6
 You should see:
 
 ```
-r4t: FLUSH dump turn -> sol (conversation idle > 60s)
-turn: 1 message(s) -> Sol (threads 01ABC..., rig solo)
-done: Sol, exit 0 in 28.8s
-r4t: ECHO-REPLY sol (rig solo) 674 bytes of cleaned stdout staged as the reply to r4t:solo
-r4t: RELEASED solo:sol -> r4t:solo thread=01ABC... hop=1
-r4t: FLUSH retired sol's conversation — the next real message refounds it from state on disk
+r4t: FLUSH dump turn -> wren (conversation idle > 60s)
+turn: 1 message(s) -> Wren (threads 01ABC..., rig solo)
+done: Wren, exit 0 in 28.8s
+r4t: ECHO-REPLY wren (rig solo) 674 bytes of cleaned stdout staged as the reply to r4t:solo
+r4t: RELEASED solo:wren -> r4t:solo thread=01ABC... hop=1
+r4t: FLUSH retired wren's conversation — the next real message refounds it from state on disk
 ```
 
 Two `FLUSH` events bracket a real turn. The **dump turn** is an ordinary
 continuing turn whose prompt asks one thing: "Save your current state and
 progress to STATUS.md." It is logged, captured, and budgeted like any
 other turn, and only if it exits cleanly is the conversation retired. Look
-at what Sol wrote:
+at what Wren wrote:
 
 **Run**
 
@@ -137,7 +137,7 @@ cat STATUS.md
 You should see:
 
 ```
-# STATUS.md — Sol
+# STATUS.md — Wren
 
 ## Codeword
 TIDEPOOL (confirmed)
@@ -152,11 +152,11 @@ Active. No open tasks. Waiting for instructions.
 Session initialized. Stored codeword and supply cache location.
 ```
 
-Sol chose that structure himself — the dump prompt names the file, not the
+Wren chose that structure himself — the dump prompt names the file, not the
 format. (Where the file lands depends on the harness: OpenCode anchors
 relative paths at the repo root, so on the free path it appears at
-`~/ark/solo/STATUS.md`; a harness that stays in Sol's `Workdir:` writes
-`agents/sol/STATUS.md` instead. Either way it is inside the team repo,
+`~/ark/solo/STATUS.md`; a harness that stays in Wren's `Workdir:` writes
+`agents/wren/STATUS.md` instead. Either way it is inside the team repo,
 which matters at the commit point.)
 
 The conversation is now retired. Ask for the fact back:
@@ -171,7 +171,7 @@ r4t seat inbox --node solo
 You should see:
 
 ```
-── from solo:sol (2026-07-29T05:23:14.719675Z)
+── from solo:wren (2026-07-29T05:23:14.719675Z)
 The codeword was **TIDEPOOL** and the supply cache is located at **grid square K-19**.
 ```
 
@@ -187,7 +187,7 @@ Flush is scheduled death. A rig swap is sudden death: the conversation is
 keyed on the CLI that holds it, so a rig that now drives a *different* CLI
 cannot resume it — and r4t does not try, because the old CLI may be
 quota-dead and unable to run a dump turn. State on disk is whatever the
-last flush left. Swap Sol to the other path's harness (this beat needs a
+last flush left. Swap Wren to the other path's harness (this beat needs a
 second continue-capable CLI installed — `agent` here; free-path readers
 with only ollama can read along, the machinery is identical):
 
@@ -195,7 +195,7 @@ with only ollama can read along, the machinery is identical):
 
 ```bash
 r4t rig swap solo cursor --model claude-fable-5-medium
-r4t seat send --node solo "New rig, same Sol? Tell me the codeword and the cache location."
+r4t seat send --node solo "New rig, same Wren? Tell me the codeword and the cache location."
 r4t seat inbox --node solo
 ```
 
@@ -204,8 +204,8 @@ You should see:
 ```
 swapped rig 'solo' to cursor in /home/you/.config/r4t/rigs.json
   invoke: agent --model claude-fable-5-medium -p --trust --force --approve-mcps {prompt}
-── from solo:sol (2026-07-29T05:26:27.150992Z)
-Same Sol. Codeword: **TIDEPOOL**. Supply cache: **grid square K-19**. Both verified against STATUS.md.
+── from solo:wren (2026-07-29T05:26:27.150992Z)
+Same Wren. Codeword: **TIDEPOOL**. Supply cache: **grid square K-19**. Both verified against STATUS.md.
 ```
 
 And the log names what happened:
@@ -219,19 +219,19 @@ r4t logs --node solo -n 8
 You should see:
 
 ```
-r4t: QUEUED solo:you -> sol thread=01ABC... hop=0 "New rig, same Sol? Tell me the codeword and the cache location." (depth 1)
-r4t: CONTINUE-SWAP sol (rig solo) drives 'agent' but the conversation lives on 'opencode' — retired; this turn refounds from state on disk
-turn: 1 message(s) -> Sol (threads 01ABC..., rig solo)
-done: Sol, exit 0 in 12.4s
-r4t: ECHO-REPLY sol (rig solo) 102 bytes of cleaned stdout staged as the reply to solo:you
-r4t: SEAT you <- solo:sol (parked)
-r4t: RELEASED-internal solo:sol -> solo:you thread=01ABC... hop=1
-r4t: ANSWERED thread=01ABC... solo:sol -> solo:you (originator answered, thread closed)
+r4t: QUEUED solo:you -> wren thread=01ABC... hop=0 "New rig, same Wren? Tell me the codeword and the cache location." (depth 1)
+r4t: CONTINUE-SWAP wren (rig solo) drives 'agent' but the conversation lives on 'opencode' — retired; this turn refounds from state on disk
+turn: 1 message(s) -> Wren (threads 01ABC..., rig solo)
+done: Wren, exit 0 in 12.4s
+r4t: ECHO-REPLY wren (rig solo) 102 bytes of cleaned stdout staged as the reply to solo:you
+r4t: SEAT you <- solo:wren (parked)
+r4t: RELEASED-internal solo:wren -> solo:you thread=01ABC... hop=1
+r4t: ANSWERED thread=01ABC... solo:wren -> solo:you (originator answered, thread closed)
 ```
 
 `CONTINUE-SWAP`: the conversation lived on `opencode`, the rig now drives
 `agent`, so the old conversation is retired and this turn refounds — same
-mechanics as after a flush, minus the dump. Sol's identity crossed a CLI
+mechanics as after a flush, minus the dump. Wren's identity crossed a CLI
 boundary on the strength of a markdown file. Swap back:
 
 **Run**
@@ -247,7 +247,7 @@ You should see:
 ```
 swapped rig 'solo' to opencode-ollama in /home/you/.config/r4t/rigs.json
   invoke: ollama launch opencode --model qwen3.6 -- run --auto --dir . {prompt}
-── from solo:sol (2026-07-29T05:27:48.329830Z)
+── from solo:wren (2026-07-29T05:27:48.329830Z)
 Codeword: TIDEPOOL — Cache: grid square K-19
 ```
 
@@ -256,8 +256,8 @@ subtlety the event teaches: a swap that keeps the CLI (a model change, or
 `opencode` ↔ `opencode-ollama`, which both drive `opencode`) keeps the
 conversation — only a real CLI change retires it.
 
-(If a send comes back with `queued — Sol is resting (member budget ...)`,
-you have simply outrun Sol's spend budget with all this demo traffic. The
+(If a send comes back with `queued — Wren is resting (member budget ...)`,
+you have simply outrun Wren's spend budget with all this demo traffic. The
 message is queued, not lost; wait the minutes it names and run
 `r4t clear --node solo`. Chapter 4 makes that machinery the main event.)
 
@@ -279,7 +279,7 @@ r4t seat inbox --node solo
 You should see:
 
 ```
-── from solo:sol (2026-07-29T05:34:01.509705Z)
+── from solo:wren (2026-07-29T05:34:01.509705Z)
 Codeword: TIDEPOOL
 ```
 
@@ -288,7 +288,7 @@ celebrating.
 
 ## 8. Diagnose
 
-The refound turn told Sol to check a file that did not exist — so why does
+The refound turn told Wren to check a file that did not exist — so why does
 he still know? Because `STATUS.md` was never the only layer. Every turn's
 prompt carries a section r4t maintains itself:
 
@@ -302,7 +302,7 @@ belt and braces: `STATUS.md` holds what the *member* chose to write down
 (judgments, progress, structure), the rolling history holds what was
 *said* recently (until it scrolls off the cap). Delete one and the other
 covers — for a while. A fact old enough to have scrolled out of history
-survives only if Sol wrote it to `STATUS.md`. That is the layer you just
+survives only if Wren wrote it to `STATUS.md`. That is the layer you just
 deleted, and on a longer-lived agent the loss would have been real.
 
 ## 9. Fix
@@ -323,7 +323,7 @@ You should see:
 
 ```
 STATUS.md
-# STATUS.md — Sol
+# STATUS.md — Wren
 
 ## Codeword
 TIDEPOOL (confirmed)
@@ -349,18 +349,18 @@ r4t seat inbox --node solo
 You should see:
 
 ```
-── from solo:sol (2026-07-29T05:38:30.929831Z)
+── from solo:wren (2026-07-29T05:38:30.929831Z)
 Codeword: TIDEPOOL — Cache: grid square K-19
 ```
 
 Flushed, refounded, swapped, swapped back, state file deleted and
-regrown — and Sol still answers. The team is whole.
+regrown — and Wren still answers. The team is whole.
 
 ## 11. Customize
 
 Put the window back where it belongs:
 
-**Replace** `~/ark/solo/ROSTER.md` — Sol's `Flush:` line becomes:
+**Replace** `~/ark/solo/ROSTER.md` — Wren's `Flush:` line becomes:
 
 ```markdown
 - **Flush:** 4h
@@ -376,21 +376,21 @@ You should see:
 
 ```
 You: note — Human without an Address (team cannot tell them)
-/home/you/ark/solo/ROSTER.md: OK (2 member(s), leader Sol)
+/home/you/ark/solo/ROSTER.md: OK (2 member(s), leader Wren)
 ```
 
 Choosing a window is cache economics: a conversation left idle falls out
 of the provider's prompt cache, and re-caching weeks of stale context at
 frontier prices is real money spent on messages nobody needed — flush
 early enough to avoid that, late enough that normal working pauses don't
-cost Sol his short-term memory. Four hours suits a daily-driver agent; on
+cost Wren his short-term memory. Four hours suits a daily-driver agent; on
 the free path the meter is zero and the window is purely about context
 hygiene.
 
 ## 12. Commit point
 
-`STATUS.md` is Sol's own writing and it lives in the repo — version it.
-The snapshot you commit is the state Sol would refound from if the
+`STATUS.md` is Wren's own writing and it lives in the repo — version it.
+The snapshot you commit is the state Wren would refound from if the
 machine died right now:
 
 **Run**
@@ -398,7 +398,7 @@ machine died right now:
 ```bash
 cd ~/ark/solo
 git add ROSTER.md STATUS.md
-git commit -q -m "solo: Sol's first memory dump"
+git commit -q -m "solo: Wren's first memory dump"
 ```
 
-Chapter 4 gives Sol something no amount of memory provides: a teammate.
+Chapter 4 gives Wren something no amount of memory provides: a teammate.

--- a/guides/04-a-second-pair-of-hands.md
+++ b/guides/04-a-second-pair-of-hands.md
@@ -2,16 +2,16 @@
 
 ## 1. Capability
 
-At the end of this chapter the roster is two: Sol leads, and **Pip** — a
+At the end of this chapter the roster is two: Wren leads, and **Moss** — a
 zero-cost helper on the same local model — answers his questions. You will
-send Sol a task, watch him delegate to Pip with `tell`, watch Pip's answer
-come back, and read the whole exchange in the team log. You will also see,
-honestly, where a small free model fumbles the last step — and why the
-machinery guarantees the *messages* even when it cannot guarantee the
-model. Then you will starve Pip's budget and watch a message wait, unharmed,
-for the refill.
+send Wren a task, watch him delegate to Moss with `tell`, watch Moss's
+answer come back, and read the whole exchange in the team log. You will
+also see, honestly, where a small free model fumbles the last step — and
+why the machinery guarantees the *messages* even when it cannot guarantee
+the model. Then you will starve Moss's budget and watch a message wait,
+unharmed, for the refill.
 
-This chapter also keeps chapter 2's promise: echo comes off Sol here. An
+This chapter also keeps chapter 2's promise: echo comes off Wren here. An
 echo member never sees `tell`, and a leader who cannot `tell` cannot
 delegate.
 
@@ -21,11 +21,11 @@ About 30 minutes.
 
 ## 3. Starting state
 
-- Chapter 3 complete: Sol on `Continue: on` / `Flush: 4h`, answering at
+- Chapter 3 complete: Wren on `Continue: on` / `Flush: 4h`, answering at
   the seat.
 - The free path runs both members on one `qwen3.6` — no second model, no
-  extra download. (Subscription path: Pip still runs local and free; only
-  Sol's rig differs, exactly as in chapters 2–3.)
+  extra download. (Subscription path: Moss still runs local and free; only
+  Wren's rig differs, exactly as in chapters 2–3.)
 
 ## 4. The change
 
@@ -40,37 +40,37 @@ Two edits: the roster grows a member, and the rig config grows a rig.
 - **Status:** Human
 - **Role:** Owner
 
-### Sol
+### Wren
 - **Status:** AI
 - **Rig:** solo
 - **Leader:** yes
 - **Continue:** on
 - **Flush:** 4h
-- **Workdir:** agents/sol
+- **Workdir:** agents/wren
 - **Role:** The solo agent — does the work and answers the owner
 
-Sol is a roster of one: leader, developer, and correspondent in a single
+Wren is a roster of one: leader, developer, and correspondent in a single
 seat. Keep answers short and concrete.
 
-### Pip
+### Moss
 - **Status:** AI
 - **Rig:** helper
-- **Workdir:** agents/pip
-- **Role:** Helper — quick lookups and drafts for Sol
+- **Workdir:** agents/moss
+- **Role:** Helper — quick lookups and drafts for Wren
 
-Pip answers fast and short: facts, lists, first drafts. No long essays.
+Moss answers fast and short: facts, lists, first drafts. No long essays.
 ```
 
-Pip gets no `Leader:`, no `Continue:` — external mail still enters at Sol,
+Moss gets no `Leader:`, no `Continue:` — external mail still enters at Wren,
 and a helper that starts cold every turn is fine for quick lookups. The
-separate `Workdir:` keeps Pip's conversation and files out of Sol's
+separate `Workdir:` keeps Moss's conversation and files out of Wren's
 directory (two members driving the same CLI in one directory would share
-one conversation — `r4t roster check` warns about exactly that). Sol's
+one conversation — `r4t roster check` warns about exactly that). Wren's
 persona line still says "a roster of one" — as of this chapter that is a
 lie he tells himself; persona is free prose, edit it whenever you like.
 
-Now the rig. Pip is an **echo** member — stdout-only, no messaging
-doctrine, the right shape for a small model that answers questions. Sol
+Now the rig. Moss is an **echo** member — stdout-only, no messaging
+doctrine, the right shape for a small model that answers questions. Wren
 loses echo in the same breath, because the leader now has somebody to
 message:
 
@@ -93,20 +93,20 @@ Reference it from ROSTER.md: `- **Rig:** helper`
 set helper echo = true in /home/you/.config/r4t/rigs.json
 unset solo echo in /home/you/.config/r4t/rigs.json
 You: note — Human without an Address (team cannot tell them)
-/home/you/ark/solo/ROSTER.md: OK (3 member(s), leader Sol)
+/home/you/ark/solo/ROSTER.md: OK (3 member(s), leader Wren)
 ```
 
-From this turn on, Sol's prompt carries the messaging doctrine — the
-`tell` command, and a teammate list naming You and Pip.
+From this turn on, Wren's prompt carries the messaging doctrine — the
+`tell` command, and a teammate list naming You and Moss.
 
 ## 5. Run it
 
-Give Sol a task that names Pip:
+Give Wren a task that names Moss:
 
 **Run**
 
 ```bash
-r4t seat send --node solo "Ask Pip for three name ideas for our team mascot, an octopus. Pick your favorite and tell me."
+r4t seat send --node solo "Ask Moss for three name ideas for our team mascot, an octopus. Pick your favorite and tell me."
 r4t seat inbox --node solo
 ```
 
@@ -124,32 +124,32 @@ the team log (`r4t logs --node solo` shows these events; turn boundaries
 between them omitted here):
 
 ```
-r4t: QUEUED solo:you -> sol thread=01ABC... hop=0 "Ask Pip for three name ideas for our team mascot, an octopus. Pick your favorite" (depth 1)
-r4t: QUEUED solo:sol -> pip thread=01ABC... hop=1 "I need three name ideas for our team mascot — an octopus. Keep them punchy, memo" (depth 1)
-r4t: ECHO-REPLY pip (rig helper) 232 bytes of cleaned stdout staged as the reply to solo:sol
-r4t: QUEUED solo:pip -> sol thread=01ABC... hop=2 "1. **Inkwell** — evokes the octopus "pen" while sounding sharp and professional " (depth 1)
-r4t: STDOUT-REPLY sol (rig solo) released nothing; 156 bytes of cleaned stdout staged as a reply to solo:pip
-r4t: QUEUED solo:sol -> pip thread=01ABC... hop=3 "**Inkwell** is the pick. Sharp, professional, and the octopus pun lands without " (depth 1)
-r4t: ECHO-REPLY pip (rig helper) 22 bytes of cleaned stdout staged as the reply to solo:sol
-r4t: QUEUED solo:pip -> sol thread=01ABC... hop=4 "Noted. Inkwell it is 🐙" (depth 1)
+r4t: QUEUED solo:you -> wren thread=01ABC... hop=0 "Ask Moss for three name ideas for our team mascot, an octopus. Pick your favorit" (depth 1)
+r4t: QUEUED solo:wren -> moss thread=01ABC... hop=1 "I need three name ideas for our team mascot — an octopus. Keep them punchy, memo" (depth 1)
+r4t: ECHO-REPLY moss (rig helper) 232 bytes of cleaned stdout staged as the reply to solo:wren
+r4t: QUEUED solo:moss -> wren thread=01ABC... hop=2 "1. **Inkwell** — evokes the octopus "pen" while sounding sharp and professional " (depth 1)
+r4t: STDOUT-REPLY wren (rig solo) released nothing; 156 bytes of cleaned stdout staged as a reply to solo:moss
+r4t: QUEUED solo:wren -> moss thread=01ABC... hop=3 "**Inkwell** is the pick. Sharp, professional, and the octopus pun lands without " (depth 1)
+r4t: ECHO-REPLY moss (rig helper) 22 bytes of cleaned stdout staged as the reply to solo:wren
+r4t: QUEUED solo:moss -> wren thread=01ABC... hop=4 "Noted. Inkwell it is 🐙" (depth 1)
 ```
 
-Read it hop by hop. **Hop 1** is the delegation working: Sol ran `tell pip`
-himself — a real shell command, composed and executed by a small local
-model. **Hop 2** is Pip's echo: no tools, no doctrine, just three names
-staged straight back as the reply. **Hop 3** is the fumble: Sol *decided*
-("Inkwell is the pick") but printed his answer instead of telling you, so
-the `STDOUT-REPLY` fallback staged his stdout as a reply to the newest
-sender — which was Pip, not you. Pip politely acknowledged (hop 4), the
-two drifted into housekeeping for a few more hops, and r4t ended the loop
-the boring way:
+Read it hop by hop. **Hop 1** is the delegation working: Wren ran
+`tell moss` himself — a real shell command, composed and executed by a
+small local model. **Hop 2** is Moss's echo: no tools, no doctrine, just
+three names staged straight back as the reply. **Hop 3** is the fumble:
+Wren *decided* ("Inkwell is the pick") but printed his answer instead of
+telling you, so the `STDOUT-REPLY` fallback staged his stdout as a reply
+to the newest sender — which was Moss, not you. Moss politely
+acknowledged (hop 4), the two drifted into housekeeping for a few more
+hops, and r4t ended the loop the boring way:
 
 ```
-r4t: SILENT sol (rig solo) exit 0 with 85 bytes of stdout but nothing worth relaying survived transcript cleaning
+r4t: SILENT wren (rig solo) exit 0 with 85 bytes of stdout but nothing worth relaying survived transcript cleaning
 ```
 
 Nothing crashed, nothing looped forever, nobody spent money — but you
-never got your answer, because the last mile (Sol messaging *you*) is the
+never got your answer, because the last mile (Wren messaging *you*) is the
 one step that needs the model to follow instructions, and small local
 models follow them intermittently. Watch it happen in miniature — ask
 again and demand the `tell`:
@@ -166,7 +166,7 @@ You should see:
 
 ```
 (no unread messages)
-### Output (Sol, exit 0 in 13.2s)
+### Output (Wren, exit 0 in 13.2s)
 
 [0m
 > build · qwen3.6:latest
@@ -174,53 +174,53 @@ You should see:
 tell you "Inkwell 🐙"
 ```
 
-Sol *printed* `tell you "Inkwell 🐙"` as text — the exact mistake the
+Wren *printed* `tell you "Inkwell 🐙"` as text — the exact mistake the
 doctrine warns about ("printing it as text sends nothing"). Twelve
 characters of perfect answer, discarded as terminal chrome by the sub-80
-threshold you met in chapter 2. This is why chapter 2 shipped Sol with
+threshold you met in chapter 2. This is why chapter 2 shipped Wren with
 echo on, and it is the honest cost of lifting it.
 
 Now the two ways you actually get answers out of this team. First: the
-stdout fallback *does* reach you whenever Sol's answer has substance,
+stdout fallback *does* reach you whenever Wren's answer has substance,
 because a fresh question from you makes you the newest sender:
 
 **Run**
 
 ```bash
-r4t seat send --node solo "Report in two or three full sentences: what did you ask Pip, what did Pip offer, and which mascot name won?"
+r4t seat send --node solo "Report in two or three full sentences: what did you ask Moss, what did Moss offer, and which mascot name won?"
 r4t seat inbox --node solo
 ```
 
 You should see:
 
 ```
-── from solo:sol (2026-07-29T05:47:12.961106Z)
-I asked Pip for three octopus name ideas. Pip offered Inkwell, Blotz, and Eight. Inkwell won — sharp, professional, with a subtle ink pun that lands cleanly.
+── from solo:wren (2026-07-29T05:47:12.961106Z)
+I asked Moss for three octopus name ideas. Moss offered Inkwell, Blotz, and Eight. Inkwell won — sharp, professional, with a subtle ink pun that lands cleanly.
 ```
 
-There is the delegated round trip, synthesized and delivered — Sol never
+There is the delegated round trip, synthesized and delivered — Wren never
 ran `tell`, and the machinery covered for him: the log shows
-`r4t: STDOUT-REPLY sol (rig solo) released nothing; 157 bytes of cleaned
+`r4t: STDOUT-REPLY wren (rig solo) released nothing; 157 bytes of cleaned
 stdout staged as a reply to solo:you`. Second: the direct route. The seat
 can address any member, so for quick lookups skip the middleman:
 
 **Run**
 
 ```bash
-r4t seat send --node solo --to pip "Three verbs that describe what an octopus does. Just the list."
+r4t seat send --node solo --to moss "Three verbs that describe what an octopus does. Just the list."
 r4t seat inbox --node solo
 ```
 
 You should see:
 
 ```
-── from solo:pip (2026-07-29T05:47:58.265173Z)
+── from solo:moss (2026-07-29T05:47:58.265173Z)
 1. Jet
 2. Camouflage
 3. Grasp
 ```
 
-(On the subscription path Sol runs `tell` reliably and the first send
+(On the subscription path Wren runs `tell` reliably and the first send
 comes back synthesized on hop 3 — the machinery is identical, the model
 discipline is what you are paying for.) Now look at the team as a whole:
 
@@ -235,8 +235,8 @@ You should see (roster section):
 ```
 Roster  (repo settings: /home/you/ark/solo/ROSTER.md)
     You  Human  address=(none)   (try: add an **Address:** line so the team can reach them)
-  ✓ Sol  rig=solo  budget=5.2/8  [leader]
-  ✓ Pip  rig=helper  budget=7/8
+  ✓ Wren  rig=solo  budget=5.2/8  [leader]
+  ✓ Moss  rig=helper  budget=7/8
 ```
 
 Two members, two spend buckets, every turn above accounted for.
@@ -246,16 +246,16 @@ Two members, two spend buckets, every turn above accounted for.
 Budgets have been sitting in that status line since chapter 2 without ever
 biting. Make one bite. Each rig can carry a machine-global spend bucket —
 `rig_budget_max` units, refilled at `rig_budget_earn_per_hour` — sized for
-the real subscription behind it. Give Pip's rig a bucket of one:
+the real subscription behind it. Give Moss's rig a bucket of one:
 
 **Run**
 
 ```bash
 r4t rig set helper rig_budget_max 1
 r4t rig set helper rig_budget_earn_per_hour 1
-r4t seat send --node solo --to pip "One fun fact about octopus arms."
+r4t seat send --node solo --to moss "One fun fact about octopus arms."
 r4t seat inbox --node solo
-r4t seat send --node solo --to pip "And one about octopus hearts."
+r4t seat send --node solo --to moss "And one about octopus hearts."
 ```
 
 You should see:
@@ -263,10 +263,10 @@ You should see:
 ```
 set helper rig_budget_max = 1 in /home/you/.config/r4t/rigs.json
 set helper rig_budget_earn_per_hour = 1 in /home/you/.config/r4t/rigs.json
-── from solo:pip (2026-07-29T05:48:56.279303Z)
+── from solo:moss (2026-07-29T05:48:56.279303Z)
 Each of an octopus's eight arms can taste, touch, and move independently—thanks to most of its neurons residing in the arms rather than the brain.
 
-queued — Pip is resting — rig helper exhausted (0), ready in ~59 min
+queued — Moss is resting — rig helper exhausted (0), ready in ~59 min
 ```
 
 The first question ran — and spent the bucket's single unit. The second
@@ -286,12 +286,12 @@ r4t logs --node solo -n 1
 You should see (roster section, and the log line):
 
 ```
-  ✓ Pip  rig=helper  budget=6.1/8  rig=0/1  1 queued  RESTING (rig helper, ready in ~59 min)
-r4t: RESTING pip — resting — rig helper exhausted (0), ready in ~59 min (1 queued)
+  ✓ Moss  rig=helper  budget=6.1/8  rig=0/1  1 queued  RESTING (rig helper, ready in ~59 min)
+r4t: RESTING moss — resting — rig helper exhausted (0), ready in ~59 min (1 queued)
 ```
 
 Nothing was refused and nothing was dropped: the message is **queued**,
-durably, in Pip's queue on disk. An empty bucket means *resting*, not
+durably, in Moss's queue on disk. An empty bucket means *resting*, not
 *muted* — the queue simply holds until the bucket refills, and then the
 turn runs with every queued message in one batch. This is the doctrine the
 whole dispatcher is built on: gates govern *when* a member runs, never
@@ -318,7 +318,7 @@ unset helper rig_budget_max in /home/you/.config/r4t/rigs.json
 unset helper rig_budget_earn_per_hour in /home/you/.config/r4t/rigs.json
 drained 1 queued turn(s); nudged the leader on 0 quiet thread(s)
 pruned 0 stale lock(s); expired 0 thread(s); drained 0 more queued turn(s)
-── from solo:pip (2026-07-29T05:50:20.969451Z)
+── from solo:moss (2026-07-29T05:50:20.969451Z)
 An octopus has three hearts. Two pump blood to the gills, one to the body. The main heart stops when swimming, which is why they prefer crawling.
 ```
 
@@ -333,25 +333,25 @@ One full round trip through the leader, end to end:
 **Run**
 
 ```bash
-r4t seat send --node solo "In two or three full sentences: what has Pip contributed to this team so far?"
+r4t seat send --node solo "In two or three full sentences: what has Moss contributed to this team so far?"
 r4t seat inbox --node solo
 ```
 
 You should see:
 
 ```
-── from solo:sol (2026-07-29T05:56:13.232267Z)
-Two things, both concrete: Pip drafted three octopus name options for our mascot (we landed on Inkwell), then committed ROSTER.md with Pip added to the team at `0a80bcf`. That's it — two small, done items.
+── from solo:wren (2026-07-29T05:56:13.232267Z)
+Two things, both concrete: Moss drafted three octopus name options for our mascot (we landed on Inkwell), then committed ROSTER.md with Moss added to the team at `0a80bcf`. That's it — two small, done items.
 ```
 
-Sol knows what his helper has done. (That commit hash is real: the
+Wren knows what his helper has done. (That commit hash is real: the
 "housekeeping drift" in section 6 was the pair committing the roster on
 their own initiative — `git log` in the team repo will show it.) The team
 is whole — and it is a team now.
 
 ## 11. Customize
 
-Pip's model is one setting. Any model in `ollama ls` slots in:
+Moss's model is one setting. Any model in `ollama ls` slots in:
 
 **Run**
 
@@ -365,8 +365,8 @@ You should see:
 set helper model = qwen3:1.7b in /home/you/.config/r4t/rigs.json
 ```
 
-A 1.7B Pip answers in a fraction of the time and a fraction of the
-quality — try one `--to pip` lookup and judge the trade; set it back the
+A 1.7B Moss answers in a fraction of the time and a fraction of the
+quality — try one `--to moss` lookup and judge the trade; set it back the
 same way. One more knob while you are here: `echo_max_chars` (default
 1500) caps an echo member's reply body — anything longer is truncated
 with the full text attached to the same envelope as a markdown file.
@@ -381,7 +381,7 @@ repo with `solo`, by design.)
 ```bash
 cd ~/ark/solo
 git add ROSTER.md
-git commit -q -m "solo roster: Pip joins — helper rig, echo lifted from Sol"
+git commit -q -m "solo roster: Moss joins — helper rig, echo lifted from Wren"
 ```
 
 Copy-paste templates for this chapter's final state live in

--- a/guides/README.md
+++ b/guides/README.md
@@ -26,9 +26,9 @@ along; the wordmark just files the paperwork.
 | # | Chapter | What you raise |
 |---|---------|----------------|
 | 01 | [Hello, Agent](01-hello-agent.md) | Your first a8s agent — tell it something, get a reply. No LLM required. |
-| 02 | [The Solo Agent](02-the-solo-agent.md) | A governed roster of one: Sol, on r4t, with a conversation that persists. |
-| 03 | [The Long Memory](03-the-long-memory.md) | Flush, refound, and rig portability — what Sol keeps when the conversation ends. |
-| 04 | [A Second Pair of Hands](04-a-second-pair-of-hands.md) | The roster grows to two: Sol delegates, Pip answers for free, budgets bite. |
+| 02 | [The Solo Agent](02-the-solo-agent.md) | A governed roster of one: Wren, on r4t, with a conversation that persists. |
+| 03 | [The Long Memory](03-the-long-memory.md) | Flush, refound, and rig portability — what Wren keeps when the conversation ends. |
+| 04 | [A Second Pair of Hands](04-a-second-pair-of-hands.md) | The roster grows to two: Wren delegates, Moss answers for free, budgets bite. |
 | 05+ | *(coming)* | k7e, more seats, cells, missions, and the machinery of a real crew. |
 
 ## Two blessed paths

--- a/guides/templates/02-solo-cursor/README.md
+++ b/guides/templates/02-solo-cursor/README.md
@@ -1,3 +1,4 @@
-Chapter 2's final state on the subscription path (Cursor agent CLI, Fable-class model).
+Chapter 2's final state on the subscription path (Cursor agent CLI, the
+subscription's default model — no `--model` pin).
 Copy ROSTER.md into your team repo (e.g. `~/ark/solo/`), then run rig-setup.sh.
 Used by [guides/02-the-solo-agent.md](../../02-the-solo-agent.md).

--- a/guides/templates/02-solo-cursor/ROSTER.md
+++ b/guides/templates/02-solo-cursor/ROSTER.md
@@ -4,14 +4,14 @@
 - **Status:** Human
 - **Role:** Owner
 
-### Sol
+### Wren
 - **Status:** AI
 - **Rig:** solo
 - **Leader:** yes
 - **Continue:** on
 - **Flush:** 4h
-- **Workdir:** agents/sol
+- **Workdir:** agents/wren
 - **Role:** The solo agent — does the work and answers the owner
 
-Sol is a roster of one: leader, developer, and correspondent in a single
+Wren is a roster of one: leader, developer, and correspondent in a single
 seat. Keep answers short and concrete.

--- a/guides/templates/02-solo-cursor/rig-setup.sh
+++ b/guides/templates/02-solo-cursor/rig-setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-r4t rig add solo cursor --model claude-fable-5-medium
+r4t rig add solo cursor
 r4t rig set solo echo true

--- a/guides/templates/02-solo-opencode-ollama/ROSTER.md
+++ b/guides/templates/02-solo-opencode-ollama/ROSTER.md
@@ -4,14 +4,14 @@
 - **Status:** Human
 - **Role:** Owner
 
-### Sol
+### Wren
 - **Status:** AI
 - **Rig:** solo
 - **Leader:** yes
 - **Continue:** on
 - **Flush:** 4h
-- **Workdir:** agents/sol
+- **Workdir:** agents/wren
 - **Role:** The solo agent — does the work and answers the owner
 
-Sol is a roster of one: leader, developer, and correspondent in a single
+Wren is a roster of one: leader, developer, and correspondent in a single
 seat. Keep answers short and concrete.

--- a/guides/templates/04-two-member/README.md
+++ b/guides/templates/04-two-member/README.md
@@ -1,4 +1,4 @@
-Chapter 4's final state on the free path (Sol + Pip, both OpenCode via
-ollama, qwen3.6; echo lifted from Sol, echo on Pip).
+Chapter 4's final state on the free path (Wren + Moss, both OpenCode via
+ollama, qwen3.6; echo lifted from Wren, echo on Moss).
 Copy ROSTER.md into your team repo (e.g. `~/ark/solo/`), then run rig-setup.sh.
 Used by [guides/04-a-second-pair-of-hands.md](../../04-a-second-pair-of-hands.md).

--- a/guides/templates/04-two-member/ROSTER.md
+++ b/guides/templates/04-two-member/ROSTER.md
@@ -4,22 +4,22 @@
 - **Status:** Human
 - **Role:** Owner
 
-### Sol
+### Wren
 - **Status:** AI
 - **Rig:** solo
 - **Leader:** yes
 - **Continue:** on
 - **Flush:** 4h
-- **Workdir:** agents/sol
+- **Workdir:** agents/wren
 - **Role:** The solo agent — does the work and answers the owner
 
-Sol is a roster of one: leader, developer, and correspondent in a single
+Wren is a roster of one: leader, developer, and correspondent in a single
 seat. Keep answers short and concrete.
 
-### Pip
+### Moss
 - **Status:** AI
 - **Rig:** helper
-- **Workdir:** agents/pip
-- **Role:** Helper — quick lookups and drafts for Sol
+- **Workdir:** agents/moss
+- **Role:** Helper — quick lookups and drafts for Wren
 
-Pip answers fast and short: facts, lists, first drafts. No long essays.
+Moss answers fast and short: facts, lists, first drafts. No long essays.


### PR DESCRIPTION
Closes #268.

## Why

The Ark Raising's tutorial agents were named **Sol** and **Pip**. Both collide with something the reader has open in the same terminal:

- **Sol** is OpenAI's flagship model. Model ids like `gpt-5.6-sol` show up beside the guide's own commands, and a reader cannot tell whether "Sol" names their agent or a model slug.
- **Pip** is Python's `pip`. A tutorial that says "ask Pip" next to install instructions teaches ambiguity.

New names: **Sol → Wren**, **Pip → Moss**.

Also: chapter 2's subscription path pinned `--model claude-fable-5-medium` on the Cursor rig. Wrong default to teach — with no `--model` the harness runs whatever the Cursor subscription defaults to (covered by what the reader already pays), while a pinned frontier model bills as usage-based credits that a chatty agent burns through fast.

## What changed

Renamed occurrences per file (prose, ROSTER headings, `Workdir:` dirs, and captured terminal output all moved together):

| File | Renames |
|---|---|
| `guides/02-the-solo-agent.md` | 27 |
| `guides/03-the-long-memory.md` | 54 |
| `guides/04-a-second-pair-of-hands.md` | 89 |
| `guides/README.md` | 4 |
| `guides/templates/02-solo-cursor/ROSTER.md` | 3 |
| `guides/templates/02-solo-opencode-ollama/ROSTER.md` | 3 |
| `guides/templates/04-two-member/README.md` | 4 |
| `guides/templates/04-two-member/ROSTER.md` | 7 |
| **Total** | **191** |

Captured output moved with the prose: `solo:sol` → `solo:wren`, `solo:pip` → `solo:moss`, `-> sol` / `-> pip` log targets, `ECHO-REPLY`/`STDOUT-REPLY`/`RESTING`/`CONTINUE-SWAP`/`FLUSH` event lines, `leader Sol` → `leader Wren` in `roster check`, `# STATUS.md — Sol` → `— Wren`, and the `r4t status` roster rows. The one QUEUED preview whose text contains an agent name was re-truncated to the dispatcher's real 80-char cap (`dispatch.py:830`) so the longer name does not silently produce an 81-char preview.

### Cursor rig — no `--model`

`r4t rig add solo cursor` (and `templates/02-solo-cursor/rig-setup.sh`, and chapter 2's swap-back aside) drop the model pin. Re-captured for real by running `apps/r4t/r4t.py rig add solo cursor` in a scratch `R4T_HOME`, path-normalized to the guide's `/home/you` style:

```
added rig 'solo' (cursor) to /home/you/.config/r4t/rigs.json
  invoke: agent -p --trust --force --approve-mcps {prompt}
Reference it from ROSTER.md: `- **Rig:** solo`
set solo echo = true in /home/you/.config/r4t/rigs.json
```

(The `set solo echo` line was likewise re-captured; the `invoke:` line is the substantive change — no `--model` flag reaches the harness.) A short note under the block names the trade-off so `--model` stays a deliberate choice.

Chapter 3's `r4t rig swap solo cursor --model claude-fable-5-medium` is **left as-is**: that beat deliberately demonstrates a model-pinned swap and its captured `invoke:` line is self-consistent with the command above it.

### Door-open sentence

At chapter 2's rig fork: the two blessed presets are not the only ones — `r4t rig presets` lists the other popular harness CLIs, added by the same one-line command, and later guide branches may walk through more of them. Nothing implemented for them here.

## Verification

- `grep -rniE '\bsol\b|\bpip\b' guides/` → **zero hits**. No residual left alone: every lowercase `sol`/`pip` in the guides was the agent (I enumerated all 57 matches before touching anything — none was Python's `pip`).
- `solo` survives intact everywhere it should: the team, the namespace, the rig name, `solo-node`, `~/ark/solo`, and the chapter title "The Solo Agent". Word-boundary matching (`\bSol\b`) never fires inside `Solo`/`solo`.
- Templates are internally consistent — `### Wren` / `Workdir: agents/wren` and `### Moss` / `Workdir: agents/moss` in all three ROSTERs; `rig-setup.sh` rig names (`solo`, `helper`) match the `Rig:` lines.
- Prose re-wrapped where the longer names broke the ~76-col fill (chapter 4 sections 1 and 6). No line the change touched now exceeds the file's existing width; the 5 remaining over-width lines are pre-existing and untouched.
- No guide-specific CI job exists (`.github/workflows/test.yml` filters on `apps/**`); the PR-only `pii-check` job applies and the diff introduces no flagged terms.

## Scope guard

The `a8s add ... example-definition.json` / `a8s namespace` / `a8s start` registration lines in `02-the-solo-agent.md` are **not touched** — verified with `git diff | grep 'a8s add\|definition:\|example-definition'` returning nothing — so the in-flight named-`r4t`-definition PR merges cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
