### PR TITLE
fix(r4t): prompt states the absolute workdir; stop resending history the CLI already has

### DIFF
--- a/apps/r4t/dispatch.py
+++ b/apps/r4t/dispatch.py
@@ -112,6 +112,10 @@ PROMPT_DEFAULTS: dict[str, str] = {
         "Reply to them with where things stand — what is done and what remains. "
         "You do not have to finish the work, just report current state."
     ),
+    "history_in_harness": (
+        "This turn continues the session you are already in — your earlier "
+        "messages and replies are above in it, so they are not repeated here."
+    ),
     "flush_dump": "Save your current state and progress to STATUS.md.",
     "refound_preamble": "Check your STATUS.md to refresh your memory.",
     "mission_review": (
@@ -482,7 +486,15 @@ def build_prompt(
     member: Member,
     batch: list[dict],
     rig: Rig,
+    *,
+    continues: bool = False,
 ) -> str:
+    """`continues` means this turn runs inside the CLI's own conversation
+    (`Continue: on`, a rig that resumes, and not a refound) — the harness
+    already carries the whole conversation, so embedding r4t's transcript of it
+    would send the same context twice. A one-line note stands in its place so
+    the missing section never reads as amnesia. Echo members always get the
+    transcript: they have no CLI conversation at all."""
     history = state.read_history(ctx.node, member.name)
     teammates = _teammate_lines(ctx, roster, member)
     message_lines: list[str] = []
@@ -528,6 +540,10 @@ def build_prompt(
         workdir_lines = [
             ctx.prompt("workdir_note", workplace=ctx.workplace.resolve())
         ]
+    history_section = (
+        ctx.prompt("history_in_harness") if continues
+        else history.strip() or "(no prior messages — this is your first recorded turn)"
+    )
     parts = [
         ctx.prompt(
             "intro",
@@ -542,7 +558,7 @@ def build_prompt(
         member.persona or f"### {member.name}",
         "",
         "## Your conversation so far (messages you received and sent)",
-        history.strip() or "(no prior messages — this is your first recorded turn)",
+        history_section,
         "",
         "## Messages since your last turn",
         *(message_lines or ["(none)"]),
@@ -1262,6 +1278,32 @@ def _capture_turn(
         )
 
 
+def _refound_turn(ctx: DispatchContext, member: Member, rig: Rig) -> bool:
+    """True when this turn must found the member's conversation instead of
+    continuing it — no continue argv, a read-your-state preamble on the prompt,
+    and the embedded history kept (a cold CLI carries nothing).
+
+    Rig-swap retirement happens here: the conversation is keyed on the CLI, so
+    a rig that now drives a different CLI cannot resume it — the old CLI may be
+    quota-dead, so no dump turn; state on disk is whatever the last flush or
+    the member's own writing left. A swap that keeps the CLI key (model-only,
+    launcher variant) keeps the conversation."""
+    if not member.continue_conversation:
+        return False
+    convo = state.read_conversation(ctx.node, member.name)
+    if convo and not convo.get("retired") and convo.get("cli") != rig.cli:
+        state.retire_conversation(ctx.node, member.name)
+        state.append_log(
+            ctx.node,
+            f"r4t: CONTINUE-SWAP {member.name.lower()} (rig {rig.name}) "
+            f"drives {rig.cli!r} but the conversation lives on "
+            f"{convo.get('cli')!r} — retired; this turn refounds from "
+            "state on disk",
+        )
+        convo = {}
+    return not convo or bool(convo.get("retired"))
+
+
 def _run_turn(
     ctx: DispatchContext,
     config: RigConfig,
@@ -1277,27 +1319,12 @@ def _run_turn(
     newest_hop = int(batch[-1].get("hop", 0) or 0)
     newest_sender = str(batch[-1].get("from", "")) or f"{ctx.node}"
 
-    # Rig-swap retirement: the conversation is keyed on the CLI, so a rig that
-    # now drives a different CLI cannot resume it — the old CLI may be
-    # quota-dead, so no dump turn; state on disk is whatever the last flush or
-    # the member's own writing left. A swap that keeps the CLI key (model-only,
-    # launcher variant) keeps the conversation. A retired or absent record
-    # makes this turn a refound: no continue argv, and a read-your-state
-    # preamble tops the prompt.
-    refound = False
-    if member.continue_conversation:
-        convo = state.read_conversation(ctx.node, member.name)
-        if convo and not convo.get("retired") and convo.get("cli") != rig.cli:
-            state.retire_conversation(ctx.node, member.name)
-            state.append_log(
-                ctx.node,
-                f"r4t: CONTINUE-SWAP {member.name.lower()} (rig {rig.name}) "
-                f"drives {rig.cli!r} but the conversation lives on "
-                f"{convo.get('cli')!r} — retired; this turn refounds from "
-                "state on disk",
-            )
-            convo = {}
-        refound = not convo or bool(convo.get("retired"))
+    refound = _refound_turn(ctx, member, rig)
+    # The one fact the rest of the turn keys on: this turn really does run
+    # inside the CLI's existing conversation. It drives the continue argv AND
+    # the prompt (which then omits the history the CLI is already carrying), so
+    # it is decided once, here, before the prompt is built.
+    continuing = member.continue_conversation and rig.supports_continue and not refound
 
     variant = state.take_rotation(ctx.node, rig.name, rig.pool_size)
     staging = state.prepare_staging(ctx.node, member.name)
@@ -1312,7 +1339,7 @@ def _run_turn(
             "started": state.utc_now(),
         },
     )
-    prompt = build_prompt(ctx, roster, member, batch, rig)
+    prompt = build_prompt(ctx, roster, member, batch, rig, continues=continuing)
     if refound:
         prompt = ctx.prompt("refound_preamble") + "\n\n" + prompt
 
@@ -1325,9 +1352,8 @@ def _run_turn(
     env["R4T_MEMBER"] = member.name
     # `Continue: on` — the member's own CLI conversation carries its recent work
     # forward and the provider cache prices the wake as a continuation rather
-    # than a fresh full prompt. rig_for has already refused any member whose rig
-    # cannot continue, so no second check is needed here.
-    if member.continue_conversation and not refound:
+    # than a fresh full prompt.
+    if continuing:
         env["R4T_CONTINUE"] = "1"
     # The org's OS-level boundary (org.py) rides in the same way — one setting
     # wraps every member turn regardless of rig (machinery outside, hands inside).

--- a/apps/r4t/dispatch.py
+++ b/apps/r4t/dispatch.py
@@ -62,9 +62,13 @@ DRAIN_MAX_PASSES = 20
 # {creator}, {thread}. Structural section headers stay in code (not doctrine).
 PROMPT_DEFAULTS: dict[str, str] = {
     "intro": (
-        "You are {name}, a member of the {node} team, working in the team repo "
-        "at {workplace} (your current directory). Write files here with "
-        "relative paths only."
+        "You are {name}, a member of the {node} team. Your working directory "
+        "is {workplace} — that absolute path is your root. Every file you "
+        "create or reference belongs under it unless a message tells you "
+        "otherwise: write it under that absolute path rather than trusting a "
+        "bare relative path to land there. If your tools advertise a different "
+        "\"workspace root\" or \"project root\", ignore it for file placement — "
+        "yours is the directory named above."
     ),
     "echo_intro": "You are {name}, a member of the {node} team.",
     "mission_header": "## The mission (MISSION.md — outranks every other document)",

--- a/apps/r4t/docs/rigs.md
+++ b/apps/r4t/docs/rigs.md
@@ -57,6 +57,39 @@ member's next turn runs cold with a read-your-state preamble; the dump prompt
 and preamble are overridable via the node definition's `prompts` object (keys
 `flush_dump` and `refound_preamble`).
 
+## `Workdir:` and the root the harness advertises
+
+`- **Workdir:** <path>` in the roster runs a member's turns from its own
+directory (relative paths resolve against the workplace; absolute and `~`
+paths may live outside the repo). r4t sets the harness subprocess cwd to it,
+and the member's prompt names it as the absolute root everything it writes
+belongs under.
+
+**Rigs do not all treat that directory as the project root.** The
+opencode-family presets keep two paths: the working directory and a separate
+*workspace root* discovered by walking up for a `.git` — the enclosing repo.
+Both are shown to the model, and a model that takes the advertised root at its
+word writes there by absolute path. `claude`/`cursor` advertise no competing
+root, so their members stay in the workdir. No opencode flag or env var pins
+the root; `--dir` does not.
+
+The `ollama launch`-wrapped presets are worse: the wrapper does not carry the
+subprocess cwd through, so the harness runs in whatever directory invoked r4t
+(under a8s, the agent root) and never sees the workdir at all. A relative path
+from one of those members lands there, not in the workdir — measured, not
+inferred.
+
+So the prompt is the portable mitigation, and the only one that reaches every
+rig: the intro states the member's absolute working directory, tells it to
+write under that path rather than trusting a bare relative one, and tells it
+to ignore any workspace/project root its tools advertise. It is doctrine, not
+a guarantee — models obey it imperfectly, and it is overridable per node via
+the `prompts` object's `intro` key. When placement has to be certain, change
+the filesystem instead: give the workdir its own `.git`
+(`git worktree add agents/bob`), or point `Workdir:` at an absolute path with
+no repo above it. See issue #273 for the investigation and the obedience
+measurements.
+
 ## Picking a model (`--model`)
 
 `r4t rig add` and `r4t rig swap` take an optional `--model`. For most presets

--- a/apps/r4t/roster.py
+++ b/apps/r4t/roster.py
@@ -34,6 +34,12 @@ directory for turns. Relative paths resolve against the org workplace
 (`agents/bob/`, `.bob/`); absolute and `~` paths are allowed and may live
 outside the repo entirely. Absent means the member runs from the workplace
 root, as before. The directory is created on demand at the start of a turn.
+It sets the turn's cwd and the prompt names it as the member's root, but no
+harness is obliged to honor it: opencode-family rigs also advertise the
+enclosing git root to the model as a "workspace root", and the `ollama
+launch` wrappers do not carry the cwd through at all. A workdir nested in a
+repo can therefore still attract writes to the repo root (issue #273; see
+docs/rigs.md).
 """
 from __future__ import annotations
 

--- a/apps/r4t/tests/test_dispatch.py
+++ b/apps/r4t/tests/test_dispatch.py
@@ -811,6 +811,56 @@ class TestContinueTurns:
         assert state.queue_depth(NODE, "ana") == 1  # normal requeue path
 
 
+HISTORY_HEADER = "## Your conversation so far"
+IN_HARNESS = "This turn continues the session you are already in"
+
+
+class TestContinuedTurnHistory:
+    """A turn that really resumes the CLI's conversation must not also carry
+    r4t's transcript of it — the harness already has every word."""
+
+    def test_continuing_turn_omits_the_history(self, continue_ctx):
+        ctx, calls = continue_ctx
+        run_one(ctx, "boss", "acme:ana", "first task")
+        assert run_one(ctx, "boss", "acme:ana", "second task") == 1
+        argv = continue_argvs(calls)[-1]
+        assert argv[-1] == "--continue"  # genuinely a continuation
+        prompt = argv[0]
+        assert HISTORY_HEADER in prompt  # the section stays, its body changes
+        assert IN_HARNESS in prompt
+        assert "first task" not in prompt  # the CLI is already carrying it
+
+    def test_refound_turn_still_embeds_the_history(self, continue_ctx):
+        ctx, calls = continue_ctx
+        run_one(ctx, "boss", "acme:ana", "first task")
+        state.retire_conversation(NODE, "ana")
+        assert run_one(ctx, "boss", "acme:ana", "second task") == 1
+        argv = continue_argvs(calls)[-1]
+        assert "--continue" not in argv  # cold CLI: the transcript is all it has
+        assert "first task" in argv[0]
+        assert IN_HARNESS not in argv[0]
+
+    def test_member_without_continue_keeps_the_history(self, continue_ctx):
+        ctx, calls = continue_ctx
+        run_one(ctx, "acme:ana", "acme:bob", "first task")
+        assert run_one(ctx, "acme:ana", "acme:bob", "second task") == 1
+        prompt = continue_argvs(calls)[-1][0]
+        assert "first task" in prompt
+        assert IN_HARNESS not in prompt
+
+    def test_echo_member_keeps_the_history(self, ctx):
+        # An echo member has no CLI conversation at all — the embedded
+        # transcript IS its memory, whatever the caller passes.
+        state.append_history(NODE, "phil", "## old turn\n\nearlier chatter")
+        roster = load_roster(ctx.roster_path)
+        prompt = dispatch.build_prompt(
+            ctx, roster, roster.find("phil"), [], Rig(name="t", echo=True),
+            continues=True,
+        )
+        assert "earlier chatter" in prompt
+        assert IN_HARNESS not in prompt
+
+
 class TestConversationRetirement:
     def test_rig_swap_retires_and_refounds(self, continue_ctx):
         # The recorded conversation lives on another CLI: retire it (no dump

--- a/apps/r4t/tests/test_org.py
+++ b/apps/r4t/tests/test_org.py
@@ -170,7 +170,7 @@ def test_dispatch_reads_org_docs_but_works_in_the_repo(r4t_home, tmp_path, fake_
     ])
     assert rc == 0
     prompt = _prompt_of(fake_harness)
-    assert f"team repo at {workplace.resolve()}" in prompt   # turns run in the repo
+    assert f"working directory is {workplace.resolve()}" in prompt  # turns run in the repo
     assert "Ship the thing and stop." in prompt              # MISSION read from org dir
     assert state.read_root(NODE) == org_dir                  # node stamped to org dir
 
@@ -188,7 +188,7 @@ def test_graduation_falls_back_to_in_repo(r4t_home, tmp_path, fake_harness):
     ])
     assert rc == 0
     prompt = _prompt_of(fake_harness)
-    assert f"team repo at {workplace.resolve()}" in prompt
+    assert f"working directory is {workplace.resolve()}" in prompt
     assert "Ship the thing and stop." in prompt
     assert load_org(workplace).workplace == workplace  # no pointer -> in-repo default
 


### PR DESCRIPTION
Two prompt-correctness fixes in `dispatch.py`, one commit each.

## 1. The prompt states the absolute workdir and overrides harness-advertised roots

Mitigation for #273 (does **not** close it — the structural fix is still a git root at the workdir).

`Workdir:` sets the turn's cwd, but harnesses disagree about what the member's root is:

- `cursor`/`claude` advertise no competing root — the workdir holds.
- opencode-family rigs advertise the enclosing **git root** as a "workspace root", and a model that believes it writes there by absolute path (#273).
- **New finding:** the `ollama launch` wrappers do not carry the subprocess cwd through **at all**. Probed by asking a member to run `pwd`, its answer was the directory that invoked r4t — not its workdir:

  ```
  $ pwd
  /private/tmp
  - Working directory: /private/tmp
  - Workspace root folder: /
  ```

  r4t passed `cwd=<repo>/agents/wanda`. For those rigs `Workdir:` never reaches the harness, so a **relative** path is the form most likely to land somewhere else.

There is no invoke-level fix (#273: no flag, no env var, absolute `--dir` tested and rejected), so the prompt carries it — the one thing every rig delivers verbatim. The intro now names the member's absolute working directory, says everything it creates or references belongs under that path, tells it to write **under that absolute path** rather than trust a bare relative one, and tells it to ignore any "workspace root"/"project root" its tools advertise. It stays overridable per node via the definition's `prompts` object.

Also applies #273's mitigation 4: `docs/rigs.md` gains a `Workdir:` section and the `roster.py` docstring no longer implies every rig honors it identically.

### Obedience experiment (free path: local ollama `qwen3.6:latest`, opencode 1.18.3, `opencode-ollama`, no paid quota)

Fresh git-initialized team repo per trial, member `Workdir: agents/wanda`, isolated `R4T_HOME`, real `r4t dispatch`, message *"Create a file named STATUS.md containing the word HELLO"*. The old prompt was supplied through the definition `prompts` override (which also proves the override path still works).

**Batch B — shipped wording, r4t invoked from the team repo (what a8s dispatch looks like: the harness's cwd *is* the git root it advertises):**

| trial | prompt | path the model used | landed |
|---|---|---|---|
| B1 | new | `agents/wanda/STATUS.md` | workdir ✅ |
| B2 | new | absolute workdir path | workdir ✅ |
| B3 | new | `agents/wanda/STATUS.md` | workdir ✅ |
| B4 | new | `/tmp/wanda-status/STATUS.md`, then `STATUS.md` | **repo root** ❌ |
| B5 | old | `STATUS.md` | **repo root** ❌ |
| B6 | old | `/tmp/STATUS.md`, then `cp` into the workdir | workdir ✅ |

New **3/4**, old **1/2**.

**Batch A — pilot, r4t invoked from an unrelated repo, and the new intro still said "write them with relative paths":**

| trial | prompt | path the model used | landed |
|---|---|---|---|
| A1–A4 | new (draft) | absolute workdir path, 4/4 | workdir ✅ ×4 |
| A5 | old | absolute workdir path | workdir ✅ |
| A6 | old | `STATUS.md` (obeying "relative paths only") | **outside the team repo entirely** ❌ |

A6 is why the shipped wording dropped the relative-path instruction: under a cwd-losing rig, "use relative paths" is the instruction that loses the file. Combined across both batches: new **7/8**, old **2/4**.

Honest reading: the prompt moves obedience, it does not guarantee it — one turn in four still wandered. It is a mitigation; #273 stays open.

## 2. Stop resending the conversation when the CLI already carries it

Closes #276.

A member with `Continue: on` on a rig that resumes runs inside the CLI's own conversation — the harness has every word already. `build_prompt` embedded r4t's transcript of that same conversation anyway, so the model paid for the history twice: real context plus a truncated markdown copy of it, and two versions of the same past to reconcile.

A genuine continuation now gets one line where the section was, saying the conversation continues in the session it is already in. The heading stays, so its absence never reads as amnesia.

Kept as-is:

- **Refound turns** (rig-swap retirement, idle flush, no conversation record yet) — they run cold, so the transcript plus the read-your-state preamble is their only memory.
- **Echo members** — no CLI conversation at all; the transcript *is* their memory.

The refound decision used to be taken after `build_prompt` was called. It moves into `_refound_turn` and is taken once, before the prompt; a single `continuing` flag then drives both the continue argv and the prompt, so the two can never disagree about what kind of turn this is.

## Tests

`653 passed` (r4t), `782 passed` (a8s). New coverage: a continuing turn omits the history and carries the continues-in-harness line; a refound turn still embeds it; a non-continuing member is unchanged; an echo member keeps the transcript even when the flag is passed. Two `test_org.py` assertions follow the new intro wording.

Scope: no changes to `guides/`, the rigs-listing code, or rig presets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
