### PR TITLE
feat(r4t): user-first CLI surface — one command table, machinery hidden

### DIFF
--- a/apps/r4t/r4t.py
+++ b/apps/r4t/r4t.py
@@ -16,6 +16,7 @@ import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import NamedTuple
 
 import state
 import tasks
@@ -60,31 +61,95 @@ from roster import (
 
 DEFAULT_TASK_TTL_SECONDS = 7 * 86400
 
+
+class Command(NamedTuple):
+    """One row of the visible CLI surface.
+
+    `parser` names the top-level subcommand whose argparse `help=` this row's
+    blurb becomes, so the bare-`r4t` panel and `r4t --help` share one wording.
+    """
+
+    display: str
+    blurb: str
+    parser: str | None = None
+    hint: str | None = None
+
+
 COMMAND_HELP = [
-    ("init", "Write starter ROSTER.md and ~/.config/r4t/rigs.json; print a8s registration"),
-    ("status", "Budgets, queues, open threads, dead letters for one team"),
-    ("logs", "The team's event log: every governance decision and turn boundary"),
-    ("chat", "Interactive human seat: messages and team activity in one window"),
-    ("seat", "The roster human's team mailbox and voice (bare: summary)"),
-    ("rig list", "Rigs, limits, and roster rig resolution (alias: ls)"),
-    ("rig presets", "Named CLI presets aligned with a8s definitions"),
-    ("rig add <rig> <preset>", "Add a rig to ~/.config/r4t/rigs.json from a preset"),
-    ("rig remove <rig>", "Remove a rig from the config (alias: rm)"),
-    ("rig set <rig> <key> <val>", "Write a rig setting (get/unset/configure too)"),
-    ("judge <node> --rig <rig>", "Grade a finished run against the MAST failure taxonomy"),
-    ("roster check", "Lint ROSTER.md against the rig config"),
-    ("task list", "List conversation threads for a team"),
-    ("task show <id>", "Show one task ledger record as JSON"),
-    ("clear", "Prune stale locks, expire idle threads, drain queued turns"),
-    ("flush <member>", "Dump a member's state, retire the conversation, archive its history"),
-    ("idle", "Nudge agents with unfinished work, then clear"),
-    ("sandbox", "Disposable end-to-end run with graded report"),
-    ("sandbox --fake", "Same pipeline with deterministic fake agents (no LLM)"),
-    ("sandbox --fake --break dev", "Fake run with a member whose harness always fails"),
-    ("sandbox --preset NAME", "Live sandbox harness (see `r4t rig presets`)"),
-    ("sandbox --preset opencode-ollama --model M", "Live sandbox via Ollama-local OpenCode"),
-    ("dispatch", "Handle one delivered message (a8s invoke entry)"),
+    (
+        "Getting started",
+        [
+            Command("init", "Set up this repo: a starter roster and rig config", "init"),
+            Command(
+                "roster check",
+                "Check the roster reads cleanly and every rig resolves",
+                "roster",
+            ),
+            Command("rig", "Rigs: what each name on the roster actually runs", "rig"),
+            Command("rig list", "Your rigs, and the member riding each one"),
+            Command(
+                "rig presets",
+                "Ready-made rigs to start from",
+                None,
+                "r4t rig add <rig> <preset>",
+            ),
+            Command("rig add <rig> <preset>", "Add a rig from a preset"),
+            Command("rig set <rig> <key> <val>", "Change one rig setting"),
+        ],
+    ),
+    (
+        "Every day",
+        [
+            Command(
+                "status",
+                "Where a team stands: budgets, queues, open threads",
+                "status",
+            ),
+            Command(
+                "logs",
+                "Everything the team does, as it happens",
+                "logs",
+                "r4t logs -f",
+            ),
+            Command(
+                "chat",
+                "Your seat at the team: speak, and watch the work land",
+                "chat",
+            ),
+            Command(
+                "seat",
+                "Read messages waiting for you and answer them",
+                "seat",
+            ),
+            Command(
+                "flush <member>",
+                "Save a member's state and start the conversation fresh",
+                "flush",
+            ),
+            Command("task list", "The team's conversation threads", "task"),
+            Command("task show <id>", "One thread, in full"),
+        ],
+    ),
+    (
+        "Verification",
+        [
+            Command(
+                "check",
+                "Sweep a team's work for the patterns you forbid",
+                "check",
+            ),
+        ],
+    ),
 ]
+
+PARSER_HELP = {
+    cmd.parser: cmd.blurb
+    for _section, cmds in COMMAND_HELP
+    for cmd in cmds
+    if cmd.parser
+}
+
+HIDDEN_COMMANDS = ("clear", "dispatch", "idle", "judge", "lab", "sandbox")
 
 ROSTER_TEMPLATE = """\
 # Team Roster
@@ -347,6 +412,23 @@ def _print_team_summaries() -> None:
             print(f"    locked: {lock.get('agent', '?')} pid={lock.get('pid', '?')}")
 
 
+def _cmd_help(name: str) -> str:
+    return PARSER_HELP[name] + "."
+
+
+def _print_command_panel() -> None:
+    width = max(len(cmd.display) for _section, cmds in COMMAND_HELP for cmd in cmds)
+    for index, (section, cmds) in enumerate(COMMAND_HELP):
+        if index:
+            print()
+        print(section)
+        for cmd in cmds:
+            line = f"  {cmd.display:<{width}}  {cmd.blurb}"
+            if cmd.hint:
+                line += f"   (try: {cmd.hint})"
+            print(line)
+
+
 def _next_steps(
     *,
     config_missing: bool,
@@ -366,9 +448,10 @@ def _next_steps(
         steps.append("`r4t init` — prints the a8s add / namespace / start sequence")
     elif len(teams) == 1:
         steps.append(f"`r4t status --node {teams[0]}` — budgets, queues, threads")
+        steps.append(f"`r4t chat --node {teams[0]}` — take your seat at the team")
     else:
         steps.append("`r4t status --node <team>` — pick a team from the list above")
-    steps.append("`r4t sandbox --fake` — end-to-end plumbing check without LLM calls")
+        steps.append("`r4t chat --node <team>` — take your seat at the team")
     return steps
 
 
@@ -408,10 +491,7 @@ def cmd_default(_args: argparse.Namespace) -> int:
     else:
         print(f"  no ROSTER.md under {root}")
     print()
-    print("Commands")
-    width = max(len(name) for name, _ in COMMAND_HELP)
-    for name, blurb in COMMAND_HELP:
-        print(f"  {name:<{width}}  {blurb}")
+    _print_command_panel()
     print()
     print("Next steps")
     for step in _next_steps(
@@ -1109,7 +1189,7 @@ def cmd_rig_overview(args: argparse.Namespace) -> int:
         if roster_path.is_file():
             print("  - `r4t roster check` — lint roster ↔ rig mappings")
         print("  - `r4t rig add <rig> <preset>` — add another rig")
-        print("  - `r4t sandbox --fake` — end-to-end plumbing check without LLM calls")
+        print("  - `r4t rig get <rig>` — see a rig's effective settings")
     return 0
 
 
@@ -1587,166 +1667,29 @@ def build_parser() -> argparse.ArgumentParser:
         prog="r4t",
         description="Roster For Teams — define agents in ROSTER.md; govern turns on a8s.",
     )
-    sub = p.add_subparsers(dest="command", required=False)
+    sub = p.add_subparsers(dest="command", required=False, metavar="COMMAND")
     p.set_defaults(func=cmd_default)
 
-    dispatch_p = sub.add_parser(
-        "dispatch", help="Handle one delivered message (the a8s invoke entry)."
+    init_p = sub.add_parser(
+        "init",
+        help=_cmd_help("init"),
+        description="Write a starter ROSTER.md and ~/.config/r4t/rigs.json; print "
+        "the a8s registration sequence.",
     )
-    _add_common(dispatch_p)
-    dispatch_p.add_argument("--from", dest="from_agent", required=True)
-    dispatch_p.add_argument(
-        "--to",
-        required=True,
-        help="Full recipient as delivered ($RECIPIENT): <node> or <node>:<member>.",
-    )
-    dispatch_p.add_argument("--message", required=True)
-    dispatch_p.add_argument(
-        "--no-drain",
-        action="store_true",
-        help="Skip the deferred-message drain passes around this message.",
-    )
-    _add_tell_flags(dispatch_p)
-    dispatch_p.set_defaults(func=cmd_dispatch)
+    init_p.add_argument("--root", help="Repo to initialize (default: cwd).")
+    init_p.set_defaults(func=cmd_init)
 
-    clear_p = sub.add_parser(
-        "clear", help="Maintenance: prune stale locks, expire tasks, drain."
-    )
-    _add_common(clear_p, with_node=True)
-    _add_older_than(clear_p)
-    _add_tell_flags(clear_p)
-    clear_p.set_defaults(func=cmd_clear)
-
-    flush_p = sub.add_parser(
-        "flush",
-        help="Save a member's state to disk and start their conversation over.",
-    )
-    _add_common(flush_p, with_node=True)
-    flush_p.add_argument(
-        "members", nargs="*", metavar="MEMBER", help="Members to flush."
-    )
-    flush_p.add_argument(
-        "--all", action="store_true", help="Every member on the roster."
-    )
-    flush_p.add_argument(
-        "--no-dump",
-        action="store_true",
-        help="Skip the save turn — for a conversation that cannot or should "
-        "not write its state down.",
-    )
-    _add_tell_flags(flush_p)
-    flush_p.set_defaults(func=cmd_flush)
-
-    idle_p = sub.add_parser(
-        "idle",
-        help="Idle pass: nudge active agents with unfinished business, then clear.",
-    )
-    _add_common(idle_p, with_node=True)
-    _add_older_than(idle_p)
-    _add_tell_flags(idle_p)
-    idle_p.set_defaults(func=cmd_idle)
-
-    status_p = sub.add_parser("status", help="Per-team status.")
-    _add_common(status_p, with_node=True)
-    _add_tell_flags(status_p)
-    status_p.set_defaults(func=cmd_status)
-
-    logs_p = sub.add_parser(
-        "logs", help="The team's own event log: every governance decision "
-        "and turn boundary, including traffic that never reaches a8s."
-    )
-    _add_common(logs_p, with_node=True)
-    logs_p.add_argument(
-        "-f", "--follow", action="store_true", help="Keep streaming new events."
-    )
-    logs_p.add_argument(
-        "-n", "--lines", type=int, default=40,
-        help="Backfill this many lines first (0 = everything kept on disk).",
-    )
-    logs_p.add_argument(
-        "--full", action="store_true",
-        help="Raw daily log, prompts and transcripts included.",
-    )
-    logs_p.add_argument(
-        "--agent", metavar="MEMBER",
-        help="Only one member's activity; with --full, their captured turns.",
-    )
-    logs_p.set_defaults(func=cmd_logs)
-
-    check_p = sub.add_parser(
-        "check",
-        help="Forbidden-pattern sweep: opaque pass/fail on stdout, findings on "
-        "stderr. Patterns live in ~/.config/r4t/checklists/.",
-    )
-    _add_common(check_p)
-    check_p.add_argument(
-        "node", nargs="?",
-        help="Team node name (default: sole ~/.config/r4t team).",
-    )
-    check_p.set_defaults(func=cmd_check)
-
-    judge_p = sub.add_parser(
-        "judge",
-        help="Grade a finished run against the MAST failure taxonomy "
-        "(post-hoc; the report is for humans, not agents).",
-    )
-    judge_p.add_argument(
-        "node", nargs="?",
-        help="Team node name (default: sole ~/.config/r4t team).",
-    )
-    judge_p.add_argument(
-        "--rig", required=True,
-        help="Configured rig that runs the judge prompts.",
-    )
-    judge_p.add_argument(
-        "--json", action="store_true",
-        help="Machine-readable report on stdout.",
-    )
-    judge_p.add_argument(
-        "--rig-config",
-        help="Harness config path (default: ~/.config/r4t/rigs.json).",
-    )
-    judge_p.set_defaults(func=cmd_judge)
-
-    chat_p = sub.add_parser(
-        "chat", help="Interactive human seat: messages and team activity in one window."
-    )
-    _add_common(chat_p, with_node=True)
-    _add_tell_flags(chat_p)
-    chat_p.add_argument(
-        "--plain", action="store_true",
-        help="Line UI instead of the full-screen TUI.",
-    )
-    chat_p.add_argument(
-        "--attach", metavar="MEMBER",
-        help="Open watching a member read-only (messages in and turn output live).",
-    )
-    chat_p.set_defaults(func=cmd_chat)
-
-    seat_p = sub.add_parser(
-        "seat", help="The roster human's team mailbox and voice (bare: summary)."
-    )
-    seat_p.add_argument(
-        "action", nargs="?", choices=["inbox", "send"],
-        help="inbox: read parked messages; send: speak as the human.",
-    )
-    seat_p.add_argument("message", nargs="*", help="send: message text.")
-    seat_p.add_argument("--to", help="send: member first name (default: the leader).")
-    seat_p.add_argument(
-        "--peek", action="store_true", help="inbox: leave messages unread."
-    )
-    seat_p.add_argument(
-        "--json", action="store_true", dest="as_json",
-        help="inbox: one JSON object per message.",
-    )
-    _add_common(seat_p, with_node=True)
-    _add_tell_flags(seat_p)
-    seat_p.set_defaults(func=cmd_seat)
+    roster_p = sub.add_parser("roster", help=_cmd_help("roster"))
+    roster_sub = roster_p.add_subparsers(dest="action", required=True)
+    roster_check_p = roster_sub.add_parser("check", help="Lint the roster.")
+    _add_common(roster_check_p)
+    roster_check_p.set_defaults(func=cmd_roster_check)
 
     rig_p = sub.add_parser(
         "rig",
         aliases=["rigs"],
-        help="Harness config commands (bare: overview + next steps).",
+        help=_cmd_help("rig"),
+        description="Harness config commands (bare: overview + next steps).",
     )
     rig_p.set_defaults(func=cmd_rig_overview)
     rig_sub = rig_p.add_subparsers(dest="action", required=False)
@@ -1891,29 +1834,170 @@ def build_parser() -> argparse.ArgumentParser:
     )
     rig_unset_p.set_defaults(func=cmd_rig_unset)
 
-    task_p = sub.add_parser("task", help="Task ledger commands.")
+    status_p = sub.add_parser("status", help=_cmd_help("status"))
+    _add_common(status_p, with_node=True)
+    _add_tell_flags(status_p)
+    status_p.set_defaults(func=cmd_status)
+
+    logs_p = sub.add_parser("logs", help=_cmd_help("logs"))
+    _add_common(logs_p, with_node=True)
+    logs_p.add_argument(
+        "-f", "--follow", action="store_true", help="Keep streaming new events."
+    )
+    logs_p.add_argument(
+        "-n", "--lines", type=int, default=40,
+        help="Backfill this many lines first (0 = everything kept on disk).",
+    )
+    logs_p.add_argument(
+        "--full", action="store_true",
+        help="Raw daily log, prompts and transcripts included.",
+    )
+    logs_p.add_argument(
+        "--agent", metavar="MEMBER",
+        help="Only one member's activity; with --full, their captured turns.",
+    )
+    logs_p.set_defaults(func=cmd_logs)
+
+    chat_p = sub.add_parser(
+        "chat",
+        help=_cmd_help("chat"),
+        description="Interactive human seat: messages and team activity in one window.",
+    )
+    _add_common(chat_p, with_node=True)
+    _add_tell_flags(chat_p)
+    chat_p.add_argument(
+        "--plain", action="store_true",
+        help="Line UI instead of the full-screen TUI.",
+    )
+    chat_p.add_argument(
+        "--attach", metavar="MEMBER",
+        help="Open watching a member read-only (messages in and turn output live).",
+    )
+    chat_p.set_defaults(func=cmd_chat)
+
+    seat_p = sub.add_parser(
+        "seat",
+        help=_cmd_help("seat"),
+        description="The roster human's team mailbox and voice (bare: summary).",
+    )
+    seat_p.add_argument(
+        "action", nargs="?", choices=["inbox", "send"],
+        help="inbox: read parked messages; send: speak as the human.",
+    )
+    seat_p.add_argument("message", nargs="*", help="send: message text.")
+    seat_p.add_argument("--to", help="send: member first name (default: the leader).")
+    seat_p.add_argument(
+        "--peek", action="store_true", help="inbox: leave messages unread."
+    )
+    seat_p.add_argument(
+        "--json", action="store_true", dest="as_json",
+        help="inbox: one JSON object per message.",
+    )
+    _add_common(seat_p, with_node=True)
+    _add_tell_flags(seat_p)
+    seat_p.set_defaults(func=cmd_seat)
+
+    flush_p = sub.add_parser("flush", help=_cmd_help("flush"))
+    _add_common(flush_p, with_node=True)
+    flush_p.add_argument(
+        "members", nargs="*", metavar="MEMBER", help="Members to flush."
+    )
+    flush_p.add_argument(
+        "--all", action="store_true", help="Every member on the roster."
+    )
+    flush_p.add_argument(
+        "--no-dump",
+        action="store_true",
+        help="Skip the save turn — for a conversation that cannot or should "
+        "not write its state down.",
+    )
+    _add_tell_flags(flush_p)
+    flush_p.set_defaults(func=cmd_flush)
+
+    task_p = sub.add_parser("task", help=_cmd_help("task"))
     task_p.add_argument("action", choices=["list", "show"])
     task_p.add_argument("id", nargs="?", help="Task ULID.")
     task_p.add_argument("--node", help="Team node name (default: sole ~/.config/r4t team).")
     task_p.set_defaults(func=cmd_task)
 
-    roster_p = sub.add_parser("roster", help="Roster commands.")
-    roster_sub = roster_p.add_subparsers(dest="action", required=True)
-    roster_check_p = roster_sub.add_parser("check", help="Lint the roster.")
-    _add_common(roster_check_p)
-    roster_check_p.set_defaults(func=cmd_roster_check)
-
-    init_p = sub.add_parser(
-        "init",
-        help="Write a starter ROSTER.md and ~/.config/r4t/rigs.json; print the "
-        "a8s registration sequence.",
+    check_p = sub.add_parser(
+        "check",
+        help=_cmd_help("check"),
+        description="Forbidden-pattern sweep: opaque pass/fail on stdout, findings "
+        "on stderr. Patterns live in ~/.config/r4t/checklists/.",
     )
-    init_p.add_argument("--root", help="Repo to initialize (default: cwd).")
-    init_p.set_defaults(func=cmd_init)
+    _add_common(check_p)
+    check_p.add_argument(
+        "node", nargs="?",
+        help="Team node name (default: sole ~/.config/r4t team).",
+    )
+    check_p.set_defaults(func=cmd_check)
+
+    # HIDDEN_COMMANDS from here down: machinery a8s and cron invoke, plus
+    # maintainer tooling. Omitting `help=` keeps each command and its own
+    # --help intact while dropping it from the top-level listing.
+    dispatch_p = sub.add_parser(
+        "dispatch", description="Handle one delivered message (the a8s invoke entry)."
+    )
+    _add_common(dispatch_p)
+    dispatch_p.add_argument("--from", dest="from_agent", required=True)
+    dispatch_p.add_argument(
+        "--to",
+        required=True,
+        help="Full recipient as delivered ($RECIPIENT): <node> or <node>:<member>.",
+    )
+    dispatch_p.add_argument("--message", required=True)
+    dispatch_p.add_argument(
+        "--no-drain",
+        action="store_true",
+        help="Skip the deferred-message drain passes around this message.",
+    )
+    _add_tell_flags(dispatch_p)
+    dispatch_p.set_defaults(func=cmd_dispatch)
+
+    clear_p = sub.add_parser(
+        "clear", description="Maintenance: prune stale locks, expire tasks, drain."
+    )
+    _add_common(clear_p, with_node=True)
+    _add_older_than(clear_p)
+    _add_tell_flags(clear_p)
+    clear_p.set_defaults(func=cmd_clear)
+
+    idle_p = sub.add_parser(
+        "idle",
+        description="Idle pass: nudge active agents with unfinished business, then clear.",
+    )
+    _add_common(idle_p, with_node=True)
+    _add_older_than(idle_p)
+    _add_tell_flags(idle_p)
+    idle_p.set_defaults(func=cmd_idle)
+
+    judge_p = sub.add_parser(
+        "judge",
+        description="Grade a finished run against the MAST failure taxonomy "
+        "(post-hoc; the report is for humans, not agents).",
+    )
+    judge_p.add_argument(
+        "node", nargs="?",
+        help="Team node name (default: sole ~/.config/r4t team).",
+    )
+    judge_p.add_argument(
+        "--rig", required=True,
+        help="Configured rig that runs the judge prompts.",
+    )
+    judge_p.add_argument(
+        "--json", action="store_true",
+        help="Machine-readable report on stdout.",
+    )
+    judge_p.add_argument(
+        "--rig-config",
+        help="Harness config path (default: ~/.config/r4t/rigs.json).",
+    )
+    judge_p.set_defaults(func=cmd_judge)
 
     sandbox_p = sub.add_parser(
         "sandbox",
-        help="Disposable end-to-end team run in a temp A8S_HOME/R4T_HOME; "
+        description="Disposable end-to-end team run in a temp A8S_HOME/R4T_HOME; "
         "logs to stderr, report on stdout.",
     )
     sandbox_p.add_argument(
@@ -1944,7 +2028,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     lab_p = sub.add_parser(
         "lab",
-        help="Run repo-bundled repeatable experiments (see apps/r4t/experiments/).",
+        description="Run repo-bundled repeatable experiments (see apps/r4t/experiments/).",
     )
     lab_p.set_defaults(func=cmd_lab_overview)
     lab_sub = lab_p.add_subparsers(dest="action", required=False)

--- a/apps/r4t/tests/test_cli_surface.py
+++ b/apps/r4t/tests/test_cli_surface.py
@@ -1,0 +1,115 @@
+"""The CLI surface: what a reader of the guides sees, and what stays hidden."""
+from __future__ import annotations
+
+import re
+
+import pytest
+
+import r4t
+from r4t import main as r4t_main
+
+VISIBLE = ["init", "roster", "rig", "status", "logs", "chat", "seat", "flush", "task", "check"]
+
+
+def _top_level_help() -> str:
+    return r4t.build_parser().format_help()
+
+
+def _panel_rows() -> list[r4t.Command]:
+    return [cmd for _section, cmds in r4t.COMMAND_HELP for cmd in cmds]
+
+
+def _argv_for(display: str) -> list[str]:
+    """Command path from a panel label, dropping <placeholder> arguments."""
+    tokens = []
+    for token in display.split():
+        if token.startswith("<"):
+            break
+        tokens.append(token)
+    return tokens
+
+
+def test_help_hides_machinery_and_maintainer_verbs():
+    text = _top_level_help()
+    for name in r4t.HIDDEN_COMMANDS:
+        assert not re.search(rf"\b{name}\b", text), f"{name} leaked into --help"
+
+
+def test_help_usage_line_does_not_enumerate_commands():
+    usage = _top_level_help().splitlines()[0]
+    assert usage == "usage: r4t [-h] COMMAND ..."
+
+
+def test_help_lists_every_user_command():
+    text = _top_level_help()
+    for name in VISIBLE:
+        assert re.search(rf"^    {name}\b", text, re.MULTILINE), f"{name} missing from --help"
+
+
+@pytest.mark.parametrize("name", r4t.HIDDEN_COMMANDS)
+def test_hidden_commands_still_have_their_own_help(name):
+    with pytest.raises(SystemExit) as exc:
+        r4t_main([name, "--help"])
+    assert exc.value.code == 0
+
+
+def test_hidden_commands_still_parse():
+    args = r4t.build_parser().parse_args(
+        ["dispatch", "--from", "gerry", "--to", "acme:phil", "--message", "hi"]
+    )
+    assert args.func is r4t.cmd_dispatch
+    assert r4t.build_parser().parse_args(["sandbox", "--fake"]).fake is True
+    assert r4t.build_parser().parse_args(["idle"]).func is r4t.cmd_idle
+    assert r4t.build_parser().parse_args(["clear"]).func is r4t.cmd_clear
+    assert r4t.build_parser().parse_args(["lab", "list"]).func is r4t.cmd_lab_list
+    assert r4t.build_parser().parse_args(["judge", "--rig", "j"]).func is r4t.cmd_judge
+
+
+def test_panel_is_sectioned(capsys):
+    r4t._print_command_panel()
+    out = capsys.readouterr().out
+    assert "Getting started" in out
+    assert "Every day" in out
+    assert "Verification" in out
+    for name in ("logs", "chat", "seat", "flush", "status", "task list", "check"):
+        assert name in out
+
+
+def test_panel_hides_the_same_commands_as_help():
+    text = "\n".join(cmd.display for cmd in _panel_rows())
+    for name in r4t.HIDDEN_COMMANDS:
+        assert not re.search(rf"\b{name}\b", text), f"{name} leaked into the panel"
+
+
+def test_overview_renders_the_panel(r4t_home, repo, capsys, monkeypatch):
+    monkeypatch.chdir(repo)
+    assert r4t_main([]) == 0
+    out = capsys.readouterr().out
+    assert "Getting started" in out
+    assert "Every day" in out
+    assert "Next steps" in out
+    for name in r4t.HIDDEN_COMMANDS:
+        assert not re.search(rf"\b{name}\b", out), f"{name} leaked into the overview"
+
+
+@pytest.mark.parametrize("display", [cmd.display for cmd in _panel_rows()])
+def test_every_panel_command_parses(display):
+    with pytest.raises(SystemExit) as exc:
+        r4t_main([*_argv_for(display), "--help"])
+    assert exc.value.code == 0
+
+
+def test_panel_owns_the_subcommand_help_strings():
+    text = _top_level_help()
+    for cmd in _panel_rows():
+        if cmd.parser:
+            assert cmd.blurb in text, f"{cmd.parser} help drifted from the table"
+
+
+def test_try_hints_point_at_visible_commands():
+    for cmd in _panel_rows():
+        if not cmd.hint:
+            continue
+        with pytest.raises(SystemExit) as exc:
+            r4t_main([*_argv_for(cmd.hint.removeprefix("r4t ")), "--help"])
+        assert exc.value.code == 0

--- a/apps/r4t/tests/test_dispatch.py
+++ b/apps/r4t/tests/test_dispatch.py
@@ -2513,8 +2513,8 @@ class TestDefault:
         assert "r4t — Roster For Teams" in out
         assert f"R4T_HOME: {r4t_home}" in out
         assert "Rigs" in out and "junior-dev" in out and "RIG " in out
-        assert "Commands" in out and "init" in out
-        assert "sandbox --fake" in out
+        assert "Getting started" in out and "init" in out
+        assert "Every day" in out and "flush <member>" in out
         assert "Next steps" in out
         assert f"{NODE}:" in out
         assert "ROSTER.md" in out


### PR DESCRIPTION
The CLI mixed three audiences flat. Of sixteen subcommands in `--help`, a
guide reader types about eight; five of twenty-one bare-overview lines were
`sandbox` variants. This splits the surface by audience, keeps every verb
working, and renders both surfaces from one table.

## Shape

- **Hide, don't delete.** `dispatch`, `clear`, `idle` (machinery a8s and cron
  invoke) and `sandbox`, `lab`, `judge` (maintainer tooling) leave the
  top-level listing: no `help=` on their subparser, plus `metavar="COMMAND"`
  on `add_subparsers` so the usage line stops enumerating. Their former
  `help=` text moves to `description=`, so `r4t sandbox --help` is complete.
- **One command table.** `COMMAND_HELP` is a list of sections of `Command`
  rows (display, blurb, owning parser, optional `(try:)` hint). `PARSER_HELP`
  derives the argparse `help=` for the ten visible top-level commands from the
  same rows, so the panel and `--help` share one edit site — the class of drift
  that dropped `logs` from the panel in #296 can't recur.
- **Sectioned panel.** *Getting started* / *Every day* / *Verification*, with
  `check` last. One short user-altitude sentence per row.
- Subparser registration follows panel order, so `--help` reads top-down like
  the panel. `Next steps` (top level and `r4t rig`) no longer suggests hidden
  commands.

## Before / after — `r4t --help`

Before (16 commands, usage line enumerated every one):

```
usage: r4t [-h]
           {dispatch,clear,flush,idle,status,logs,check,judge,chat,seat,rig,rigs,task,roster,init,sandbox,lab}
           ...
  dispatch    Handle one delivered message (the a8s invoke entry).
  clear       Maintenance: prune stale locks, expire tasks, drain.
  flush       Save a member's state to disk and start their conversation over.
  idle        Idle pass: nudge active agents with unfinished business, then clear.
  status      Per-team status.
  logs        The team's own event log: every governance decision and turn boundary, ...
  check       Forbidden-pattern sweep: opaque pass/fail on stdout, findings on stderr. ...
  judge       Grade a finished run against the MAST failure taxonomy ...
  chat        Interactive human seat: messages and team activity in one window.
  seat        The roster human's team mailbox and voice (bare: summary).
  rig (rigs)  Harness config commands (bare: overview + next steps).
  task        Task ledger commands.
  roster      Roster commands.
  init        Write a starter ROSTER.md and ~/.config/r4t/rigs.json; print the ...
  sandbox     Disposable end-to-end team run in a temp A8S_HOME/R4T_HOME; ...
  lab         Run repo-bundled repeatable experiments (see apps/r4t/experiments/).
```

After:

```
usage: r4t [-h] COMMAND ...

Roster For Teams — define agents in ROSTER.md; govern turns on a8s.

positional arguments:
  COMMAND
    init        Set up this repo: a starter roster and rig config.
    roster      Check the roster reads cleanly and every rig resolves.
    rig (rigs)  Rigs: what each name on the roster actually runs.
    status      Where a team stands: budgets, queues, open threads.
    logs        Everything the team does, as it happens.
    chat        Your seat at the team: speak, and watch the work land.
    seat        Read messages waiting for you and answer them.
    flush       Save a member's state and start the conversation fresh.
    task        The team's conversation threads.
    check       Sweep a team's work for the patterns you forbid.

options:
  -h, --help    show this help message and exit
```

## After — the bare `r4t` panel

```
Getting started
  init                       Set up this repo: a starter roster and rig config
  roster check               Check the roster reads cleanly and every rig resolves
  rig                        Rigs: what each name on the roster actually runs
  rig list                   Your rigs, and the member riding each one
  rig presets                Ready-made rigs to start from   (try: r4t rig add <rig> <preset>)
  rig add <rig> <preset>     Add a rig from a preset
  rig set <rig> <key> <val>  Change one rig setting

Every day
  status                     Where a team stands: budgets, queues, open threads
  logs                       Everything the team does, as it happens   (try: r4t logs -f)
  chat                       Your seat at the team: speak, and watch the work land
  seat                       Read messages waiting for you and answer them
  flush <member>             Save a member's state and start the conversation fresh
  task list                  The team's conversation threads
  task show <id>             One thread, in full

Verification
  check                      Sweep a team's work for the patterns you forbid
```

## Verification

- `apps/r4t/tests/` — **705 passed**.
- `python3 apps/r4t/r4t.py sandbox --fake` → `sandbox: all mechanical checks
  passed`, exit 0. Hidden is not broken.
- New `apps/r4t/tests/test_cli_surface.py` (11 tests, 30 cases with parametrization): no hidden verb appears
  in `--help`, the panel, or the overview; each hidden command's own `--help`
  exits 0 and still parses its arguments; the panel is sectioned and lists
  `logs`/`chat`/`seat`/`flush`; every panel row and every `(try:)` hint parses;
  each table blurb appears in `--help`.
- Guides quote no output this changes (`ark`, `status`, `seat`, `logs` blocks
  only) — grepped for `r4t --help`, the overview panel, and command-listing
  rows; nothing to update.

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)
