### PR TITLE
feat(r4t): manual flush verb — dump, retire, archive the history log

### DIFF
--- a/apps/r4t/dispatch.py
+++ b/apps/r4t/dispatch.py
@@ -1892,6 +1892,112 @@ def _flush_sweep(
     return flushed
 
 
+# ---------- manual flush (the on-demand verb) ----------
+#
+# The sweep waits out `Flush:`; the verb runs on the operator's word, so it
+# checks neither. It goes one step further than the sweep and archives the
+# member's history log: the refound then reads STATUS.md and nothing else,
+# which is what makes a memory test provable and what cures a conversation
+# whose recent transcript is the problem.
+
+
+def _flush_member(
+    ctx: DispatchContext,
+    config: RigConfig,
+    roster: Roster,
+    member: Member,
+    dump: bool,
+    run_fn,
+) -> dict:
+    result = {
+        "member": member.name,
+        "dumped": False,
+        "retired": False,
+        "archived": None,
+        "skipped": "",
+        "failed": "",
+    }
+    if member.is_human:
+        result["skipped"] = "human member"
+        return result
+    if member.errors:
+        result["skipped"] = member.error
+        return result
+    convo = state.read_conversation(ctx.node, member.name)
+    live = bool(convo) and not convo.get("retired")
+    if dump and live:
+        rig, err, _pinned = config.rig_for(member)
+        if rig is None:
+            result["skipped"] = err
+            return result
+        runnable, reason = _runnable(ctx, config, member, rig)
+        if not runnable:
+            state.append_log(
+                ctx.node, f"r4t: FLUSH deferred — {member.name.lower()} {reason}"
+            )
+            result["failed"] = reason
+            return result
+        state.enqueue(
+            ctx.node,
+            member.name,
+            {
+                "from": f"r4t:{ctx.node}",
+                "to": f"{ctx.node}:{member.name.lower()}",
+                "thread": tasks.new_thread_id(),
+                "hop": 0,
+                "class": "auto",
+                "body": ctx.prompt("flush_dump"),
+            },
+        )
+        state.append_log(
+            ctx.node, f"r4t: FLUSH dump turn -> {member.name.lower()} (r4t flush)"
+        )
+        ran = _run_member_turn(ctx, config, roster, member, rig, run_fn)
+        last_turn = state.read_meta(ctx.node, member.name).get("last_turn") or {}
+        if ran != RAN or last_turn.get("exit") != 0 or last_turn.get("timed_out"):
+            # Nothing was banked, so nothing is thrown away: the conversation
+            # still holds the state the dump failed to write. --no-dump is the
+            # way past a conversation that cannot dump at all.
+            result["failed"] = "the dump turn did not complete"
+            return result
+        result["dumped"] = True
+    if live:
+        state.retire_conversation(ctx.node, member.name)
+        state.append_log(
+            ctx.node,
+            f"r4t: FLUSH retired {member.name.lower()}'s conversation — "
+            "the next real message refounds it from state on disk",
+        )
+        result["retired"] = True
+    archived = state.archive_history(ctx.node, member.name)
+    if archived is not None:
+        state.append_log(
+            ctx.node,
+            f"r4t: FLUSH archived {member.name.lower()}'s history log as "
+            f"{archived.name} — a fresh one starts at the next turn",
+        )
+        result["archived"] = archived
+    return result
+
+
+def run_flush(
+    ctx: DispatchContext,
+    config: RigConfig,
+    roster: Roster,
+    members: list[Member],
+    *,
+    dump: bool = True,
+    run_fn=run_harness,
+) -> list[dict]:
+    """Flush each member on demand: dump turn, retire the conversation, archive
+    the history log. `dump=False` skips the turn — a poisoned or quota-dead
+    conversation must not be asked to write its state down. Returns one result
+    per member, in the order asked."""
+    return [
+        _flush_member(ctx, config, roster, member, dump, run_fn) for member in members
+    ]
+
+
 # ---------- mission-review idle turn (the furnace burns on its own) ----------
 
 MISSION_REVIEW_BACKOFF_BASE = 2

--- a/apps/r4t/docs/rigs.md
+++ b/apps/r4t/docs/rigs.md
@@ -57,6 +57,18 @@ member's next turn runs cold with a read-your-state preamble; the dump prompt
 and preamble are overridable via the node definition's `prompts` object (keys
 `flush_dump` and `refound_preamble`).
 
+`r4t flush <member> [<member> ...]` (or `--all` for the whole roster) does the
+same on demand, for any member — no `Flush:` field and no idle wait. It runs
+the dump turn, retires the conversation, and then archives the member's
+`agents/<member>/history.md` to a timestamped sibling, so the refound reads
+STATUS.md rather than a transcript of everything it was told. Nothing is
+deleted; the archive stays on disk. `--no-dump` skips the turn for a
+conversation that cannot dump (quota-dead) or should not (one whose recent
+context is itself the problem — a dump would bank it into STATUS.md). A dump
+turn that fails changes nothing: the conversation and the history stay put,
+and the exit code names the member. The idle sweep keeps the history in place,
+because there the refound is meant to carry rolling context forward.
+
 ## `Workdir:` and the root the harness advertises
 
 `- **Workdir:** <path>` in the roster runs a member's turns from its own

--- a/apps/r4t/r4t.py
+++ b/apps/r4t/r4t.py
@@ -24,6 +24,7 @@ from dispatch import (
     DispatchContext,
     handle_message,
     run_clear,
+    run_flush,
     run_idle,
     split_recipient,
 )
@@ -73,6 +74,7 @@ COMMAND_HELP = [
     ("task list", "List conversation threads for a team"),
     ("task show <id>", "Show one task ledger record as JSON"),
     ("clear", "Prune stale locks, expire idle threads, drain queued turns"),
+    ("flush <member>", "Dump a member's state, retire the conversation, archive its history"),
     ("idle", "Nudge agents with unfinished work, then clear"),
     ("sandbox", "Disposable end-to-end run with graded report"),
     ("sandbox --fake", "Same pipeline with deterministic fake agents (no LLM)"),
@@ -448,6 +450,66 @@ def cmd_clear(args: argparse.Namespace) -> int:
         + f"; drained {summary['drained']} queued turn(s)"
     )
     return 0
+
+
+def _flush_line(result: dict) -> str:
+    name = result["member"].lower()
+    if result["skipped"]:
+        return f"skipped {name} — {result['skipped']}"
+    if result["failed"]:
+        return (
+            f"failed {name} — {result['failed']}; conversation and history "
+            "left as they are"
+        )
+    done = []
+    if result["dumped"]:
+        done.append("dumped state to disk")
+    if result["retired"]:
+        done.append("retired the conversation")
+    if result["archived"] is not None:
+        done.append(f"archived history as {result['archived'].name}")
+    if not done:
+        return f"nothing to flush for {name} — no conversation, no history"
+    return f"flushed {name} — {', '.join(done)}"
+
+
+def cmd_flush(args: argparse.Namespace) -> int:
+    node = _resolve_node(args.node)
+    if node is None:
+        return 2
+    if bool(args.members) == bool(args.all):
+        print(
+            "flush: name the members to flush, or pass --all — not both "
+            f"(try: r4t flush --node {node} <name>)",
+            file=sys.stderr,
+        )
+        return 2
+    ctx = _context(args, node)
+    try:
+        roster = load_roster(ctx.roster_path)
+        config = load_rig_config(ctx.config_path)
+    except (RosterError, RigError) as e:
+        print(f"flush: {e}", file=sys.stderr)
+        return 2
+    if args.all:
+        members = list(roster.members)
+    else:
+        members = []
+        for raw in args.members:
+            member = roster.find(raw)
+            if member is None:
+                names = ", ".join(roster.names()) or "(none)"
+                print(
+                    f"flush: no team member named {raw!r} — "
+                    f"(try: r4t flush --node {node} <name>; members: {names})",
+                    file=sys.stderr,
+                )
+                return 2
+            members.append(member)
+    results = run_flush(ctx, config, roster, members, dump=not args.no_dump)
+    for result in results:
+        print(_flush_line(result))
+    return 1 if any(r["failed"] for r in results) else 0
 
 
 def cmd_idle(args: argparse.Namespace) -> int:
@@ -1555,6 +1617,26 @@ def build_parser() -> argparse.ArgumentParser:
     _add_older_than(clear_p)
     _add_tell_flags(clear_p)
     clear_p.set_defaults(func=cmd_clear)
+
+    flush_p = sub.add_parser(
+        "flush",
+        help="Save a member's state to disk and start their conversation over.",
+    )
+    _add_common(flush_p, with_node=True)
+    flush_p.add_argument(
+        "members", nargs="*", metavar="MEMBER", help="Members to flush."
+    )
+    flush_p.add_argument(
+        "--all", action="store_true", help="Every member on the roster."
+    )
+    flush_p.add_argument(
+        "--no-dump",
+        action="store_true",
+        help="Skip the save turn — for a conversation that cannot or should "
+        "not write its state down.",
+    )
+    _add_tell_flags(flush_p)
+    flush_p.set_defaults(func=cmd_flush)
 
     idle_p = sub.add_parser(
         "idle",

--- a/apps/r4t/state.py
+++ b/apps/r4t/state.py
@@ -189,6 +189,20 @@ def append_history(
     _atomic_write_text(history_path(node, name), _truncate_history(combined, max_bytes))
 
 
+def archive_history(node: str, name: str) -> Path | None:
+    """Rename the member's history log to a timestamped sibling, so the next
+    turn starts a fresh one and the prompt carries no transcript. Returns the
+    archive path, or None when the member has no history. Never deletes — the
+    log is the record of what was said."""
+    path = history_path(node, name)
+    if not path.is_file():
+        return None
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+    archive = path.with_name(f"history-{stamp}.md")
+    os.replace(path, archive)
+    return archive
+
+
 # ---------- locks ----------
 
 def _pid_alive(pid: int) -> bool:

--- a/apps/r4t/tests/test_dispatch.py
+++ b/apps/r4t/tests/test_dispatch.py
@@ -992,6 +992,162 @@ class TestIdleFlush:
         assert convo["retired"] is False
 
 
+def flush(ctx, *names, dump=True, run_fn=run_harness):
+    roster = load_roster(ctx.roster_path)
+    config = load_rig_config(ctx.config_path)
+    members = [roster.find(n) for n in names]
+    return dispatch.run_flush(ctx, config, roster, members, dump=dump, run_fn=run_fn)
+
+
+def history_archives(name="ana"):
+    return sorted(state.agent_dir(NODE, name).glob("history-*.md"))
+
+
+class TestFlushVerb:
+    def found(self, ctx):
+        assert run_one(ctx, "boss", "acme:ana", "first task") == 1
+
+    def test_dump_turn_retires_and_archives_the_history(self, continue_ctx):
+        ctx, calls = continue_ctx
+        self.found(ctx)
+        (result,) = flush(ctx, "ana")
+        dump = continue_argvs(calls)[-1]
+        assert dump[-1] == "--continue"  # the dump rides the conversation
+        assert DUMP_PROMPT in dump[0]
+        assert result["dumped"] and result["retired"]
+        assert state.read_conversation(NODE, "ana")["retired"] is True
+        (archive,) = history_archives()
+        assert "first task" in archive.read_text(encoding="utf-8")
+        assert state.read_history(NODE, "ana") == ""
+        assert "FLUSH archived ana" in read_log()
+
+    def test_flush_needs_no_idle_wait_and_no_flush_field(self, continue_ctx):
+        # The sweep waits out `Flush:`; a fresh turn is flushable on the word.
+        ctx, _calls = continue_ctx
+        self.found(ctx)
+        assert run_idle(ctx)["flushed"] == []
+        assert flush(ctx, "ana")[0]["retired"] is True
+
+    def test_refound_after_flush_carries_no_transcript(self, continue_ctx):
+        ctx, calls = continue_ctx
+        self.found(ctx)
+        flush(ctx, "ana")
+        assert run_one(ctx, "boss", "acme:ana", "new work") == 1
+        argv = continue_argvs(calls)[-1]
+        assert "--continue" not in argv
+        assert argv[0].startswith(REFOUND_PREAMBLE)
+        assert "first task" not in argv[0]
+
+    def test_no_dump_retires_and_archives_without_a_turn(self, continue_ctx):
+        ctx, calls = continue_ctx
+        self.found(ctx)
+        before = len(continue_argvs(calls))
+        (result,) = flush(ctx, "ana", dump=False)
+        assert len(continue_argvs(calls)) == before
+        assert not result["dumped"]
+        assert result["retired"] and result["archived"] is not None
+        assert state.read_conversation(NODE, "ana")["retired"] is True
+
+    def test_several_members_in_one_call(self, continue_ctx):
+        ctx, _calls = continue_ctx
+        self.found(ctx)
+        assert run_one(ctx, "acme:ana", "acme:bob", "task") == 1
+        results = flush(ctx, "ana", "bob")
+        assert [r["member"] for r in results] == ["Ana", "Bob"]
+        assert all(r["archived"] is not None for r in results)
+        assert results[1]["retired"] is False  # Bob holds no conversation
+
+    def test_member_with_nothing_to_flush_reports_clean(self, continue_ctx):
+        ctx, _calls = continue_ctx
+        (result,) = flush(ctx, "bob")
+        assert not result["failed"] and not result["skipped"]
+        assert not result["retired"] and result["archived"] is None
+
+    def test_failed_dump_keeps_the_conversation_and_the_history(self, continue_ctx):
+        """A dump turn that fails banked nothing, so the flush takes nothing
+        away: the conversation still holds the state that never reached disk,
+        and the history log stays in the prompt path. `--no-dump` is the way
+        through for a conversation that can never dump."""
+        ctx, _calls = continue_ctx
+        self.found(ctx)
+        (result,) = flush(ctx, "ana", run_fn=fail_run)
+        assert result["failed"]
+        assert state.read_conversation(NODE, "ana")["retired"] is False
+        assert "first task" in state.read_history(NODE, "ana")
+        assert history_archives() == []
+
+    def test_human_and_broken_members_are_skipped_by_name(self, continue_ctx):
+        ctx, calls = continue_ctx
+        ctx.roster_path.write_text(
+            CONTINUE_ROSTER + "\n### Zoe\n- **Human:** yes\n\n### Rex\n- **Continue:** on\n",
+            encoding="utf-8",
+        )
+        results = flush(ctx, "zoe", "rex")
+        assert results[0]["skipped"] == "human member"
+        assert "Rig" in results[1]["skipped"]
+        assert continue_argvs(calls) == []
+
+    def test_resting_member_is_reported_as_failed(self, continue_ctx):
+        ctx, _calls = continue_ctx
+        self.found(ctx)
+        empty_member_budget(ctx, "ana")
+        (result,) = flush(ctx, "ana")
+        assert "resting" in result["failed"]
+        assert state.read_conversation(NODE, "ana")["retired"] is False
+        assert "FLUSH deferred — ana" in read_log()
+
+
+def flush_cli(ctx, *args):
+    return r4t_main([
+        "flush", "--node", NODE, "--root", str(ctx.root),
+        "--rig-config", str(ctx.config_path), "--no-notify", *args,
+    ])
+
+
+class TestFlushCommand:
+    def test_bare_flush_is_an_error(self, continue_ctx, capsys):
+        ctx, _calls = continue_ctx
+        assert flush_cli(ctx) == 2
+        assert "--all" in capsys.readouterr().err
+
+    def test_members_and_all_together_are_an_error(self, continue_ctx):
+        ctx, _calls = continue_ctx
+        assert flush_cli(ctx, "ana", "--all") == 2
+
+    def test_unknown_member_is_an_error(self, continue_ctx, capsys):
+        ctx, _calls = continue_ctx
+        assert flush_cli(ctx, "zed") == 2
+        assert "no team member named 'zed'" in capsys.readouterr().err
+
+    def test_named_member_flushes(self, continue_ctx, capsys):
+        ctx, _calls = continue_ctx
+        assert run_one(ctx, "boss", "acme:ana", "first task") == 1
+        assert flush_cli(ctx, "ana") == 0
+        out = capsys.readouterr().out
+        assert "flushed ana" in out and "archived history as history-" in out
+        assert state.read_conversation(NODE, "ana")["retired"] is True
+
+    def test_all_covers_the_roster_and_names_who_was_skipped(
+        self, continue_ctx, capsys
+    ):
+        ctx, _calls = continue_ctx
+        assert run_one(ctx, "boss", "acme:ana", "first task") == 1
+        assert flush_cli(ctx, "--all", "--no-dump") == 0
+        out = capsys.readouterr().out
+        assert "flushed ana" in out
+        assert "nothing to flush for bob" in out
+
+    def test_failed_dump_exits_non_zero(self, continue_ctx, capsys, tmp_path):
+        ctx, _calls = continue_ctx
+        assert run_one(ctx, "boss", "acme:ana", "first task") == 1
+        (tmp_path / "continue-harness.py").write_text(
+            "import sys\nsys.exit(1)\n", encoding="utf-8"
+        )
+        assert flush_cli(ctx, "ana") == 1
+        assert "failed ana" in capsys.readouterr().out
+        assert state.read_conversation(NODE, "ana")["retired"] is False
+
+
 class TestTurnSerialization:
     def test_message_arriving_mid_turn_never_spawns_a_second_turn(self, ctx):
         """Pins the guarantee continue depends on: one turn at a time per

--- a/guides/03-the-long-memory.md
+++ b/guides/03-the-long-memory.md
@@ -2,17 +2,16 @@
 
 ## 1. Capability
 
-At the end of this chapter Wren survives conversation death. You will watch
-the **flush cycle** end an idle conversation on purpose — Wren is prompted
-once to write his state to `STATUS.md`, the conversation is retired, and
-the next real message **refounds** him from that file. Then you will do
-something harsher: swap Wren's rig to a different CLI mid-life and watch him
-come back coherent on the other side. The conversation is disposable; the
-agent is not.
+At the end of this chapter Wren survives conversation death. You will end
+his conversation on purpose — Wren is prompted once to write his state to
+`STATUS.md`, the conversation is retired, and the next real message
+**refounds** him from that file. Then you will do something harsher: swap
+Wren's rig to a different CLI mid-life and watch him come back coherent on
+the other side. The conversation is disposable; the agent is not.
 
 ## 2. Time
 
-About 30 minutes, most of it deliberate waiting.
+About 20 minutes.
 
 ## 3. Starting state
 
@@ -24,17 +23,19 @@ About 30 minutes, most of it deliberate waiting.
 ## 4. The change
 
 `Flush: 15m` is a promise you made in chapter 2 without seeing it kept: a
-conversation idle past fifteen minutes is retired. Fifteen minutes is the
-right setting and still the wrong demo — you are not going to sit here
-watching a clock. The value takes bare seconds or an `s`/`m`/`h`/`d`
-suffix, so shrink the window further for one session:
+conversation idle past fifteen minutes is retired on the node's next idle
+pass. Fifteen minutes is the right setting and the wrong demo — you are not
+going to sit here watching a clock. `r4t flush` is the same cycle on your
+word:
 
-**Replace** `~/ark/silo/ROSTER.md` — in Wren's block, the `Flush:` line
-becomes:
-
-```markdown
-- **Flush:** 60
+```bash
+r4t flush --node silo wren
 ```
+
+It runs the dump turn, retires the conversation, and archives Wren's
+message history — the transcript r4t keeps for him — so a refounded Wren
+has exactly one place left to remember from. That last part is what makes
+the rest of this chapter a test rather than a demonstration.
 
 **Run**
 
@@ -50,8 +51,8 @@ You: note — Human without an Address (team cannot tell them)
 /home/you/ark/silo/ROSTER.md: OK (2 member(s), leader Wren)
 ```
 
-One rule worth knowing before you rely on this line: `Flush:` only means
-something next to `Continue: on` — flush retires a *continuing*
+One rule worth knowing before you rely on the roster field: `Flush:` only
+means something next to `Continue: on` — flush retires a *continuing*
 conversation. Set it on a member without `Continue: on` and the lint warns
 instead of blocking:
 
@@ -82,51 +83,48 @@ You should see:
 Supply cache at grid square K-19 recorded. Confirming storage complete.
 ```
 
-Now leave the team alone for a bit over a minute — the window is 60
-seconds of *idle*, measured from Wren's last completed turn. Then run the
-idle sweep. `r4t idle` is the janitor pass a running node performs on its
-own; invoking it by hand lets you watch it work:
+Now end the conversation:
 
 **Run**
 
 ```bash
-r4t idle --node silo
+r4t flush --node silo wren
 ```
 
 You should see:
 
 ```
-drained 0 queued turn(s); nudged the leader on 0 quiet thread(s)
-pruned 0 stale lock(s); expired 0 thread(s); drained 0 more queued turn(s)
+flushed wren — dumped state to disk, retired the conversation, archived history as history-20260729T052013449271Z.md
 ```
 
-The summary doesn't mention the flush — the receipt lives in the team log
-and on disk, which is where the next section takes you.
+One line per member. The full receipt lives in the team log and on disk,
+which is where the next section takes you.
 
 ## 6. Expected receipt
 
 **Run**
 
 ```bash
-r4t logs --node silo -n 6
+r4t logs --node silo -n 7
 ```
 
 You should see:
 
 ```
-r4t: FLUSH dump turn -> wren (conversation idle > 60s)
+r4t: FLUSH dump turn -> wren (r4t flush)
 turn: 1 message(s) -> Wren (threads 01ABC..., rig silo)
 done: Wren, exit 0 in 28.8s
 r4t: ECHO-REPLY wren (rig silo) 674 bytes of cleaned stdout staged as the reply to r4t:silo
 r4t: RELEASED silo:wren -> r4t:silo thread=01ABC... hop=1
 r4t: FLUSH retired wren's conversation — the next real message refounds it from state on disk
+r4t: FLUSH archived wren's history log as history-20260729T052013449271Z.md — a fresh one starts at the next turn
 ```
 
-Two `FLUSH` events bracket a real turn. The **dump turn** is an ordinary
+Three `FLUSH` events around a real turn. The **dump turn** is an ordinary
 continuing turn whose prompt asks one thing: "Save your current state and
 progress to STATUS.md." It is logged, captured, and budgeted like any
-other turn, and only if it exits cleanly is the conversation retired. Look
-at what Wren wrote:
+other turn, and only if it exits cleanly does the retirement — and the
+archiving — follow. Look at what Wren wrote:
 
 **Run**
 
@@ -159,7 +157,8 @@ relative paths at the repo root, so on the free path it appears at
 `agents/wren/STATUS.md` instead. Either way it is inside the team repo,
 which matters at the commit point.)
 
-The conversation is now retired. Ask for the fact back:
+The conversation is retired and the message history is out of the prompt
+path. Ask for the fact back:
 
 **Run**
 
@@ -179,15 +178,16 @@ That turn was a **refound**: no continue flag on the CLI (there is no
 conversation left to continue), and the prompt opens with a preamble —
 "Check your STATUS.md to refresh your memory." A fresh conversation,
 founded from saved state, holding facts learned in a conversation that no
-longer exists.
+longer exists. There was one place that answer could have come from: the
+file you just read.
 
 ### The rig swap
 
-Flush is scheduled death. A rig swap is sudden death: the conversation is
-keyed on the CLI that holds it, so a rig that now drives a *different* CLI
-cannot resume it — and r4t does not try, because the old CLI may be
-quota-dead and unable to run a dump turn. State on disk is whatever the
-last flush left. Swap Wren to the other path's harness (this beat needs a
+Flush is death you schedule or ask for. A rig swap is sudden death: the
+conversation is keyed on the CLI that holds it, so a rig that now drives a
+*different* CLI cannot resume it — and r4t does not try, because the old CLI
+may be quota-dead and unable to run a dump turn. State on disk is whatever
+the last flush left. Swap Wren to the other path's harness (this beat needs a
 second continue-capable CLI installed — `agent` here; free-path readers
 with only ollama can read along, the machinery is identical):
 
@@ -263,14 +263,13 @@ message is queued, not lost; wait the minutes it names and run
 
 ## 7. Break it
 
-`STATUS.md` looks like a single point of failure, so attack it. Retire the
-conversation again — wait a bit over a minute, flush, then delete the
-state file before sending the recall:
+`STATUS.md` is now the single point of failure, so attack it. Flush again,
+delete the state file, then send the recall:
 
 **Run**
 
 ```bash
-r4t idle --node silo
+r4t flush --node silo wren
 rm STATUS.md
 r4t seat send --node silo "What was the codeword?"
 r4t seat inbox --node silo
@@ -280,48 +279,63 @@ You should see:
 
 ```
 ── from silo:wren (2026-07-29T05:34:01.509705Z)
-Codeword: TIDEPOOL
+I have no record of a codeword — STATUS.md is missing and I have nothing else on file.
 ```
 
-The lobotomy failed. Worth understanding rather than celebrating.
+The lobotomy worked. Worth understanding rather than panicking over.
 
 ## 8. Diagnose
 
-The refound turn told Wren to check a file that did not exist — so why does
-he still know? Because `STATUS.md` was never the only layer. Every turn's
-prompt carries a section r4t maintains itself:
+Two layers hold a refounded Wren's memory, and you have now removed both.
+`STATUS.md` is the layer Wren writes himself — judgments, progress,
+structure. The other is machinery-kept: every turn's prompt carries a
+section r4t maintains for him,
 
 ```
 ## Your conversation so far (messages you received and sent)
 ```
 
-— the member's rolling message history, machinery-kept, capped by the
-rig's history budget. The codeword rode in on that. So refound memory is
-belt and braces: `STATUS.md` holds what the *member* chose to write down
-(judgments, progress, structure), the rolling history holds what was
-*said* recently (until it scrolls off the cap). Delete one and the other
-covers — for a while. A fact old enough to have scrolled out of history
-survives only if Wren wrote it to `STATUS.md`. That is the layer you just
-deleted, and on a longer-lived agent the loss would have been real.
-
-## 9. Fix
-
-Nothing is broken in the machinery — what's missing is the file, and the
-machinery that wrote it once will write it again. Wait past the window and
-run another sweep:
+— the rolling message history, capped by the rig's history budget. `r4t
+flush` archives that log instead of carrying it forward, which is why the
+recall in section 6 proved anything at all:
 
 **Run**
 
 ```bash
-r4t idle --node silo
-ls STATUS.md
+ls ~/.config/r4t/teams/silo/agents/wren/
+```
+
+You should see:
+
+```
+history-20260729T052013449271Z.md  history.md  meta.json
+history-20260729T053355901744Z.md  live.log    turns
+```
+
+Nothing is deleted — every archived word is still readable — but an
+archived log is out of the prompt, so a refounded Wren answers from
+`STATUS.md` or not at all. On a long-lived agent that is the real stake: a
+fact old enough to have scrolled past the history cap survives only where
+Wren wrote it down.
+
+## 9. Fix
+
+Nothing is broken in the machinery — what's missing is the file, and the
+machinery that wrote it once will write it again. Give Wren the fact and
+flush:
+
+**Run**
+
+```bash
+r4t seat send --node silo "The codeword is TIDEPOOL and the supply cache is at grid square K-19."
+r4t flush --node silo wren
 head -8 STATUS.md
 ```
 
 You should see:
 
 ```
-STATUS.md
+flushed wren — dumped state to disk, retired the conversation, archived history as history-20260729T053902117630Z.md
 # STATUS.md — Wren
 
 ## Codeword
@@ -331,7 +345,7 @@ TIDEPOOL (confirmed)
 - Supply cache location: grid square K-19
 ```
 
-The dump turn regenerated it from the live conversation.
+The dump turn wrote it back out of the live conversation.
 
 ## 10. Check
 
@@ -353,39 +367,39 @@ Codeword: TIDEPOOL — Cache: grid square K-19
 ```
 
 Flushed, refounded, swapped, swapped back, state file deleted and
-regrown — and Wren still answers. The team is whole.
+rewritten — and Wren still answers. The team is whole.
 
 ## 11. Customize
 
-Put the window back where it belongs:
-
-**Replace** `~/ark/silo/ROSTER.md` — Wren's `Flush:` line becomes:
-
-```markdown
-- **Flush:** 15m
-```
+Park the whole team on your way out — one flag, every member:
 
 **Run**
 
 ```bash
-r4t roster check
+r4t flush --node silo --all
 ```
 
 You should see:
 
 ```
-You: note — Human without an Address (team cannot tell them)
-/home/you/ark/silo/ROSTER.md: OK (2 member(s), leader Wren)
+flushed wren — dumped state to disk, retired the conversation, archived history as history-20260729T054417338205Z.md
+skipped you — human member
 ```
 
-The window says how long a pause Wren's conversation survives. Fifteen
-minutes is a good default: short pauses keep their momentum, and after a
-longer one the flush has already banked everything that matters in
-`STATUS.md`, so the next message starts fresh without starting over.
-Set it late enough that normal working pauses don't cost Wren his
-short-term memory, early enough that he isn't dragging yesterday into
-today. On paid rigs a short window also keeps resumed context from
-billing at full length; the mechanics behind that live in
+That is the habit worth keeping: before a long break, after a run that
+filled a conversation with dead ends, or when a member starts answering
+from stale context. `--no-dump` skips the save turn for a conversation you
+do not want banked — a rig that is out of quota and cannot run the turn, or
+one whose recent context is exactly what you are trying to be rid of.
+
+The `Flush:` window covers the same ground while you are not looking, and
+fifteen minutes is a good default: short pauses keep their momentum, and
+after a longer one the flush has already banked what matters in
+`STATUS.md`, so the next message starts fresh without starting over. Set it
+late enough that normal working pauses don't cost Wren his short-term
+memory, early enough that he isn't dragging yesterday into today. On paid
+rigs a short window also keeps resumed context from billing at full length;
+the mechanics behind that live in
 [Prompt-Cache Economics](https://github.com/neilobremski/bin/wiki/Prompt-Cache-Economics).
 
 ## 12. Commit point


### PR DESCRIPTION
`r4t flush <member> [<member> ...]` — or `--all` for the roster — runs the
flush cycle on demand: dump turn, retire the conversation, archive the
member's history log. Grammar mirrors the existing multi-arg verbs; bare
`r4t flush` is an error, so roster-wide is always a deliberate `--all`.

## The two jobs

**A ch.3 memory test that proves something.** The tutorial asks Wren for a
fact after a flush, but a refound prompt re-embeds r4t's rolling history, so
the answer could always have come from the transcript rather than
`STATUS.md`. The verb archives `agents/<member>/history.md` out of the
prompt path, leaving exactly one place the answer can come from. Chapter 3
is reworked around it: flush on the word instead of shrinking `Flush:` to 60
and waiting out the window, and "Break it" now lands — delete `STATUS.md`
after a flush and the fact is genuinely gone, which is the lesson the
chapter was reaching for.

**Curing a poisoned conversation.** `--no-dump` skips the turn: a dump asks
the conversation to write its state to `STATUS.md`, which banks the poison,
and a quota-dead rig cannot run the turn at all. Retire and archive still
happen. Live ops hit both cases this month (silo rechristening, cursor
usage-limit rotate) and got there by hand-editing `meta.json`.

## Archive, never delete

The history log is the record of what was said. Flush renames it to a
timestamped sibling; a fresh one accrues from the next turn (`read_history`
already returns `""` when the file is missing). `ls` on the member's state
dir shows every archive, and the guide's diagnose beat now walks the reader
through exactly that.

## Sweep vs verb

The idle `_flush_sweep` is unchanged and still leaves history in place — a
sweep flush wants the refound to carry rolling context forward. The verb's
archival exists for the on-demand case, where the point is a clean slate.
The split is deliberate rather than an inconsistency: the two callers want
different things from the same retirement.

## Failure handling

A dump turn that fails leaves the conversation and the history exactly as
they were — nothing was banked, so nothing is thrown away — and the command
exits non-zero naming the member. A member resting on budget reports the
same way. `--no-dump` is the documented way past a conversation that can
never dump.

## Tests

15 new tests in `apps/r4t/tests/test_dispatch.py` (happy path, `--no-dump`,
multi-member, `--all`, nothing-to-flush member, human/broken member skips,
resting member, failed dump, refound-carries-no-transcript, plus the CLI
grammar and exit codes). Full suite: 668 passed.

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)

