### PR TITLE
feat(r4t): replace roster Status with Human boolean

### DIFF
--- a/apps/r4t/chat.py
+++ b/apps/r4t/chat.py
@@ -45,7 +45,7 @@ def load_seat(ctx: DispatchContext) -> tuple[Roster, Member]:
     human = next((m for m in roster.members if m.is_human), None)
     if human is None:
         raise SeatError(
-            "no human member in the roster — add one to ROSTER.md (Status: Human)"
+            "no human member in the roster — add one to ROSTER.md (Human: yes)"
         )
     return roster, human
 

--- a/apps/r4t/docs/org.md
+++ b/apps/r4t/docs/org.md
@@ -13,7 +13,6 @@ to); the top lead reports to the human:
 
 ```markdown
 ### Cass
-- **Status:** AI
 - **Rig:** specialist
 - **Cell:** design
 - **Lead:** Vela

--- a/apps/r4t/docs/tutorial.md
+++ b/apps/r4t/docs/tutorial.md
@@ -84,13 +84,13 @@ exists in `rigs.json`:
 
 ```markdown
 ### Reviewer
-- **Status:** AI
 - **Rig:** reviewer
 - **Role:** Code reviewer
 ```
 
-Humans use `Status: Human` and never get a rig. Optional
-`Address:` is their a8s name for outbound tells.
+AI is the default and carries no marker. The human seat is marked
+`Human: yes` and must not carry a rig. Optional `Address:` is their a8s
+name for outbound tells.
 
 ### 5. Lint before going live
 

--- a/apps/r4t/experiments/n5a/org-a/ROSTER.md
+++ b/apps/r4t/experiments/n5a/org-a/ROSTER.md
@@ -18,7 +18,6 @@ The org is a depth-2 tree of cells. Each AI member carries `Cell:` and
 ## Leadership
 
 ### Rowan
-- **Status:** AI
 - **Rig:** specialist
 - **Leader:** yes
 - **Cell:** leadership
@@ -42,7 +41,6 @@ Reports to Rowan. Owns the prose — every chapter passes through this cell
 before it exists.
 
 ### Odile
-- **Status:** AI
 - **Rig:** specialist
 - **Cell:** writing
 - **Lead:** Rowan
@@ -56,7 +54,6 @@ Delegates by first name; reports to Rowan with what's drafted and what's
 next.
 
 ### Ivo
-- **Status:** AI
 - **Rig:** simple
 - **Cell:** writing
 - **Lead:** Odile
@@ -68,7 +65,6 @@ good one. Takes Odile's line notes without flinching and redrafts until it
 holds.
 
 ### Sten
-- **Status:** AI
 - **Rig:** simple
 - **Cell:** writing
 - **Lead:** Odile
@@ -79,7 +75,6 @@ pens so it moves at a readable pace. Slower and more deliberate; best at the
 quiet chapters where not much happens but everything matters.
 
 ### Marek
-- **Status:** AI
 - **Rig:** simple
 - **Cell:** writing
 - **Lead:** Odile
@@ -98,7 +93,6 @@ Reports to Rowan. The story's memory — nothing contradicts anything once
 this cell has looked at it.
 
 ### Sorrel
-- **Status:** AI
 - **Rig:** specialist
 - **Cell:** continuity
 - **Lead:** Rowan
@@ -111,7 +105,6 @@ note-keeping to Tam; escalates to Rowan only when a contradiction means
 rewriting something already blessed.
 
 ### Bex
-- **Status:** AI
 - **Rig:** simple
 - **Cell:** continuity
 - **Lead:** Sorrel
@@ -123,7 +116,6 @@ plainly — "chapter six says the letter was burned; chapter nine quotes it" —
 and lets Sorrel decide what to do about it.
 
 ### Tam
-- **Status:** AI
 - **Rig:** dumb
 - **Cell:** continuity
 - **Lead:** Sorrel
@@ -141,7 +133,6 @@ Reports to Rowan. Reads the book as a stranger would — no goodwill, no
 inside knowledge of how hard a chapter was to write.
 
 ### Priya
-- **Status:** AI
 - **Rig:** specialist
 - **Cell:** reader
 - **Lead:** Rowan
@@ -154,7 +145,6 @@ actually pays off what came before. A finding from this cell outranks a
 compliment from anyone who wrote the pages.
 
 ### Nessa
-- **Status:** AI
 - **Rig:** simple
 - **Cell:** reader
 - **Lead:** Priya
@@ -169,7 +159,7 @@ missed is worth a second look either way.
 ## Human
 
 ### Neil
-- **Status:** Human
+- **Human:** yes
 - **Address:** PLACEHOLDER
 - **Role:** Owns the mission, blesses the milestones
 

--- a/apps/r4t/experiments/n5a/org-b/ROSTER.md
+++ b/apps/r4t/experiments/n5a/org-b/ROSTER.md
@@ -18,7 +18,6 @@ Rowan; there are no cells beneath him.
 ## Newsroom
 
 ### Rowan
-- **Status:** AI
 - **Rig:** specialist
 - **Leader:** yes
 - **Cell:** newsroom
@@ -35,7 +34,6 @@ briefback to Neil: restate the intent and end state in your own words and
 wait for his correction before any work resumes.
 
 ### Odile
-- **Status:** AI
 - **Rig:** specialist
 - **Cell:** newsroom
 - **Lead:** Rowan
@@ -47,7 +45,6 @@ book gets measured against; if a chapter doesn't sound right, ask Odile what
 she'd change before anyone else.
 
 ### Ivo
-- **Status:** AI
 - **Rig:** simple
 - **Cell:** newsroom
 - **Lead:** Rowan
@@ -59,7 +56,6 @@ good one. Takes line notes without flinching, from whoever on the desk gives
 them, and redrafts until it holds.
 
 ### Sten
-- **Status:** AI
 - **Rig:** simple
 - **Cell:** newsroom
 - **Lead:** Rowan
@@ -70,7 +66,6 @@ readable pace. Slower and more deliberate; best at the quiet chapters where
 not much happens but everything matters.
 
 ### Marek
-- **Status:** AI
 - **Rig:** simple
 - **Cell:** newsroom
 - **Lead:** Rowan
@@ -82,7 +77,6 @@ tension curves, not scenes. Takes it straight to whoever wrote the chapter,
 and to Rowan if it isn't fixed.
 
 ### Sorrel
-- **Status:** AI
 - **Rig:** specialist
 - **Cell:** newsroom
 - **Lead:** Rowan
@@ -94,7 +88,6 @@ what she finds straight to Rowan and to whichever drafter wrote the page.
 There is no cell between her and the desk.
 
 ### Bex
-- **Status:** AI
 - **Rig:** simple
 - **Cell:** newsroom
 - **Lead:** Rowan
@@ -106,7 +99,6 @@ plainly — "chapter six says the letter was burned; chapter nine quotes it" —
 straight to Rowan and to whoever wrote the pages in question.
 
 ### Tam
-- **Status:** AI
 - **Rig:** dumb
 - **Cell:** newsroom
 - **Lead:** Rowan
@@ -117,7 +109,6 @@ what state they're in, and the outline as it's revised. Answers with the
 note itself, nothing else.
 
 ### Priya
-- **Status:** AI
 - **Rig:** specialist
 - **Cell:** newsroom
 - **Lead:** Rowan
@@ -130,7 +121,6 @@ actually pays off what came before. A finding from her outranks a compliment
 from anyone who wrote the pages.
 
 ### Nessa
-- **Status:** AI
 - **Rig:** simple
 - **Cell:** newsroom
 - **Lead:** Rowan
@@ -145,7 +135,7 @@ the other missed is worth a second look either way.
 ## Human
 
 ### Neil
-- **Status:** Human
+- **Human:** yes
 - **Address:** PLACEHOLDER
 - **Role:** Owns the mission, blesses the milestones
 

--- a/apps/r4t/r4t.py
+++ b/apps/r4t/r4t.py
@@ -85,20 +85,20 @@ COMMAND_HELP = [
 ROSTER_TEMPLATE = """\
 # Team Roster
 
-Members are `### <Name>` blocks. `Status: Human` members are never
-dispatched: mail to them parks in the team's seat mailbox (`r4t seat`,
-`r4t chat`), and the optional `Address:` is a doorbell — a copy forwarded
-over a8s when no seat session is attached. `Rig:` names a SYMBOLIC rig
-defined in the out-of-repo rig config (~/.config/r4t/rigs.json). Free
-prose in a block becomes the member's persona.
+Members are `### <Name>` blocks. AI is the default and carries no marker.
+`Human: yes` members are never dispatched: mail to them parks in the team's
+seat mailbox (`r4t seat`, `r4t chat`), and the optional `Address:` is a
+doorbell — a copy forwarded over a8s when no seat session is attached.
+`Rig:` names a SYMBOLIC rig defined in the out-of-repo rig config
+(~/.config/r4t/rigs.json) and belongs only to AI members. Free prose in a
+block becomes the member's persona.
 
 ### Owner
-- **Status:** Human
+- **Human:** yes
 - **Address:** YOUR-A8S-NAME
 - **Role:** Product owner
 
 ### Lead
-- **Status:** AI
 - **Rig:** leader
 - **Leader:** yes
 - **Role:** Team lead — delegates work and answers the owner
@@ -107,7 +107,6 @@ Coordinates the team. Delegates implementation, follows up on replies, and
 synthesizes answers for whoever asked.
 
 ### Dev
-- **Status:** AI
 - **Rig:** member
 - **Role:** Developer
 
@@ -942,7 +941,7 @@ def cmd_seat(args: argparse.Namespace) -> int:
     if human is None:
         print(
             "seat: no human member in the roster — add one to ROSTER.md "
-            "(Status: Human)",
+            "(Human: yes)",
             file=sys.stderr,
         )
         return 2

--- a/apps/r4t/roster.py
+++ b/apps/r4t/roster.py
@@ -3,7 +3,6 @@
 Format: `### <Name>` blocks with bullet fields:
 
     ### Phil
-    - **Status:** AI
     - **Rig:** junior-dev
     - **Role:** Lead Backend Engineer
     - **Leader:** yes
@@ -22,8 +21,10 @@ dump state to disk, then refound on the next real message. Bare seconds or an
 s/m/h/d suffix (`Flush: 4h`). Without `Continue: on` it is ignored;
 `r4t roster check` warns.
 
-Humans (`- **Status:** Human`) are never dispatched; an optional
-`- **Address:** <a8s-name>` tells teammates how to reach them. The Rig
+AI is the default and carries no marker. The human seat is marked
+`- **Human:** yes` and is never dispatched; an optional
+`- **Address:** <a8s-name>` tells teammates how to reach them. A human with
+a `Rig:` is an error — humans sit outside the turn system. The Rig
 value is a SYMBOLIC rig name resolved against the out-of-repo rig
 config — never a command. Parsing is defensive: a malformed block disables
 that one member (Member.error set) without crashing dispatch.
@@ -68,7 +69,7 @@ class RosterError(Exception):
 @dataclass
 class Member:
     name: str
-    status: str = "AI"
+    human: bool = False
     rig: str | None = None
     role: str = ""
     leader: bool = False
@@ -83,7 +84,7 @@ class Member:
 
     @property
     def is_human(self) -> bool:
-        return self.status.lower() == "human"
+        return self.human
 
     @property
     def error(self) -> str | None:
@@ -255,11 +256,12 @@ def _member_from_block(name: str, lines: list[str]) -> Member:
         if key not in fields:
             fields[key] = _clean(match.group(2))
 
-    status = fields.get("status", "AI")
-    if status.lower() not in ("ai", "human"):
-        m.errors.append(f"Status must be Human or AI (got {status!r})")
-    else:
-        m.status = "Human" if status.lower() == "human" else "AI"
+    if "status" in fields:
+        m.errors.append(
+            "Status: is gone — mark the human seat with **Human:** yes; "
+            "AI members carry no marker"
+        )
+    m.human = _is_true(fields.get("human", ""))
 
     m.role = fields.get("role", fields.get("mandate", ""))
     m.leader = _is_true(fields.get("leader", ""))
@@ -276,7 +278,11 @@ def _member_from_block(name: str, lines: list[str]) -> Member:
     m.workdir = fields.get("workdir", "")
 
     rig = fields.get("rig", "")
-    if rig:
+    if rig and m.is_human:
+        m.errors.append(
+            "Human members carry no Rig — humans are outside the turn system"
+        )
+    elif rig:
         if RIG_RE.match(rig):
             m.rig = rig.lower()
         else:

--- a/apps/r4t/sandbox/ROSTER.md
+++ b/apps/r4t/sandbox/ROSTER.md
@@ -3,12 +3,11 @@
 Three-agent pipeline: Lead delegates → Dev builds → Tester verifies → Lead answers human.
 
 ### Owner
-- **Status:** Human
+- **Human:** yes
 - **Address:** human
 - **Role:** Product owner
 
 ### Lead
-- **Status:** AI
 - **Rig:** leader
 - **Leader:** yes
 - **Role:** Team lead
@@ -18,14 +17,12 @@ Three-agent pipeline: Lead delegates → Dev builds → Tester verifies → Lead
 **Turn 3 (from Tester, VERIFIED):** run `tell human "Done: battleship.py verified"` — do not delegate.
 
 ### Dev
-- **Status:** AI
 - **Rig:** member
 - **Role:** Developer
 
 Write **battleship.py** in this repo root. Then run `tell tester "battleship.py is ready"`. Stop.
 
 ### Tester
-- **Status:** AI
 - **Rig:** member
 - **Role:** Tester
 

--- a/apps/r4t/tests/conftest.py
+++ b/apps/r4t/tests/conftest.py
@@ -46,7 +46,6 @@ ROSTER_TEXT = textwrap.dedent(
     Preamble prose that is not a member block.
 
     ### Gerry
-    - **Status:** AI
     - **Rig:** leader
     - **Role:** Technical Producer
     - **Cell:** leadership
@@ -55,20 +54,18 @@ ROSTER_TEXT = textwrap.dedent(
     The Orchestrator. Defends the schedule.
 
     ### Phil
-    - **Status:** AI
     - **Rig:** junior-dev
     - **Role:** Lead Backend Engineer
 
     Grumpy, cynical veteran. Despises feature creep.
 
     ### Neil
-    - **Status:** Human
+    - **Human:** yes
     - **Address:** neil
     - **Role:** Game Director
 
     ### Broken
-    - **Status:** Sometimes
-    - **Rig:** junior-dev
+    - **Rig:** ./run-agent.sh --headless
     """
 )
 

--- a/apps/r4t/tests/docker/inside.sh
+++ b/apps/r4t/tests/docker/inside.sh
@@ -50,7 +50,6 @@ cat >/etc/r4t-org/ROSTER.md <<'EOF'
 # Team
 
 ### Worker
-- **Status:** AI
 - **Rig:** solo
 - **Leader:** yes
 EOF

--- a/apps/r4t/tests/test_chat.py
+++ b/apps/r4t/tests/test_chat.py
@@ -167,7 +167,7 @@ def test_poll_inbox_consumes_and_renders(session, r4t_home):
 
 def test_run_chat_requires_human(ctx, repo, r4t_home):
     (repo / "ROSTER.md").write_text(
-        "# Roster\n\n### Gerry\n- **Status:** AI\n- **Rig:** leader\n"
+        "# Roster\n\n### Gerry\n- **Rig:** leader\n"
         "- **Leader:** yes\n",
         encoding="utf-8",
     )

--- a/apps/r4t/tests/test_dispatch.py
+++ b/apps/r4t/tests/test_dispatch.py
@@ -93,30 +93,26 @@ TREE_ROSTER = textwrap.dedent(
     # Tree Team
 
     ### Vic
-    - **Status:** AI
     - **Rig:** leader
     - **Leader:** yes
     - **Cell:** lead
     - **Lead:** Ned
 
     ### Ned
-    - **Status:** Human
+    - **Human:** yes
     - **Address:** ned
 
     ### Ann
-    - **Status:** AI
     - **Rig:** junior-dev
     - **Cell:** design
     - **Lead:** Vic
 
     ### Bea
-    - **Status:** AI
     - **Rig:** junior-dev
     - **Cell:** design
     - **Lead:** Ann
 
     ### Cal
-    - **Status:** AI
     - **Rig:** junior-dev
     - **Cell:** build
     - **Lead:** Vic
@@ -289,7 +285,7 @@ class TestRejections:
 
     def test_unknown_rig_dead_letters(self, ctx, repo, tells, fake_harness):
         (repo / "ROSTER.md").write_text(
-            "### Ghost\n- **Status:** AI\n- **Rig:** phantom\n- **Leader:** yes\n",
+            "### Ghost\n- **Rig:** phantom\n- **Leader:** yes\n",
             encoding="utf-8",
         )
         sent, _ = tells
@@ -305,7 +301,7 @@ class TestRejections:
 
     def test_no_leader_for_bare_node(self, ctx, repo, tells, fake_harness):
         (repo / "ROSTER.md").write_text(
-            "### Phil\n- **Status:** AI\n- **Rig:** junior-dev\n", encoding="utf-8"
+            "### Phil\n- **Rig:** junior-dev\n", encoding="utf-8"
         )
         sent, _ = tells
         handle_message(ctx, "gerry", "acme", "hi")
@@ -669,14 +665,12 @@ CONTINUE_ROSTER = textwrap.dedent(
     # Continue Team
 
     ### Ana
-    - **Status:** AI
     - **Rig:** resuming
     - **Leader:** yes
     - **Continue:** on
     - **Flush:** 1h
 
     ### Bob
-    - **Status:** AI
     - **Rig:** cold
     - **Flush:** 1h
     """
@@ -2115,12 +2109,10 @@ class TestCli:
             textwrap.dedent(
                 """\
                 ### Gerry
-                - **Status:** AI
                 - **Rig:** leader
                 - **Leader:** yes
 
                 ### Phil
-                - **Status:** AI
                 - **Rig:** junior-dev
                 """
             ),
@@ -2134,7 +2126,7 @@ class TestCli:
         root = tmp_path / "leaderless"
         root.mkdir()
         (root / "ROSTER.md").write_text(
-            "### Phil\n- **Status:** AI\n- **Rig:** junior-dev\n", encoding="utf-8"
+            "### Phil\n- **Rig:** junior-dev\n", encoding="utf-8"
         )
         rc = self.run("roster", "check", "--root", str(root), "--rig-config", str(rig_config))
         assert rc == 1
@@ -2143,10 +2135,10 @@ class TestCli:
     def test_roster_check_warns_on_oversized_cell(self, r4t_home, tmp_path, rig_config, capsys):
         root = tmp_path / "bigcell"
         root.mkdir()
-        text = "### Boss\n- **Status:** AI\n- **Rig:** leader\n- **Leader:** yes\n- **Cell:** hq\n"
+        text = "### Boss\n- **Rig:** leader\n- **Leader:** yes\n- **Cell:** hq\n"
         for i in range(7):
             text += (
-                f"### M{i}\n- **Status:** AI\n- **Rig:** junior-dev\n"
+                f"### M{i}\n- **Rig:** junior-dev\n"
                 f"- **Cell:** c\n- **Lead:** Boss\n"
             )
         (root / "ROSTER.md").write_text(text, encoding="utf-8")
@@ -2160,9 +2152,9 @@ class TestCli:
         root = tmp_path / "sharedcli"
         root.mkdir()
         (root / "ROSTER.md").write_text(
-            "### Ana\n- **Status:** AI\n- **Rig:** solo\n- **Leader:** yes\n"
+            "### Ana\n- **Rig:** solo\n- **Leader:** yes\n"
             "- **Continue:** on\n"
-            "### Bob\n- **Status:** AI\n- **Rig:** solo\n",
+            "### Bob\n- **Rig:** solo\n",
             encoding="utf-8",
         )
         config = tmp_path / "shared-rigs.json"
@@ -2180,7 +2172,7 @@ class TestCli:
         root = tmp_path / "nocontinue"
         root.mkdir()
         (root / "ROSTER.md").write_text(
-            "### Ana\n- **Status:** AI\n- **Rig:** solo\n- **Leader:** yes\n"
+            "### Ana\n- **Rig:** solo\n- **Leader:** yes\n"
             "- **Continue:** on\n",
             encoding="utf-8",
         )
@@ -2198,8 +2190,8 @@ class TestCli:
         root = tmp_path / "badlead"
         root.mkdir()
         (root / "ROSTER.md").write_text(
-            "### Boss\n- **Status:** AI\n- **Rig:** leader\n- **Leader:** yes\n"
-            "### Kid\n- **Status:** AI\n- **Rig:** junior-dev\n- **Lead:** Ghost\n",
+            "### Boss\n- **Rig:** leader\n- **Leader:** yes\n"
+            "### Kid\n- **Rig:** junior-dev\n- **Lead:** Ghost\n",
             encoding="utf-8",
         )
         rc = self.run("roster", "check", "--root", str(root), "--rig-config", str(rig_config))
@@ -2208,8 +2200,8 @@ class TestCli:
 
     def _clean_roster(self, root):
         (root / "ROSTER.md").write_text(
-            "### Gerry\n- **Status:** AI\n- **Rig:** leader\n- **Leader:** yes\n"
-            "### Phil\n- **Status:** AI\n- **Rig:** junior-dev\n",
+            "### Gerry\n- **Rig:** leader\n- **Leader:** yes\n"
+            "### Phil\n- **Rig:** junior-dev\n",
             encoding="utf-8",
         )
 
@@ -2434,12 +2426,10 @@ class TestDoorbellGate:
 WORKDIR_ROSTER = textwrap.dedent(
     """\
     ### Gerry
-    - **Status:** AI
     - **Rig:** leader
     - **Leader:** yes
 
     ### Bob
-    - **Status:** AI
     - **Rig:** junior-dev
     - **Workdir:** {workdir}
     """

--- a/apps/r4t/tests/test_isolate.py
+++ b/apps/r4t/tests/test_isolate.py
@@ -210,12 +210,10 @@ ROSTER = textwrap.dedent(
     # Team
 
     ### Gerry
-    - **Status:** AI
     - **Rig:** leader
     - **Leader:** yes
 
     ### Phil
-    - **Status:** AI
     - **Rig:** junior-dev
     """
 )

--- a/apps/r4t/tests/test_node_root.py
+++ b/apps/r4t/tests/test_node_root.py
@@ -129,7 +129,7 @@ def test_bare_status_resolves_from_workplace_cwd(
     workplace.mkdir()
     org_dir = _portable(tmp_path, NODE, "org", workplace)
     (org_dir / "ROSTER.md").write_text(
-        "# Roster\n\n### Gerry\n- **Status:** AI\n- **Rig:** leader\n"
+        "# Roster\n\n### Gerry\n- **Rig:** leader\n"
         "- **Leader:** yes\n",
         encoding="utf-8",
     )

--- a/apps/r4t/tests/test_org.py
+++ b/apps/r4t/tests/test_org.py
@@ -16,18 +16,16 @@ CLEAN_ROSTER = """\
 # Team Roster
 
 ### Neil
-- **Status:** Human
+- **Human:** yes
 - **Address:** neil
 - **Role:** Director
 
 ### Gerry
-- **Status:** AI
 - **Rig:** leader
 - **Role:** Lead
 - **Leader:** yes
 
 ### Phil
-- **Status:** AI
 - **Rig:** junior-dev
 - **Role:** Developer
 """
@@ -251,7 +249,6 @@ SHADOW_ROSTER = """\
 # Shadow
 
 ### Impostor
-- **Status:** AI
 - **Rig:** leader
 - **Leader:** yes
 """

--- a/apps/r4t/tests/test_rig.py
+++ b/apps/r4t/tests/test_rig.py
@@ -432,21 +432,21 @@ class TestContinueCollisions:
 
     def test_no_warning_when_clis_differ(self, tmp_path):
         assert self.collisions(tmp_path, (
-            "### Ana\n- **Status:** AI\n- **Rig:** solo\n- **Continue:** on\n\n"
-            "### Bob\n- **Status:** AI\n- **Rig:** other\n"
+            "### Ana\n- **Rig:** solo\n- **Continue:** on\n\n"
+            "### Bob\n- **Rig:** other\n"
         )) == []
 
     def test_no_warning_when_nobody_continues(self, tmp_path):
         assert self.collisions(tmp_path, (
-            "### Ana\n- **Status:** AI\n- **Rig:** solo\n\n"
-            "### Bob\n- **Status:** AI\n- **Rig:** solo\n"
+            "### Ana\n- **Rig:** solo\n\n"
+            "### Bob\n- **Rig:** solo\n"
         )) == []
 
     def test_warns_when_a_teammate_shares_the_cli(self, tmp_path):
         # Bob does not continue — he still writes the conversation Ana resumes.
         warnings = self.collisions(tmp_path, (
-            "### Ana\n- **Status:** AI\n- **Rig:** solo\n- **Continue:** on\n\n"
-            "### Bob\n- **Status:** AI\n- **Rig:** solo\n"
+            "### Ana\n- **Rig:** solo\n- **Continue:** on\n\n"
+            "### Bob\n- **Rig:** solo\n"
         ))
         assert len(warnings) == 1
         assert warnings[0].startswith("Ana: Continue: on")
@@ -454,8 +454,8 @@ class TestContinueCollisions:
 
     def test_warns_across_different_rigs_on_one_cli(self, tmp_path):
         warnings = self.collisions(tmp_path, (
-            "### Ana\n- **Status:** AI\n- **Rig:** solo\n- **Continue:** on\n\n"
-            "### Bob\n- **Status:** AI\n- **Rig:** twin\n"
+            "### Ana\n- **Rig:** solo\n- **Continue:** on\n\n"
+            "### Bob\n- **Rig:** twin\n"
         ))
         assert len(warnings) == 1 and "Bob" in warnings[0]
 
@@ -463,8 +463,8 @@ class TestContinueCollisions:
         # One member reaches opencode through `ollama launch`, the other runs it
         # directly — same per-directory session store, so they still collide.
         warnings = self.collisions(tmp_path, (
-            "### Ana\n- **Status:** AI\n- **Rig:** launched\n- **Continue:** on\n\n"
-            "### Bob\n- **Status:** AI\n- **Rig:** cloud\n"
+            "### Ana\n- **Rig:** launched\n- **Continue:** on\n\n"
+            "### Bob\n- **Rig:** cloud\n"
         ))
         assert len(warnings) == 1
         assert "Bob" in warnings[0] and "'opencode'" in warnings[0]
@@ -472,31 +472,31 @@ class TestContinueCollisions:
 
     def test_humans_and_broken_members_never_collide(self, tmp_path):
         assert self.collisions(tmp_path, (
-            "### Ana\n- **Status:** AI\n- **Rig:** solo\n- **Continue:** on\n\n"
-            "### Cid\n- **Status:** Human\n- **Address:** cid\n\n"
-            "### Dot\n- **Status:** AI\n"
+            "### Ana\n- **Rig:** solo\n- **Continue:** on\n\n"
+            "### Cid\n- **Human:** yes\n- **Address:** cid\n\n"
+            "### Dot\n"
         )) == []
 
     def test_distinct_workdirs_on_one_cli_do_not_collide(self, tmp_path):
         # The conversation is keyed on (CLI, directory): a member with its own
         # Workdir: runs the shared CLI somewhere else entirely.
         assert self.collisions(tmp_path, (
-            "### Ana\n- **Status:** AI\n- **Rig:** solo\n- **Continue:** on\n\n"
-            "### Bob\n- **Status:** AI\n- **Rig:** solo\n- **Workdir:** agents/bob\n"
+            "### Ana\n- **Rig:** solo\n- **Continue:** on\n\n"
+            "### Bob\n- **Rig:** solo\n- **Workdir:** agents/bob\n"
         )) == []
 
     def test_same_explicit_workdir_still_collides(self, tmp_path):
         warnings = self.collisions(tmp_path, (
-            "### Ana\n- **Status:** AI\n- **Rig:** solo\n- **Continue:** on\n"
+            "### Ana\n- **Rig:** solo\n- **Continue:** on\n"
             "- **Workdir:** shared\n\n"
-            "### Bob\n- **Status:** AI\n- **Rig:** solo\n- **Workdir:** shared\n"
+            "### Bob\n- **Rig:** solo\n- **Workdir:** shared\n"
         ))
         assert len(warnings) == 1 and "Bob" in warnings[0]
 
     def test_workdir_resolving_to_the_workplace_collides(self, tmp_path):
         warnings = self.collisions(tmp_path, (
-            "### Ana\n- **Status:** AI\n- **Rig:** solo\n- **Continue:** on\n\n"
-            "### Bob\n- **Status:** AI\n- **Rig:** solo\n- **Workdir:** .\n"
+            "### Ana\n- **Rig:** solo\n- **Continue:** on\n\n"
+            "### Bob\n- **Rig:** solo\n- **Workdir:** .\n"
         ))
         assert len(warnings) == 1 and "Bob" in warnings[0]
 

--- a/apps/r4t/tests/test_roster.py
+++ b/apps/r4t/tests/test_roster.py
@@ -16,16 +16,13 @@ from roster import (
 CONTINUE_TEXT = textwrap.dedent(
     """\
     ### Ana
-    - **Status:** AI
     - **Rig:** r
     - **Continue:** on
 
     ### Bob
-    - **Status:** AI
     - **Rig:** r
 
     ### Cid
-    - **Status:** AI
     - **Rig:** r
     - **Continue:** off
     """
@@ -39,30 +36,26 @@ def parse(text: str):
 TREE_TEXT = textwrap.dedent(
     """\
     ### Vic
-    - **Status:** AI
     - **Rig:** r
     - **Leader:** yes
     - **Cell:** lead
     - **Lead:** Ned
 
     ### Ned
-    - **Status:** Human
+    - **Human:** yes
     - **Address:** ned
 
     ### Ann
-    - **Status:** AI
     - **Rig:** r
     - **Cell:** design
     - **Lead:** Vic
 
     ### Bea
-    - **Status:** AI
     - **Rig:** r
     - **Cell:** design
     - **Lead:** Ann
 
     ### Cal
-    - **Status:** AI
     - **Rig:** r
     - **Cell:** build
     - **Lead:** Vic
@@ -75,7 +68,7 @@ class TestParsing:
         roster = load_roster(repo / "ROSTER.md")
         gerry = roster.find("gerry")
         assert gerry is not None
-        assert gerry.status == "AI"
+        assert gerry.is_human is False
         assert gerry.rig == "leader"
         assert gerry.role == "Technical Producer"
         assert gerry.leader
@@ -106,7 +99,7 @@ class TestParsing:
 
     def test_flush_bare_seconds(self):
         roster = parse(
-            "### A\n- **Status:** AI\n- **Rig:** r\n- **Continue:** on\n"
+            "### A\n- **Rig:** r\n- **Continue:** on\n"
             "- **Flush:** 90\n"
         )
         assert roster.find("a").flush_seconds == 90.0
@@ -117,7 +110,7 @@ class TestParsing:
     )
     def test_flush_suffixes(self, value, seconds):
         roster = parse(
-            f"### A\n- **Status:** AI\n- **Rig:** r\n- **Continue:** on\n"
+            f"### A\n- **Rig:** r\n- **Continue:** on\n"
             f"- **Flush:** {value}\n"
         )
         assert roster.find("a").flush_seconds == seconds
@@ -127,21 +120,21 @@ class TestParsing:
 
     def test_flush_malformed_disables_member(self):
         roster = parse(
-            "### A\n- **Status:** AI\n- **Rig:** r\n- **Continue:** on\n"
+            "### A\n- **Rig:** r\n- **Continue:** on\n"
             "- **Flush:** soon\n"
         )
         assert "Flush" in roster.find("a").error
 
     def test_flush_without_continue_warns(self):
         roster = parse(
-            "### A\n- **Status:** AI\n- **Rig:** r\n- **Flush:** 4h\n"
+            "### A\n- **Rig:** r\n- **Flush:** 4h\n"
         )
         warnings = flush_warnings(roster)
         assert len(warnings) == 1 and warnings[0].startswith("A: Flush")
 
     def test_flush_with_continue_does_not_warn(self):
         roster = parse(
-            "### A\n- **Status:** AI\n- **Rig:** r\n- **Continue:** on\n"
+            "### A\n- **Rig:** r\n- **Continue:** on\n"
             "- **Flush:** 4h\n"
         )
         assert flush_warnings(roster) == []
@@ -160,13 +153,13 @@ class TestParsing:
         assert roster.leader().name == "Gerry"
 
     def test_no_leader(self):
-        roster = parse("### Solo\n- **Status:** AI\n- **Rig:** t\n")
+        roster = parse("### Solo\n- **Rig:** t\n")
         assert roster.leader() is None
 
     def test_human_leader_not_dispatched_as_leader(self):
         roster = parse(
-            "### Boss\n- **Status:** Human\n- **Leader:** yes\n"
-            "### Dev\n- **Status:** AI\n- **Rig:** t\n"
+            "### Boss\n- **Human:** yes\n- **Leader:** yes\n"
+            "### Dev\n- **Rig:** t\n"
         )
         assert roster.leader() is None
 
@@ -177,20 +170,28 @@ class TestParsing:
         assert not neil.errors
 
     def test_human_needs_no_harness(self):
-        roster = parse("### Human\n- **Status:** Human\n")
+        roster = parse("### Human\n- **Human:** yes\n")
         assert not roster.find("human").errors
 
+    def test_unmarked_member_is_ai(self):
+        member = parse("### A\n- **Rig:** t\n").find("a")
+        assert member.is_human is False
+        assert not member.errors
+
+    def test_human_no_is_ai(self):
+        assert parse("### A\n- **Human:** no\n- **Rig:** t\n").find("a").is_human is False
+
     def test_backticked_rig(self):
-        roster = parse("### A\n- **Status:** AI\n- **Rig:** `rig-1`\n")
+        roster = parse("### A\n- **Rig:** `rig-1`\n")
         assert roster.find("a").rig == "rig-1"
 
     def test_rig_is_lowercased(self):
-        roster = parse("### A\n- **Status:** AI\n- **Rig:** Leader\n")
+        roster = parse("### A\n- **Rig:** Leader\n")
         assert roster.find("a").rig == "leader"
 
     def test_workdir_captured(self):
         roster = parse(
-            "### A\n- **Status:** AI\n- **Rig:** t\n- **Workdir:** agents/bob\n"
+            "### A\n- **Rig:** t\n- **Workdir:** agents/bob\n"
         )
         assert roster.find("a").workdir == "agents/bob"
 
@@ -199,48 +200,63 @@ class TestParsing:
 
     def test_mandate_accepted_as_role(self):
         roster = parse(
-            "### A\n- **Status:** AI\n- **Rig:** t\n- **Mandate:** The Server\n"
+            "### A\n- **Rig:** t\n- **Mandate:** The Server\n"
         )
         assert roster.find("a").role == "The Server"
 
     def test_blocks_end_at_next_heading(self):
         roster = parse(
-            "### A\n- **Status:** AI\n- **Rig:** t\npersona a\n"
+            "### A\n- **Rig:** t\npersona a\n"
             "## Section\nloose prose\n"
-            "### B\n- **Status:** AI\n- **Rig:** t\n"
+            "### B\n- **Rig:** t\n"
         )
         assert "loose prose" not in roster.find("a").persona
         assert roster.find("b") is not None
 
 
 class TestMalformed:
-    def test_bad_status_disables_member(self, repo):
+    def test_bad_rig_disables_member(self, repo):
         roster = load_roster(repo / "ROSTER.md")
         broken = roster.find("broken")
         assert broken.errors
-        assert "Status" in broken.error
+        assert "symbolic rig" in broken.error
+
+    def test_human_with_rig_disabled(self):
+        member = parse("### A\n- **Human:** yes\n- **Rig:** solo\n").find("a")
+        assert member.rig is None
+        assert "Human members carry no Rig" in member.error
+
+    def test_legacy_status_line_disables_member(self):
+        member = parse("### A\n- **Status:** Human\n").find("a")
+        assert member.error == (
+            "Status: is gone — mark the human seat with **Human:** yes; "
+            "AI members carry no marker; missing Rig line"
+        )
+
+    def test_legacy_status_value_is_never_parsed(self):
+        assert parse("### A\n- **Status:** Human\n").find("a").is_human is False
 
     def test_command_harness_disables_member(self):
         roster = parse(
-            "### A\n- **Status:** AI\n- **Rig:** `agent -p --yolo {prompt}`\n"
+            "### A\n- **Rig:** `agent -p --yolo {prompt}`\n"
         )
         member = roster.find("a")
         assert member.errors
         assert "symbolic rig" in member.error
 
     def test_ai_without_rig_disabled(self):
-        roster = parse("### A\n- **Status:** AI\n")
+        roster = parse("### A\n")
         assert "missing Rig" in roster.find("a").error
 
     def test_duplicate_names_disable_both(self):
         roster = parse(
-            "### A\n- **Status:** AI\n- **Rig:** t\n"
-            "### a\n- **Status:** AI\n- **Rig:** t\n"
+            "### A\n- **Rig:** t\n"
+            "### a\n- **Rig:** t\n"
         )
         assert all("duplicate" in m.error for m in roster.members)
 
     def test_malformed_block_never_raises(self):
-        roster = parse("### \n### A\n- **Status:**\n- garbage ** stuff\n")
+        roster = parse("### \n### A\n- **Human:**\n- garbage ** stuff\n")
         assert isinstance(roster.members, list)
 
 
@@ -270,13 +286,13 @@ class TestTree:
         assert r.find("vic").lead == "Ned"
 
     def test_lead_empty_when_absent(self):
-        assert parse("### A\n- **Status:** AI\n- **Rig:** r\n").find("a").lead == ""
+        assert parse("### A\n- **Rig:** r\n").find("a").lead == ""
 
     def test_declares_tree_only_with_lead_lines(self):
         assert parse(TREE_TEXT).declares_tree
         flat = parse(
-            "### A\n- **Status:** AI\n- **Rig:** r\n- **Leader:** yes\n- **Cell:** x\n"
-            "### B\n- **Status:** AI\n- **Rig:** r\n- **Cell:** x\n"
+            "### A\n- **Rig:** r\n- **Leader:** yes\n- **Cell:** x\n"
+            "### B\n- **Rig:** r\n- **Cell:** x\n"
         )
         assert not flat.declares_tree
 
@@ -303,39 +319,39 @@ class TestTree:
 
     def test_flat_roster_has_no_tree_problems(self):
         # Cell lines but no Lead lines anywhere: many members, still flat.
-        text = "### Top\n- **Status:** AI\n- **Rig:** r\n- **Leader:** yes\n"
+        text = "### Top\n- **Rig:** r\n- **Leader:** yes\n"
         for i in range(12):
-            text += f"### M{i}\n- **Status:** AI\n- **Rig:** r\n"
+            text += f"### M{i}\n- **Rig:** r\n"
         assert parse(text).tree_problems() == []
 
     def test_unknown_lead_is_error(self):
         r = parse(
-            "### Top\n- **Status:** AI\n- **Rig:** r\n- **Leader:** yes\n"
-            "### Kid\n- **Status:** AI\n- **Rig:** r\n- **Lead:** Ghost\n"
+            "### Top\n- **Rig:** r\n- **Leader:** yes\n"
+            "### Kid\n- **Rig:** r\n- **Lead:** Ghost\n"
         )
         assert any(s == "error" and "Ghost" in msg for s, msg in r.tree_problems())
 
     def test_cell_over_six_warns(self):
-        text = "### Top\n- **Status:** AI\n- **Rig:** r\n- **Leader:** yes\n- **Cell:** hq\n"
+        text = "### Top\n- **Rig:** r\n- **Leader:** yes\n- **Cell:** hq\n"
         for i in range(7):
-            text += f"### M{i}\n- **Status:** AI\n- **Rig:** r\n- **Cell:** c\n- **Lead:** Top\n"
+            text += f"### M{i}\n- **Rig:** r\n- **Cell:** c\n- **Lead:** Top\n"
         probs = parse(text).tree_problems()
         assert any(s == "warn" and "soft cap 6" in msg for s, msg in probs)
         assert not any(s == "error" for s, _ in probs)
 
     def test_cell_over_ten_errors(self):
-        text = "### Top\n- **Status:** AI\n- **Rig:** r\n- **Leader:** yes\n- **Cell:** hq\n"
+        text = "### Top\n- **Rig:** r\n- **Leader:** yes\n- **Cell:** hq\n"
         for i in range(11):
-            text += f"### M{i}\n- **Status:** AI\n- **Rig:** r\n- **Cell:** c\n- **Lead:** Top\n"
+            text += f"### M{i}\n- **Rig:** r\n- **Cell:** c\n- **Lead:** Top\n"
         assert any(
             s == "error" and "hard cap 10" in msg for s, msg in parse(text).tree_problems()
         )
 
     def test_depth_over_two_warns(self):
         r = parse(
-            "### L0\n- **Status:** AI\n- **Rig:** r\n- **Leader:** yes\n"
-            "### L1\n- **Status:** AI\n- **Rig:** r\n- **Lead:** L0\n"
-            "### L2\n- **Status:** AI\n- **Rig:** r\n- **Lead:** L1\n"
-            "### L3\n- **Status:** AI\n- **Rig:** r\n- **Lead:** L2\n"
+            "### L0\n- **Rig:** r\n- **Leader:** yes\n"
+            "### L1\n- **Rig:** r\n- **Lead:** L0\n"
+            "### L2\n- **Rig:** r\n- **Lead:** L1\n"
+            "### L3\n- **Rig:** r\n- **Lead:** L2\n"
         )
         assert any(s == "warn" and "depth" in msg for s, msg in r.tree_problems())

--- a/guides/02-the-solo-agent.md
+++ b/guides/02-the-solo-agent.md
@@ -70,11 +70,10 @@ with a roster of one AI and one human — you:
 # Team Roster
 
 ### You
-- **Status:** Human
+- **Human:** yes
 - **Role:** Owner
 
 ### Wren
-- **Status:** AI
 - **Rig:** solo
 - **Leader:** yes
 - **Continue:** on

--- a/guides/04-a-second-pair-of-hands.md
+++ b/guides/04-a-second-pair-of-hands.md
@@ -37,11 +37,10 @@ Two edits: the roster grows a member, and the rig config grows a rig.
 # Team Roster
 
 ### You
-- **Status:** Human
+- **Human:** yes
 - **Role:** Owner
 
 ### Wren
-- **Status:** AI
 - **Rig:** solo
 - **Leader:** yes
 - **Continue:** on
@@ -53,7 +52,6 @@ Wren is a roster of one: leader, developer, and correspondent in a single
 seat. Keep answers short and concrete.
 
 ### Moss
-- **Status:** AI
 - **Rig:** helper
 - **Workdir:** agents/moss
 - **Role:** Helper — quick lookups and drafts for Wren

--- a/guides/templates/02-solo-cursor/ROSTER.md
+++ b/guides/templates/02-solo-cursor/ROSTER.md
@@ -1,11 +1,10 @@
 # Team Roster
 
 ### You
-- **Status:** Human
+- **Human:** yes
 - **Role:** Owner
 
 ### Wren
-- **Status:** AI
 - **Rig:** solo
 - **Leader:** yes
 - **Continue:** on

--- a/guides/templates/02-solo-opencode-ollama/ROSTER.md
+++ b/guides/templates/02-solo-opencode-ollama/ROSTER.md
@@ -1,11 +1,10 @@
 # Team Roster
 
 ### You
-- **Status:** Human
+- **Human:** yes
 - **Role:** Owner
 
 ### Wren
-- **Status:** AI
 - **Rig:** solo
 - **Leader:** yes
 - **Continue:** on

--- a/guides/templates/04-two-member/ROSTER.md
+++ b/guides/templates/04-two-member/ROSTER.md
@@ -1,11 +1,10 @@
 # Team Roster
 
 ### You
-- **Status:** Human
+- **Human:** yes
 - **Role:** Owner
 
 ### Wren
-- **Status:** AI
 - **Rig:** solo
 - **Leader:** yes
 - **Continue:** on
@@ -17,7 +16,6 @@ Wren is a roster of one: leader, developer, and correspondent in a single
 seat. Keep answers short and concrete.
 
 ### Moss
-- **Status:** AI
 - **Rig:** helper
 - **Workdir:** agents/moss
 - **Role:** Helper — quick lookups and drafts for Wren


### PR DESCRIPTION
Closes #277

`Status:` read as health when it actually declared species. Species is binary and lopsided — almost every seat is an AI — so the AI case is now silent and only the exception is marked: `- **Human:** yes`, in the same boolean grammar as the `Leader:` line beside it. An unmarked member is an AI.

## Lints, fail-closed both ways

- A member with `Human: yes` **and** a `Rig:` is an error — humans sit outside the turn system, so a rig on a human seat is always a mistake.
- An AI member without a `Rig:` stays the error it already was.

## Migration is loud, not silent

A roster still carrying a `Status:` line errors with:

```
Status: is gone — mark the human seat with **Human:** yes; AI members carry no marker
```

The old value is never parsed. Silently ignoring it would quietly demote an old human seat into an AI member with no rig, surfacing only as confusing downstream failures.

## Internals

`Member.is_human` remains the single discriminator every consumer (dispatch, chat, chat_tui) reads; only its backing changes from a string compare to the new boolean field. `Member.status` is gone.

## Sweep

Parser and docstrings, `r4t init` starter roster, `r4t seat` / `r4t chat` error text, sandbox + n5a experiment rosters, `docs/tutorial.md`, `docs/org.md`, test fixtures across the suite, guides chapters 02/04 and `guides/templates/*/ROSTER.md`. Archived design docs under `apps/r4t/plans/history/` are left as the historical record they are.

## Tests

`apps/r4t/tests/` 647 passed · `apps/a8s/tests/` 782 passed.

New coverage: `Human: yes` + `Rig:` errors; a legacy `Status:` line errors with the pointed message and its value is never parsed; an unmarked member parses as AI; `Human: no` is AI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)