### PR TITLE
fix(r4t): overview panel lists logs, chat, seat

### DIFF
--- a/apps/r4t/r4t.py
+++ b/apps/r4t/r4t.py
@@ -64,6 +64,9 @@ DEFAULT_TASK_TTL_SECONDS = 7 * 86400
 COMMAND_HELP = [
     ("init", "Write starter ROSTER.md and ~/.config/r4t/rigs.json; print a8s registration"),
     ("status", "Budgets, queues, open threads, dead letters for one team"),
+    ("logs", "The team's event log: every governance decision and turn boundary"),
+    ("chat", "Interactive human seat: messages and team activity in one window"),
+    ("seat", "The roster human's team mailbox and voice (bare: summary)"),
     ("rig list", "Rigs, limits, and roster rig resolution (alias: ls)"),
     ("rig presets", "Named CLI presets aligned with a8s definitions"),
     ("rig add <rig> <preset>", "Add a rig to ~/.config/r4t/rigs.json from a preset"),


### PR DESCRIPTION
The bare `r4t` overview's Commands panel omitted `logs`, `chat`, and `seat` — the most human-facing verbs. Hit live on qwen-solo: needing the team log, the panel gave no clue whether the verb was `log` or `logs`. One panel entry each, style unchanged; full suite green (668 passed).

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)