### PR TITLE
docs(guides): tutorial team is silo from chapter 1

### DIFF
--- a/guides/02-the-solo-agent.md
+++ b/guides/02-the-solo-agent.md
@@ -34,37 +34,45 @@ ollama pull qwen3.6
 
 A team is two files with two jobs: `ROSTER.md` in the team repo says *who*
 exists, and `~/.config/r4t/rigs.json` — outside the repo, where a repo
-edit can't reach it — says what each member's **rig** actually runs. Make
-the team directory and let r4t write the starters:
+edit can't reach it — says what each member's **rig** actually runs.
+
+The team is named **silo**, and the directory name is the team name — r4t
+reads it straight off the folder. From outside a silo is one address;
+everything behind it — who exists, what they run, how they remember — is
+machinery the sender never sees. Today this one genuinely holds a single
+agent; chapter 4 puts a second pair of hands inside it without the address
+changing.
+
+Make the team directory and let r4t write the starters:
 
 **Run**
 
 ```bash
-mkdir -p ~/ark/solo
-cd ~/ark/solo
+mkdir -p ~/ark/silo
+cd ~/ark/silo
 r4t init
 ```
 
 You should see:
 
 ```
-roster: wrote starter /home/you/ark/solo/ROSTER.md
+roster: wrote starter /home/you/ark/silo/ROSTER.md
 rig config: wrote starter /home/you/.config/r4t/rigs.json
 
 Register and start the team (a namespace prefix cannot share a
 name with its agent, so the node is registered as <team>-node):
 
-  a8s add solo-node /home/you/ark/solo r4t
-  a8s namespace solo solo-node
-  a8s start solo-node
-  tell solo "hello"            # bare namespace -> roster leader
-  tell solo:dev "hello"        # namespace:member -> specific member
+  a8s add silo-node /home/you/ark/silo r4t
+  a8s namespace silo silo-node
+  a8s start silo-node
+  tell silo "hello"            # bare namespace -> roster leader
+  tell silo:dev "hello"        # namespace:member -> specific member
 ```
 
 The starter roster is a three-member team. Ours is smaller. Replace it
 with a roster of one AI and one human — you:
 
-**Replace** `~/ark/solo/ROSTER.md` (whole file)
+**Replace** `~/ark/silo/ROSTER.md` (whole file)
 
 ```markdown
 # Team Roster
@@ -74,7 +82,7 @@ with a roster of one AI and one human — you:
 - **Role:** Owner
 
 ### Wren
-- **Rig:** solo
+- **Rig:** silo
 - **Leader:** yes
 - **Continue:** on
 - **Workdir:** agents/wren
@@ -85,13 +93,13 @@ seat. Keep answers short and concrete.
 ```
 
 Four lines carry the weight. `Leader: yes` — external mail enters at Wren.
-`Rig: solo` — a symbolic name; what it runs comes next, from outside the
+`Rig: silo` — a symbolic name; what it runs comes next, from outside the
 repo. `Continue: on` — Wren's turns resume its CLI's own conversation
 instead of starting cold every wake. `Workdir: agents/wren` — Wren gets its
 own subfolder, so its conversation and files never collide with a future
 teammate's.
 
-Now define the `solo` rig. Pick your path — and note that these two
+Now define the `silo` rig. Pick your path — and note that these two
 presets are only the blessed pair: the other popular harness CLIs are
 presets too (`r4t rig presets` lists them, and later guide branches may
 walk through more of them), added by the same one-line command.
@@ -99,33 +107,33 @@ walk through more of them), added by the same one-line command.
 **Run** (free path)
 
 ```bash
-r4t rig add solo opencode-ollama --model qwen3.6
-r4t rig set solo echo true
+r4t rig add silo opencode-ollama --model qwen3.6
+r4t rig set silo echo true
 ```
 
 You should see:
 
 ```
-added rig 'solo' (opencode-ollama) to /home/you/.config/r4t/rigs.json
+added rig 'silo' (opencode-ollama) to /home/you/.config/r4t/rigs.json
   invoke: ollama launch opencode --model qwen3.6 -- run --auto --dir . {prompt}
-Reference it from ROSTER.md: `- **Rig:** solo`
-set solo echo = true in /home/you/.config/r4t/rigs.json
+Reference it from ROSTER.md: `- **Rig:** silo`
+set silo echo = true in /home/you/.config/r4t/rigs.json
 ```
 
 **Run** (subscription path)
 
 ```bash
-r4t rig add solo cursor
-r4t rig set solo echo true
+r4t rig add silo cursor
+r4t rig set silo echo true
 ```
 
 You should see:
 
 ```
-added rig 'solo' (cursor) to /home/you/.config/r4t/rigs.json
+added rig 'silo' (cursor) to /home/you/.config/r4t/rigs.json
   invoke: agent --model auto -p --trust --force --approve-mcps {prompt}
-Reference it from ROSTER.md: `- **Rig:** solo`
-set solo echo = true in /home/you/.config/r4t/rigs.json
+Reference it from ROSTER.md: `- **Rig:** silo`
+set silo echo = true in /home/you/.config/r4t/rigs.json
 ```
 
 Naming no model of your own is the deliberate part: the preset writes
@@ -151,7 +159,7 @@ Lint before going live — r4t fails closed on any roster/rig disagreement:
 **Run**
 
 ```bash
-cd ~/ark/solo
+cd ~/ark/silo
 r4t roster check
 ```
 
@@ -159,7 +167,7 @@ You should see:
 
 ```
 You: note — Human without an Address (team cannot tell them)
-/home/you/ark/solo/ROSTER.md: OK (2 member(s), leader Wren)
+/home/you/ark/silo/ROSTER.md: OK (2 member(s), leader Wren)
 ```
 
 The note is expected: you have no a8s doorbell address yet, so the team
@@ -169,18 +177,18 @@ instead. Finally, register the node on a8s exactly as `r4t init` printed:
 **Run**
 
 ```bash
-a8s add solo-node ~/ark/solo r4t
-a8s namespace solo solo-node
-a8s start solo-node
+a8s add silo-node ~/ark/silo r4t
+a8s namespace silo silo-node
+a8s start silo-node
 ```
 
 You should see:
 
 ```
-added solo-node -> /home/you/ark/solo
+added silo-node -> /home/you/ark/silo
 definition: /home/you/bin/apps/a8s/definitions/r4t.json  (explicit)
-bound solo: -> solo-node
-started solo-node as PID 23851
+bound silo: -> silo-node
+started silo-node as PID 23851
 ```
 
 ## 5. Run it
@@ -193,12 +201,12 @@ model loads; later turns take seconds.
 **Run**
 
 ```bash
-cd ~/ark/solo
-r4t seat send --node solo "In one sentence: what is your job on this team?"
-r4t seat inbox --node solo
+cd ~/ark/silo
+r4t seat send --node silo "In one sentence: what is your job on this team?"
+r4t seat inbox --node silo
 ```
 
-(`--node solo` is needed the first time; once the team has dispatched a
+(`--node silo` is needed the first time; once the team has dispatched a
 turn, r4t finds the node from inside the repo on its own.)
 
 ## 6. Expected receipt
@@ -206,7 +214,7 @@ turn, r4t finds the node from inside the repo on its own.)
 You should see:
 
 ```
-── from solo:wren (2026-07-29T04:55:04.121285Z)
+── from silo:wren (2026-07-29T04:55:04.121285Z)
 My job is to do the work and answer to the owner — handling everything from leadership to development as the sole member of the solo team.
 ```
 
@@ -216,14 +224,14 @@ that `Continue: on` means what it says — plant a codeword in one turn:
 **Run**
 
 ```bash
-r4t seat send --node solo "Remember this codeword: TIDEPOOL. Confirm you have it."
-r4t seat inbox --node solo
+r4t seat send --node silo "Remember this codeword: TIDEPOOL. Confirm you have it."
+r4t seat inbox --node silo
 ```
 
 You should see:
 
 ```
-── from solo:wren (2026-07-29T04:55:15.702909Z)
+── from silo:wren (2026-07-29T04:55:15.702909Z)
 Codeword confirmed: TIDEPOOL.
 ```
 
@@ -232,14 +240,14 @@ And ask for it back in a second, separate turn:
 **Run**
 
 ```bash
-r4t seat send --node solo "What was the codeword?"
-r4t seat inbox --node solo
+r4t seat send --node silo "What was the codeword?"
+r4t seat inbox --node silo
 ```
 
 You should see:
 
 ```
-── from solo:wren (2026-07-29T04:55:30.722365Z)
+── from silo:wren (2026-07-29T04:55:30.722365Z)
 TIDEPOOL.
 ```
 
@@ -255,17 +263,17 @@ session store, no continue support:
 **Run**
 
 ```bash
-r4t rig swap solo ollama --model qwen3.6
+r4t rig swap silo ollama --model qwen3.6
 r4t roster check
 ```
 
 You should see:
 
 ```
-swapped rig 'solo' to ollama in /home/you/.config/r4t/rigs.json
+swapped rig 'silo' to ollama in /home/you/.config/r4t/rigs.json
   invoke: ollama run qwen3.6 {prompt}
 You: note — Human without an Address (team cannot tell them)
-Wren: Wren has Continue: on but rig 'solo' does not support it (preset ollama; presets that continue: agy, claude, codex, cursor, opencode, opencode-ollama) — try: r4t rig swap solo <preset>
+Wren: Wren has Continue: on but rig 'silo' does not support it (preset ollama; presets that continue: agy, claude, codex, cursor, opencode, opencode-ollama) — try: r4t rig swap silo <preset>
 1 problem(s)
 ```
 
@@ -285,7 +293,7 @@ Take the error's suggestion:
 **Run**
 
 ```bash
-r4t rig swap solo opencode-ollama --model qwen3.6
+r4t rig swap silo opencode-ollama --model qwen3.6
 r4t roster check
 ```
 
@@ -294,10 +302,10 @@ r4t roster check
 You should see:
 
 ```
-swapped rig 'solo' to opencode-ollama in /home/you/.config/r4t/rigs.json
+swapped rig 'silo' to opencode-ollama in /home/you/.config/r4t/rigs.json
   invoke: ollama launch opencode --model qwen3.6 -- run --auto --dir . {prompt}
 You: note — Human without an Address (team cannot tell them)
-/home/you/ark/solo/ROSTER.md: OK (2 member(s), leader Wren)
+/home/you/ark/silo/ROSTER.md: OK (2 member(s), leader Wren)
 ```
 
 ## 10. Check
@@ -307,14 +315,14 @@ The codeword is the health check. Ask again:
 **Run**
 
 ```bash
-r4t seat send --node solo "What was the codeword?"
-r4t seat inbox --node solo
+r4t seat send --node silo "What was the codeword?"
+r4t seat inbox --node silo
 ```
 
 You should see:
 
 ```
-── from solo:wren (2026-07-29T04:55:49.122781Z)
+── from silo:wren (2026-07-29T04:55:49.122781Z)
 TIDEPOOL.
 ```
 
@@ -324,7 +332,7 @@ Wren still knows. The team is whole.
 
 One line in the roster: bound how long Wren's conversation may sit idle.
 
-**Replace** `~/ark/solo/ROSTER.md` — in Wren's block, directly under
+**Replace** `~/ark/silo/ROSTER.md` — in Wren's block, directly under
 `- **Continue:** on`, add:
 
 ```markdown
@@ -348,7 +356,7 @@ You should see:
 
 ```
 You: note — Human without an Address (team cannot tell them)
-/home/you/ark/solo/ROSTER.md: OK (2 member(s), leader Wren)
+/home/you/ark/silo/ROSTER.md: OK (2 member(s), leader Wren)
 ```
 
 ## 12. Commit point
@@ -360,10 +368,10 @@ in commands.)
 **Run**
 
 ```bash
-cd ~/ark/solo
+cd ~/ark/silo
 git init -q
 git add ROSTER.md
-git commit -q -m "solo roster: Wren, continue on, flush 15m"
+git commit -q -m "silo roster: Wren, continue on, flush 15m"
 ```
 
 Copy-paste templates for this chapter's final state live in

--- a/guides/03-the-long-memory.md
+++ b/guides/03-the-long-memory.md
@@ -29,7 +29,7 @@ right setting and still the wrong demo — you are not going to sit here
 watching a clock. The value takes bare seconds or an `s`/`m`/`h`/`d`
 suffix, so shrink the window further for one session:
 
-**Replace** `~/ark/solo/ROSTER.md` — in Wren's block, the `Flush:` line
+**Replace** `~/ark/silo/ROSTER.md` — in Wren's block, the `Flush:` line
 becomes:
 
 ```markdown
@@ -39,7 +39,7 @@ becomes:
 **Run**
 
 ```bash
-cd ~/ark/solo
+cd ~/ark/silo
 r4t roster check
 ```
 
@@ -47,7 +47,7 @@ You should see:
 
 ```
 You: note — Human without an Address (team cannot tell them)
-/home/you/ark/solo/ROSTER.md: OK (2 member(s), leader Wren)
+/home/you/ark/silo/ROSTER.md: OK (2 member(s), leader Wren)
 ```
 
 One rule worth knowing before you rely on this line: `Flush:` only means
@@ -58,7 +58,7 @@ instead of blocking:
 ```
 warning: Wren: Flush: set but Continue: is off — flush retires a continuing
 conversation, so it is ignored here
-/home/you/ark/solo/ROSTER.md: OK (2 member(s), leader Wren, 1 warning(s))
+/home/you/ark/silo/ROSTER.md: OK (2 member(s), leader Wren, 1 warning(s))
 ```
 
 Harmless, but it means the field is doing nothing. Yours says OK — keep
@@ -71,14 +71,14 @@ Give Wren a fact to hold, and prove he has it:
 **Run**
 
 ```bash
-r4t seat send --node solo "Hold this fact for later: the supply cache is at grid square K-19. Confirm."
-r4t seat inbox --node solo
+r4t seat send --node silo "Hold this fact for later: the supply cache is at grid square K-19. Confirm."
+r4t seat inbox --node silo
 ```
 
 You should see:
 
 ```
-── from solo:wren (2026-07-29T05:19:47.051352Z)
+── from silo:wren (2026-07-29T05:19:47.051352Z)
 Supply cache at grid square K-19 recorded. Confirming storage complete.
 ```
 
@@ -90,7 +90,7 @@ own; invoking it by hand lets you watch it work:
 **Run**
 
 ```bash
-r4t idle --node solo
+r4t idle --node silo
 ```
 
 You should see:
@@ -108,17 +108,17 @@ and on disk, which is where the next section takes you.
 **Run**
 
 ```bash
-r4t logs --node solo -n 6
+r4t logs --node silo -n 6
 ```
 
 You should see:
 
 ```
 r4t: FLUSH dump turn -> wren (conversation idle > 60s)
-turn: 1 message(s) -> Wren (threads 01ABC..., rig solo)
+turn: 1 message(s) -> Wren (threads 01ABC..., rig silo)
 done: Wren, exit 0 in 28.8s
-r4t: ECHO-REPLY wren (rig solo) 674 bytes of cleaned stdout staged as the reply to r4t:solo
-r4t: RELEASED solo:wren -> r4t:solo thread=01ABC... hop=1
+r4t: ECHO-REPLY wren (rig silo) 674 bytes of cleaned stdout staged as the reply to r4t:silo
+r4t: RELEASED silo:wren -> r4t:silo thread=01ABC... hop=1
 r4t: FLUSH retired wren's conversation — the next real message refounds it from state on disk
 ```
 
@@ -155,7 +155,7 @@ Session initialized. Stored codeword and supply cache location.
 Wren chose that structure himself — the dump prompt names the file, not the
 format. (Where the file lands depends on the harness: OpenCode anchors
 relative paths at the repo root, so on the free path it appears at
-`~/ark/solo/STATUS.md`; a harness that stays in Wren's `Workdir:` writes
+`~/ark/silo/STATUS.md`; a harness that stays in Wren's `Workdir:` writes
 `agents/wren/STATUS.md` instead. Either way it is inside the team repo,
 which matters at the commit point.)
 
@@ -164,14 +164,14 @@ The conversation is now retired. Ask for the fact back:
 **Run**
 
 ```bash
-r4t seat send --node solo "What was the codeword, and where is the supply cache?"
-r4t seat inbox --node solo
+r4t seat send --node silo "What was the codeword, and where is the supply cache?"
+r4t seat inbox --node silo
 ```
 
 You should see:
 
 ```
-── from solo:wren (2026-07-29T05:23:14.719675Z)
+── from silo:wren (2026-07-29T05:23:14.719675Z)
 The codeword was **TIDEPOOL** and the supply cache is located at **grid square K-19**.
 ```
 
@@ -194,17 +194,17 @@ with only ollama can read along, the machinery is identical):
 **Run**
 
 ```bash
-r4t rig swap solo cursor --model claude-fable-5-medium
-r4t seat send --node solo "New rig, same Wren? Tell me the codeword and the cache location."
-r4t seat inbox --node solo
+r4t rig swap silo cursor --model claude-fable-5-medium
+r4t seat send --node silo "New rig, same Wren? Tell me the codeword and the cache location."
+r4t seat inbox --node silo
 ```
 
 You should see:
 
 ```
-swapped rig 'solo' to cursor in /home/you/.config/r4t/rigs.json
+swapped rig 'silo' to cursor in /home/you/.config/r4t/rigs.json
   invoke: agent --model claude-fable-5-medium -p --trust --force --approve-mcps {prompt}
-── from solo:wren (2026-07-29T05:26:27.150992Z)
+── from silo:wren (2026-07-29T05:26:27.150992Z)
 Same Wren. Codeword: **TIDEPOOL**. Supply cache: **grid square K-19**. Both verified against STATUS.md.
 ```
 
@@ -213,20 +213,20 @@ And the log names what happened:
 **Run**
 
 ```bash
-r4t logs --node solo -n 8
+r4t logs --node silo -n 8
 ```
 
 You should see:
 
 ```
-r4t: QUEUED solo:you -> wren thread=01ABC... hop=0 "New rig, same Wren? Tell me the codeword and the cache location." (depth 1)
-r4t: CONTINUE-SWAP wren (rig solo) drives 'agent' but the conversation lives on 'opencode' — retired; this turn refounds from state on disk
-turn: 1 message(s) -> Wren (threads 01ABC..., rig solo)
+r4t: QUEUED silo:you -> wren thread=01ABC... hop=0 "New rig, same Wren? Tell me the codeword and the cache location." (depth 1)
+r4t: CONTINUE-SWAP wren (rig silo) drives 'agent' but the conversation lives on 'opencode' — retired; this turn refounds from state on disk
+turn: 1 message(s) -> Wren (threads 01ABC..., rig silo)
 done: Wren, exit 0 in 12.4s
-r4t: ECHO-REPLY wren (rig solo) 102 bytes of cleaned stdout staged as the reply to solo:you
-r4t: SEAT you <- solo:wren (parked)
-r4t: RELEASED-internal solo:wren -> solo:you thread=01ABC... hop=1
-r4t: ANSWERED thread=01ABC... solo:wren -> solo:you (originator answered, thread closed)
+r4t: ECHO-REPLY wren (rig silo) 102 bytes of cleaned stdout staged as the reply to silo:you
+r4t: SEAT you <- silo:wren (parked)
+r4t: RELEASED-internal silo:wren -> silo:you thread=01ABC... hop=1
+r4t: ANSWERED thread=01ABC... silo:wren -> silo:you (originator answered, thread closed)
 ```
 
 `CONTINUE-SWAP`: the conversation lived on `opencode`, the rig now drives
@@ -237,17 +237,17 @@ boundary on the strength of a markdown file. Swap back:
 **Run**
 
 ```bash
-r4t rig swap solo opencode-ollama --model qwen3.6
-r4t seat send --node solo "Back on the local rig. Codeword and cache location, one line."
-r4t seat inbox --node solo
+r4t rig swap silo opencode-ollama --model qwen3.6
+r4t seat send --node silo "Back on the local rig. Codeword and cache location, one line."
+r4t seat inbox --node silo
 ```
 
 You should see:
 
 ```
-swapped rig 'solo' to opencode-ollama in /home/you/.config/r4t/rigs.json
+swapped rig 'silo' to opencode-ollama in /home/you/.config/r4t/rigs.json
   invoke: ollama launch opencode --model qwen3.6 -- run --auto --dir . {prompt}
-── from solo:wren (2026-07-29T05:27:48.329830Z)
+── from silo:wren (2026-07-29T05:27:48.329830Z)
 Codeword: TIDEPOOL — Cache: grid square K-19
 ```
 
@@ -259,7 +259,7 @@ conversation — only a real CLI change retires it.
 (If a send comes back with `queued — Wren is resting (member budget ...)`,
 you have simply outrun Wren's spend budget with all this demo traffic. The
 message is queued, not lost; wait the minutes it names and run
-`r4t clear --node solo`. Chapter 4 makes that machinery the main event.)
+`r4t clear --node silo`. Chapter 4 makes that machinery the main event.)
 
 ## 7. Break it
 
@@ -270,16 +270,16 @@ state file before sending the recall:
 **Run**
 
 ```bash
-r4t idle --node solo
+r4t idle --node silo
 rm STATUS.md
-r4t seat send --node solo "What was the codeword?"
-r4t seat inbox --node solo
+r4t seat send --node silo "What was the codeword?"
+r4t seat inbox --node silo
 ```
 
 You should see:
 
 ```
-── from solo:wren (2026-07-29T05:34:01.509705Z)
+── from silo:wren (2026-07-29T05:34:01.509705Z)
 Codeword: TIDEPOOL
 ```
 
@@ -314,7 +314,7 @@ run another sweep:
 **Run**
 
 ```bash
-r4t idle --node solo
+r4t idle --node silo
 ls STATUS.md
 head -8 STATUS.md
 ```
@@ -342,14 +342,14 @@ chapter has been circling:
 **Run**
 
 ```bash
-r4t seat send --node solo "Codeword and cache location, one line."
-r4t seat inbox --node solo
+r4t seat send --node silo "Codeword and cache location, one line."
+r4t seat inbox --node silo
 ```
 
 You should see:
 
 ```
-── from solo:wren (2026-07-29T05:38:30.929831Z)
+── from silo:wren (2026-07-29T05:38:30.929831Z)
 Codeword: TIDEPOOL — Cache: grid square K-19
 ```
 
@@ -360,7 +360,7 @@ regrown — and Wren still answers. The team is whole.
 
 Put the window back where it belongs:
 
-**Replace** `~/ark/solo/ROSTER.md` — Wren's `Flush:` line becomes:
+**Replace** `~/ark/silo/ROSTER.md` — Wren's `Flush:` line becomes:
 
 ```markdown
 - **Flush:** 15m
@@ -376,7 +376,7 @@ You should see:
 
 ```
 You: note — Human without an Address (team cannot tell them)
-/home/you/ark/solo/ROSTER.md: OK (2 member(s), leader Wren)
+/home/you/ark/silo/ROSTER.md: OK (2 member(s), leader Wren)
 ```
 
 Choosing a window is cache economics, and two different clocks are
@@ -418,9 +418,9 @@ machine died right now:
 **Run**
 
 ```bash
-cd ~/ark/solo
+cd ~/ark/silo
 git add ROSTER.md STATUS.md
-git commit -q -m "solo: Wren's first memory dump"
+git commit -q -m "silo: Wren's first memory dump"
 ```
 
 Chapter 4 gives Wren something no amount of memory provides: a teammate.

--- a/guides/04-a-second-pair-of-hands.md
+++ b/guides/04-a-second-pair-of-hands.md
@@ -31,7 +31,7 @@ About 30 minutes.
 
 Two edits: the roster grows a member, and the rig config grows a rig.
 
-**Replace** `~/ark/solo/ROSTER.md` (whole file)
+**Replace** `~/ark/silo/ROSTER.md` (whole file)
 
 ```markdown
 # Team Roster
@@ -41,7 +41,7 @@ Two edits: the roster grows a member, and the rig config grows a rig.
 - **Role:** Owner
 
 ### Wren
-- **Rig:** solo
+- **Rig:** silo
 - **Leader:** yes
 - **Continue:** on
 - **Flush:** 15m
@@ -77,8 +77,8 @@ message:
 ```bash
 r4t rig add helper opencode-ollama --model qwen3.6
 r4t rig set helper echo true
-r4t rig unset solo echo
-cd ~/ark/solo
+r4t rig unset silo echo
+cd ~/ark/silo
 r4t roster check
 ```
 
@@ -89,9 +89,9 @@ added rig 'helper' (opencode-ollama) to /home/you/.config/r4t/rigs.json
   invoke: ollama launch opencode --model qwen3.6 -- run --auto --dir . {prompt}
 Reference it from ROSTER.md: `- **Rig:** helper`
 set helper echo = true in /home/you/.config/r4t/rigs.json
-unset solo echo in /home/you/.config/r4t/rigs.json
+unset silo echo in /home/you/.config/r4t/rigs.json
 You: note — Human without an Address (team cannot tell them)
-/home/you/ark/solo/ROSTER.md: OK (3 member(s), leader Wren)
+/home/you/ark/silo/ROSTER.md: OK (3 member(s), leader Wren)
 ```
 
 From this turn on, Wren's prompt carries the messaging doctrine — the
@@ -104,8 +104,8 @@ Give Wren a task that names Moss:
 **Run**
 
 ```bash
-r4t seat send --node solo "Ask Moss for three name ideas for our team mascot, an octopus. Pick your favorite and tell me."
-r4t seat inbox --node solo
+r4t seat send --node silo "Ask Moss for three name ideas for our team mascot, an octopus. Pick your favorite and tell me."
+r4t seat inbox --node silo
 ```
 
 ## 6. Expected receipt
@@ -118,18 +118,18 @@ You should see:
 
 Not a typo. On the free path this is the *real* result, and it is worth
 more than a staged success. The work happened — read the thread's spine in
-the team log (`r4t logs --node solo` shows these events; turn boundaries
+the team log (`r4t logs --node silo` shows these events; turn boundaries
 between them omitted here):
 
 ```
-r4t: QUEUED solo:you -> wren thread=01ABC... hop=0 "Ask Moss for three name ideas for our team mascot, an octopus. Pick your favorit" (depth 1)
-r4t: QUEUED solo:wren -> moss thread=01ABC... hop=1 "I need three name ideas for our team mascot — an octopus. Keep them punchy, memo" (depth 1)
-r4t: ECHO-REPLY moss (rig helper) 232 bytes of cleaned stdout staged as the reply to solo:wren
-r4t: QUEUED solo:moss -> wren thread=01ABC... hop=2 "1. **Inkwell** — evokes the octopus "pen" while sounding sharp and professional " (depth 1)
-r4t: STDOUT-REPLY wren (rig solo) released nothing; 156 bytes of cleaned stdout staged as a reply to solo:moss
-r4t: QUEUED solo:wren -> moss thread=01ABC... hop=3 "**Inkwell** is the pick. Sharp, professional, and the octopus pun lands without " (depth 1)
-r4t: ECHO-REPLY moss (rig helper) 22 bytes of cleaned stdout staged as the reply to solo:wren
-r4t: QUEUED solo:moss -> wren thread=01ABC... hop=4 "Noted. Inkwell it is 🐙" (depth 1)
+r4t: QUEUED silo:you -> wren thread=01ABC... hop=0 "Ask Moss for three name ideas for our team mascot, an octopus. Pick your favorit" (depth 1)
+r4t: QUEUED silo:wren -> moss thread=01ABC... hop=1 "I need three name ideas for our team mascot — an octopus. Keep them punchy, memo" (depth 1)
+r4t: ECHO-REPLY moss (rig helper) 232 bytes of cleaned stdout staged as the reply to silo:wren
+r4t: QUEUED silo:moss -> wren thread=01ABC... hop=2 "1. **Inkwell** — evokes the octopus "pen" while sounding sharp and professional " (depth 1)
+r4t: STDOUT-REPLY wren (rig silo) released nothing; 156 bytes of cleaned stdout staged as a reply to silo:moss
+r4t: QUEUED silo:wren -> moss thread=01ABC... hop=3 "**Inkwell** is the pick. Sharp, professional, and the octopus pun lands without " (depth 1)
+r4t: ECHO-REPLY moss (rig helper) 22 bytes of cleaned stdout staged as the reply to silo:wren
+r4t: QUEUED silo:moss -> wren thread=01ABC... hop=4 "Noted. Inkwell it is 🐙" (depth 1)
 ```
 
 Read it hop by hop. **Hop 1** is the delegation working: Wren ran
@@ -143,7 +143,7 @@ acknowledged (hop 4), the two drifted into housekeeping for a few more
 hops, and r4t ended the loop the boring way:
 
 ```
-r4t: SILENT wren (rig solo) exit 0 with 85 bytes of stdout but nothing worth relaying survived transcript cleaning
+r4t: SILENT wren (rig silo) exit 0 with 85 bytes of stdout but nothing worth relaying survived transcript cleaning
 ```
 
 Nothing crashed, nothing looped forever, nobody spent money — but you
@@ -155,9 +155,9 @@ again and demand the `tell`:
 **Run**
 
 ```bash
-r4t seat send --node solo "Which mascot name did you pick? Send me the answer with the tell command."
-r4t seat inbox --node solo
-r4t logs --node solo --full -n 8
+r4t seat send --node silo "Which mascot name did you pick? Send me the answer with the tell command."
+r4t seat inbox --node silo
+r4t logs --node silo --full -n 8
 ```
 
 You should see:
@@ -185,34 +185,34 @@ because a fresh question from you makes you the newest sender:
 **Run**
 
 ```bash
-r4t seat send --node solo "Report in two or three full sentences: what did you ask Moss, what did Moss offer, and which mascot name won?"
-r4t seat inbox --node solo
+r4t seat send --node silo "Report in two or three full sentences: what did you ask Moss, what did Moss offer, and which mascot name won?"
+r4t seat inbox --node silo
 ```
 
 You should see:
 
 ```
-── from solo:wren (2026-07-29T05:47:12.961106Z)
+── from silo:wren (2026-07-29T05:47:12.961106Z)
 I asked Moss for three octopus name ideas. Moss offered Inkwell, Blotz, and Eight. Inkwell won — sharp, professional, with a subtle ink pun that lands cleanly.
 ```
 
 There is the delegated round trip, synthesized and delivered — Wren never
 ran `tell`, and the machinery covered for him: the log shows
-`r4t: STDOUT-REPLY wren (rig solo) released nothing; 157 bytes of cleaned
-stdout staged as a reply to solo:you`. Second: the direct route. The seat
+`r4t: STDOUT-REPLY wren (rig silo) released nothing; 157 bytes of cleaned
+stdout staged as a reply to silo:you`. Second: the direct route. The seat
 can address any member, so for quick lookups skip the middleman:
 
 **Run**
 
 ```bash
-r4t seat send --node solo --to moss "Three verbs that describe what an octopus does. Just the list."
-r4t seat inbox --node solo
+r4t seat send --node silo --to moss "Three verbs that describe what an octopus does. Just the list."
+r4t seat inbox --node silo
 ```
 
 You should see:
 
 ```
-── from solo:moss (2026-07-29T05:47:58.265173Z)
+── from silo:moss (2026-07-29T05:47:58.265173Z)
 1. Jet
 2. Camouflage
 3. Grasp
@@ -225,15 +225,15 @@ discipline is what you are paying for.) Now look at the team as a whole:
 **Run**
 
 ```bash
-r4t status --node solo
+r4t status --node silo
 ```
 
 You should see (roster section):
 
 ```
-Roster  (repo settings: /home/you/ark/solo/ROSTER.md)
+Roster  (repo settings: /home/you/ark/silo/ROSTER.md)
     You  Human  address=(none)   (try: add an **Address:** line so the team can reach them)
-  ✓ Wren  rig=solo  budget=5.2/8  [leader]
+  ✓ Wren  rig=silo  budget=5.2/8  [leader]
   ✓ Moss  rig=helper  budget=7/8
 ```
 
@@ -251,9 +251,9 @@ the real subscription behind it. Give Moss's rig a bucket of one:
 ```bash
 r4t rig set helper rig_budget_max 1
 r4t rig set helper rig_budget_earn_per_hour 1
-r4t seat send --node solo --to moss "One fun fact about octopus arms."
-r4t seat inbox --node solo
-r4t seat send --node solo --to moss "And one about octopus hearts."
+r4t seat send --node silo --to moss "One fun fact about octopus arms."
+r4t seat inbox --node silo
+r4t seat send --node silo --to moss "And one about octopus hearts."
 ```
 
 You should see:
@@ -261,7 +261,7 @@ You should see:
 ```
 set helper rig_budget_max = 1 in /home/you/.config/r4t/rigs.json
 set helper rig_budget_earn_per_hour = 1 in /home/you/.config/r4t/rigs.json
-── from solo:moss (2026-07-29T05:48:56.279303Z)
+── from silo:moss (2026-07-29T05:48:56.279303Z)
 Each of an octopus's eight arms can taste, touch, and move independently—thanks to most of its neurons residing in the arms rather than the brain.
 
 queued — Moss is resting — rig helper exhausted (0), ready in ~59 min
@@ -277,8 +277,8 @@ Read the receipt, then confirm it from the other two surfaces:
 **Run**
 
 ```bash
-r4t status --node solo
-r4t logs --node solo -n 1
+r4t status --node silo
+r4t logs --node silo -n 1
 ```
 
 You should see (roster section, and the log line):
@@ -305,8 +305,8 @@ Or lift the ceiling you just installed:
 ```bash
 r4t rig unset helper rig_budget_max
 r4t rig unset helper rig_budget_earn_per_hour
-r4t idle --node solo
-r4t seat inbox --node solo
+r4t idle --node silo
+r4t seat inbox --node silo
 ```
 
 You should see:
@@ -316,7 +316,7 @@ unset helper rig_budget_max in /home/you/.config/r4t/rigs.json
 unset helper rig_budget_earn_per_hour in /home/you/.config/r4t/rigs.json
 drained 1 queued turn(s); nudged the leader on 0 quiet thread(s)
 pruned 0 stale lock(s); expired 0 thread(s); drained 0 more queued turn(s)
-── from solo:moss (2026-07-29T05:50:20.969451Z)
+── from silo:moss (2026-07-29T05:50:20.969451Z)
 An octopus has three hearts. Two pump blood to the gills, one to the body. The main heart stops when swimming, which is why they prefer crawling.
 ```
 
@@ -331,14 +331,14 @@ One full round trip through the leader, end to end:
 **Run**
 
 ```bash
-r4t seat send --node solo "In two or three full sentences: what has Moss contributed to this team so far?"
-r4t seat inbox --node solo
+r4t seat send --node silo "In two or three full sentences: what has Moss contributed to this team so far?"
+r4t seat inbox --node silo
 ```
 
 You should see:
 
 ```
-── from solo:wren (2026-07-29T05:56:13.232267Z)
+── from silo:wren (2026-07-29T05:56:13.232267Z)
 Two things, both concrete: Moss drafted three octopus name options for our mascot (we landed on Inkwell), then committed ROSTER.md with Moss added to the team at `0a80bcf`. That's it — two small, done items.
 ```
 
@@ -372,14 +372,14 @@ with the full text attached to the same envelope as a markdown file.
 ## 12. Commit point
 
 The roster is the team; commit it. (The `helper` rig lives outside the
-repo with `solo`, by design.)
+repo with `silo`, by design.)
 
 **Run**
 
 ```bash
-cd ~/ark/solo
+cd ~/ark/silo
 git add ROSTER.md
-git commit -q -m "solo roster: Moss joins — helper rig, echo lifted from Wren"
+git commit -q -m "silo roster: Moss joins — helper rig, echo lifted from Wren"
 ```
 
 Copy-paste templates for this chapter's final state live in

--- a/guides/templates/02-solo-cursor/README.md
+++ b/guides/templates/02-solo-cursor/README.md
@@ -1,4 +1,4 @@
 Chapter 2's final state on the subscription path (Cursor agent CLI, the
 subscription's default model — the preset's `--model auto`).
-Copy ROSTER.md into your team repo (e.g. `~/ark/solo/`), then run rig-setup.sh.
+Copy ROSTER.md into your team repo (e.g. `~/ark/silo/`), then run rig-setup.sh.
 Used by [guides/02-the-solo-agent.md](../../02-the-solo-agent.md).

--- a/guides/templates/02-solo-cursor/ROSTER.md
+++ b/guides/templates/02-solo-cursor/ROSTER.md
@@ -5,7 +5,7 @@
 - **Role:** Owner
 
 ### Wren
-- **Rig:** solo
+- **Rig:** silo
 - **Leader:** yes
 - **Continue:** on
 - **Flush:** 15m

--- a/guides/templates/02-solo-cursor/rig-setup.sh
+++ b/guides/templates/02-solo-cursor/rig-setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-r4t rig add solo cursor
-r4t rig set solo echo true
+r4t rig add silo cursor
+r4t rig set silo echo true

--- a/guides/templates/02-solo-opencode-ollama/README.md
+++ b/guides/templates/02-solo-opencode-ollama/README.md
@@ -1,3 +1,3 @@
 Chapter 2's final state on the free path (OpenCode via ollama, qwen3.6).
-Copy ROSTER.md into your team repo (e.g. `~/ark/solo/`), then run rig-setup.sh.
+Copy ROSTER.md into your team repo (e.g. `~/ark/silo/`), then run rig-setup.sh.
 Used by [guides/02-the-solo-agent.md](../../02-the-solo-agent.md).

--- a/guides/templates/02-solo-opencode-ollama/ROSTER.md
+++ b/guides/templates/02-solo-opencode-ollama/ROSTER.md
@@ -5,7 +5,7 @@
 - **Role:** Owner
 
 ### Wren
-- **Rig:** solo
+- **Rig:** silo
 - **Leader:** yes
 - **Continue:** on
 - **Flush:** 15m

--- a/guides/templates/02-solo-opencode-ollama/rig-setup.sh
+++ b/guides/templates/02-solo-opencode-ollama/rig-setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-r4t rig add solo opencode-ollama --model qwen3.6
-r4t rig set solo echo true
+r4t rig add silo opencode-ollama --model qwen3.6
+r4t rig set silo echo true

--- a/guides/templates/04-two-member/README.md
+++ b/guides/templates/04-two-member/README.md
@@ -1,4 +1,4 @@
 Chapter 4's final state on the free path (Wren + Moss, both OpenCode via
 ollama, qwen3.6; echo lifted from Wren, echo on Moss).
-Copy ROSTER.md into your team repo (e.g. `~/ark/solo/`), then run rig-setup.sh.
+Copy ROSTER.md into your team repo (e.g. `~/ark/silo/`), then run rig-setup.sh.
 Used by [guides/04-a-second-pair-of-hands.md](../../04-a-second-pair-of-hands.md).

--- a/guides/templates/04-two-member/ROSTER.md
+++ b/guides/templates/04-two-member/ROSTER.md
@@ -5,7 +5,7 @@
 - **Role:** Owner
 
 ### Wren
-- **Rig:** solo
+- **Rig:** silo
 - **Leader:** yes
 - **Continue:** on
 - **Flush:** 15m

--- a/guides/templates/04-two-member/rig-setup.sh
+++ b/guides/templates/04-two-member/rig-setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-r4t rig add solo opencode-ollama --model qwen3.6
+r4t rig add silo opencode-ollama --model qwen3.6
 r4t rig add helper opencode-ollama --model qwen3.6
 r4t rig set helper echo true


### PR DESCRIPTION
The live reference team was renamed solo -> silo, and The Ark Raising should teach the name it will keep.

**Why silo.** It names the encapsulation the chapters are actually demonstrating: from outside there is one address, and everything behind it — who exists, what each member runs, how they remember — is machinery the sender never sees. "Solo" describes a roster size, and that description stops being true in chapter 4, the moment Moss joins. A name that expires two chapters after the reader types it is a bad name to put in a `mkdir`.

**What changed — identifiers only.**

| was | now |
|---|---|
| `~/ark/solo` (and `/home/you/ark/solo`) | `~/ark/silo` |
| `a8s add solo-node` / `a8s start solo-node` | `silo-node` |
| `a8s namespace solo solo-node`, `tell solo`, `solo:wren`, `solo:moss`, `solo:you`, `r4t:solo` | `silo` / `silo:…` |
| `r4t rig add\|set\|unset\|swap solo`, `- **Rig:** solo`, `(rig solo)`, `rig=solo` | `silo` |

Chapters 2-4, `guides/README.md` (no change needed), and all three template bundles. Chapter 1 has no team yet and is untouched.

**What deliberately stayed "solo".** The concept is still the chapter's subject: the title "The Solo Agent" and its filename, the persona line `- **Role:** The solo agent — does the work and answers the owner`, "a roster of one", and the captured reply where Wren calls itself "the sole member of the solo team" (that is Wren paraphrasing its own Role line, not naming the team — left verbatim per the guides' normalization rule). Template folder names `02-solo-cursor/`, `02-solo-opencode-ollama/`, `04-two-member/` label chapter variants, not the team.

**New in chapter 2.** Three sentences where the team directory is created, so the reader typing `mkdir -p ~/ark/silo` knows the folder name *is* the team name and that the address survives a second member arriving.

**Verification.** Every captured block whose shape could have shifted was re-run against this branch's `apps/r4t/r4t.py` and `apps/a8s/a8s.py` in a throwaway `R4T_HOME`/`A8S_HOME` (real `~/.config/{r4t,a8s}` untouched, `TELL_OUTBOX_DIR` unset): `r4t init`, `r4t rig add silo cursor`, `r4t rig set/unset silo echo`, `r4t rig swap silo ollama`, `r4t roster check` (both the OK line and the `Continue: on but rig 'silo' does not support it` error), `a8s add silo-node`, `a8s namespace silo silo-node`. All match the guide byte for byte under the documented `/home/you/...` normalization. `tests/test_pii.py` passes; no other suite touches `guides/`.

Docs only — no code paths changed.

Closes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)