### PR TITLE
docs(guides): flush-window teaching at guide altitude

### DIFF
--- a/guides/03-the-long-memory.md
+++ b/guides/03-the-long-memory.md
@@ -379,33 +379,14 @@ You: note — Human without an Address (team cannot tell them)
 /home/you/ark/silo/ROSTER.md: OK (2 member(s), leader Wren)
 ```
 
-Choosing a window is cache economics, and two different clocks are
-running. The conversation is yours — it sits on disk and expires only
-when you say so. The provider's prompt cache is merely a discount on
-replaying that conversation, and it is the discount that lapses. When it
-has lapsed the harness resends the same transcript and nothing is
-forgotten; the tokens are simply re-billed, and not the same way
-everywhere. Anthropic charges the re-cached prefix as a cache *write*, a
-premium over ordinary input. Most OpenAI models charge plain input with
-no surcharge at all, though GPT-5.6 writes at a premium again. One miss,
-three different bills.
-
-The boundaries are short. Anthropic's caches hold five minutes by default
-and an hour at the outside; GPT-5.6 guarantees at least thirty; older
-OpenAI models can stretch to a day. Fifteen minutes is the default taught
-here because it falls inside the shortest of them: a pause that long has
-usually cost you the discount already, so retiring the conversation gives
-up nothing you still had, and the next turn carries only what `STATUS.md`
-says matters.
-
-The subscription path is not exempt. Cursor and Copilot plans meter
-cache-writes against your included usage the way they meter everything
-else, so a long-idle conversation resumed at full length spends real
-allowance on messages nobody needed. On the free path the meter reads
-zero and the window is purely context hygiene — set it late enough that
-normal working pauses don't cost Wren his short-term memory, early enough
-that he isn't dragging yesterday into today. The pricing and retention
-figures behind all of this are collected in
+The window says how long a pause Wren's conversation survives. Fifteen
+minutes is a good default: short pauses keep their momentum, and after a
+longer one the flush has already banked everything that matters in
+`STATUS.md`, so the next message starts fresh without starting over.
+Set it late enough that normal working pauses don't cost Wren his
+short-term memory, early enough that he isn't dragging yesterday into
+today. On paid rigs a short window also keeps resumed context from
+billing at full length; the mechanics behind that live in
 [Prompt-Cache Economics](https://github.com/neilobremski/bin/wiki/Prompt-Cache-Economics).
 
 ## 12. Commit point


### PR DESCRIPTION
Replaces three paragraphs of provider cache-economics detail in ch.3 with one short paragraph: what the window means, the 15m default, how to think about tuning it, and a pointer to the wiki reference for mechanics. The guide is about memory — r4t does the right thing, the guide helps the user use it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)