### PR TITLE
feat(r4t): the idle window rides Continue:, one field

### DIFF
--- a/apps/r4t/dispatch.py
+++ b/apps/r4t/dispatch.py
@@ -1848,7 +1848,7 @@ def _quiet_task_sweep(
 #
 # A continuing conversation left idle eventually goes stale or falls out of
 # the provider cache — re-caching a huge context at frontier prices costs real
-# money for one message. `Flush: <duration>` bounds that: once the member's
+# money for one message. `Continue: <duration>` bounds that: once the member's
 # last turn is older than the duration, a DUMP TURN (a normal continuing turn
 # whose prompt asks the member to write its state to disk) runs and the
 # conversation is retired; the next real message refounds cold from that state.
@@ -1927,9 +1927,9 @@ def _flush_sweep(
 
 # ---------- manual flush (the on-demand verb) ----------
 #
-# The sweep waits out `Flush:`; the verb runs on the operator's word, so it
-# checks neither. It goes one step further than the sweep and archives the
-# member's history log: the refound then reads STATUS.md and nothing else,
+# The sweep waits out the `Continue:` window; the verb runs on the operator's
+# word, so it checks neither. It goes one step further than the sweep and
+# archives the member's history log: the refound reads STATUS.md and nothing else,
 # which is what makes a memory test provable and what cures a conversation
 # whose recent transcript is the problem.
 

--- a/apps/r4t/docs/rigs.md
+++ b/apps/r4t/docs/rigs.md
@@ -46,9 +46,12 @@ CLI from the same effective directory (the workplace root, or their resolved
 `Workdir:`) land in the same one. `r4t roster check` warns when that happens —
 it never blocks, but the fix is another CLI or distinct `Workdir:` lines.
 
-An optional `- **Flush:** 4h` (bare seconds or an s/m/h/d suffix) bounds how
-long a continuing conversation may sit idle before it is retired — dumped to
-disk, then refounded from that state on the next real message. The `r4t idle`
+`- **Continue:** 4h` (bare seconds or a duration with an s/m/h/d suffix)
+continues the conversation *and* bounds how long it may sit idle before it is
+retired — dumped to disk, then refounded from that state on the next real
+message. `on` leaves the window open; anything but `on`, `off`, or a positive
+duration is a roster error, so an idle window can never ride a member that
+runs cold. The `r4t idle`
 sweep retires a conversation idle past the duration by running a budget-gated
 dump turn (a normal continuing turn prompting the member to save its state to
 STATUS.md). A rig swap that changes the CLI retires the conversation
@@ -58,7 +61,7 @@ and preamble are overridable via the node definition's `prompts` object (keys
 `flush_dump` and `refound_preamble`).
 
 `r4t flush <member> [<member> ...]` (or `--all` for the whole roster) does the
-same on demand, for any member — no `Flush:` field and no idle wait. It runs
+same on demand, for any member — no window and no idle wait. It runs
 the dump turn, retires the conversation, and then archives the member's
 `agents/<member>/history.md` to a timestamped sibling, so the refound reads
 STATUS.md rather than a transcript of everything it was told. Nothing is

--- a/apps/r4t/r4t.py
+++ b/apps/r4t/r4t.py
@@ -54,7 +54,6 @@ from roster import (
     Member,
     Roster,
     RosterError,
-    flush_warnings,
     load_roster,
     resolve_roster_path,
 )
@@ -1425,9 +1424,6 @@ def cmd_roster_check(args: argparse.Namespace) -> int:
         for message in continue_collisions(roster, config, org.workplace):
             print(f"warning: {message}")
             warnings += 1
-    for message in flush_warnings(roster):
-        print(f"warning: {message}")
-        warnings += 1
     for severity, message in roster.tree_problems():
         if severity == "error":
             print(message)

--- a/apps/r4t/roster.py
+++ b/apps/r4t/roster.py
@@ -15,11 +15,11 @@ work, and the provider cache makes an expensive rig affordable. It needs a rig
 whose preset supports it (rig.py), and members sharing a CLI in one directory
 share that conversation, so `r4t roster check` warns about the overlap.
 
-`Flush:` (optional, only meaningful with `Continue: on`) is how long the
-member's conversation may sit idle before the `r4t idle` sweep retires it —
-dump state to disk, then refound on the next real message. Bare seconds or an
-s/m/h/d suffix (`Flush: 4h`). Without `Continue: on` it is ignored;
-`r4t roster check` warns.
+`Continue: on` keeps that conversation until something else retires it.
+`Continue: 15m` — bare seconds or a duration with an s/m/h/d suffix — bounds
+it: the `r4t idle` sweep retires a conversation that has sat idle that long,
+dumping state to disk so the member refounds on the next real message. Any
+other value is a member error.
 
 AI is the default and carries no marker. The human seat is marked
 `- **Human:** yes` and is never dispatched; an optional
@@ -58,14 +58,20 @@ FLUSH_RE = re.compile(r"^(\d+(?:\.\d+)?)\s*([smhd]?)$", re.IGNORECASE)
 FLUSH_UNIT_SECONDS = {"": 1, "s": 1, "m": 60, "h": 3600, "d": 86400}
 
 
+CONTINUE_ERROR = (
+    "Continue must be on, off, or an idle window like 15m "
+    "(seconds or a duration with an s/m/h/d suffix)"
+)
+
+
 def parse_flush(value: str) -> float:
     match = FLUSH_RE.match(value.strip())
     if not match:
-        raise ValueError(
-            f"Flush must be seconds or a duration with an s/m/h/d suffix "
-            f"(got {value!r})"
-        )
-    return float(match.group(1)) * FLUSH_UNIT_SECONDS[match.group(2).lower()]
+        raise ValueError(f"{CONTINUE_ERROR} (got {value!r})")
+    seconds = float(match.group(1)) * FLUSH_UNIT_SECONDS[match.group(2).lower()]
+    if seconds <= 0:
+        raise ValueError(f"{CONTINUE_ERROR} (got {value!r})")
+    return seconds
 
 
 class RosterError(Exception):
@@ -219,20 +225,6 @@ class Roster:
         return out
 
 
-def flush_warnings(roster: Roster) -> list[str]:
-    """Warn (never block) where `Flush:` is set without `Continue: on` — flush
-    only retires a continuing conversation, so the field does nothing there."""
-    return [
-        f"{m.name}: Flush: set but Continue: is off — flush retires a "
-        f"continuing conversation, so it is ignored here"
-        for m in roster.members
-        if not m.is_human
-        and not m.errors
-        and m.flush_seconds is not None
-        and not m.continue_conversation
-    ]
-
-
 def resolve_roster_path(root: Path, raw: str | None) -> Path:
     if not raw:
         return root / DEFAULT_ROSTER_NAME
@@ -248,6 +240,10 @@ def _clean(value: str) -> str:
 
 def _is_true(value: str) -> bool:
     return value.strip().lower() in ("yes", "true", "y", "1", "on")
+
+
+def _is_false(value: str) -> bool:
+    return value.strip().lower() in ("", "no", "false", "n", "off")
 
 
 def _member_from_block(name: str, lines: list[str]) -> Member:
@@ -272,13 +268,21 @@ def _member_from_block(name: str, lines: list[str]) -> Member:
     m.role = fields.get("role", fields.get("mandate", ""))
     m.leader = _is_true(fields.get("leader", ""))
     m.address = fields.get("address") or None
-    m.continue_conversation = _is_true(fields.get("continue", ""))
-    flush = fields.get("flush", "")
-    if flush:
+    if "flush" in fields:
+        m.errors.append(
+            "Flush: is not a field — the idle window rides Continue: "
+            "(try: Continue: 15m)"
+        )
+    cont = fields.get("continue", "")
+    if _is_true(cont):
+        m.continue_conversation = True
+    elif not _is_false(cont):
         try:
-            m.flush_seconds = parse_flush(flush)
+            m.flush_seconds = parse_flush(cont)
         except ValueError as e:
             m.errors.append(str(e))
+        else:
+            m.continue_conversation = True
     m.cell = fields.get("cell", "")
     m.lead = fields.get("lead", "")
     m.workdir = fields.get("workdir", "")

--- a/apps/r4t/tests/test_dispatch.py
+++ b/apps/r4t/tests/test_dispatch.py
@@ -667,12 +667,10 @@ CONTINUE_ROSTER = textwrap.dedent(
     ### Ana
     - **Rig:** resuming
     - **Leader:** yes
-    - **Continue:** on
-    - **Flush:** 1h
+    - **Continue:** 1h
 
     ### Bob
     - **Rig:** cold
-    - **Flush:** 1h
     """
 )
 
@@ -937,8 +935,8 @@ class TestIdleFlush:
         assert run_idle(ctx)["flushed"] == []
         assert len(continue_argvs(calls)) == before
 
-    def test_flush_ignored_without_continue(self, continue_ctx):
-        # Bob carries Flush: without Continue: on — lint warns; dispatch ignores.
+    def test_no_flush_without_continue(self, continue_ctx):
+        # Bob runs fresh every turn — there is no conversation to retire.
         ctx, calls = continue_ctx
         assert run_one(ctx, "acme:ana", "acme:bob", "task") == 1
         age_last_turn("bob")
@@ -1021,8 +1019,8 @@ class TestFlushVerb:
         assert state.read_history(NODE, "ana") == ""
         assert "FLUSH archived ana" in read_log()
 
-    def test_flush_needs_no_idle_wait_and_no_flush_field(self, continue_ctx):
-        # The sweep waits out `Flush:`; a fresh turn is flushable on the word.
+    def test_flush_needs_no_idle_wait(self, continue_ctx):
+        # The sweep waits out the window; a fresh turn is flushable on the word.
         ctx, _calls = continue_ctx
         self.found(ctx)
         assert run_idle(ctx)["flushed"] == []

--- a/apps/r4t/tests/test_roster.py
+++ b/apps/r4t/tests/test_roster.py
@@ -7,7 +7,6 @@ import pytest
 
 from roster import (
     RosterError,
-    flush_warnings,
     load_roster,
     parse_roster,
     resolve_roster_path,
@@ -97,47 +96,43 @@ class TestParsing:
         assert ana.rig == "r"
         assert not ana.errors
 
-    def test_flush_bare_seconds(self):
-        roster = parse(
-            "### A\n- **Rig:** r\n- **Continue:** on\n"
-            "- **Flush:** 90\n"
-        )
-        assert roster.find("a").flush_seconds == 90.0
+    def test_continue_on_has_no_flush_window(self):
+        assert parse(CONTINUE_TEXT).find("ana").flush_seconds is None
+
+    def test_continue_bare_seconds(self):
+        member = parse("### A\n- **Rig:** r\n- **Continue:** 90\n").find("a")
+        assert member.continue_conversation is True
+        assert member.flush_seconds == 90.0
 
     @pytest.mark.parametrize(
         "value,seconds",
         [("30s", 30.0), ("5m", 300.0), ("4h", 14400.0), ("2d", 172800.0)],
     )
-    def test_flush_suffixes(self, value, seconds):
-        roster = parse(
-            f"### A\n- **Rig:** r\n- **Continue:** on\n"
-            f"- **Flush:** {value}\n"
-        )
-        assert roster.find("a").flush_seconds == seconds
+    def test_continue_duration_suffixes(self, value, seconds):
+        member = parse(f"### A\n- **Rig:** r\n- **Continue:** {value}\n").find("a")
+        assert member.continue_conversation is True
+        assert member.flush_seconds == seconds
 
-    def test_flush_absent_is_none(self):
-        assert parse(CONTINUE_TEXT).find("ana").flush_seconds is None
+    def test_continue_off_has_no_flush_window(self):
+        assert parse(CONTINUE_TEXT).find("cid").flush_seconds is None
 
-    def test_flush_malformed_disables_member(self):
-        roster = parse(
-            "### A\n- **Rig:** r\n- **Continue:** on\n"
-            "- **Flush:** soon\n"
-        )
-        assert "Flush" in roster.find("a").error
+    @pytest.mark.parametrize("value", ["0", "0m", "-5m"])
+    def test_continue_non_positive_duration_disables_member(self, value):
+        member = parse(f"### A\n- **Rig:** r\n- **Continue:** {value}\n").find("a")
+        assert "Continue must be on, off, or an idle window" in member.error
+        assert member.continue_conversation is False
 
-    def test_flush_without_continue_warns(self):
-        roster = parse(
-            "### A\n- **Rig:** r\n- **Flush:** 4h\n"
-        )
-        warnings = flush_warnings(roster)
-        assert len(warnings) == 1 and warnings[0].startswith("A: Flush")
+    def test_continue_garbage_disables_member(self):
+        member = parse("### A\n- **Rig:** r\n- **Continue:** soon\n").find("a")
+        assert "Continue must be on, off, or an idle window" in member.error
+        assert member.continue_conversation is False
 
-    def test_flush_with_continue_does_not_warn(self):
-        roster = parse(
-            "### A\n- **Rig:** r\n- **Continue:** on\n"
-            "- **Flush:** 4h\n"
-        )
-        assert flush_warnings(roster) == []
+    def test_flush_field_disables_member(self):
+        member = parse(
+            "### A\n- **Rig:** r\n- **Continue:** on\n- **Flush:** 4h\n"
+        ).find("a")
+        assert "Flush: is not a field" in member.error
+        assert "(try: Continue: 15m)" in member.error
 
     def test_lookup_is_case_insensitive(self, repo):
         roster = load_roster(repo / "ROSTER.md")

--- a/guides/02-the-solo-agent.md
+++ b/guides/02-the-solo-agent.md
@@ -332,11 +332,11 @@ Wren still knows. The team is whole.
 
 One line in the roster: bound how long Wren's conversation may sit idle.
 
-**Replace** `~/ark/silo/ROSTER.md` — in Wren's block, directly under
-`- **Continue:** on`, add:
+**Replace** `~/ark/silo/ROSTER.md` — in Wren's block, swap the `Continue:`
+line for a duration:
 
 ```markdown
-- **Flush:** 15m
+- **Continue:** 15m
 ```
 
 A conversation idle past fifteen minutes is retired — Wren is prompted
@@ -371,7 +371,7 @@ in commands.)
 cd ~/ark/silo
 git init -q
 git add ROSTER.md
-git commit -q -m "silo roster: Wren, continue on, flush 15m"
+git commit -q -m "silo roster: Wren, continue 15m"
 ```
 
 Copy-paste templates for this chapter's final state live in

--- a/guides/03-the-long-memory.md
+++ b/guides/03-the-long-memory.md
@@ -15,14 +15,14 @@ About 20 minutes.
 
 ## 3. Starting state
 
-- Chapter 2 complete: Wren answers at the seat, `Continue: on`, and the
-  customize step left `Flush: 15m` in his roster block.
+- Chapter 2 complete: Wren answers at the seat, and the customize step left
+  `Continue: 15m` in his roster block.
 - Wren's conversation is live — if you just restarted the machine, send one
   seat message so there is a conversation to flush.
 
 ## 4. The change
 
-`Flush: 15m` is a promise you made in chapter 2 without seeing it kept: a
+`Continue: 15m` is a promise you made in chapter 2 without seeing it kept: a
 conversation idle past fifteen minutes is retired on the node's next idle
 pass. Fifteen minutes is the right setting and the wrong demo — you are not
 going to sit here watching a clock. `r4t flush` is the same cycle on your
@@ -51,19 +51,8 @@ You: note — Human without an Address (team cannot tell them)
 /home/you/ark/silo/ROSTER.md: OK (2 member(s), leader Wren)
 ```
 
-One rule worth knowing before you rely on the roster field: `Flush:` only
-means something next to `Continue: on` — flush retires a *continuing*
-conversation. Set it on a member without `Continue: on` and the lint warns
-instead of blocking:
-
-```
-warning: Wren: Flush: set but Continue: is off — flush retires a continuing
-conversation, so it is ignored here
-/home/you/ark/silo/ROSTER.md: OK (2 member(s), leader Wren, 1 warning(s))
-```
-
-Harmless, but it means the field is doing nothing. Yours says OK — keep
-going.
+The idle window rides the same field that turns the conversation on, so a
+member who runs cold can never carry one.
 
 ## 5. Run it
 
@@ -393,7 +382,7 @@ from stale context. `--no-dump` skips the save turn for a conversation you
 do not want banked — a rig that is out of quota and cannot run the turn, or
 one whose recent context is exactly what you are trying to be rid of.
 
-The `Flush:` window covers the same ground while you are not looking, and
+The `Continue:` window covers the same ground while you are not looking, and
 fifteen minutes is a good default: short pauses keep their momentum, and
 after a longer one the flush has already banked what matters in
 `STATUS.md`, so the next message starts fresh without starting over. Set it

--- a/guides/04-a-second-pair-of-hands.md
+++ b/guides/04-a-second-pair-of-hands.md
@@ -21,8 +21,7 @@ About 30 minutes.
 
 ## 3. Starting state
 
-- Chapter 3 complete: Wren on `Continue: on` / `Flush: 15m`, answering at
-  the seat.
+- Chapter 3 complete: Wren on `Continue: 15m`, answering at the seat.
 - The free path runs both members on one `qwen3.6` — no second model, no
   extra download. (Subscription path: Moss still runs local and free; only
   Wren's rig differs, exactly as in chapters 2–3.)
@@ -43,8 +42,7 @@ Two edits: the roster grows a member, and the rig config grows a rig.
 ### Wren
 - **Rig:** silo
 - **Leader:** yes
-- **Continue:** on
-- **Flush:** 15m
+- **Continue:** 15m
 - **Workdir:** agents/wren
 - **Role:** The solo agent — does the work and answers the owner
 

--- a/guides/templates/02-solo-cursor/ROSTER.md
+++ b/guides/templates/02-solo-cursor/ROSTER.md
@@ -7,8 +7,7 @@
 ### Wren
 - **Rig:** silo
 - **Leader:** yes
-- **Continue:** on
-- **Flush:** 15m
+- **Continue:** 15m
 - **Workdir:** agents/wren
 - **Role:** The solo agent — does the work and answers the owner
 

--- a/guides/templates/02-solo-opencode-ollama/ROSTER.md
+++ b/guides/templates/02-solo-opencode-ollama/ROSTER.md
@@ -7,8 +7,7 @@
 ### Wren
 - **Rig:** silo
 - **Leader:** yes
-- **Continue:** on
-- **Flush:** 15m
+- **Continue:** 15m
 - **Workdir:** agents/wren
 - **Role:** The solo agent — does the work and answers the owner
 

--- a/guides/templates/04-two-member/ROSTER.md
+++ b/guides/templates/04-two-member/ROSTER.md
@@ -7,8 +7,7 @@
 ### Wren
 - **Rig:** silo
 - **Leader:** yes
-- **Continue:** on
-- **Flush:** 15m
+- **Continue:** 15m
 - **Workdir:** agents/wren
 - **Role:** The solo agent — does the work and answers the owner
 


### PR DESCRIPTION
`Flush:` collapses into `Continue:`. The pairing `Flush:` without `Continue: on` was the only thing `flush_warnings` existed to catch; the schema now holds that edge instead of a lint.

## Schema (roster.py)

| Roster line | Result |
| --- | --- |
| `Continue: on` (any truthy word) | continuing conversation, no idle window |
| `Continue: 15m` (bare seconds or s/m/h/d) | continuing conversation, retired after that idle window |
| `Continue: off` / falsy / absent | fresh conversation every turn |
| anything else, including `0` | member error |

- `Flush:` is a hard member error: `Flush: is not a field — the idle window rides Continue: (try: Continue: 15m)`. Pre-v1 carries no migration shim, and silently ignoring the field would silently disarm a live flush window, so this is boundary validation.
- Zero and non-positive durations are errors, not a synonym for infinity.
- `flush_warnings` and its `r4t roster check` call are deleted.
- Internals unchanged (`continue_conversation` + `flush_seconds`), so `_flush_sweep` and the `r4t flush` verb needed no change.

## Docs and guides

- `apps/r4t/docs/rigs.md` — the field paragraph merges into the Continue teaching; the `r4t flush` verb paragraph stays.
- Guide ch.2 customize step swaps the `Continue:` line for a duration; ch.3 intro and §11 name the `Continue:` window, and the lint beat is replaced by one sentence saying the window rides the same field; ch.4 starting state and roster block.
- All three `guides/templates/*/ROSTER.md` carry `Continue: 15m`.

## Tests

675 pass (`venv/bin/python3 -m pytest apps/r4t/tests/`). New coverage: truthy Continue, duration Continue, zero/negative duration, garbage value, and the `Flush:` error with its hint. `r4t sandbox --fake` reports all mechanical checks passed.

Closes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)