### PR TITLE
fix(r4t): no stdout-derived reply to the synthetic r4t sender

### DIFF
--- a/apps/r4t/dispatch.py
+++ b/apps/r4t/dispatch.py
@@ -1564,9 +1564,9 @@ def _run_turn(
             f"failed turns, rig {rig.name}) — turns pause; one probe per "
             f"{config.breaker_cooldown_seconds:g}s until a turn succeeds",
         )
-    if exit_code == 127:
+    if exit_code == 127 and reply_target:
         _tell_error(
-            ctx, newest_sender,
+            ctx, reply_target,
             f"{member.name}'s harness (rig {rig.name}) failed to start: "
             f"{output.strip()}",
             thread=newest_thread, roster=roster,

--- a/apps/r4t/dispatch.py
+++ b/apps/r4t/dispatch.py
@@ -1196,10 +1196,14 @@ def _stage_echo_reply(
     discarded. Output past `echo_max_chars` is truncated in the body with the
     full text riding the same envelope as a markdown attachment (the a8s
     bundle-dir mechanism `tell --attach` uses). Empty or chrome-only output
-    stays silent, SILENT logged."""
+    stays silent, SILENT logged; so does an empty `to`, the turn that answered
+    nobody but r4t."""
     staging = state.staging_dir(ctx.node, member.name)
     for stale in state.staged_envelopes(ctx.node, member.name):
         stale.unlink(missing_ok=True)
+    if not to:
+        _log_internal_only(ctx, member, rig, output)
+        return
     reply = clean_transcript(output)
     if not reply:
         state.append_log(
@@ -1232,6 +1236,20 @@ def _stage_echo_reply(
         f"r4t: ECHO-REPLY {member.name.lower()} (rig {rig.name}) "
         f"{len(reply)} bytes of cleaned stdout staged as the reply to {to}"
         + (" (full text attached)" if files else ""),
+    )
+
+
+def _log_internal_only(
+    ctx: DispatchContext,
+    member: Member,
+    rig: Rig,
+    output: str,
+) -> None:
+    state.append_log(
+        ctx.node,
+        f"r4t: SILENT {member.name.lower()} (rig {rig.name}) answered only "
+        f"r4t-internal senders; its {len(output.strip())} bytes of stdout stay "
+        "transcript, nothing staged",
     )
 
 
@@ -1318,6 +1336,19 @@ def _run_turn(
     newest_thread = str(batch[-1].get("thread", "")) or "?"
     newest_hop = int(batch[-1].get("hop", 0) or 0)
     newest_sender = str(batch[-1].get("from", "")) or f"{ctx.node}"
+    # `r4t:<node>` is a synthetic sender — the dispatcher's own voice on dump,
+    # error and review turns — not a mailbox, so no stdout-derived reply may be
+    # addressed to it. The reply target is the newest sender that is a real one;
+    # a batch carrying nothing but r4t's own prompts has no target at all.
+    internal_sender = f"r4t:{ctx.node}"
+    reply_target = next(
+        (
+            str(env_msg.get("from", "")) or f"{ctx.node}"
+            for env_msg in reversed(batch)
+            if str(env_msg.get("from", "")) != internal_sender
+        ),
+        "",
+    )
 
     refound = _refound_turn(ctx, member, rig)
     # The one fact the rest of the turn keys on: this turn really does run
@@ -1445,7 +1476,7 @@ def _run_turn(
                 max_bytes=rig.history_max_bytes,
             )
         if rig.echo:
-            _stage_echo_reply(ctx, member, rig, newest_sender, output)
+            _stage_echo_reply(ctx, member, rig, reply_target, output)
         elif not state.staged_envelopes(ctx.node, member.name):
             # The classic weak-rig shape: the model answers on stdout instead
             # of running `tell`. `tell` always wins — a turn that staged
@@ -1453,17 +1484,19 @@ def _run_turn(
             # released nothing gets its cleaned stdout staged as ONE reply to
             # the newest message's sender, riding the normal release gates.
             reply = clean_transcript(output)
-            if len(reply) > STDOUT_REPLY_MIN_CHARS:
+            if len(reply) > STDOUT_REPLY_MIN_CHARS and not reply_target:
+                _log_internal_only(ctx, member, rig, output)
+            elif len(reply) > STDOUT_REPLY_MIN_CHARS:
                 msg_id = tasks.new_thread_id()
                 state.atomic_write_json(
                     state.staging_dir(ctx.node, member.name) / f"{msg_id}.json",
-                    {"id": msg_id, "to": newest_sender, "content": reply, "files": []},
+                    {"id": msg_id, "to": reply_target, "content": reply, "files": []},
                 )
                 state.append_log(
                     ctx.node,
                     f"r4t: STDOUT-REPLY {member.name.lower()} (rig {rig.name}) "
                     f"released nothing; {len(reply)} bytes of cleaned stdout "
-                    f"staged as a reply to {newest_sender}",
+                    f"staged as a reply to {reply_target}",
                 )
             elif not output.strip():
                 # The blank-response quota signal (Neil's field observation):

--- a/apps/r4t/docs/rigs.md
+++ b/apps/r4t/docs/rigs.md
@@ -176,6 +176,12 @@ simply asked a question just answers). A reply longer than `echo_max_chars`
 (default 1500) is truncated in the body with the full text attached to the
 same envelope as a markdown file; empty or chrome-only output stays silent.
 
+`r4t:<node>` is the dispatcher's own voice — the flush dump prompt, an error
+notice, a mission review — and no mailbox. A turn whose whole batch came from
+it has no sender to answer, so the stdout stays transcript (`SILENT` in the
+log); the same rule holds the `STDOUT-REPLY` fallback on non-echo rigs. A batch
+mixing r4t's prompt with a real message still replies to the real sender.
+
 ## The economics: budgets, not cuts
 
 A member runs while its own spend bucket, the shared cell bucket, and (if the

--- a/apps/r4t/tests/test_dispatch.py
+++ b/apps/r4t/tests/test_dispatch.py
@@ -1179,6 +1179,15 @@ def stdout_only(rig, prompt, cwd, *, env=None, variant=0):
     return 0, ANSWER, 1.0, False
 
 
+def enqueue_internal(ctx, name, body="Save your state to STATUS.md."):
+    """The shape every r4t-generated turn shares — flush dump, class=error,
+    mission review: a prompt from the synthetic sender `r4t:<node>`."""
+    state.enqueue(NODE, name, {
+        "from": f"r4t:{NODE}", "to": f"{NODE}:{name}",
+        "thread": new_ulid(), "hop": 0, "class": "auto", "body": body,
+    })
+
+
 class TestStdoutFallback:
     def test_stdout_becomes_reply_to_external_sender(self, ctx, repo, r4t_home):
         handle_message(ctx, "boss", "acme:gerry", "question", run_fn=stdout_only)
@@ -1280,6 +1289,15 @@ class TestStdoutFallback:
         handle_message(ctx, "boss", "acme:gerry", "question", run_fn=crashed)
         assert outbox_envelopes(repo) == []
         assert "STDOUT-REPLY" not in read_log()
+
+    def test_internal_only_batch_stages_nothing(self, ctx, repo, r4t_home):
+        enqueue_internal(ctx, "gerry")
+        assert drain(ctx, run_fn=stdout_only) == 1
+        assert outbox_envelopes(repo) == []
+        text = read_log()
+        assert "r4t: SILENT gerry" in text
+        assert "r4t-internal senders" in text
+        assert "STDOUT-REPLY" not in text
 
 
 def set_echo(config_path, rig_name="leader", **extra):
@@ -1385,6 +1403,40 @@ class TestEchoRig:
         assert [m["from"] for m in parked] == ["acme:gerry"]
         assert parked[0]["content"] == ANSWER.strip()
         assert outbox_envelopes(repo) == []
+
+    def test_dump_turn_stages_nothing(self, ctx, repo, r4t_home):
+        # The flush leak (#293): a dump turn's only sender is `r4t:acme`, which
+        # is no mailbox — its chatter stays transcript.
+        def tell_and_chatter(rig, prompt, cwd, *, env=None, variant=0):
+            outbox = dispatch.Path(env["TELL_OUTBOX_DIR"])
+            msg_id = new_ulid()
+            (outbox / f"{msg_id}.json").write_text(
+                json.dumps({"id": msg_id, "to": "outsider", "content": "sneaky"}),
+                encoding="utf-8",
+            )
+            return 0, ANSWER, 1.0, False
+
+        set_echo(ctx.config_path)
+        enqueue_internal(ctx, "gerry")
+        assert drain(ctx, run_fn=tell_and_chatter) == 1
+        assert outbox_envelopes(repo) == []  # staged noise still discarded
+        assert seat_messages() == []
+        text = read_log()
+        assert "r4t: SILENT gerry" in text
+        assert "r4t-internal senders" in text
+        assert "ECHO-REPLY" not in text
+
+    def test_mixed_batch_replies_to_the_real_sender(self, ctx, repo, r4t_home):
+        # A dump prompt landing behind a real message must not swallow the
+        # reply: the newest REAL sender is the target.
+        set_echo(ctx.config_path)
+        handle_message(ctx, "boss", "acme:gerry", "question", drain_after=False)
+        enqueue_internal(ctx, "gerry")
+        assert drain(ctx, run_fn=stdout_only) == 1
+        envelopes = outbox_envelopes(repo)
+        assert [e["to"] for e in envelopes] == ["boss"]
+        assert envelopes[0]["content"] == ANSWER.strip()
+        assert "r4t: ECHO-REPLY gerry" in read_log()
 
     def test_reply_to_internal_sender_wakes_them(self, ctx, fake_harness, r4t_home):
         set_echo(ctx.config_path, rig_name="junior-dev")

--- a/apps/r4t/tests/test_dispatch.py
+++ b/apps/r4t/tests/test_dispatch.py
@@ -1299,6 +1299,18 @@ class TestStdoutFallback:
         assert "r4t-internal senders" in text
         assert "STDOUT-REPLY" not in text
 
+    def test_spawn_failure_on_internal_batch_tells_no_ghost(
+        self, ctx, repo, r4t_home, tells
+    ):
+        sent, _capture = tells
+        enqueue_internal(ctx, "gerry")
+
+        def spawnfail(rig, prompt, cwd, *, env=None, variant=0):
+            return 127, "failed to spawn", 0.1, False
+
+        drain(ctx, run_fn=spawnfail)
+        assert sent == []
+
 
 def set_echo(config_path, rig_name="leader", **extra):
     config = json.loads(Path(config_path).read_text(encoding="utf-8"))

--- a/guides/03-the-long-memory.md
+++ b/guides/03-the-long-memory.md
@@ -105,7 +105,7 @@ which is where the next section takes you.
 **Run**
 
 ```bash
-r4t logs --node silo -n 7
+r4t logs --node silo -n 6
 ```
 
 You should see:
@@ -114,8 +114,7 @@ You should see:
 r4t: FLUSH dump turn -> wren (r4t flush)
 turn: 1 message(s) -> Wren (threads 01ABC..., rig silo)
 done: Wren, exit 0 in 28.8s
-r4t: ECHO-REPLY wren (rig silo) 674 bytes of cleaned stdout staged as the reply to r4t:silo
-r4t: RELEASED silo:wren -> r4t:silo thread=01ABC... hop=1
+r4t: SILENT wren (rig silo) answered only r4t-internal senders; its 674 bytes of stdout stay transcript, nothing staged
 r4t: FLUSH retired wren's conversation — the next real message refounds it from state on disk
 r4t: FLUSH archived wren's history log as history-20260729T052013449271Z.md — a fresh one starts at the next turn
 ```
@@ -124,7 +123,9 @@ Three `FLUSH` events around a real turn. The **dump turn** is an ordinary
 continuing turn whose prompt asks one thing: "Save your current state and
 progress to STATUS.md." It is logged, captured, and budgeted like any
 other turn, and only if it exits cleanly does the retirement — and the
-archiving — follow. Look at what Wren wrote:
+archiving — follow. The `SILENT` line is that turn answering r4t rather than a
+teammate: no one asked, so whatever Wren said on his way to disk stays in the
+turn capture instead of landing in someone's inbox. Look at what Wren wrote:
 
 **Run**
 


### PR DESCRIPTION
## Mechanism

Forcing `r4t idle` on the qwen-solo roster made the member send the human a message. The flush dump turn did it.

- `_flush_sweep` (and the `r4t flush` verb's `_flush_member`) enqueues the dump prompt `from: "r4t:<node>"`, class `auto`.
- `_run_turn` took the reply target from the batch's last envelope — for a pure dump turn that is `r4t:<node>`.
- An echo rig's only reply path stages cleaned stdout as one envelope to that address, unconditionally. The non-echo `STDOUT-REPLY` fallback has the same shape whenever the turn released nothing and cleaned stdout clears the floor (a dump turn never asks for `tell`).
- `r4t:<node>` is not an internal address, so the envelope rides the egress gate. In a roster of one the member is the top leader — the message went out.

## Fix

`r4t:<node>` is the dispatcher's own voice — dump turns, `class=error` notices, mission review all speak with it — and it is no mailbox. The reply target is now the newest sender in the batch that is *not* that synthetic one, so every internal enqueue is covered by construction rather than by special-casing flush.

- No real sender in the batch → echo staging and the stdout fallback both stand down; the stdout stays transcript, logged `r4t: SILENT <member> (rig <rig>) answered only r4t-internal senders; ...`.
- Mixed batch (a teammate's message with a dump prompt behind it) → the reply still goes to the teammate.
- Envelopes the member staged itself via `tell` are untouched — only stdout-derived replies change — and an echo rig still discards staged noise on the turns it stays silent for.

`_flush_sweep`/`_flush_member` are unchanged; the fix lives where the reply target is chosen.

## Docs

- `guides/03-the-long-memory.md` section 6 showed the leak as expected output (`ECHO-REPLY ... to r4t:silo` plus `RELEASED silo:wren -> r4t:silo`). Those two lines are the new `SILENT` line, and the receipt command drops to `r4t logs --node silo -n 6`. One sentence of prose names the rule.
- `apps/r4t/docs/rigs.md` states the synthetic-sender rule under Echo rigs.

## Tests

Four new cases in `apps/r4t/tests/test_dispatch.py`: echo pure-dump batch (nothing staged, `SILENT` logged, staged noise still discarded), echo mixed batch (reply to the real sender), non-echo fallback on a pure r4t-internal batch, plus the shared `enqueue_internal` helper. Full suite: **671 passed**. `r4t sandbox --fake` exits 0 with all mechanical checks passed.

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)