### PR TITLE
fix(r4t): cursor preset pins --model auto; correct cache-economics teaching

### DIFF
--- a/apps/r4t/rig.py
+++ b/apps/r4t/rig.py
@@ -140,6 +140,12 @@ HARNESS_PRESETS: dict[str, dict] = {
             "{prompt}",
         ],
         "model_argv": ["--model", "{model}"],
+        # `agent` reuses the LAST --model it was given when the flag is
+        # omitted, so an unpinned invoke inherits invisible machine-global
+        # state — a rig founded "modelless" kept riding a usage-limited
+        # frontier model (#275). `auto` is the CLI's own way to say "the
+        # subscription default", so pin it; an explicit --model still wins.
+        "model_default": "auto",
         "continue_argv": ["--continue"],
         "no_prior_conversation": r"no previous chats found",
     },
@@ -570,8 +576,13 @@ def continue_collisions(roster: Roster, config: RigConfig, workplace: Path) -> l
 
 
 def format_preset_invoke(preset: str) -> str:
+    """The invoke a bare `rig add <preset>` produces, for display. Presets whose
+    argv carries an inline `{model}` show the placeholder — they have no bare
+    form to display."""
     entry = HARNESS_PRESETS[preset]
-    return " ".join(entry["invoke"])
+    if any("{model}" in arg for arg in entry["invoke"]):
+        return " ".join(entry["invoke"])
+    return " ".join(build_preset_invoke(preset))
 
 
 def build_preset_invoke(preset: str, *, model: str | None = None) -> list[str]:
@@ -587,14 +598,16 @@ def build_preset_invoke(preset: str, *, model: str | None = None) -> list[str]:
       ships new versions, so a value baked in at add-time would go stale).
     - `model_argv` presets without a resolver (claude/codex/cursor/opencode):
       splice the flag pair with the resolved value now. --model is OPTIONAL —
-      absent, the base argv is returned and the CLI's own default applies.
+      absent, the base argv is returned and the CLI's own default applies,
+      unless the preset names a `model_default` to stand in (cursor, whose CLI
+      would otherwise reuse the last model used on the machine).
     """
     preset_key = preset.strip().lower()
     if preset_key not in HARNESS_PRESETS:
         known = ", ".join(preset_names())
         raise RigError(f"unknown preset {preset!r}; choose one of: {known}")
     entry = HARNESS_PRESETS[preset_key]
-    model_value = (model or "").strip()
+    model_value = (model or "").strip() or entry.get("model_default", "")
 
     if any("{model}" in arg for arg in entry["invoke"]):
         if not model_value:

--- a/apps/r4t/tests/test_rig.py
+++ b/apps/r4t/tests/test_rig.py
@@ -778,8 +778,16 @@ class TestModelSplice:
     resolution)."""
 
     def test_optional_when_absent_returns_base(self):
-        for preset in ("claude", "codex", "cursor", "opencode", "agy"):
+        for preset in ("claude", "codex", "opencode", "agy"):
             assert build_preset_invoke(preset) == HARNESS_PRESETS[preset]["invoke"]
+
+    def test_cursor_pins_auto_when_no_model_is_given(self):
+        # `agent` reuses the last --model used on the machine when the flag is
+        # omitted, so the bare preset must still name one (#275).
+        argv = build_preset_invoke("cursor")
+        assert argv[:3] == ["agent", "--model", "auto"]
+        assert argv[-1] == "{prompt}"
+        assert format_preset_invoke("cursor").startswith("agent --model auto")
 
     def test_claude_splices_after_executable(self):
         argv = build_preset_invoke("claude", model="sonnet")
@@ -794,6 +802,18 @@ class TestModelSplice:
     def test_cursor_splices_after_executable(self):
         argv = build_preset_invoke("cursor", model="sonnet-4-thinking")
         assert argv[:3] == ["agent", "--model", "sonnet-4-thinking"]
+        assert "auto" not in argv
+
+    def test_cursor_add_without_model_records_the_auto_pin(self, tmp_path):
+        path = tmp_path / "rigs.json"
+        add_preset_rig(path, "solo", "cursor")
+        assert load_rig_config(path).rigs["solo"].invoke[:3] == [
+            "agent", "--model", "auto",
+        ]
+        add_preset_rig(path, "pinned", "cursor", model="sonnet-4-thinking")
+        assert load_rig_config(path).rigs["pinned"].invoke[:3] == [
+            "agent", "--model", "sonnet-4-thinking",
+        ]
 
     def test_opencode_splices_after_run(self):
         argv = build_preset_invoke("opencode", model="anthropic/claude-sonnet-4-5")

--- a/guides/02-the-solo-agent.md
+++ b/guides/02-the-solo-agent.md
@@ -124,17 +124,20 @@ You should see:
 
 ```
 added rig 'solo' (cursor) to /home/you/.config/r4t/rigs.json
-  invoke: agent -p --trust --force --approve-mcps {prompt}
+  invoke: agent --model auto -p --trust --force --approve-mcps {prompt}
 Reference it from ROSTER.md: `- **Rig:** solo`
 set solo echo = true in /home/you/.config/r4t/rigs.json
 ```
 
-No `--model` is the deliberate part: the invoke line carries no model
-flag, so the harness runs whatever your Cursor subscription defaults to —
-covered by what you already pay. Pin one with `--model <name>` and you
-can land on a frontier model billed as usage-based credits, which a
-chatty agent burns through fast; add the flag only when you mean to.
-(`agent models` lists what your account can run.)
+Naming no model of your own is the deliberate part: the preset writes
+`--model auto`, which is the Cursor CLI's own way of saying *whatever my
+subscription defaults to* — covered by what you already pay. The pin
+itself matters. Left off entirely, `agent` reuses the last model it was
+given on this machine, so an invoke with no flag inherits a choice you
+cannot see and did not make here. Name one yourself with
+`--model <name>` and you can land on a frontier model billed as
+usage-based credits, which a chatty agent burns through fast; do that
+only when you mean to. (`agent models` lists what your account can run.)
 
 `echo true` makes Wren **stdout-only**: its turn prompt carries no
 messaging doctrine, and whatever it prints becomes its one reply to you.

--- a/guides/02-the-solo-agent.md
+++ b/guides/02-the-solo-agent.md
@@ -329,14 +329,15 @@ One line in the roster: bound how long Wren's conversation may sit idle.
 `- **Continue:** on`, add:
 
 ```markdown
-- **Flush:** 4h
+- **Flush:** 15m
 ```
 
-A conversation idle past four hours is retired — Wren is prompted once to
-write its state to disk, and the next real message founds a fresh
+A conversation idle past fifteen minutes is retired — Wren is prompted
+once to write its state to disk, and the next real message founds a fresh
 conversation from that saved state. It keeps a long-lived agent from
-dragging weeks of stale context into every turn; the full mechanics are
-chapter 3's subject.
+dragging weeks of stale context into every turn, and it sits near where
+the providers stop discounting a resumed conversation; the full mechanics
+are chapter 3's subject.
 
 **Run**
 
@@ -363,7 +364,7 @@ in commands.)
 cd ~/ark/solo
 git init -q
 git add ROSTER.md
-git commit -q -m "solo roster: Wren, continue on, flush 4h"
+git commit -q -m "solo roster: Wren, continue on, flush 15m"
 ```
 
 Copy-paste templates for this chapter's final state live in

--- a/guides/03-the-long-memory.md
+++ b/guides/03-the-long-memory.md
@@ -17,17 +17,17 @@ About 30 minutes, most of it deliberate waiting.
 ## 3. Starting state
 
 - Chapter 2 complete: Wren answers at the seat, `Continue: on`, and the
-  customize step left `Flush: 4h` in his roster block.
+  customize step left `Flush: 15m` in his roster block.
 - Wren's conversation is live — if you just restarted the machine, send one
   seat message so there is a conversation to flush.
 
 ## 4. The change
 
-`Flush: 4h` is a promise you made in chapter 2 without seeing it kept: a
-conversation idle past four hours is retired. Four hours is the right
-setting and the wrong demo — you are not going to sit here for four hours.
-The value takes bare seconds or an `s`/`m`/`h`/`d` suffix, so shrink the
-window for one session:
+`Flush: 15m` is a promise you made in chapter 2 without seeing it kept: a
+conversation idle past fifteen minutes is retired. Fifteen minutes is the
+right setting and still the wrong demo — you are not going to sit here
+watching a clock. The value takes bare seconds or an `s`/`m`/`h`/`d`
+suffix, so shrink the window further for one session:
 
 **Replace** `~/ark/solo/ROSTER.md` — in Wren's block, the `Flush:` line
 becomes:
@@ -363,7 +363,7 @@ Put the window back where it belongs:
 **Replace** `~/ark/solo/ROSTER.md` — Wren's `Flush:` line becomes:
 
 ```markdown
-- **Flush:** 4h
+- **Flush:** 15m
 ```
 
 **Run**
@@ -379,13 +379,35 @@ You: note — Human without an Address (team cannot tell them)
 /home/you/ark/solo/ROSTER.md: OK (2 member(s), leader Wren)
 ```
 
-Choosing a window is cache economics: a conversation left idle falls out
-of the provider's prompt cache, and re-caching weeks of stale context at
-frontier prices is real money spent on messages nobody needed — flush
-early enough to avoid that, late enough that normal working pauses don't
-cost Wren his short-term memory. Four hours suits a daily-driver agent; on
-the free path the meter is zero and the window is purely about context
-hygiene.
+Choosing a window is cache economics, and two different clocks are
+running. The conversation is yours — it sits on disk and expires only
+when you say so. The provider's prompt cache is merely a discount on
+replaying that conversation, and it is the discount that lapses. When it
+has lapsed the harness resends the same transcript and nothing is
+forgotten; the tokens are simply re-billed, and not the same way
+everywhere. Anthropic charges the re-cached prefix as a cache *write*, a
+premium over ordinary input. Most OpenAI models charge plain input with
+no surcharge at all, though GPT-5.6 writes at a premium again. One miss,
+three different bills.
+
+No provider's boundary sits anywhere near four hours, which is what this
+chapter used to teach. Anthropic's caches hold five minutes by default
+and an hour at the outside; GPT-5.6 guarantees at least thirty; older
+OpenAI models can stretch to a day. Fifteen minutes is the default taught
+here because it falls inside the shortest of them: a pause that long has
+usually cost you the discount already, so retiring the conversation gives
+up nothing you still had, and the next turn carries only what `STATUS.md`
+says matters.
+
+The subscription path is not exempt. Cursor and Copilot plans meter
+cache-writes against your included usage the way they meter everything
+else, so a long-idle conversation resumed at full length spends real
+allowance on messages nobody needed. On the free path the meter reads
+zero and the window is purely context hygiene — set it late enough that
+normal working pauses don't cost Wren his short-term memory, early enough
+that he isn't dragging yesterday into today. The pricing and retention
+figures behind all of this are collected in
+[Prompt-Cache Economics](https://github.com/neilobremski/bin/wiki/Prompt-Cache-Economics).
 
 ## 12. Commit point
 

--- a/guides/04-a-second-pair-of-hands.md
+++ b/guides/04-a-second-pair-of-hands.md
@@ -21,7 +21,7 @@ About 30 minutes.
 
 ## 3. Starting state
 
-- Chapter 3 complete: Wren on `Continue: on` / `Flush: 4h`, answering at
+- Chapter 3 complete: Wren on `Continue: on` / `Flush: 15m`, answering at
   the seat.
 - The free path runs both members on one `qwen3.6` — no second model, no
   extra download. (Subscription path: Moss still runs local and free; only
@@ -45,7 +45,7 @@ Two edits: the roster grows a member, and the rig config grows a rig.
 - **Rig:** solo
 - **Leader:** yes
 - **Continue:** on
-- **Flush:** 4h
+- **Flush:** 15m
 - **Workdir:** agents/wren
 - **Role:** The solo agent — does the work and answers the owner
 

--- a/guides/templates/02-solo-cursor/README.md
+++ b/guides/templates/02-solo-cursor/README.md
@@ -1,4 +1,4 @@
 Chapter 2's final state on the subscription path (Cursor agent CLI, the
-subscription's default model — no `--model` pin).
+subscription's default model — the preset's `--model auto`).
 Copy ROSTER.md into your team repo (e.g. `~/ark/solo/`), then run rig-setup.sh.
 Used by [guides/02-the-solo-agent.md](../../02-the-solo-agent.md).

--- a/guides/templates/02-solo-cursor/ROSTER.md
+++ b/guides/templates/02-solo-cursor/ROSTER.md
@@ -9,7 +9,7 @@
 - **Rig:** solo
 - **Leader:** yes
 - **Continue:** on
-- **Flush:** 4h
+- **Flush:** 15m
 - **Workdir:** agents/wren
 - **Role:** The solo agent — does the work and answers the owner
 

--- a/guides/templates/02-solo-opencode-ollama/ROSTER.md
+++ b/guides/templates/02-solo-opencode-ollama/ROSTER.md
@@ -9,7 +9,7 @@
 - **Rig:** solo
 - **Leader:** yes
 - **Continue:** on
-- **Flush:** 4h
+- **Flush:** 15m
 - **Workdir:** agents/wren
 - **Role:** The solo agent — does the work and answers the owner
 

--- a/guides/templates/04-two-member/ROSTER.md
+++ b/guides/templates/04-two-member/ROSTER.md
@@ -9,7 +9,7 @@
 - **Rig:** solo
 - **Leader:** yes
 - **Continue:** on
-- **Flush:** 4h
+- **Flush:** 15m
 - **Workdir:** agents/wren
 - **Role:** The solo agent — does the work and answers the owner
 


### PR DESCRIPTION
Two independent corrections, one per commit.

## 1. Cursor preset pins `--model auto` (Closes #275)

Cursor's `agent` CLI reuses the **last** `--model` it was given when the flag is omitted, so a cursor rig founded without `--model` was never "the subscription default" — it silently inherited whatever model last ran on this machine. Verified live today: after the pinned model hit its monthly usage limit, a freshly founded "modelless" turn balked with the same `ActionRequiredError`, because the sticky model rode along invisibly.

Rigs exist to make an invoke deterministic, so the cursor preset now carries `model_default: "auto"` (`auto` is the CLI's own name for the subscription default) and `build_preset_invoke` falls back to it when no model is given. An explicit `--model <name>` at `rig add`/`rig swap` time still wins. No other preset declares a default, so nothing else changes.

`format_preset_invoke` now renders the argv `rig add` would actually write, so `r4t rig presets` cannot advertise an invoke the tool would not produce.

The chapter 2 capture was **re-run for real** in a scratch `R4T_HOME` against this branch's `r4t.py`, then path-normalized to the guide's `/home/you` style:

```
added rig 'solo' (cursor) to /home/you/.config/r4t/rigs.json
  invoke: agent --model auto -p --trust --force --approve-mcps {prompt}
```

The adjacent subscription note now explains what `auto` means, instead of explaining the absence of a flag.

## 2. Cache-economics correction; flush default 15m

Chapter 3 taught that an idle conversation "falls out of the provider's prompt cache" and that re-caching it at frontier prices is the reason to flush, with four hours as the sensible window. Deep research into the actual provider mechanics — [Prompt-Cache Economics](https://github.com/neilobremski/bin/wiki/Prompt-Cache-Economics) on the repo wiki — returned **"partly true, but materially misleading"**:

- Conversation persistence and cache persistence are different things. Expiry loses the *discount*, not the memory.
- A miss is not re-billed the same way everywhere: Anthropic charges a cache-write premium, most OpenAI models charge plain input with no surcharge, GPT-5.6 charges a write again.
- Four hours matches no provider boundary — Anthropic 5m default / 1h max, GPT-5.6 at least 30m, older OpenAI models up to 24h.
- Subscription pools are **not** exempt: Cursor and Copilot both meter cache-writes against included usage.

The passage is rewritten to teach those distinctions and cites the wiki page. The taught default moves from `Flush: 4h` to `Flush: 15m` — inside the shortest real boundary, where retiring a conversation gives up a discount that was already lost — across chapter prose (02, 03, 04) and the three `guides/templates/*/ROSTER.md` files. On the free path the meter reads zero and the window remains pure context hygiene.

No capture needed adjusting: the only flush window embedded in a captured line is chapter 3's own 60-second demo, which is unaffected. `apps/r4t/docs/rigs.md` still shows `4h` as a syntax example for the suffix format, not as a taught default — left alone deliberately.

## Scope

Member `Status:`/`Human` lines were not touched, and neither were `apps/r4t/roster.py` or `apps/r4t/dispatch.py`, to stay clear of the in-flight PR on the same files.

## Tests

- `apps/r4t/tests/` — 644 passed
- `apps/a8s/tests/` — 782 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)