### PR TITLE
docs: SKILL.md quoted-scalar rule names the enforcing parser

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,9 +98,10 @@ and on-disk pid/log paths. The contract changes only when the user declares v1.
 
 ### SKILL.md YAML — quoted scalars only
 
-Codex's YAML parser is strict and fails silently on unquoted descriptions
-containing colons or `FILE:` lines. Always quote `name:` and `description:`
-in skill frontmatter.
+Harness YAML parsers differ: copilot rejects unquoted descriptions
+containing colons outright (skill dropped), and other parsers have their
+own strictness. Always quote `name:` and `description:` in skill
+frontmatter.
 
 ## Top-level scripts: `tell`
 


### PR DESCRIPTION
The #290 skill-matrix investigation planted an unquoted colon-bearing description: copilot dropped the skill with a YAML error, codex 0.144.6 loaded it fine. Rule unchanged — always quote — but the stated reason now matches measured behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)