### PR TITLE
feat(r4t): teach tell via stdin heredoc — kill the quoting class

### DIFF
--- a/apps/r4t/dispatch.py
+++ b/apps/r4t/dispatch.py
@@ -90,9 +90,13 @@ PROMPT_DEFAULTS: dict[str, str] = {
     ),
     "work_tell": (
         "- Send messages with the `tell` shell command (run it via your shell "
-        "tool — printing it as text sends nothing):\n"
-        "    - reply to whoever asked: tell <name> \"<message>\"\n"
-        "    - a teammate: tell <name> \"<message>\". Teammates:"
+        "tool — printing it as text sends nothing). Body on stdin, delimiter "
+        "quoted so nothing expands ($ ` \\ arrive byte-exact):\n"
+        "        tell <name> - <<'EOF'\n"
+        "        <your message>\n"
+        "        EOF\n"
+        "    Or write the body with your file tool: tell <name> - < msg.md. "
+        "<name> is whoever asked, or a teammate. Teammates:"
     ),
     "work_direct": (
         "- Speak to teammates directly and one at a time — do not post to "

--- a/apps/r4t/tests/test_dispatch.py
+++ b/apps/r4t/tests/test_dispatch.py
@@ -1976,6 +1976,15 @@ class TestMissionInjection:
         assert "the only thing the recipient sees" in prompt
         assert "not done until it is committed" in prompt
 
+    def test_tell_teaching_is_stdin_with_a_quoted_heredoc(self, ctx):
+        # The quoted delimiter is the load-bearing part: it suppresses every
+        # shell expansion, so a body carrying $, ` or \ arrives byte-exact.
+        prompt = self._prompt(ctx, "Phil")
+        assert "tell <name> - <<'EOF'" in prompt
+        assert "\nEOF" in prompt.replace("        ", "")
+        assert "tell <name> - < msg.md" in prompt
+        assert 'tell <name> "<message>"' not in prompt
+
 
 class TestTreeEnforcement:
     def test_non_adjacent_tell_reroutes_to_lead(self, tree_ctx, monkeypatch):


### PR DESCRIPTION
Move one of the hybrid: r4t's per-turn messaging block teaches `tell` via
stdin behind a quoted heredoc delimiter. The quoted delimiter is the whole
fix — the shell performs no expansion inside the body, so `$1.25`, backticks
and `C:\temp\...` reach the recipient byte-exact. Zero code changes
underneath: `tell` already reads a literal `-` from stdin
(`apps/a8s/tell.py` `resolve_message_body`).

## The taught form

```
- Send messages with the `tell` shell command (run it via your shell tool — printing it as text sends nothing). Body on stdin, delimiter quoted so nothing expands ($ ` \ arrive byte-exact):
        tell <name> - <<'EOF'
        <your message>
        EOF
    Or write the body with your file tool: tell <name> - < msg.md. <name> is whoever asked, or a teammate. Teammates:
```

5 rendered lines against the previous 3 — the heredoc cannot be shown in
one. Context stays the constraint: 372 chars vs 219.

## Verification

Both forms staged into a throwaway `TELL_OUTBOX_DIR` (nothing routed,
nothing sent, no user state touched). Envelope contents, byte-exact:

```
"content": "The refund is $1.25 and 100% of `whoami` stays literal; path C:\\temp\\notes.txt and $500 too"
"content": "Body from a file: $1.25, `backticks`, C:\\temp\\notes.txt"
```

- `apps/r4t/tests/` — **706 passed**, including a new
  `test_tell_teaching_is_stdin_with_a_quoted_heredoc` that pins the heredoc
  shape, the quoted delimiter, the file variant, and the absence of the old
  double-quoted form.
- `python3 apps/r4t/r4t.py sandbox --fake` — `sandbox: all mechanical checks passed`.
- The prompt stays definition-overridable (#190): `TestPromptOverrides`
  passes unchanged — only the default text moved.

## Sweep

No other member-facing surface teaches the double-quoted form.
`apps/r4t/docs/message-flow.md` and the ch.1 guides show the *human's* own
`tell`, which stays simple. Chapter 4's `tell you "Inkwell 🐙"` is a captured
transcript of what a local model actually printed — a record, left verbatim.

Closes #305
Refs #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)
