### PR TITLE
fix(r4t): rigs ls alias + aligned human-readable listing

### DIFF
--- a/apps/r4t/README.md
+++ b/apps/r4t/README.md
@@ -34,7 +34,7 @@ Now a real team on your repo:
 cd ~/your-repo
 r4t init          # writes ROSTER.md (owner + Lead + Dev) and rigs.json
 r4t roster check  # -> ".../ROSTER.md: OK (3 member(s), leader Lead)"
-r4t rig list      # each rig's CLI, limits, and roster resolution
+r4t rig ls        # each rig's model, limits, and roster resolution
 ```
 
 The roster names members and symbolic rigs; `~/.config/r4t/rigs.json` maps

--- a/apps/r4t/docs/tutorial.md
+++ b/apps/r4t/docs/tutorial.md
@@ -96,7 +96,7 @@ Humans use `Status: Human` and never get a rig. Optional
 
 ```bash
 r4t roster check      # roster shape + every Rig line resolves to a rig
-r4t rig list      # rigs, invoke lines, and roster resolution
+r4t rig ls        # rigs, limits, and roster resolution (--wide adds invokes)
 ```
 
 Fix anything `roster check` reports before registering the team or sending
@@ -201,7 +201,7 @@ ordinary `tell` and release after the turn. Full walk-through:
 | `r4t init` | Starter `ROSTER.md` + `~/.config/r4t/rigs.json` |
 | `r4t rig presets` | Named CLI templates (from a8s definitions) |
 | `r4t rig add <rig> <preset>` | Define a rig in the rig config |
-| `r4t rig list` | Show rigs and how roster members resolve |
+| `r4t rig list` (alias `ls`) | Show rigs and how roster members resolve (`--wide` for invoke lines) |
 | `r4t roster check` | Lint roster and rig mappings |
 | `r4t status --node <team>` | Member budgets, queue depths, threads, dead letters |
 | `r4t sandbox --fake` | End-to-end plumbing test without LLM calls |

--- a/apps/r4t/r4t.py
+++ b/apps/r4t/r4t.py
@@ -28,6 +28,7 @@ from dispatch import (
     split_recipient,
 )
 from rig import (
+    DEFAULT_CONCURRENCY,
     RigError,
     HARNESS_PRESETS,
     add_preset_rig,
@@ -63,7 +64,7 @@ R4T_DIR = Path(__file__).resolve().parent
 COMMAND_HELP = [
     ("init", "Write starter ROSTER.md and ~/.config/r4t/rigs.json; print a8s registration"),
     ("status", "Budgets, queues, open threads, dead letters for one team"),
-    ("rig list", "Rig invoke lines, limits, and roster rig resolution"),
+    ("rig list", "Rigs, limits, and roster rig resolution (alias: ls)"),
     ("rig presets", "Named CLI presets aligned with a8s definitions"),
     ("rig add <rig> <preset>", "Add a rig to ~/.config/r4t/rigs.json from a preset"),
     ("rig remove <rig>", "Remove a rig from the config (alias: rm)"),
@@ -173,69 +174,152 @@ def _context(args: argparse.Namespace, node: str) -> DispatchContext:
     )
 
 
-def _print_rig_summary(config_path: Path, roster_path: Path | None = None) -> None:
+def _print_table(
+    headers: list[str], rows: list[tuple[str, ...]], indent: str = ""
+) -> None:
+    """Aligned columns in the shape `a8s ls` uses: uppercase header, three-space
+    gutters, no padding on the trailing column."""
+    widths = [len(h) for h in headers]
+    for row in rows:
+        for i, cell in enumerate(row):
+            widths[i] = max(widths[i], len(cell))
+
+    def fmt(cells: tuple[str, ...]) -> str:
+        last = len(cells) - 1
+        line = "   ".join(
+            cell.ljust(widths[i]) if i < last else cell
+            for i, cell in enumerate(cells)
+        )
+        return f"{indent}{line}"
+
+    print(fmt(tuple(headers)))
+    for row in rows:
+        print(fmt(row))
+
+
+def _rig_model(rig) -> str:
+    """What this rig actually runs. An explicit `model` setting wins; otherwise
+    read the token after --model/-m, which is where a preset-built invoke
+    carries it."""
+    if rig.model:
+        return rig.model
+    argv = next(iter(rig.pool()), [])
+    for flag in ("--model", "-m"):
+        if flag in argv:
+            at = argv.index(flag) + 1
+            if at < len(argv):
+                return argv[at]
+    return "-"
+
+
+def _print_rig_table(config, indent: str, wide: bool) -> None:
+    rigs = [(n, config.rigs[n]) for n in sorted(config.rigs) if not config.rigs[n].error]
+    show_concurrency = any(r.concurrency != DEFAULT_CONCURRENCY for _, r in rigs)
+    show_rig_budget = any(r.rig_budget_max is not None for _, r in rigs)
+
+    headers = ["RIG", "PRESET", "MODEL"]
+    if show_concurrency:
+        headers.append("CONC")
+    headers += ["TIMEOUT", "SENDS", "BUDGET"]
+    if show_rig_budget:
+        headers.append("RIG-BUDGET")
+    if wide:
+        headers.append("INVOKE")
+
+    rows: list[tuple[str, ...]] = []
+    for name, rig in rigs:
+        row = [name, rig.preset or "-", _rig_model(rig)]
+        if show_concurrency:
+            row.append(str(rig.concurrency))
+        row += [
+            f"{rig.timeout_seconds:g}s",
+            str(rig.max_sends_per_turn),
+            f"{rig.budget_max:g}/+{rig.budget_earn_per_hour:g}h",
+        ]
+        if show_rig_budget:
+            row.append(
+                "-"
+                if rig.rig_budget_max is None
+                else f"{rig.rig_budget_max:g}/+{rig.rig_budget_earn_per_hour:g}h"
+            )
+        if wide:
+            pool = rig.pool()
+            argv = " ".join(pool[0])
+            if len(pool) > 1:
+                argv += f"  [+{len(pool) - 1} pool variant(s)]"
+            row.append(argv)
+        rows.append(tuple(row))
+
+    if rows:
+        _print_table(headers, rows, indent)
+    invalid = [(n, config.rigs[n]) for n in sorted(config.rigs) if config.rigs[n].error]
+    if invalid:
+        print()
+        print(f"{indent}invalid:")
+        for name, rig in invalid:
+            print(f"{indent}  {name}: {rig.error}")
+        print(f"{indent}  (try: edit {config.path})")
+
+
+def _print_roster_table(config, roster_path: Path, indent: str) -> None:
+    try:
+        roster = load_roster(roster_path)
+    except RosterError as e:
+        print(f"{indent}roster ({roster_path.name}): {e}")
+        return
+    rows: list[tuple[str, ...]] = []
+    for m in roster.members:
+        if m.is_human:
+            rows.append((m.name, "-", "human"))
+        elif m.errors:
+            rows.append((m.name, "-", f"DISABLED — {m.error}"))
+        else:
+            rig, err, pinned = config.rig_for(m)
+            if rig is None:
+                rows.append((m.name, "-", f"FAIL CLOSED — {err}"))
+            else:
+                rows.append((m.name, rig.name, "pinned" if pinned else ""))
+    print(f"{indent}roster ({roster_path}):")
+    _print_table(["MEMBER", "RIG", "NOTE"], rows, indent + "  ")
+
+
+def _print_rig_summary(
+    config_path: Path,
+    roster_path: Path | None = None,
+    *,
+    indent: str = "  ",
+    wide: bool = False,
+) -> None:
     try:
         config = load_rig_config(config_path)
     except RigError as e:
-        print(f"  error: {e}")
+        print(f"{indent}error: {e}")
         return
     if config.missing:
-        print("  (no rigs yet — try: r4t rig add <rig> <preset>, or r4t init)")
+        print(f"{indent}(no rigs yet — try: r4t rig add <rig> <preset>, or r4t init)")
         return
-    for name in sorted(config.rigs):
-        rig = config.rigs[name]
-        if rig.error:
-            print(f"  {name}: INVALID — {rig.error}")
-            continue
-        pool = rig.pool()
-        argv = " ".join(pool[0])
-        if len(pool) > 1:
-            argv += f"  [+{len(pool) - 1} pool variant(s)]"
-        limits = (
-            f"timeout={rig.timeout_seconds:g}s "
-            f"budget={rig.budget_max:g}/+{rig.budget_earn_per_hour:g}per-h "
-            f"sends={rig.max_sends_per_turn}"
-        )
-        if rig.rig_budget_max is not None:
-            limits += (
-                f" rig-budget={rig.rig_budget_max:g}/"
-                f"+{rig.rig_budget_earn_per_hour:g}per-h"
-            )
-        print(f"  {name}: {argv}  ({limits})")
+    _print_rig_table(config, indent, wide)
     if config.pins:
-        print("  pins:")
+        print()
+        print(f"{indent}pins:")
         for agent in sorted(config.pins):
-            print(f"    {agent} -> {config.pins[agent]}")
+            print(f"{indent}  {agent} -> {config.pins[agent]}")
+    print()
     print(
-        f"  throttle: max_concurrent={config.throttle.max_concurrent} "
+        f"{indent}throttle:   max_concurrent={config.throttle.max_concurrent} "
         f"min_seconds_between_turn_starts="
         f"{config.throttle.min_seconds_between_turn_starts:g}"
     )
     print(
-        f"  governance: cell_budget={config.cell_budget_max:g}/"
+        f"{indent}governance: cell_budget={config.cell_budget_max:g}/"
         f"+{config.cell_budget_earn_per_hour:g}per-h "
         f"quiet_task={config.quiet_task_seconds:g}s "
         f"breaker_cap={config.breaker_cap} "
         f"breaker_cooldown={config.breaker_cooldown_seconds:g}s"
     )
     if roster_path and roster_path.is_file():
-        try:
-            roster = load_roster(roster_path)
-        except RosterError as e:
-            print(f"  roster ({roster_path.name}): {e}")
-            return
-        print(f"  roster ({roster_path}):")
-        for m in roster.members:
-            if m.is_human:
-                print(f"    {m.name}: Human")
-            elif m.errors:
-                print(f"    {m.name}: DISABLED — {m.error}")
-            else:
-                rig, err, pinned = config.rig_for(m)
-                if rig is None:
-                    print(f"    {m.name}: FAIL CLOSED — {err}")
-                else:
-                    print(f"    {m.name}: {rig.name}" + (" (pinned)" if pinned else ""))
+        print()
+        _print_roster_table(config, roster_path, indent)
 
 
 def _print_team_summaries() -> None:
@@ -926,7 +1010,7 @@ def cmd_seat(args: argparse.Namespace) -> int:
 
 
 RIG_COMMAND_HELP = [
-    ("rig list", "Rig invoke lines, limits, and roster rig resolution"),
+    ("rig list", "Rigs, limits, and roster rig resolution (alias: ls; --wide)"),
     ("rig presets", "Named CLI presets aligned with a8s definitions"),
     ("rig add <rig> <preset>", "Add a rig (creates the config if needed; --model M, --force)"),
     ("rig swap <rig> <preset>", "Switch an existing rig to a preset, keeping its settings"),
@@ -970,8 +1054,17 @@ def cmd_rig_overview(args: argparse.Namespace) -> int:
 def cmd_rig_list(args: argparse.Namespace) -> int:
     config_path = resolve_config_path(args.rig_config)
     print(f"rig config: {config_path}" + (" (missing)" if not config_path.is_file() else ""))
+    print()
     roster_path = resolve_roster_path(_resolve_root(args.root), args.roster)
-    _print_rig_summary(config_path, roster_path if roster_path.is_file() else None)
+    _print_rig_summary(
+        config_path,
+        roster_path if roster_path.is_file() else None,
+        indent="",
+        wide=args.wide,
+    )
+    if config_path.is_file() and not args.wide:
+        print()
+        print("(full invoke lines: r4t rig ls --wide)")
     return 0
 
 
@@ -1580,9 +1673,16 @@ def build_parser() -> argparse.ArgumentParser:
     rig_p.set_defaults(func=cmd_rig_overview)
     rig_sub = rig_p.add_subparsers(dest="action", required=False)
     rig_list_p = rig_sub.add_parser(
-        "list", help="Show configured rigs and resolved roster rigs."
+        "list",
+        aliases=["ls"],
+        help="Show configured rigs and resolved roster rigs.",
     )
     _add_common(rig_list_p)
+    rig_list_p.add_argument(
+        "--wide",
+        action="store_true",
+        help="Add each rig's full invoke line as a trailing column.",
+    )
     rig_list_p.set_defaults(func=cmd_rig_list)
 
     rig_presets_p = rig_sub.add_parser(

--- a/apps/r4t/tests/test_dispatch.py
+++ b/apps/r4t/tests/test_dispatch.py
@@ -2002,10 +2002,35 @@ class TestCli:
         rc = self.run("rig", "list", "--root", str(repo), "--rig-config", str(rig_config))
         assert rc == 0
         out = capsys.readouterr().out
-        assert "junior-dev:" in out
+        lines = out.splitlines()
+        header = next(line for line in lines if line.startswith("RIG "))
+        assert header.split() == [
+            "RIG", "PRESET", "MODEL", "CONC", "TIMEOUT", "SENDS", "BUDGET",
+        ]
+        rig_rows = [line for line in lines if line.startswith(("leader ", "junior-dev "))]
+        assert len(rig_rows) == 2
+        assert "{prompt}" not in out
         assert "gerry -> leader" in out
-        assert "Phil: junior-dev" in out
-        assert "Neil: Human" in out
+        assert "throttle:" in out and "governance:" in out
+        assert "MEMBER" in out and "Phil" in out and "junior-dev" in out
+        assert "Neil" in out and "human" in out
+        assert "(full invoke lines: r4t rig ls --wide)" in out
+
+    def test_rigs_ls_matches_rig_list(self, r4t_home, repo, rig_config, capsys):
+        args = ("--root", str(repo), "--rig-config", str(rig_config))
+        assert self.run("rig", "list", *args) == 0
+        listed = capsys.readouterr().out
+        assert self.run("rigs", "ls", *args) == 0
+        assert capsys.readouterr().out == listed
+
+    def test_rig_list_wide_shows_invoke(self, r4t_home, repo, rig_config, capsys):
+        rc = self.run(
+            "rig", "list", "--wide", "--root", str(repo), "--rig-config", str(rig_config)
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert next(line for line in out.splitlines() if line.startswith("RIG ")).split()[-1] == "INVOKE"
+        assert "{prompt}" in out
 
     def test_rig_presets(self, capsys):
         rc = self.run("rig", "presets")
@@ -2227,7 +2252,7 @@ class TestDefault:
         out = capsys.readouterr().out
         assert "r4t — Roster For Teams" in out
         assert f"R4T_HOME: {r4t_home}" in out
-        assert "Rigs" in out and "junior-dev:" in out
+        assert "Rigs" in out and "junior-dev" in out and "RIG " in out
         assert "Commands" in out and "init" in out
         assert "sandbox --fake" in out
         assert "Next steps" in out


### PR DESCRIPTION
`r4t rigs ls` now parses, and the listing is an aligned table in the same
shape as `a8s ls`. Closes #271.

## Before — `r4t rig list` (a splatter; `rigs ls` was a parse error)

```
rig config: /scratch/rigs.json
  cloud: opencode run -m opencode/nemotron-3-ultra-free --auto --dir . {prompt}  (timeout=900s budget=8/+4per-h sends=6)
  dumb: agy --dangerously-skip-permissions --model {model} --mode accept-edits --print {prompt}  (timeout=300s budget=8/+4per-h sends=6 rig-budget=10/+15per-h)
  helper: ollama launch opencode --model qwen3.6 -- run --auto --dir . {prompt}  (timeout=900s budget=8/+4per-h sends=6)
  local: ollama run qwen3.6 {prompt}  (timeout=900s budget=8/+4per-h sends=6)
  orchestrator: agy --dangerously-skip-permissions --mode accept-edits --print {prompt}  (timeout=900s budget=8/+4per-h sends=6)
  producer: agy --dangerously-skip-permissions --mode accept-edits --print {prompt}  (timeout=900s budget=8/+4per-h sends=6)
  reserve: agy --model {model} --dangerously-skip-permissions --mode accept-edits --print {prompt}  (timeout=900s budget=8/+4per-h sends=6)
  silo: agent --model claude-fable-5-medium -p --trust --force --approve-mcps {prompt}  (timeout=900s budget=8/+4per-h sends=6)
  simple: agy --dangerously-skip-permissions --model {model} --mode accept-edits --print {prompt}  (timeout=300s budget=8/+4per-h sends=6 rig-budget=20/+30per-h)
  specialist: agy --dangerously-skip-permissions --model {model} --mode accept-edits --print {prompt}  (timeout=900s budget=8/+4per-h sends=6 rig-budget=20/+30per-h)
  throttle: max_concurrent=1 min_seconds_between_turn_starts=15
  governance: cell_budget=24/+60per-h quiet_task=1800s breaker_cap=5 breaker_cooldown=600s
```

## After — `r4t rigs ls`

Rendered against a copy of a real `rigs.json` in a scratch `R4T_HOME`:

```
rig config: /scratch/rigs.json

RIG            PRESET            MODEL                            CONC   TIMEOUT   SENDS   BUDGET   RIG-BUDGET
cloud          opencode          opencode/nemotron-3-ultra-free   1      900s      6       8/+4h    -
dumb           agy               Gemini 3.5 Flash (Low)           1      300s      6       8/+4h    10/+15h
helper         opencode-ollama   qwen3.6                          1      900s      6       8/+4h    -
local          ollama            -                                1      900s      6       8/+4h    -
orchestrator   agy               -                                2      900s      6       8/+4h    -
producer       agy               -                                2      900s      6       8/+4h    -
reserve        agy               opus                             1      900s      6       8/+4h    -
silo           cursor            -                                1      900s      6       8/+4h    -
simple         agy               Gemini 3.5 Flash (High)          1      300s      6       8/+4h    20/+30h
specialist     agy               Gemini 3.1 Pro (High)            1      900s      6       8/+4h    20/+30h

throttle:   max_concurrent=1 min_seconds_between_turn_starts=15
governance: cell_budget=24/+60per-h quiet_task=1800s breaker_cap=5 breaker_cooldown=600s

(full invoke lines: r4t rig ls --wide)
```

`--wide` appends the invoke as a trailing column (the only other surface it
had; `rig get` covers configurable settings only):

```
RIG      PRESET     MODEL                            ...   INVOKE
cloud    opencode   opencode/nemotron-3-ultra-free   ...   opencode run -m opencode/nemotron-3-ultra-free --auto --dir . {prompt}
silo     cursor     -                                ...   agent -p --trust --force --approve-mcps {prompt}
```

## Notes

- `list` gains `aliases=["ls"]`, matching how `remove`/`rm` is already wired.
- CONC and RIG-BUDGET appear only when a rig sets them, mirroring the
  conditional NAMESPACES column in `a8s ls`.
- MODEL falls back to the token after `--model`/`-m` when no explicit `model`
  setting exists, since preset-built invokes carry it there.
- Pins, invalid rigs, throttle/governance and roster resolution are separate
  sections now; roster resolution is its own MEMBER / RIG / NOTE table.
- Same table helper shape as `a8s ls` (uppercase header, three-space gutters,
  no trailing padding), so the output stays greppable — no `--json` added.

## Tests

- `pytest apps/r4t/tests/` — 638 passed
- `pytest apps/a8s/tests/` — 778 passed
- Updated `test_rig_list` (header row, one row per rig, no invoke by default)
  and added `test_rigs_ls_matches_rig_list` + `test_rig_list_wide_shows_invoke`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
