### PR TITLE
feat(guides): solo to silo — ch.1 ships a real agent, ch.2 founds the team

### DIFF
--- a/apps/r4t/README.md
+++ b/apps/r4t/README.md
@@ -85,7 +85,7 @@ in production too. Full flow: [docs/message-flow.md](docs/message-flow.md).
 
 ## Learn more
 
-- [The Ark Raising](../../guides/README.md) — the suite build-along; [chapter 2](../../guides/02-the-solo-agent.md) raises a governed roster of one
+- [The Ark Raising](../../guides/README.md) — the suite build-along; [chapter 2](../../guides/02-the-founding.md) founds a governed roster of one
 - [Tutorial](docs/tutorial.md) — first team, step by step, fail-closed rules
 - [Rigs](docs/rigs.md) — presets, `--model`, settings, the governance knob table
 - [Message flow](docs/message-flow.md) — threads, queues, the stdout fallback

--- a/guides/01-hello-agent.md
+++ b/guides/01-hello-agent.md
@@ -1,17 +1,21 @@
 # Chapter 1 — Hello, Agent
 
+**Teaches A — [a8s](../apps/a8s/README.md), the message router.**
+
 ## 1. Capability
 
-At the end of this chapter you will have a registered a8s agent running on
-your machine that you can message with `tell` and that messages you back.
-You will have seen the whole loop — outbox, router, inbox, wake, reply —
-and broken it once on purpose. No LLM is involved: your first agent is a
-shell script, which is the point. An a8s agent is anything that can read a
-message and send one.
+At the end of this chapter you will have `solo`: an agent registered on a8s,
+running on your own machine, that you message with `tell` and that answers
+you. Not an echo — a real model behind a real harness, with tools, reading
+its own files when you ask it to. You will have seen the whole loop (outbox,
+router, inbox, wake, reply), taken solo's handler away and watched a message
+wait instead of die, and changed solo's character by editing one string.
 
 ## 2. Time
 
-About 20 minutes.
+About 20 minutes of hands-on time. On the free path start the model download
+first — it runs in the background while you read, and it is the only long
+wait in the chapter.
 
 ## 3. Starting state
 
@@ -25,6 +29,19 @@ source ~/bin/install.sh
 ```
 
 - Python 3 installed (`python3 --version` answers).
+- One harness. **Pick your path** — the free path is the default, and every
+  pasted output below was captured on it:
+  - **Free path** — [OpenCode](https://opencode.ai/) plus `ollama`. Start the
+    download now:
+
+**Run**
+
+```bash
+ollama pull qwen3.6
+```
+
+  - **Subscription path** — the Cursor agent CLI (`agent`), installed and
+    logged in.
 
 Now type the suite's front door command:
 
@@ -90,54 +107,77 @@ Services
 
 Tooling
   ✓ git  git version 2.50.1 (Apple Git-155)
-
-✓ core prerequisites satisfied  (10/10 probes green)
 ```
 
 Your panel will show ✗ for harnesses you haven't installed — that is fine.
-This chapter needs **none** of them. Chapter 2 needs exactly one: `ollama`
-with a model pulled (free path) or `agent` (subscription path). If you want
-to get ahead, install that one now; otherwise keep going.
+This chapter needs one path's worth: `opencode` plus `ollama` on the free
+path, or `agent` on the subscription path. Everything else can stay red.
 
 ## 4. The change
 
-Two directories: one agent that replies, and one seat for you to speak
-from.
+Two directories: one agent that thinks, and one seat for you to speak from.
 
-The agent is a script. When a message arrives, a8s wakes the agent by
-running the command in its *definition* — a small JSON file — substituting
-`$SENDER` and `$MESSAGE`. Our script replies with the one verb every agent
-gets: `tell`.
+An a8s agent is a directory plus a **definition** — a small JSON file naming
+the command that wakes it. When a message arrives, a8s substitutes `$SENDER`
+and `$MESSAGE` into that command and runs it, with the agent's own directory
+as the working directory. a8s never looks inside; whether the command is a
+shell script, a model harness, or both is entirely your business.
 
 **Run**
 
 ```bash
-mkdir -p ~/ark/hello ~/ark/me
+mkdir -p ~/ark/solo ~/ark/me
 ```
 
-**Create** `~/ark/hello/reply.sh`
+solo's wake command is three moves: seed a prompt, hand it to the harness,
+send the answer back with `tell`.
+
+**Create** `~/ark/solo/reply.sh` (free path)
 
 ```bash
 #!/usr/bin/env bash
 sender="$1"
 message="$2"
-tell "$sender" "hello received: $message"
+
+prompt="You are solo, an AI agent on this machine. Answer in one or two
+sentences, no preamble.
+
+$sender asks: $message"
+
+answer="$(ollama launch opencode --model qwen3.6 -- run --auto --dir . "$prompt" 2>/dev/null)"
+tell "$sender" "$answer"
 ```
 
-**Create** `~/ark/hello/hello.json`
+**Subscription path** — one line differs. Use this `answer=` line instead:
+
+```bash
+answer="$(agent --model auto -p --trust --force --approve-mcps "$prompt" 2>/dev/null)"
+```
+
+The `2>/dev/null` is doing real work: a harness paints its progress UI on
+stderr and puts the finished answer alone on stdout, so throwing stderr away
+leaves you holding exactly the reply and nothing else. `--auto` (free path)
+and `--trust --force` (subscription path) are the headless permission flags —
+without them the harness waits forever for a prompt nobody is there to
+answer.
+
+The `prompt=` block is the **seeded prompt**: solo's character first, then
+who is asking and what they asked. It is the only place solo's personality
+lives, and it is a shell string you own outright.
+
+**Create** `~/ark/solo/solo.json`
 
 ```json
 {
-  "description": "hello agent — replies to every tell with a script",
-  "invoke": ["bash", "reply.sh", "$SENDER", "$MESSAGE"]
+  "description": "solo — a local agent: a harness CLI behind a8s",
+  "invoke": ["bash", "reply.sh", "$SENDER", "$MESSAGE"],
+  "max_wake_seconds": 600
 }
 ```
 
-**Run**
-
-```bash
-chmod +x ~/ark/hello/reply.sh
-```
+`max_wake_seconds` is the one guard rail worth setting today: harnesses
+occasionally hang instead of exiting, and this kills a wake that runs long
+rather than letting it hold the agent forever.
 
 `~/ark/me` is your **filedrop seat**: a directory a8s delivers your mail
 into, with no CLI to wake — you read it with `tells`. Register both, then
@@ -147,7 +187,7 @@ look at the roster:
 
 ```bash
 a8s add me ~/ark/me filedrop
-a8s add hello ~/ark/hello ~/ark/hello/hello.json
+a8s add solo ~/ark/solo ~/ark/solo/solo.json
 a8s ls
 ```
 
@@ -156,40 +196,42 @@ You should see:
 ```
 added me -> /home/you/ark/me
 definition: /home/you/bin/apps/a8s/definitions/filedrop.json  (explicit)
-added hello -> /home/you/ark/hello
-definition: /home/you/ark/hello/hello.json  (explicit)
-NAME    STATUS    DEFINITION   ROOT
-hello   stopped   hello        /home/you/ark/hello
-me      stopped   filedrop     /home/you/ark/me
+added solo -> /home/you/ark/solo
+definition: /home/you/ark/solo/solo.json  (explicit)
+NAME   STATUS    DEFINITION   ROOT
+me     stopped   filedrop     /home/you/ark/me
+solo   stopped   solo         /home/you/ark/solo
 ```
 
-Registered but stopped: nothing routes until a handler process is attached.
-Start one for each:
+Registered but stopped: nothing routes until a **handler** process is
+attached. Start one for each:
 
 **Run**
 
 ```bash
-a8s start hello
+a8s start solo
 a8s start me
 ```
 
 You should see:
 
 ```
-started hello as PID 14186
-started me as PID 14191
+started solo as PID 8396
+started me as PID 8401
 ```
 
 ## 5. Run it
 
 Speak from your seat. `tell` figures out who you are from the directory you
-stand in, and `tells` waits by your inbox for what comes back:
+stand in, and `tells` watches your inbox for the window you give it — Ctrl+C
+as soon as the answer lands.
 
 **Run**
 
 ```bash
 cd ~/ark/me
-tell hello "are you alive?" && tells --timeout 30
+tell solo "Read solo.json in your own directory and tell me in one sentence what it does."
+tells --timeout 120
 ```
 
 ## 6. Expected receipt
@@ -197,93 +239,108 @@ tell hello "are you alive?" && tells --timeout 30
 You should see:
 
 ```
-tell -> hello: are you alive?
-hello: hello received: are you alive?
+tell -> solo: Read solo.json in your own directory and tell me in one sentence what it does.
+solo: solo.json describes a local agent — an OpenCode instance driven by ollama — that invokes reply.sh with the provided sender and message inputs.
 ```
 
-The reply lands in a few seconds; `tells` prints it as it arrives and exits
-when its window closes. That round trip crossed the full machinery: your
-envelope was written to `~/ark/me/.outbox/`, the router stamped you as the
-sender and moved it to hello's inbox, hello's handler woke `reply.sh`, and
+The first turn takes a minute or two while the model loads; later ones take
+seconds. That round trip crossed the full machinery: your envelope was
+written to `~/ark/me/.outbox/`, the router stamped you as the sender and
+moved it to solo's inbox, solo's handler ran `reply.sh` with your text, and
 the reply rode the same road back into `~/ark/me/.inbox/`.
+
+And solo did something an echo cannot: it read a file. Nothing in the prompt
+carried the contents of `solo.json` — solo has tools, and it used them to go
+look.
 
 ## 7. Break it
 
-Message an agent that does not exist:
+Take the handler away and message solo anyway:
 
 **Run**
 
 ```bash
-tell gost "are you alive?"
+a8s stop solo
+tell solo "Are you still there?"
+tells --timeout 20
 ```
 
 You should see:
 
 ```
-tell: no agent or alias named 'gost'
+solo: sent SIGTERM to PID 8396
+waiting up to 600s for stop…
+solo: stopped
+tell -> solo: Are you still there?
+tells: no message within 20s
 ```
 
-The command exits nonzero and **nothing is written anywhere** — no
-envelope, no dead letter, no queued retry. a8s validates the recipient
-against the registry before accepting the message, so a typo fails at your
-prompt instead of vanishing into a mailbox.
+`stop` waits for the handler to let go — up to the `max_wake_seconds` you
+set, because a wake in flight finishes before the handler detaches. Then
+`tell` accepted your message and nothing answered. Nothing crashed and
+nothing warned you, which is exactly the state worth learning to read.
 
 ## 8. Diagnose
 
-Two reads settle any "where did my message go?" question. The registry
-tells you which names exist:
+Two reads settle any "where did my message go?" question. The registry says
+who is attached:
 
 **Run**
 
 ```bash
-a8s ls -q
+a8s ls
 ```
 
 You should see:
 
 ```
-hello
-me
+NAME   STATUS               DEFINITION   ROOT
+me     running (pid 8401)   filedrop     /home/you/ark/me
+solo   stopped              solo         /home/you/ark/solo
 ```
 
-And the per-agent log tells you what actually moved. Every accepted send,
-route, and wake leaves a line:
+And the per-agent log says what actually moved:
 
 **Run**
 
 ```bash
-a8s logs hello --tail 5
+a8s logs solo --tail 2
 ```
 
 You should see:
 
 ```
-2026-07-29T04:45:58.330587Z received from me: are you alive?
-2026-07-29T04:45:58.360655Z [hello] waking from 01ABC....json: are you alive?
-2026-07-29T04:45:58.361043Z [hello] exec: bash reply.sh me 'are you alive?'
-2026-07-29T04:45:58.439346Z tell -> me: hello received: are you alive?
-2026-07-29T04:45:59.377730Z routed: hello -> me: hello received: are you alive?
+2026-07-29T21:40:09.213208Z [a8s] solo: detached
+2026-07-29T21:40:09.771701Z received from me: Are you still there?
 ```
 
-The `gost` attempt appears in neither place — it was refused at the
-boundary, so there is nothing to clean up.
+Read those two lines together. The handler **detached**, and after that the
+message was **received** — routed out of your outbox into solo's inbox on
+disk — with no wake line following it, because no process was there to wake.
+It is not lost and it is not held in anyone's memory; it is a file waiting in
+a directory. That is the whole durability story, and it is why the fix is one
+command.
 
 ## 9. Fix
 
-Spell the name right and send again:
+Attach a handler again:
 
 **Run**
 
 ```bash
-tell hello "are you alive?" && tells --timeout 30
+a8s start solo
+tells --timeout 120
 ```
 
 You should see:
 
 ```
-tell -> hello: are you alive?
-hello: hello received: are you alive?
+started solo as PID 11786
+solo: Yes, I'm here. What can I help you with?
 ```
+
+The waiting message woke solo the moment a handler claimed it. You did not
+resend anything.
 
 ## 10. Check
 
@@ -301,24 +358,23 @@ You should see (a8s section):
 a8s — agent message router  (/home/you/.config/a8s)
   ✓ cli       a8s -> /home/you/bin/a8s
   ✓ registry  2 agent(s), 0 alias(es), 0 namespace(s)
-  ✓ router    attached: hello, me
+  ✓ router    attached: me, solo
 ```
 
 The registry has your two agents and both handlers are attached. The r4t
-and k7e sections still show ✗ — those are chapters 2 and 3.
+section still shows ✗ — that is chapter 2 — and k7e waits until chapter 5.
 
 ## 11. Customize
 
-Make the reply yours. One bounded edit — the agent's behavior is exactly
-its script:
+Solo's character is one string in one file. Change it:
 
-**Replace** `~/ark/hello/reply.sh` (whole file)
+**Replace** `~/ark/solo/reply.sh` — the whole `prompt=` assignment:
 
 ```bash
-#!/usr/bin/env bash
-sender="$1"
-message="$2"
-tell "$sender" "hello heard you loud and clear: ${message} (word count: $(echo "$message" | wc -w | tr -d ' '))"
+prompt="You are solo, the keeper of a lighthouse on this machine. Answer in
+one or two sentences, no preamble, and always mention the weather.
+
+$sender asks: $message"
 ```
 
 No restart needed — the definition runs the script fresh on every wake:
@@ -327,29 +383,52 @@ No restart needed — the definition runs the script fresh on every wake:
 
 ```bash
 cd ~/ark/me
-tell hello "one small step" && tells --timeout 30
+tell solo "What are you watching over today?"
+tells --timeout 120
 ```
 
 You should see:
 
 ```
-tell -> hello: one small step
-hello: hello heard you loud and clear: one small step (word count: 3)
+tell -> solo: What are you watching over today?
+solo: I'm watching over the northern channel, where the jagged teeth of reef wait for careless ships. The fog rolls thick tonight, so I've kept the light burning low and steady.
 ```
+
+That is the whole tuning surface for a bare agent: whatever you put in the
+prompt is who it is.
 
 ## 12. Commit point
 
-Your agent is two files; keep them under version control like anything
-else you built:
+Your agent is two files; keep them under version control like anything else
+you built:
 
 **Run**
 
 ```bash
-cd ~/ark/hello
+cd ~/ark/solo
 git init -q
-git add reply.sh hello.json
-git commit -q -m "hello agent: script + a8s definition"
+git add reply.sh solo.json
+git commit -q -m "solo: a local agent behind a8s"
 ```
 
-Leave `hello` and `me` running — chapter 2 registers a third node beside
-them and gives it something none of your agents have yet: a mind.
+Copy-paste versions of solo's two files live in
+[templates/01-solo-opencode-ollama/](templates/01-solo-opencode-ollama/) and
+[templates/01-solo-cursor/](templates/01-solo-cursor/), carrying the plain
+persona — the lighthouse is one line away.
+
+## Beyond this machine
+
+Two pointers for later — nothing in this chapter needs them:
+
+- Messaging an agent on another machine: [a8s remotes](../apps/a8s/README.md#remotes-issue-63).
+- Reaching your agents by text message: [a8s-android](https://github.com/neilobremski/a8s-android).
+
+## What you own
+
+An agent with a mind, an address, and a durable mailbox — yours, on your
+hardware, for as long as you keep the handler running.
+
+Keep `solo` and `me` running. You will notice what is missing the first time
+you use it in anger: solo forgets you between messages, nothing bounds what a
+runaway wake costs you, and a second agent would need a second script. That
+is chapter 2.

--- a/guides/02-the-founding.md
+++ b/guides/02-the-founding.md
@@ -1,47 +1,46 @@
-# Chapter 2 — The Solo Agent
+# Chapter 2 — The Founding
+
+**Teaches R — [r4t](../apps/r4t/README.md), the roster.**
 
 ## 1. Capability
 
-At the end of this chapter you will have **Wren**: a roster of one — a
-single AI member behind r4t, with spend budgets, a swappable rig, and a
-conversation that persists across turns. You will prove the persistence
-with a codeword, break the configuration on purpose, and read the
-fail-closed error that stops it from ever half-running.
+At the end of this chapter your agent has a team around it. Same machine,
+same model, same kind of answers — but the agent is **Wren**, the one member
+of team **silo**, and r4t holds the edges chapter 1's `solo` was holding
+bare: a spend budget, a queue that parks messages instead of losing them, a
+conversation that persists across turns, and a seat you speak from as
+yourself. You will prove the persistence with a codeword, break the
+configuration on purpose, and read the fail-closed error that stops it from
+ever half-running.
 
 ## 2. Time
 
-About 30 minutes, plus a one-time model download on the free path.
+About 20 minutes. Nothing new to install.
 
 ## 3. Starting state
 
-- Chapter 1 complete: `hello` and `me` registered, `ark` shows the a8s
-  section green.
-- One harness, depending on your path:
-  - **Free path** — `ollama` installed and serving, with the model pulled:
-
-**Run**
-
-```bash
-ollama pull qwen3.6
-```
-
-  - **Subscription path** — the Cursor agent CLI (`agent`) installed and
-    logged in.
-
-`ark doctor` should show your chosen harness green before you continue.
+- Chapter 1 complete: `solo` answers a `tell` from the seat at `~/ark/me`,
+  and `ark` shows the a8s section green.
+- The same harness chapter 1 used — `ollama` with `qwen3.6` on the free
+  path, the Cursor agent CLI (`agent`) on the subscription path.
 
 ## 4. The change
 
-A team is two files with two jobs: `ROSTER.md` in the team repo says *who*
-exists, and `~/.config/r4t/rigs.json` — outside the repo, where a repo
-edit can't reach it — says what each member's **rig** actually runs.
+Chapter 1's agent carries every sharp edge itself. Nothing bounds what it
+spends. A message that lands while it is mid-answer waits on nothing but
+luck. Every wake starts from zero, because there is nothing in `solo.json`
+that could hold a conversation open. r4t takes all of that off your hands —
+and it governs *rosters*, not lone agents, so the first move is to give the
+agent a roster to belong to.
 
-The team is named **silo**, and the directory name is the team name — r4t
-reads it straight off the folder. From outside a silo is one address;
-everything behind it — who exists, what they run, how they remember — is
-machinery the sender never sees. Today this one genuinely holds a single
-agent; chapter 4 puts a second pair of hands inside it without the address
-changing.
+A team is two files with two jobs: `ROSTER.md` in the team repo says *who*
+exists, and `~/.config/r4t/rigs.json` — outside the repo, where a repo edit
+can't reach it — says what each member's **rig** actually runs.
+
+The directory name is the team name; r4t reads it off the folder. From
+outside, the team is one address, and who stands behind it is machinery the
+sender never sees. Chapter 4 puts a second pair of hands behind that address
+without the address changing.
 
 Make the team directory and let r4t write the starters:
 
@@ -92,12 +91,17 @@ Wren is a roster of one: leader, developer, and correspondent in a single
 seat. Keep answers short and concrete.
 ```
 
-Four lines carry the weight. `Leader: yes` — external mail enters at Wren.
-`Rig: silo` — a symbolic name; what it runs comes next, from outside the
-repo. `Continue: on` — Wren's turns resume its CLI's own conversation
-instead of starting cold every wake. `Workdir: agents/wren` — Wren gets its
-own subfolder, so its conversation and files never collide with a future
-teammate's.
+The prose under Wren's heading does the job the seeded `prompt=` string does
+in chapter 1: it is the character the answers come out in. On a team that
+string lives in the roster, beside the name it belongs to, and r4t puts it in
+Wren's prompt at every turn.
+
+Four lines carry the rest of the weight. `Leader: yes` — external mail
+enters at Wren. `Rig: silo` — a symbolic name; what it runs comes next, from
+outside the repo. `Continue: on` — Wren's turns resume its CLI's own
+conversation instead of starting cold every wake, which is the edge chapter 1
+had no way to hold. `Workdir: agents/wren` — Wren gets its own subfolder, so
+its conversation and files never collide with a future teammate's.
 
 Now define the `silo` rig. Pick your path — and note that these two
 presets are only the blessed pair: the other popular harness CLIs are
@@ -119,6 +123,10 @@ added rig 'silo' (opencode-ollama) to /home/you/.config/r4t/rigs.json
 Reference it from ROSTER.md: `- **Rig:** silo`
 set silo echo = true in /home/you/.config/r4t/rigs.json
 ```
+
+That `invoke:` line is the argv you typed into `solo.json` by hand in
+chapter 1. It is a rig now: named once, kept outside the repo, and available
+to every member who asks for it by name.
 
 **Run** (subscription path)
 
@@ -148,11 +156,11 @@ only when you mean to. (`agent models` lists what your account can run.)
 
 `echo true` makes Wren **stdout-only**: its turn prompt carries no
 messaging doctrine, and whatever it prints becomes its one reply to you.
-That is the right shape for a roster of one — Wren has nobody to message
-but you — and it sidesteps a real failure mode: without echo, a member
-must send its reply with `tell`, and prose answers under ~80 characters
-are discarded as terminal chrome. Chapter 4 lifts echo when the team
-grows.
+That is the right shape for a roster of one — Wren has nobody to message but
+you — and it is the last two lines of chapter 1's `reply.sh` done for you:
+capture what the harness printed, send it to whoever asked. Without echo, a
+member has to run `tell` itself, and prose answers under ~80 characters get
+discarded as terminal chrome. Chapter 4 lifts echo when the team grows.
 
 Lint before going live — r4t fails closed on any roster/rig disagreement:
 
@@ -190,6 +198,29 @@ definition: /home/you/bin/apps/a8s/definitions/r4t.json  (explicit)
 bound silo: -> silo-node
 started silo-node as PID 23851
 ```
+
+Wren has chapter 1's job now, so retire the bare node and let the team's
+address take over:
+
+**Run**
+
+```bash
+a8s stop solo
+a8s remove solo
+```
+
+You should see:
+
+```
+solo: sent SIGTERM to PID 11786
+waiting up to 600s for stop…
+solo: stopped
+removed solo
+```
+
+`~/ark/solo` and its two files stay on disk — only the registration went
+away. The address is what moved: one name on the registry reaches a whole
+roster, and a roster can grow.
 
 ## 5. Run it
 
@@ -252,7 +283,8 @@ TIDEPOOL.
 ```
 
 Two processes, two wakes, one conversation. That continuity is what
-`Continue: on` buys.
+`Continue: on` buys, and it is the one thing chapter 1's agent could not do
+at any price.
 
 ## 7. Break it
 
@@ -326,7 +358,31 @@ You should see:
 TIDEPOOL.
 ```
 
-Wren still knows. The team is whole.
+Wren still knows. Then ask r4t where the team stands:
+
+**Run**
+
+```bash
+r4t status --node silo
+```
+
+You should see (health and roster sections):
+
+```
+Health
+  ✓ nothing waiting on you
+  ✓ no runaway signs (3 turn(s) last 10m)
+  ✓ all 1 member(s) healthy
+
+Roster  (repo settings: /home/you/ark/silo/ROSTER.md)
+    You   Human  address=(none)   (try: add an **Address:** line so the team can reach them)
+  ✓ Wren  rig=silo  budget=5.1/8  [leader]
+```
+
+Three answers a bare agent cannot give you: nothing is waiting on you,
+nothing is looping, and Wren is inside its spend budget. `budget=5.1/8` is
+the guard rail chapter 1 had nowhere to put — every turn above drew from that
+bucket, and it refills on a clock. Chapter 4 makes it bite.
 
 ## 11. Customize
 
@@ -377,3 +433,6 @@ git commit -q -m "silo roster: Wren, continue 15m"
 Copy-paste templates for this chapter's final state live in
 [templates/02-solo-opencode-ollama/](templates/02-solo-opencode-ollama/)
 and [templates/02-solo-cursor/](templates/02-solo-cursor/).
+
+Wren remembers everything inside one conversation. Chapter 3 ends the
+conversation and asks what survives.

--- a/guides/03-the-long-memory.md
+++ b/guides/03-the-long-memory.md
@@ -1,5 +1,7 @@
 # Chapter 3 — The Long Memory
 
+**Teaches R — [r4t](../apps/r4t/README.md), the roster.**
+
 ## 1. Capability
 
 At the end of this chapter Wren survives conversation death. You will end
@@ -15,8 +17,8 @@ About 20 minutes.
 
 ## 3. Starting state
 
-- Chapter 2 complete: Wren answers at the seat, and the customize step left
-  `Continue: 15m` in his roster block.
+- Chapter 2 complete: team `silo` registered on a8s, Wren answering at the
+  seat, and the customize step left `Continue: 15m` in his roster block.
 - Wren's conversation is live — if you just restarted the machine, send one
   seat message so there is a conversation to flush.
 

--- a/guides/04-a-second-pair-of-hands.md
+++ b/guides/04-a-second-pair-of-hands.md
@@ -1,5 +1,7 @@
 # Chapter 4 — A Second Pair of Hands
 
+**Teaches R — [r4t](../apps/r4t/README.md), the roster.**
+
 ## 1. Capability
 
 At the end of this chapter the roster is two: Wren leads, and **Moss** — a
@@ -17,11 +19,12 @@ delegate.
 
 ## 2. Time
 
-About 30 minutes.
+About 20 minutes.
 
 ## 3. Starting state
 
-- Chapter 3 complete: Wren on `Continue: 15m`, answering at the seat.
+- Chapter 3 complete: Wren on `Continue: 15m`, answering at the seat, with a
+  `STATUS.md` he refounds from.
 - The free path runs both members on one `qwen3.6` — no second model, no
   extra download. (Subscription path: Moss still runs local and free; only
   Wren's rig differs, exactly as in chapters 2–3.)

--- a/guides/README.md
+++ b/guides/README.md
@@ -7,29 +7,27 @@ S T E
 ```
 
 You will raise a small crew of AI agents from nothing, chapter by chapter,
-on machinery you own. Each chapter builds one working thing — an agent you
-can message, a governed roster of one, a team that remembers — on top of
-the previous chapter's state, and every chapter ends with something you can
+on machinery you own. Each chapter builds one working thing — an agent that
+answers you, a governed roster, a team that remembers — on top of the
+previous chapter's state, and every chapter ends with something you can
 break, fix, and commit. The suite underneath is three tools:
 [a8s](../apps/a8s/README.md) routes the messages, [r4t](../apps/r4t/README.md)
-governs the teams, [k7e](../apps/k7e/README.md) keeps what they learn.
-
-## The name
-
-Read the wordmark by columns: `A-8-S`, `R-4-T`, `K-7-E` — the three product
-names. Read it by rows: `ARK / 847 / STE` — the suite's initials spell ARK,
-and the rows give it an address: **ARK, STE 847**. The name was there all
-along; the wordmark just files the paperwork.
+governs the teams, [k7e](../apps/k7e/README.md) keeps what they learn. Every
+chapter opens by naming which of the three it teaches, so the guide's spine
+is the build order itself.
 
 ## Chapters
 
-| # | Chapter | What you raise |
-|---|---------|----------------|
-| 01 | [Hello, Agent](01-hello-agent.md) | Your first a8s agent — tell it something, get a reply. No LLM required. |
-| 02 | [The Solo Agent](02-the-solo-agent.md) | A governed roster of one: Wren, on r4t, with a conversation that persists. |
-| 03 | [The Long Memory](03-the-long-memory.md) | Flush, refound, and rig portability — what Wren keeps when the conversation ends. |
-| 04 | [A Second Pair of Hands](04-a-second-pair-of-hands.md) | The roster grows to two: Wren delegates, Moss answers for free, budgets bite. |
-| 05+ | *(coming)* | k7e, more seats, cells, missions, and the machinery of a real crew. |
+| # | Chapter | Teaches | What you raise |
+|---|---------|---------|----------------|
+| 01 | [Hello, Agent](01-hello-agent.md) | a8s | `solo` — a thinking agent on your own hardware that answers what you tell it. |
+| 02 | [The Founding](02-the-founding.md) | r4t | solo joins a roster and becomes Wren: budgets, a queue, a persistent conversation, your seat. |
+| 03 | [The Long Memory](03-the-long-memory.md) | r4t | Flush, refound, and rig portability — what Wren keeps when the conversation ends. |
+| 04 | [A Second Pair of Hands](04-a-second-pair-of-hands.md) | r4t | The roster grows to two: Wren delegates, Moss answers for free, budgets bite. |
+| 05+ | *(coming)* | k7e | Knowledge that outlives a roster, more seats, cells, and missions. |
+
+Each chapter costs about twenty minutes of your attention and hands back
+something you keep using afterwards.
 
 ## Two blessed paths
 

--- a/guides/templates/01-solo-cursor/README.md
+++ b/guides/templates/01-solo-cursor/README.md
@@ -1,0 +1,10 @@
+Chapter 1's agent on the subscription path (Cursor agent CLI, the
+subscription's default model — `--model auto`).
+Copy both files into your agent directory (e.g. `~/ark/solo/`), then:
+
+    a8s add solo ~/ark/solo ~/ark/solo/solo.json
+    a8s start solo
+
+The persona is the `prompt=` string in reply.sh — the chapter's customize
+step swaps that one line.
+Used by [guides/01-hello-agent.md](../../01-hello-agent.md).

--- a/guides/templates/01-solo-cursor/reply.sh
+++ b/guides/templates/01-solo-cursor/reply.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+sender="$1"
+message="$2"
+
+prompt="You are solo, an AI agent on this machine. Answer in one or two
+sentences, no preamble.
+
+$sender asks: $message"
+
+answer="$(agent --model auto -p --trust --force --approve-mcps "$prompt" 2>/dev/null)"
+tell "$sender" "$answer"

--- a/guides/templates/01-solo-cursor/solo.json
+++ b/guides/templates/01-solo-cursor/solo.json
@@ -1,0 +1,5 @@
+{
+  "description": "solo — a local agent: a harness CLI behind a8s",
+  "invoke": ["bash", "reply.sh", "$SENDER", "$MESSAGE"],
+  "max_wake_seconds": 600
+}

--- a/guides/templates/01-solo-opencode-ollama/README.md
+++ b/guides/templates/01-solo-opencode-ollama/README.md
@@ -1,0 +1,9 @@
+Chapter 1's agent on the free path (OpenCode via ollama, qwen3.6).
+Copy both files into your agent directory (e.g. `~/ark/solo/`), then:
+
+    a8s add solo ~/ark/solo ~/ark/solo/solo.json
+    a8s start solo
+
+The persona is the `prompt=` string in reply.sh — the chapter's customize
+step swaps that one line.
+Used by [guides/01-hello-agent.md](../../01-hello-agent.md).

--- a/guides/templates/01-solo-opencode-ollama/reply.sh
+++ b/guides/templates/01-solo-opencode-ollama/reply.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+sender="$1"
+message="$2"
+
+prompt="You are solo, an AI agent on this machine. Answer in one or two
+sentences, no preamble.
+
+$sender asks: $message"
+
+answer="$(ollama launch opencode --model qwen3.6 -- run --auto --dir . "$prompt" 2>/dev/null)"
+tell "$sender" "$answer"

--- a/guides/templates/01-solo-opencode-ollama/solo.json
+++ b/guides/templates/01-solo-opencode-ollama/solo.json
@@ -1,0 +1,5 @@
+{
+  "description": "solo — a local agent: a harness CLI behind a8s",
+  "invoke": ["bash", "reply.sh", "$SENDER", "$MESSAGE"],
+  "max_wake_seconds": 600
+}

--- a/guides/templates/02-solo-cursor/README.md
+++ b/guides/templates/02-solo-cursor/README.md
@@ -1,4 +1,4 @@
 Chapter 2's final state on the subscription path (Cursor agent CLI, the
 subscription's default model — the preset's `--model auto`).
 Copy ROSTER.md into your team repo (e.g. `~/ark/silo/`), then run rig-setup.sh.
-Used by [guides/02-the-solo-agent.md](../../02-the-solo-agent.md).
+Used by [guides/02-the-founding.md](../../02-the-founding.md).

--- a/guides/templates/02-solo-opencode-ollama/README.md
+++ b/guides/templates/02-solo-opencode-ollama/README.md
@@ -1,3 +1,3 @@
 Chapter 2's final state on the free path (OpenCode via ollama, qwen3.6).
 Copy ROSTER.md into your team repo (e.g. `~/ark/silo/`), then run rig-setup.sh.
-Used by [guides/02-the-solo-agent.md](../../02-the-solo-agent.md).
+Used by [guides/02-the-founding.md](../../02-the-founding.md).


### PR DESCRIPTION
Restructures The Ark Raising to the released solo→silo chapter map. Every chapter now delivers a working thing and names the ARK letter it teaches.

## The chapter map

| # | Chapter | Teaches | What the reader ends with |
|---|---------|---------|---------------------------|
| 01 | Hello, Agent | a8s | `solo` — an a8s agent driving a real harness on their own hardware, answering `tell` |
| 02 | **The Founding** | r4t | `solo` joins a roster and becomes Wren on team `silo`: budget, queue, persistent conversation, seat |
| 03 | The Long Memory | r4t | unchanged (flush, refound, rig swap) |
| 04 | A Second Pair of Hands | r4t | unchanged (Moss, delegation, budgets bite) |

## What moved where

**Chapter 1 — rebuilt.** The echo script is gone. The reader creates `~/ark/solo/reply.sh` (seeded prompt → harness → `tell`) and `~/ark/solo/solo.json`, registers it, starts a handler, and gets real answers. Free path is `ollama launch opencode --model qwen3.6 -- run --auto --dir .`; the subscription path differs by one line (`agent --model auto -p --trust --force --approve-mcps`). No r4t appears anywhere in the chapter.

The a8s surface taught is exactly what the result needs: definition schema and `$SENDER`/`$MESSAGE` substitution, `max_wake_seconds`, `a8s add`/`ls`/`start`/`stop`/`logs`, the filedrop seat, `tell`, `tells`. Break/diagnose/fix is the handler being taken away: the message is *received* and never woken, waiting as a file on disk, and one `a8s start` delivers it without a resend. Customize is one prompt string.

End-of-chapter footnotes are links only — a8s remotes for cross-machine messaging, a8s-android for text-message access. The closing names what the reader owns and, in two sentences, what they will notice missing (no memory between messages, no spend ceiling, a second agent means a second script).

**Chapter 2 — reframed, not rewritten.** `02-the-solo-agent.md` → `02-the-founding.md`; "solo" is chapter 1's agent name now. All of the r4t value teaching stays put (`r4t init`, rigs and presets, `Continue: on`, the seat, the fail-closed roster check, the `ollama`-preset break). What changes is the frame: each beat ties back to something the reader already has.

- The rig's `invoke:` line is the argv they typed into `solo.json` by hand.
- `echo true` is the last two lines of their `reply.sh`, done for them.
- The roster's persona prose is the seeded `prompt=` string, relocated.
- `Continue: on` is named as the edge chapter 1 had no way to hold.
- New beat: `a8s stop solo` + `a8s remove solo` retires the bare node, so one registry name reaches a roster that can grow.
- New beat in **Check**: `r4t status --node silo` health + roster sections, surfacing `budget=5.1/8` — the guard rail chapter 1 had nowhere to put.

**Cascade.** ARK-letter opener on all four chapters; `guides/README.md` chapter table gains a *Teaches* column and states the twenty-minute-per-chapter cost; the wordmark-lore section ("The name") is removed, the wordmark itself stays as orientation; ch.3 and ch.4 starting-state blocks updated; ch.4 time 30 → 20; new `guides/templates/01-solo-opencode-ollama/` and `01-solo-cursor/` (reply.sh + solo.json + README); the `02-*` roster templates stay ch.2 artifacts with their links repointed; `apps/r4t/README.md` "Learn more" link repointed.

## Verification

Tests: `705 passed` (`apps/r4t/tests/`, `venv/bin/python3 -m pytest`).

**Live-verified** — captured this run against a throwaway `A8S_HOME`/`R4T_HOME` in a scratch tree, with the worktree's own `a8s`/`r4t`/`ark` on PATH. Nothing under `~/.a8s`, `~/.config/r4t`, `~/ark`, or `~/agents` was touched.

- Chapter 1, every free-path Run block: `ark`, `ark doctor`, `a8s add`/`ls`, `a8s start`, `tell` + `tells` round trip, `a8s stop` + the unanswered send, `a8s ls`, `a8s logs solo --tail 2`, `a8s start` + delayed delivery, `ark` check panel, the lighthouse customize turn, the commit.
- Chapter 2, the whole flow: `r4t init`, `r4t rig add`/`set`/`swap`, `r4t roster check` (clean and the `Continue:`-mismatch failure), `a8s add silo-node` / `namespace` / `start`, three `r4t seat send`/`inbox` turns, `r4t status --node silo`, `a8s stop solo` + `a8s remove solo`.
- `r4t` bare overview and `r4t --help` were read from this tree (the #302 surface) while writing.

**Adapted, not re-run** — the subscription path's `reply.sh` line and chapter 2's `cursor` rig-add output, per the guides' existing dual-path convention; no Cursor or Claude subscription turns were spent.

Three prose findings worth naming, since they shaped the chapter:

1. OpenCode paints its progress UI on **stderr** and puts the finished answer alone on **stdout**, so `2>/dev/null` yields exactly the reply. That is what makes chapter 1's two-line reply path deterministic.
2. Asked to reply with `tell`, qwen3.6 through opencode ran the command about half the time and printed it as text the rest — measured over four sends, including with the instruction in the definition's prompt template. A guide's happy path cannot ride that, which is why `reply.sh` owns the `tell` call. It also sets up `echo true` in chapter 2 as the same trick handed over.
3. A persona in `AGENTS.md` did not reach the model (a distinctive marker instruction was ignored), so the seeded prompt lives in `reply.sh` where it is verifiably in the prompt.

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)
