### PR TITLE
feat(windows): .ps1 shims for top-level CLIs + ark.cmd

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,11 @@ finds `python3`/`python`/`py` via `Get-Command`. The pattern uses
 multi-line comment. `tell` is a thin shim around `a8s tell`; don't add new
 polyglots without reading an existing one (e.g., `~/bin/a8s`) first.
 
+Windows can't run the extensionless polyglot from `PATH`, so the important
+top-level commands also ship a sibling `.ps1` (PowerShell prefers it over the
+extensionless file) and a `.cmd` for `cmd.exe`. Both are thin: resolve the
+repo dir, find python, exec the entry-point `.py`, propagate the exit code.
+
 ### Install hook
 
 `install.sh` is sourced from a shell rc. It adds `~/bin/` to `$PATH`. Pass

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,11 @@ finds `python3`/`python`/`py` via `Get-Command`. The pattern uses
 multi-line comment. `tell` is a thin shim around `a8s tell`; don't add new
 polyglots without reading an existing one (e.g., `~/bin/a8s`) first.
 
+Windows can't run the extensionless polyglot from `PATH`, so the important
+top-level commands also ship a sibling `.ps1` (PowerShell prefers it over the
+extensionless file) and a `.cmd` for `cmd.exe`. Both are thin: resolve the
+repo dir, find python, exec the entry-point `.py`, propagate the exit code.
+
 ### Install hook
 
 `install.sh` is sourced from a shell rc. It adds `~/bin/` to `$PATH`. Pass

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 These are my common command-line utilities. Install by `source`'ing `install.sh` after cloning.
 
+On Windows, put this directory on `PATH` and PowerShell finds the `.ps1` shims
+on its own — `ark`, `a8s`, `tell`, `tells`, `r4t`, `k7e`, and `n0b` all run
+without typing the extension. The matching `.cmd` shims cover `cmd.exe`.
+
 New to the Ark Suite (a8s + r4t + k7e)? Start with **[The Ark Raising](guides/README.md)** — a chapter-by-chapter build-along that raises a crew of AI agents from nothing.
 
 ## Note on Shebangs

--- a/a8s.ps1
+++ b/a8s.ps1
@@ -1,0 +1,11 @@
+$A8sPath = Join-Path $PSScriptRoot "apps/a8s/a8s.py"
+
+$Python = Get-Command python3 -ErrorAction SilentlyContinue
+if ($Python) { & $Python.Source $A8sPath @args; exit $LASTEXITCODE }
+$Python = Get-Command python -ErrorAction SilentlyContinue
+if ($Python) { & $Python.Source $A8sPath @args; exit $LASTEXITCODE }
+$Python = Get-Command py -ErrorAction SilentlyContinue
+if ($Python) { & $Python.Source -3 $A8sPath @args; exit $LASTEXITCODE }
+
+Write-Error "Could not find python3, python, or py on PATH."
+exit 127

--- a/ark.cmd
+++ b/ark.cmd
@@ -1,0 +1,19 @@
+@echo off
+setlocal
+set "BIN_DIR=%~dp0"
+set "ARK=%BIN_DIR%apps\ark\ark.py"
+
+where python >nul 2>&1
+if %ERRORLEVEL%==0 (
+    python "%ARK%" %*
+    exit /b %ERRORLEVEL%
+)
+
+where py >nul 2>&1
+if %ERRORLEVEL%==0 (
+    py -3 "%ARK%" %*
+    exit /b %ERRORLEVEL%
+)
+
+echo ark: python not found on PATH >&2
+exit /b 127

--- a/ark.ps1
+++ b/ark.ps1
@@ -1,0 +1,11 @@
+$ArkPath = Join-Path $PSScriptRoot "apps/ark/ark.py"
+
+$Python = Get-Command python3 -ErrorAction SilentlyContinue
+if ($Python) { & $Python.Source $ArkPath @args; exit $LASTEXITCODE }
+$Python = Get-Command python -ErrorAction SilentlyContinue
+if ($Python) { & $Python.Source $ArkPath @args; exit $LASTEXITCODE }
+$Python = Get-Command py -ErrorAction SilentlyContinue
+if ($Python) { & $Python.Source -3 $ArkPath @args; exit $LASTEXITCODE }
+
+Write-Error "Could not find python3, python, or py on PATH."
+exit 127

--- a/k7e.ps1
+++ b/k7e.ps1
@@ -1,0 +1,11 @@
+$K7ePath = Join-Path $PSScriptRoot "apps/k7e/k7e.py"
+
+$Python = Get-Command python3 -ErrorAction SilentlyContinue
+if ($Python) { & $Python.Source $K7ePath @args; exit $LASTEXITCODE }
+$Python = Get-Command python -ErrorAction SilentlyContinue
+if ($Python) { & $Python.Source $K7ePath @args; exit $LASTEXITCODE }
+$Python = Get-Command py -ErrorAction SilentlyContinue
+if ($Python) { & $Python.Source -3 $K7ePath @args; exit $LASTEXITCODE }
+
+Write-Error "Could not find python3, python, or py on PATH."
+exit 127

--- a/n0b.ps1
+++ b/n0b.ps1
@@ -1,0 +1,11 @@
+$N0bPath = Join-Path $PSScriptRoot "apps/n0b/n0b.py"
+
+$Python = Get-Command python3 -ErrorAction SilentlyContinue
+if ($Python) { & $Python.Source $N0bPath @args; exit $LASTEXITCODE }
+$Python = Get-Command python -ErrorAction SilentlyContinue
+if ($Python) { & $Python.Source $N0bPath @args; exit $LASTEXITCODE }
+$Python = Get-Command py -ErrorAction SilentlyContinue
+if ($Python) { & $Python.Source -3 $N0bPath @args; exit $LASTEXITCODE }
+
+Write-Error "Could not find python3, python, or py on PATH."
+exit 127

--- a/r4t.ps1
+++ b/r4t.ps1
@@ -1,0 +1,11 @@
+$R4tPath = Join-Path $PSScriptRoot "apps/r4t/r4t.py"
+
+$Python = Get-Command python3 -ErrorAction SilentlyContinue
+if ($Python) { & $Python.Source $R4tPath @args; exit $LASTEXITCODE }
+$Python = Get-Command python -ErrorAction SilentlyContinue
+if ($Python) { & $Python.Source $R4tPath @args; exit $LASTEXITCODE }
+$Python = Get-Command py -ErrorAction SilentlyContinue
+if ($Python) { & $Python.Source -3 $R4tPath @args; exit $LASTEXITCODE }
+
+Write-Error "Could not find python3, python, or py on PATH."
+exit 127

--- a/tell.ps1
+++ b/tell.ps1
@@ -1,0 +1,11 @@
+$A8sPath = Join-Path $PSScriptRoot "apps/a8s/a8s.py"
+
+$Python = Get-Command python3 -ErrorAction SilentlyContinue
+if ($Python) { & $Python.Source $A8sPath tell @args; exit $LASTEXITCODE }
+$Python = Get-Command python -ErrorAction SilentlyContinue
+if ($Python) { & $Python.Source $A8sPath tell @args; exit $LASTEXITCODE }
+$Python = Get-Command py -ErrorAction SilentlyContinue
+if ($Python) { & $Python.Source -3 $A8sPath tell @args; exit $LASTEXITCODE }
+
+Write-Error "Could not find python3, python, or py on PATH."
+exit 127

--- a/tells.ps1
+++ b/tells.ps1
@@ -1,0 +1,11 @@
+$A8sPath = Join-Path $PSScriptRoot "apps/a8s/a8s.py"
+
+$Python = Get-Command python3 -ErrorAction SilentlyContinue
+if ($Python) { & $Python.Source $A8sPath tells @args; exit $LASTEXITCODE }
+$Python = Get-Command python -ErrorAction SilentlyContinue
+if ($Python) { & $Python.Source $A8sPath tells @args; exit $LASTEXITCODE }
+$Python = Get-Command py -ErrorAction SilentlyContinue
+if ($Python) { & $Python.Source -3 $A8sPath tells @args; exit $LASTEXITCODE }
+
+Write-Error "Could not find python3, python, or py on PATH."
+exit 127


### PR DESCRIPTION
Closes #280

The extensionless bash+PowerShell polyglots at repo top level cannot be launched from `PATH` on Windows — PATH lookup there goes through `PATHEXT`, and a file with no extension is not a candidate. This adds a sibling `.ps1` per important command so PowerShell resolves a bare `ark` to `ark.ps1` and runs it without the extension, plus `ark.cmd` for `cmd.exe` (`a8s`, `tell`, `tells`, and `n0b` already had `.cmd`; `ark`, `r4t`, and `k7e` did not — `ark` is the one added here, per the front-door scope).

Each `.ps1` is the polyglot's own PowerShell half, extracted verbatim in behavior: resolve the repo dir from `$PSScriptRoot`, walk `python3` -> `python` -> `py -3` via `Get-Command`, exec the entry-point `.py` with `@args`, propagate `$LASTEXITCODE`. Files are ASCII with no BOM (Windows PowerShell 5.1 mis-parses a UTF-8 BOM).

**Scope:** `ark` (both `.ps1` and `.cmd`), `a8s`, `tell`, `tells`, `r4t`, `k7e`, `n0b`. Minor top-level scripts untouched.

## Behavioral differences vs the polyglots' PowerShell halves

One, deliberate: `tell` and `tells` polyglots shell out to the extensionless `a8s` wrapper (`& $A8sPath tell @args`) — which is exactly the file Windows cannot execute. The shims call `apps/a8s/a8s.py tell` / `tells` directly instead. Same dispatch (the `a8s` wrapper only execs `a8s.py`), one hop shorter, and identical to what `tell.cmd` / `tells.cmd` already do. Otherwise none.

Also: `$PSScriptRoot` replaces the polyglots' `$PSCommandPath` / `$MyInvocation` / `Get-Location` fallback ladder. A `.ps1` is always invoked as a file, so those fallbacks cannot fire.

## Verification (pwsh 7, macOS, from the worktree)

| Command | Result |
|---|---|
| `pwsh -NoProfile -File ark.ps1` | greeter renders — ARK/847/STE grid + all three product panels, exit 0 |
| `pwsh -NoProfile -File ark.ps1 doctor` | executes, 10/10 probes green, exit 0 |
| `pwsh -NoProfile -File r4t.ps1 --help` | `usage: r4t [-h] {dispatch,clear,idle,status,...}` |
| `pwsh -NoProfile -File a8s.ps1 --help` | `usage: a8s [-h] [--interval INTERVAL]` + command list |
| `pwsh -NoProfile -File k7e.ps1 --help` | `usage: k7e [-h] {search,get,supersede,store,...}` |
| `pwsh -NoProfile -File n0b.ps1 --help` | `usage: n0b [-h] GROUP ...` |
| `pwsh -NoProfile -File tell.ps1 --help` | `usage: tell [--attach PATH ...] [--split] <name> [<message...>]` |
| `pwsh -NoProfile -File tells.ps1 --help` | `usage: tells [-f|--follow] [--timeout SEC] ...` |
| `pwsh -NoProfile -File k7e.ps1 --bogus-flag` | exit 2 — `$LASTEXITCODE` propagates |

`TELL_OUTBOX_DIR` was unset for the tell/tells runs and no message was sent. `ark.cmd` is verified **by review only** — cmd.exe does not exist on macOS; it is structurally identical to the existing `a8s.cmd` / `n0b.cmd` (`%~dp0` for the repo dir, `where python` then `where py` with `py -3`, `%*` forwarding, `exit /b %ERRORLEVEL%`).

## Sanity

`install.sh` only globs `docs/*.md` and `apps/n0b/docs/*.md` — it never iterates top-level files, so the new `.ps1`/`.cmd` are invisible to it. CI (`.github/workflows/test.yml`) has no top-level glob either. Docs: a two-sentence Windows note in `README.md` next to the existing PATH/install line, and a matching paragraph in the `CLAUDE.md` / `AGENTS.md` polyglot section for future contributors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)