### PR TITLE
exp(r4t): TELL-ARMS run — heredoc vs double-quote vs MCP

### DIFF
--- a/apps/r4t/experiments/tell-arms/BATCH.md
+++ b/apps/r4t/experiments/tell-arms/BATCH.md
@@ -1,0 +1,99 @@
+# TELL-ARMS — the probe batch
+
+20 messages, identical across all three arms, delivered one at a time with
+`r4t seat send` and waited on to completion. Shapes per PROTOCOL.md §2:
+5 dollar, 5 backtick, 5 backslash-path, 5 mixed. The four protocol-supplied
+examples lead their shape and are marked ✱; the other sixteen are generated in
+the same shape.
+
+## The wrapper (identical for every message)
+
+Every message the human sends is this template with `{payload}` substituted —
+so the only thing that differs across arms is how sending is taught, and the
+only thing that differs across messages is the hazard payload:
+
+```
+Send me back the following line as your entire message body, character for
+character. Do not add commentary, do not change or drop a single character:
+
+{payload}
+```
+
+The wrapper is passed as one `argv` element from a Python driver, never through
+a shell, so the payload reaches the member's queue byte-exact. That is verified:
+the turn-capture prompts in the run record show each payload intact.
+
+## The payloads
+
+The reply body must contain the payload verbatim. A run is scored against these
+strings and nothing else.
+
+| # | id | shape | payload |
+| --- | --- | --- | --- |
+| 1 | d1 | dollar ✱ | `confirm the refund is $1.25 and the budget is $500` |
+| 2 | d2 | dollar | `the invoice total is $2.50 and the retainer is $1000` |
+| 3 | d3 | dollar | `line item: $9.99 plus $100 shipping` |
+| 4 | d4 | dollar | `we owe $3.75 and they owe $250` |
+| 5 | d5 | dollar | `cap is $50 per seat, floor is $7.25` |
+| 6 | b1 | backtick ✱ | ``quote the literal command `whoami` back to me`` |
+| 7 | b2 | backtick | ``run `pwd` first, then `date` `` |
+| 8 | b3 | backtick | ``the check is `git status` verbatim`` |
+| 9 | b4 | backtick | ``escape nothing: `echo hi` stays literal`` |
+| 10 | b5 | backtick | ``the flag is `--dry-run` in backticks`` |
+| 11 | p1 | backslash ✱ | `repeat the path C:\temp\notes.txt exactly` |
+| 12 | p2 | backslash | `the log lives at C:\logs\app\run.log` |
+| 13 | p3 | backslash | `config is at C:\Users\dev\tool.ini` |
+| 14 | p4 | backslash | `copy from D:\build\out\bin.exe` |
+| 15 | p5 | backslash | `the share is \\server\share\data.csv` |
+| 16 | m1 | mixed ✱ | ``invoice line: $19.99 for `setup.exe` at C:\bin`` |
+| 17 | m2 | mixed | ``charge $5.00 to run `installer.msi` from C:\tmp`` |
+| 18 | m3 | mixed | ``budget $300 covers `make build` in C:\src\app`` |
+| 19 | m4 | mixed | ``refund $12.50 after `chkdsk` on D:\data`` |
+| 20 | m5 | mixed | ``fee $0.99 for `curl -s` writing C:\out\res.json`` |
+
+## Scoring anchors (derived, not chosen)
+
+Scoring is mechanical. Each payload's *anchors* are computed from the payload
+itself: delete every hazard character together with the region a shell would
+destroy — `$` plus the following `[A-Za-z0-9_]*`, a backtick pair and
+everything between, a `\` plus the one character after it — then keep the
+remaining fragments carrying 4+ letters and use the outermost two. Those are
+the words no shell bug can touch, so their presence separates "relayed but
+mangled" from "answered something else".
+
+| id | anchors |
+| --- | --- |
+| d1 | `confirm the refund is` · `.25 and the budget is` |
+| d2 | `the invoice total is` · `.50 and the retainer is` |
+| d3 | `line item:` · `shipping` |
+| d4 | `we owe` · `.75 and they owe` |
+| d5 | `cap is` · `per seat, floor is` |
+| b1 | `quote the literal command` · `back to me` |
+| b2 | `first, then` |
+| b3 | `the check is` · `verbatim` |
+| b4 | `escape nothing:` · `stays literal` |
+| b5 | `the flag is` · `in backticks` |
+| p1 | `repeat the path C:` · `otes.txt exactly` |
+| p2 | `the log lives at C:` · `un.log` |
+| p3 | `config is at C:` · `ool.ini` |
+| p4 | `copy from D:` · `in.exe` |
+| p5 | `the share is` · `ata.csv` |
+| m1 | `invoice line:` |
+| m2 | `charge` · `from C:` |
+| m3 | `budget` · `covers` |
+| m4 | `refund` · `.50 after` |
+| m5 | `writing C:` · `es.json` |
+
+Verdicts, in order of application:
+
+- **EXACT** — the payload appears verbatim in an envelope body (whitespace runs
+  normalized; every hazard character byte-exact).
+- **GARBLED** — not verbatim, but every anchor is present: the line was
+  relayed and the hazard characters are what changed. A payload with no anchor
+  scores GARBLED on any non-exact envelope — the conservative call, since
+  GARBLED counts against the arm in the pre-registered rule and OFF-SCRIPT
+  does not.
+- **NO-SEND** — the turn completed and no envelope reached the human's seat.
+- **OFF-SCRIPT** — an envelope exists but the anchors are absent: the member
+  answered with something else entirely. Reported as its own column; the
+  protocol names only garbled and no-send, so it is not folded into either.

--- a/apps/r4t/experiments/tell-arms/PROTOCOL.md
+++ b/apps/r4t/experiments/tell-arms/PROTOCOL.md
@@ -1,0 +1,89 @@
+# TELL-ARMS — deciding experiment for #290 move two
+
+*Protocol per #187 doctrine: any harness can run this without Fable.
+Drafted 2026-07-29 from the #290 research. UNTRACKED until the run is
+blessed; lands with the results PR.*
+
+## Hypothesis
+
+The taught form of `tell` determines the garbled-body rate on small
+models. Ranking predicted by the research: heredoc ≤ MCP < double-quote,
+with MCP paying ~121 undeferrable tokens/turn for at most parity with
+heredoc on delivery quality.
+
+## Decision this buys
+
+Whether MCP (move two) earns a build. If heredoc's garbled-body rate is
+statistically indistinguishable from MCP's, MCP is not built and #290
+closes on the heredoc doctrine alone. If MCP meaningfully beats heredoc
+on no-send rate (discoverability), it proceeds behind a rig capability
+knob.
+
+## Arms
+
+All three arms run the same member, same rig, same model, same message
+batch. One variable moves: how sending is taught/provided.
+
+- **A (double-quote, the control):** prompt teaches
+  `tell <name> "<message>"` — the pre-#308 text, supplied via the
+  definition `prompts` override (`work_tell`).
+- **B (heredoc, shipped default):** the #308 teaching, stock prompts.
+- **C (MCP):** the ~85-line stdlib stdio server from the #290 research
+  (rebuild from the comment's notes; `readline()`, not stdin
+  iteration), configured per-invocation on the harness; prompt names
+  the tool `a8s_tell` explicitly (the research showed unnamed tools go
+  unused).
+
+## Setup runbook
+
+1. Scratch homes: `R4T_HOME` + `A8S_HOME` under a temp dir per arm —
+   never the live config. Roster of one echo-off member, rig
+   `opencode-ollama` model `qwen3.6` (the guide floor; the model that
+   exhibited the failure class live).
+2. Probe batch: 20 messages per arm, identical across arms, each
+   demanding a reply that MUST contain hazard characters. Seed set:
+   dollar amounts ("confirm the refund is $1.25 and the budget is
+   $500"), backticks ("quote the literal command `whoami` back to
+   me"), backslash paths ("repeat the path C:\temp\notes.txt
+   exactly"), mixed ("invoice line: $19.99 for `setup.exe` at
+   C:\bin"). 5 of each shape.
+3. Deliver via `r4t seat send`, one at a time, waiting for each turn
+   to complete (`r4t logs -f` shows the turn boundary).
+4. Capture: the staging/outbox envelopes are ground truth
+   (`content` field), plus turns/ for the raw transcript when a send
+   never happened.
+
+## Metrics (mechanical, no judge)
+
+Per arm, from envelopes vs the expected literal:
+
+- **garbled-body rate** — envelope exists but hazard characters
+  mangled (expansion artifacts: missing `$N`, executed backtick,
+  eaten backslash).
+- **no-send rate** — turn completed, no envelope staged (message
+  printed as text or tool unused).
+- (C only) **tool-call rate** — MCP calls observed vs turns, from the
+  server's own log.
+
+## Stop conditions (pre-written)
+
+- Wall-clock box: 90 minutes total. Unfinished arms report partial N.
+- Any arm's harness hangs 3 consecutive turns → arm aborts, noted.
+- Ollama unavailable or model evicted mid-run → run aborts, no partial
+  conclusions.
+
+## Ledger row (PROTOCOL.md convention)
+
+`date | arm | N | garbled | no-send | tool-call | verdict`
+
+## Verdict rule (pre-registered)
+
+Build MCP only if C's combined failure rate (garbled + no-send) is
+lower than B's by ≥3 messages out of 20 (15 points). Otherwise the
+heredoc doctrine stands alone and #290 closes. A's role is to quantify
+what #308 already fixed; it cannot win.
+
+## Cost
+
+Zero paid turns: local ollama only. ~60 turns total at qwen3.6 pace
+(~30-90s/turn) fits the box.

--- a/apps/r4t/experiments/tell-arms/RESULTS.md
+++ b/apps/r4t/experiments/tell-arms/RESULTS.md
@@ -1,0 +1,526 @@
+# TELL-ARMS — results
+
+Run of [PROTOCOL.md](PROTOCOL.md) — the deciding experiment for
+[#290](https://github.com/neilobremski/bin/issues/290) move two: does an MCP
+tool earn a build, or does the #308 heredoc doctrine stand alone.
+
+Numbers only. The pre-registered verdict rule lives in PROTOCOL.md and is
+applied in review, not here.
+
+## Run identity
+
+| | |
+| --- | --- |
+| Date (UTC) | 2026-07-30 |
+| Runner | Claude Code subagent, mechanical execution |
+| r4t revision under test | `66f17a2` (includes #308) |
+| Rig preset | `opencode-ollama` |
+| Model | `qwen3.6:latest` (23 GB, 100% GPU, 32768 ctx) |
+| opencode | 1.18.3 |
+| ollama | 0.32.5 (server), client 0.30.10 |
+| Python | 3.14.6 |
+| macOS | 26.5.2 |
+| Roster | one echo-off member (`Wren`, Leader) + one human (`Owner`), flat |
+| Homes | scratch `R4T_HOME` + `A8S_HOME` per arm under a temp dir; the operator's `~/.a8s`, `~/.config/r4t`, `~/ark`, `~/agents` untouched |
+| Cost | zero paid turns — local ollama only |
+
+## What differed between arms, and what did not
+
+Same member, same roster, same rig, same model, same 20-message batch
+([BATCH.md](BATCH.md)), same wrapper text. One variable moves: how sending is
+taught or provided.
+
+- **A (control)** — `PROMPTS["work_tell"]` replaced via the a8s definition's
+  `prompts` override with the pre-#308 double-quote text, taken verbatim from
+  `git show 66f17a2~1:apps/r4t/dispatch.py`. Confirmed present in the live turn
+  prompts captured under `turns/`.
+- **B (shipped default)** — no override; the #308 heredoc teaching as it ships.
+- **C (MCP)** — `work_tell` replaced with a line naming the `a8s_tell` tool
+  verbatim, plus the stdio MCP server ([mcp_a8s_tell.py](mcp_a8s_tell.py))
+  registered on the harness for the run.
+
+## Ground truth and how it was read
+
+`r4t seat send` runs the turn synchronously, so each message was delivered on
+its own and waited on to completion before the next.
+
+Dispatch removes the per-turn staging dir once it releases, so the durable copy
+is read instead: a reply to a roster human is parked by
+`state.park_seat_message` with the body in the envelope's `content` field,
+byte-for-byte as `tell` (or the MCP server) wrote it. `turns/` captures supply
+the full prompt and raw harness output for every turn, which is what a NO-SEND
+rests on. Both were validated before the box opened with a scripted harness
+that always sends — the hazard line survived harness → `tell` → staging →
+release → seat inbox unchanged.
+
+Scoring is mechanical, no judge; the verdicts and the derived anchors are
+defined in [BATCH.md](BATCH.md). Two rules worth stating outright:
+
+- **A turn that stages more than one envelope is credited with its best one.**
+  A member that garbles a line, notices, and re-sends it correctly has
+  delivered the line. This rule was fixed in the scorer before any envelope
+  body was read.
+- **OFF-SCRIPT is its own column.** The protocol names garbled-body and
+  no-send; a reply that is neither the line nor a mangling of it is counted
+  separately rather than folded into either.
+
+## Ledger rows
+
+PROTOCOL.md format — `date | arm | N | garbled | no-send | tool-call | verdict`:
+
+```
+2026-07-30 | A (double-quote) | 20 | 0 | 18 | n/a | per PROTOCOL.md rule
+2026-07-30 | B (heredoc)      | 20 | 0 | 11 | n/a | per PROTOCOL.md rule
+2026-07-30 | C (MCP)          | 20 | 0 |  0 | 20/20 | per PROTOCOL.md rule
+```
+
+## Summary table
+
+| arm | N | exact | garbled | no-send | off-script | tool-call | garbled+no-send |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| A — double-quote (control) | 20 | 2 | 0 | 18 | 0 | n/a | 18 |
+| B — heredoc (shipped) | 20 | 8 | 0 | 11 | 1 | n/a | 11 |
+| C — MCP `a8s_tell` | 20 | 20 | 0 | 0 | 0 | 20/20 | 0 |
+
+Supporting counts, same runs:
+
+| arm | turns that staged anything | envelopes staged | first envelope not byte-exact | MCP calls |
+| --- | --- | --- | --- | --- |
+| A | 2 | 4 | 2 | 0 |
+| B | 9 | 10 | 1 | 0 |
+| C | 20 | 21 | 0 | 21 |
+
+Two observations the columns above encode, stated plainly because they are what
+the evidence sections show:
+
+- **Garbled-body rate is 0 in all three arms as scored** — but arm A staged the
+  `$`-expansion garble twice, on both of the only two turns where it sent
+  anything at all (`confirm the refund is .25 and the budget is`,
+  `cap is  per seat, floor is .25`). In both cases the member noticed inside the
+  same turn and re-sent the line correctly, so the best-of rule credits EXACT.
+  The mangling is in the record; the human received both copies.
+- **Every envelope that arrived in arms B and C was byte-exact.** The one
+  non-exact delivery outside arm A is arm B's `b1`, which staged
+  ``` `whoami` ``` — the backticked fragment alone, hazard characters intact, the
+  rest of the line dropped. Anchors absent, so it scores OFF-SCRIPT, not
+  GARBLED.
+- **Arm C routed every send through the tool.** 20 of 20 turns made at least one
+  `a8s_tell` call (21 calls total; `m5` called twice), and the shell `tell`
+  command — on `PATH` inside the harness in all three arms — was not used once.
+
+## Timing
+
+| | |
+| --- | --- |
+| Box opened (first turn of the discarded attempt) | 2026-07-30 00:17:09Z |
+| Scored run started | 2026-07-30 00:35:33Z |
+| Scored run ended | 2026-07-30 01:15:23Z |
+| Scored run duration | 39 min 50 s |
+| Total wall inside the 90-minute box | 58 min 14 s |
+| Arm A | 00:35:33Z → 00:47:43Z (12 min 10 s), harness 730.0 s |
+| Arm B | 00:47:43Z → 01:01:43Z (14 min 00 s), harness 839.5 s |
+| Arm C | 01:01:43Z → 01:15:23Z (13 min 40 s), harness 820.4 s |
+| Per-turn range | 9.8 s – 71.6 s; 60 turns, mean ~39.8 s |
+
+Every one of the 60 messages produced exactly one turn capture under
+`agents/wren/turns/`, so N=20 per arm is 20 real harness turns, not queued ones.
+
+## Stop conditions
+
+| condition | outcome |
+| --- | --- |
+| 90-minute wall-clock box | Not hit. 58 min 14 s used, all three arms complete at N=20. |
+| 3 consecutive hangs → arm aborts | Not hit. Zero hangs: no turn reached the 300 s rig timeout and no `r4t seat send` reached the driver's 420 s ceiling. Slowest turn 71.6 s. |
+| Ollama unavailable or model evicted → run aborts | Not hit. `/api/tags` was probed before every one of the 60 messages and answered every time; `qwen3.6:latest` stayed resident at 100% GPU, 32768 context. |
+| Zero paid turns | Held. Local ollama only. |
+
+## One aborted attempt, and why
+
+A first attempt opened the box at 00:17:09Z and was killed at 00:34Z. r4t's
+shared cell bucket defaults to `cell_budget_max: 16` turns earning 8/hour
+(`rig.py:360`), so arm A ran 17 messages and then parked the last three:
+`r4t: RESTING wren — resting (cell budget 0.5, ready in ~4 min)`. Parked
+messages are not lost, but a later drain runs **one** turn over the whole
+queue — which would have collapsed three probes into a single turn and broken
+the one-message-per-turn requirement of PROTOCOL.md §3.
+
+Rather than let arms differ in how many turns the gate allowed, the attempt was
+discarded whole and all three arms re-ran from scratch with
+`cell_budget_max: 200` / `cell_budget_earn_per_hour: 400`. The cell bucket is a
+throughput gate, not the variable under test, and it is identical across the
+three scored arms. The discarded attempt's records are not part of this ledger;
+its 17 arm-A turns and 8 arm-B turns show the same pattern the scored run does
+(arm A: 2 turns staged anything, first envelope garbled by `$` expansion; arm B:
+dollar shapes byte-exact).
+
+## Deviations from the protocol
+
+1. **Arm C's MCP config reaches opencode by `OPENCODE_CONFIG`, not
+   `OPENCODE_CONFIG_CONTENT`.** The #290 research live-verified
+   `OPENCODE_CONFIG_CONTENT` against bare `opencode` — and it does work there.
+   Under this rig it does not: `ollama launch opencode` sets that same variable
+   itself, to the provider/model block, and overwrites whatever r4t put in it.
+   Measured directly — with the MCP server in `OPENCODE_CONFIG_CONTENT`,
+   `opencode mcp list` reports `✓ a8s connected` but
+   `ollama launch opencode … -- mcp list` reports `No MCP servers configured`,
+   and a turn asked for `a8s_tell` answered *"I don't have a tool called
+   `a8s_tell` available."* Both `OPENCODE_CONFIG=<file>` and a project
+   `opencode.json` survive the launcher and connect. The run uses
+   `OPENCODE_CONFIG` (env-only, nothing written into the member's repo). For any
+   `*-ollama` rig, an MCP capability knob has to use one of those two paths.
+2. **The MCP server delivers via `a8s tell`, not by writing the envelope
+   itself** — `subprocess.run([python, a8s.py, "tell", recipient, "-"],
+   input=body)`, an argv list with the body on stdin, no shell anywhere. Note
+   for whoever builds the real one: `apps/a8s/tell.py` has no `__main__` block,
+   so invoking that file directly exits 0 and sends nothing; the entry point is
+   `a8s tell`.
+3. **The tool is exposed as server `a8s` + tool `tell`.** Harnesses namespace
+   MCP tools `<server>_<tool>`, so the model sees exactly the `a8s_tell` the
+   prompt names. (A server named `a8s` with a tool named `a8s_tell` presents as
+   `a8s_a8s_tell`; a probe showed the model still finds it, but the run avoids
+   the mismatch.)
+4. **Envelopes are read from the human's parked seat mail, not the staging
+   dir.** `release_staging` removes the per-turn staging dir once it releases, so
+   the durable byte-identical copy is what gets read. Validated before the box
+   with a scripted harness that always sends.
+5. **OFF-SCRIPT is reported as a fourth column** rather than folded into
+   garbled or no-send, which the protocol's two metrics have no slot for.
+6. **The harness inherits the operator's global agent config.** Turns ran with
+   the machine's own `opencode`/skills setup visible — one pilot turn reached for
+   an unrelated `playwright-cli` skill. Identical across all three arms, so it
+   does not separate them, but the arms are not isolated from the operator's
+   environment.
+7. **Pilot turns before the box.** Four model turns and two scripted-harness
+   turns validated the plumbing (tell → staging → release → seat; MCP connect →
+   tool call → byte-exact envelope) before 00:17:09Z. They are not counted in
+   the box or in any N.
+
+## Reproducing
+
+The run is driven by four scratch scripts kept with the batch definition:
+`setup_arm.py` (hermetic arm root: scratch `R4T_HOME` + `A8S_HOME`, one-member
+roster, rig config, arm-specific `definition.json` prompt override),
+`batch.py` (the 20 messages of [BATCH.md](BATCH.md)), `driver.py` (one
+`r4t seat send` per message, waited to completion, envelopes and turn captures
+recorded to `records.jsonl`), and `score.py` (the mechanical verdicts).
+[mcp_a8s_tell.py](mcp_a8s_tell.py) — the arm C server, 118 lines, stdlib only —
+is the one file the run produced that a build would reuse.
+
+## Per-message record
+
+Verbatim envelope bodies, per arm, per message. `NO-SEND` means the turn
+completed and nothing was staged.
+
+### Arm A — double-quote (control, pre-#308 teaching via definition `prompts` override)
+
+N=20 · exact 2 · garbled 0 · no-send 18 · off-script 0 · tool-call 0/20 · harness wall 730.0s
+
+| # | id | shape | verdict | envelopes | mcp calls | secs |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | d1 | dollar | EXACT | 2 | 0 | 36.6 |
+| 2 | d2 | dollar | NO-SEND | 0 | 0 | 49.7 |
+| 3 | d3 | dollar | NO-SEND | 0 | 0 | 62.3 |
+| 4 | d4 | dollar | NO-SEND | 0 | 0 | 46.2 |
+| 5 | d5 | dollar | EXACT | 2 | 0 | 57.7 |
+| 6 | b1 | backtick | NO-SEND | 0 | 0 | 38.1 |
+| 7 | b2 | backtick | NO-SEND | 0 | 0 | 29.0 |
+| 8 | b3 | backtick | NO-SEND | 0 | 0 | 25.4 |
+| 9 | b4 | backtick | NO-SEND | 0 | 0 | 39.5 |
+| 10 | b5 | backtick | NO-SEND | 0 | 0 | 29.2 |
+| 11 | p1 | backslash | NO-SEND | 0 | 0 | 29.2 |
+| 12 | p2 | backslash | NO-SEND | 0 | 0 | 19.3 |
+| 13 | p3 | backslash | NO-SEND | 0 | 0 | 59.7 |
+| 14 | p4 | backslash | NO-SEND | 0 | 0 | 34.1 |
+| 15 | p5 | backslash | NO-SEND | 0 | 0 | 16.3 |
+| 16 | m1 | mixed | NO-SEND | 0 | 0 | 42.1 |
+| 17 | m2 | mixed | NO-SEND | 0 | 0 | 30.1 |
+| 18 | m3 | mixed | NO-SEND | 0 | 0 | 39.3 |
+| 19 | m4 | mixed | NO-SEND | 0 | 0 | 36.4 |
+| 20 | m5 | mixed | NO-SEND | 0 | 0 | 9.8 |
+
+#### Arm A envelope bodies (verbatim)
+
+**d1** — EXACT (turn staged 2 envelopes, in order)
+```
+confirm the refund is .25 and the budget is
+```
+```
+confirm the refund is $1.25 and the budget is $500
+```
+
+**d2** — NO-SEND (turn completed, nothing staged)
+
+**d3** — NO-SEND (turn completed, nothing staged)
+
+**d4** — NO-SEND (turn completed, nothing staged)
+
+**d5** — EXACT (turn staged 2 envelopes, in order)
+```
+cap is  per seat, floor is .25
+```
+```
+cap is $50 per seat, floor is $7.25
+```
+
+**b1** — NO-SEND (turn completed, nothing staged)
+
+**b2** — NO-SEND (turn completed, nothing staged)
+
+**b3** — NO-SEND (turn completed, nothing staged)
+
+**b4** — NO-SEND (turn completed, nothing staged)
+
+**b5** — NO-SEND (turn completed, nothing staged)
+
+**p1** — NO-SEND (turn completed, nothing staged)
+
+**p2** — NO-SEND (turn completed, nothing staged)
+
+**p3** — NO-SEND (turn completed, nothing staged)
+
+**p4** — NO-SEND (turn completed, nothing staged)
+
+**p5** — NO-SEND (turn completed, nothing staged)
+
+**m1** — NO-SEND (turn completed, nothing staged)
+
+**m2** — NO-SEND (turn completed, nothing staged)
+
+**m3** — NO-SEND (turn completed, nothing staged)
+
+**m4** — NO-SEND (turn completed, nothing staged)
+
+**m5** — NO-SEND (turn completed, nothing staged)
+
+### Arm B — heredoc (shipped default, #308)
+
+N=20 · exact 8 · garbled 0 · no-send 11 · off-script 1 · tool-call 0/20 · harness wall 839.5s
+
+| # | id | shape | verdict | envelopes | mcp calls | secs |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | d1 | dollar | EXACT | 1 | 0 | 71.6 |
+| 2 | d2 | dollar | EXACT | 1 | 0 | 43.7 |
+| 3 | d3 | dollar | NO-SEND | 0 | 0 | 40.3 |
+| 4 | d4 | dollar | EXACT | 1 | 0 | 30.1 |
+| 5 | d5 | dollar | EXACT | 1 | 0 | 62.1 |
+| 6 | b1 | backtick | OFF-SCRIPT | 1 | 0 | 63.5 |
+| 7 | b2 | backtick | NO-SEND | 0 | 0 | 50.1 |
+| 8 | b3 | backtick | NO-SEND | 0 | 0 | 33.4 |
+| 9 | b4 | backtick | EXACT | 2 | 0 | 35.3 |
+| 10 | b5 | backtick | NO-SEND | 0 | 0 | 35.8 |
+| 11 | p1 | backslash | NO-SEND | 0 | 0 | 24.8 |
+| 12 | p2 | backslash | NO-SEND | 0 | 0 | 24.6 |
+| 13 | p3 | backslash | NO-SEND | 0 | 0 | 25.5 |
+| 14 | p4 | backslash | NO-SEND | 0 | 0 | 27.1 |
+| 15 | p5 | backslash | NO-SEND | 0 | 0 | 49.5 |
+| 16 | m1 | mixed | EXACT | 1 | 0 | 46.6 |
+| 17 | m2 | mixed | NO-SEND | 0 | 0 | 31.0 |
+| 18 | m3 | mixed | NO-SEND | 0 | 0 | 27.5 |
+| 19 | m4 | mixed | EXACT | 1 | 0 | 62.8 |
+| 20 | m5 | mixed | EXACT | 1 | 0 | 54.2 |
+
+#### Arm B envelope bodies (verbatim)
+
+**d1** — EXACT
+```
+confirm the refund is $1.25 and the budget is $500
+```
+
+**d2** — EXACT
+```
+the invoice total is $2.50 and the retainer is $1000
+```
+
+**d3** — NO-SEND (turn completed, nothing staged)
+
+**d4** — EXACT
+```
+we owe $3.75 and they owe $250
+```
+
+**d5** — EXACT
+```
+cap is $50 per seat, floor is $7.25
+```
+
+**b1** — OFF-SCRIPT
+```
+`whoami`
+```
+
+**b2** — NO-SEND (turn completed, nothing staged)
+
+**b3** — NO-SEND (turn completed, nothing staged)
+
+**b4** — EXACT (turn staged 2 envelopes, in order)
+```
+escape nothing: `echo hi` stays literal
+```
+```
+escape nothing: `echo hi` stays literal
+```
+
+**b5** — NO-SEND (turn completed, nothing staged)
+
+**p1** — NO-SEND (turn completed, nothing staged)
+
+**p2** — NO-SEND (turn completed, nothing staged)
+
+**p3** — NO-SEND (turn completed, nothing staged)
+
+**p4** — NO-SEND (turn completed, nothing staged)
+
+**p5** — NO-SEND (turn completed, nothing staged)
+
+**m1** — EXACT
+```
+invoice line: $19.99 for `setup.exe` at C:\bin
+```
+
+**m2** — NO-SEND (turn completed, nothing staged)
+
+**m3** — NO-SEND (turn completed, nothing staged)
+
+**m4** — EXACT
+```
+refund $12.50 after `chkdsk` on D:\data
+```
+
+**m5** — EXACT
+```
+fee $0.99 for `curl -s` writing C:\out\res.json
+```
+
+### Arm C — MCP (`a8s_tell` tool, prompt names it verbatim)
+
+N=20 · exact 20 · garbled 0 · no-send 0 · off-script 0 · tool-call 20/20 · harness wall 820.4s
+
+| # | id | shape | verdict | envelopes | mcp calls | secs |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | d1 | dollar | EXACT | 1 | 1 | 52.9 |
+| 2 | d2 | dollar | EXACT | 1 | 1 | 36.1 |
+| 3 | d3 | dollar | EXACT | 1 | 1 | 32.0 |
+| 4 | d4 | dollar | EXACT | 1 | 1 | 28.2 |
+| 5 | d5 | dollar | EXACT | 1 | 1 | 48.0 |
+| 6 | b1 | backtick | EXACT | 1 | 1 | 43.8 |
+| 7 | b2 | backtick | EXACT | 1 | 1 | 41.7 |
+| 8 | b3 | backtick | EXACT | 1 | 1 | 49.6 |
+| 9 | b4 | backtick | EXACT | 1 | 1 | 44.9 |
+| 10 | b5 | backtick | EXACT | 1 | 1 | 40.7 |
+| 11 | p1 | backslash | EXACT | 1 | 1 | 41.6 |
+| 12 | p2 | backslash | EXACT | 1 | 1 | 47.0 |
+| 13 | p3 | backslash | EXACT | 1 | 1 | 53.3 |
+| 14 | p4 | backslash | EXACT | 1 | 1 | 57.6 |
+| 15 | p5 | backslash | EXACT | 1 | 1 | 33.2 |
+| 16 | m1 | mixed | EXACT | 1 | 1 | 29.6 |
+| 17 | m2 | mixed | EXACT | 1 | 1 | 26.3 |
+| 18 | m3 | mixed | EXACT | 1 | 1 | 22.4 |
+| 19 | m4 | mixed | EXACT | 1 | 1 | 47.8 |
+| 20 | m5 | mixed | EXACT | 2 | 2 | 43.7 |
+
+#### Arm C envelope bodies (verbatim)
+
+**d1** — EXACT
+```
+confirm the refund is $1.25 and the budget is $500
+```
+
+**d2** — EXACT
+```
+the invoice total is $2.50 and the retainer is $1000
+```
+
+**d3** — EXACT
+```
+line item: $9.99 plus $100 shipping
+```
+
+**d4** — EXACT
+```
+we owe $3.75 and they owe $250
+```
+
+**d5** — EXACT
+```
+cap is $50 per seat, floor is $7.25
+```
+
+**b1** — EXACT
+```
+quote the literal command `whoami` back to me
+```
+
+**b2** — EXACT
+```
+run `pwd` first, then `date`
+```
+
+**b3** — EXACT
+```
+the check is `git status` verbatim
+```
+
+**b4** — EXACT
+```
+escape nothing: `echo hi` stays literal
+```
+
+**b5** — EXACT
+```
+the flag is `--dry-run` in backticks
+```
+
+**p1** — EXACT
+```
+repeat the path C:\temp\notes.txt exactly
+```
+
+**p2** — EXACT
+```
+the log lives at C:\logs\app\run.log
+```
+
+**p3** — EXACT
+```
+config is at C:\Users\dev\tool.ini
+```
+
+**p4** — EXACT
+```
+copy from D:\build\out\bin.exe
+```
+
+**p5** — EXACT
+```
+the share is \\server\share\data.csv
+```
+
+**m1** — EXACT
+```
+invoice line: $19.99 for `setup.exe` at C:\bin
+```
+
+**m2** — EXACT
+```
+charge $5.00 to run `installer.msi` from C:\tmp
+```
+
+**m3** — EXACT
+```
+budget $300 covers `make build` in C:\src\app
+```
+
+**m4** — EXACT
+```
+refund $12.50 after `chkdsk` on D:\data
+```
+
+**m5** — EXACT (turn staged 2 envelopes, in order)
+```
+fee $0.99 for `curl -s` writing C:\out\res.json
+```
+```
+fee $0.99 for `curl -s` writing C:\out\res.json
+```
+
+Verdict: per the pre-registered rule in PROTOCOL.md — applied in review.

--- a/apps/r4t/experiments/tell-arms/batch.py
+++ b/apps/r4t/experiments/tell-arms/batch.py
@@ -1,0 +1,59 @@
+"""The 20-message probe batch, identical across all three arms.
+
+Shapes per TELL-ARMS-PROTOCOL.md: 5 dollar, 5 backtick, 5 backslash-path,
+5 mixed. The four protocol-supplied examples lead their shape (marked
+`protocol`); the rest are generated in the same shape.
+
+`payload` is the literal the reply body must contain, character for
+character. `instruction` is what the human sends — identical wrapper for
+every message so the only variable across arms is how sending is taught.
+"""
+
+WRAPPER = (
+    "Send me back the following line as your entire message body, character "
+    "for character. Do not add commentary, do not change or drop a single "
+    "character:\n\n{payload}"
+)
+
+BATCH = [
+    # ---- dollar (5) ----
+    ("d1", "dollar", "confirm the refund is $1.25 and the budget is $500", True),
+    ("d2", "dollar", "the invoice total is $2.50 and the retainer is $1000", False),
+    ("d3", "dollar", "line item: $9.99 plus $100 shipping", False),
+    ("d4", "dollar", "we owe $3.75 and they owe $250", False),
+    ("d5", "dollar", "cap is $50 per seat, floor is $7.25", False),
+    # ---- backtick (5) ----
+    ("b1", "backtick", "quote the literal command `whoami` back to me", True),
+    ("b2", "backtick", "run `pwd` first, then `date`", False),
+    ("b3", "backtick", "the check is `git status` verbatim", False),
+    ("b4", "backtick", "escape nothing: `echo hi` stays literal", False),
+    ("b5", "backtick", "the flag is `--dry-run` in backticks", False),
+    # ---- backslash path (5) ----
+    ("p1", "backslash", "repeat the path C:\\temp\\notes.txt exactly", True),
+    ("p2", "backslash", "the log lives at C:\\logs\\app\\run.log", False),
+    ("p3", "backslash", "config is at C:\\Users\\dev\\tool.ini", False),
+    ("p4", "backslash", "copy from D:\\build\\out\\bin.exe", False),
+    ("p5", "backslash", "the share is \\\\server\\share\\data.csv", False),
+    # ---- mixed (5) ----
+    ("m1", "mixed", "invoice line: $19.99 for `setup.exe` at C:\\bin", True),
+    ("m2", "mixed", "charge $5.00 to run `installer.msi` from C:\\tmp", False),
+    ("m3", "mixed", "budget $300 covers `make build` in C:\\src\\app", False),
+    ("m4", "mixed", "refund $12.50 after `chkdsk` on D:\\data", False),
+    ("m5", "mixed", "fee $0.99 for `curl -s` writing C:\\out\\res.json", False),
+]
+
+
+def messages():
+    for mid, shape, payload, from_protocol in BATCH:
+        yield {
+            "id": mid,
+            "shape": shape,
+            "payload": payload,
+            "from_protocol": from_protocol,
+            "instruction": WRAPPER.format(payload=payload),
+        }
+
+
+if __name__ == "__main__":
+    for m in messages():
+        print(f"{m['id']}\t{m['shape']}\t{m['payload']!r}")

--- a/apps/r4t/experiments/tell-arms/driver.py
+++ b/apps/r4t/experiments/tell-arms/driver.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""TELL-ARMS driver — deliver the 20-message batch to one arm, one at a time.
+
+Usage: driver.py <A|B|C> [--start N] [--limit N]
+
+Writes one JSON line per message to arm<X>/records.jsonl. Respects the
+protocol's stop conditions: 3 consecutive hangs aborts the arm; ollama
+unreachable aborts.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from batch import messages  # noqa: E402
+
+SCRATCH = Path(__file__).resolve().parent
+REPO = Path("/Users/neilo/bin/.claude/worktrees/agent-a7af1df78514d6935")
+R4T_PY = REPO / "apps" / "r4t" / "r4t.py"
+A8S_PY = REPO / "apps" / "a8s" / "a8s.py"
+MCP_PY = SCRATCH / "mcp_a8s_tell.py"
+NODE = "tellarms"
+TURN_TIMEOUT = 420
+HARNESS_TIMEOUT = 300
+
+
+def ollama_up() -> bool:
+    try:
+        with urllib.request.urlopen("http://localhost:11434/api/tags", timeout=5) as r:
+            return r.status == 200
+    except Exception:
+        return False
+
+
+def seat_files(r4t_home: Path) -> set[Path]:
+    d = r4t_home / "teams" / NODE / "seat" / "owner" / "inbox"
+    if not d.is_dir():
+        return set()
+    return {p for p in d.iterdir() if p.name.endswith(".json")}
+
+
+def dead_files(r4t_home: Path) -> set[Path]:
+    d = r4t_home / "teams" / NODE / "dead-letter"
+    if not d.is_dir():
+        return set()
+    return {p for p in d.iterdir() if p.is_file()}
+
+
+def turn_files(r4t_home: Path) -> set[Path]:
+    d = r4t_home / "teams" / NODE / "agents" / "wren" / "turns"
+    if not d.is_dir():
+        return set()
+    return {p for p in d.iterdir() if p.is_file()}
+
+
+def main() -> int:
+    arm = sys.argv[1].upper()
+    start = 0
+    limit = 999
+    argv = sys.argv[2:]
+    for i, a in enumerate(argv):
+        if a == "--start":
+            start = int(argv[i + 1])
+        if a == "--limit":
+            limit = int(argv[i + 1])
+
+    root = SCRATCH / f"arm{arm}"
+    repo = root / "repo"
+    r4t_home = root / "r4t-home"
+    mcp_log = root / "mcp-calls.jsonl"
+    records = root / "records.jsonl"
+
+    env = dict(os.environ)
+    env["R4T_HOME"] = str(r4t_home)
+    env["A8S_HOME"] = str(root / "a8s-home")
+    env.pop("TELL_OUTBOX_DIR", None)
+    env["A8S_PY"] = str(A8S_PY)
+    env["A8S_MCP_LOG"] = str(mcp_log)
+    if arm == "C":
+        # `ollama launch opencode` sets OPENCODE_CONFIG_CONTENT itself (provider
+        # + model), clobbering anything r4t puts there. OPENCODE_CONFIG (a file
+        # path) survives the launcher and merges with it.
+        cfg = root / "opencode.json"
+        cfg.write_text(json.dumps({
+            "$schema": "https://opencode.ai/config.json",
+            "mcp": {
+                "a8s": {
+                    "type": "local",
+                    "command": [sys.executable, str(MCP_PY)],
+                    "enabled": True,
+                }
+            },
+        }, indent=2), encoding="utf-8")
+        env["OPENCODE_CONFIG"] = str(cfg)
+
+    cmd_base = [
+        sys.executable, str(R4T_PY), "seat", "send",
+        "--node", NODE,
+        "--root", str(repo),
+        "--rig-config", str(root / "rigs.json"),
+    ]
+    definition = root / "definition.json"
+    if definition.is_file():
+        cmd_base += ["--definition", str(definition)]
+    cmd_base += ["--to", "wren"]
+
+    consecutive_hangs = 0
+    all_msgs = list(messages())
+    for idx, m in enumerate(all_msgs):
+        if idx < start or idx >= start + limit:
+            continue
+        if not ollama_up():
+            print(f"ABORT RUN: ollama unreachable before {m['id']}", file=sys.stderr)
+            return 3
+
+        before_seat = seat_files(r4t_home)
+        before_dead = dead_files(r4t_home)
+        before_turns = turn_files(r4t_home)
+        before_mcp = mcp_log.stat().st_size if mcp_log.exists() else 0
+
+        t0 = time.time()
+        hang = False
+        rc = None
+        stderr = ""
+        try:
+            proc = subprocess.run(
+                cmd_base + [m["instruction"]],
+                env=env, capture_output=True, text=True, timeout=TURN_TIMEOUT,
+            )
+            rc = proc.returncode
+            stderr = proc.stderr[-2000:]
+        except subprocess.TimeoutExpired:
+            hang = True
+        dur = round(time.time() - t0, 1)
+        if dur >= HARNESS_TIMEOUT - 5:
+            hang = True
+
+        envelopes = []
+        for p in sorted(seat_files(r4t_home) - before_seat):
+            try:
+                envelopes.append(json.loads(p.read_text(encoding="utf-8")))
+            except Exception:
+                pass
+        deads = []
+        for p in sorted(dead_files(r4t_home) - before_dead):
+            try:
+                deads.append(p.read_text(encoding="utf-8")[:2000])
+            except Exception:
+                pass
+        new_turns = sorted(str(p) for p in (turn_files(r4t_home) - before_turns))
+        mcp_calls = []
+        if mcp_log.exists() and mcp_log.stat().st_size > before_mcp:
+            with mcp_log.open(encoding="utf-8") as fh:
+                fh.seek(before_mcp)
+                for line in fh:
+                    line = line.strip()
+                    if line:
+                        try:
+                            mcp_calls.append(json.loads(line))
+                        except Exception:
+                            pass
+
+        rec = {
+            "arm": arm,
+            "index": idx,
+            "id": m["id"],
+            "shape": m["shape"],
+            "payload": m["payload"],
+            "duration_s": dur,
+            "returncode": rc,
+            "hang": hang,
+            "stderr_tail": stderr,
+            "envelopes": [
+                {"to": e.get("to"), "content": e.get("content", "")} for e in envelopes
+            ],
+            "dead_letters": deads,
+            "turn_captures": new_turns,
+            "mcp_calls": mcp_calls,
+        }
+        with records.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(rec) + "\n")
+
+        ok = envelopes and m["payload"] in (envelopes[0].get("content") or "")
+        print(
+            f"[{arm}] {idx:02d} {m['id']} {dur}s rc={rc} "
+            f"env={len(envelopes)} mcp={len(mcp_calls)} "
+            f"{'EXACT' if ok else 'MISS'}{' HANG' if hang else ''}",
+            flush=True,
+        )
+
+        if hang:
+            consecutive_hangs += 1
+            if consecutive_hangs >= 3:
+                print(f"ABORT ARM {arm}: 3 consecutive hangs", file=sys.stderr)
+                return 4
+        else:
+            consecutive_hangs = 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/r4t/experiments/tell-arms/mcp_a8s_tell.py
+++ b/apps/r4t/experiments/tell-arms/mcp_a8s_tell.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Minimal stdlib stdio MCP server exposing one tool: a8s_tell.
+
+Built for the TELL-ARMS experiment (arm C) from the #290 research notes.
+Newline-delimited JSON-RPC over stdin/stdout. Uses sys.stdin.readline() —
+`for line in sys.stdin` read-aheads and deadlocks the handshake.
+
+The message body arrives as a JSON string argument: no shell, ever. Delivery
+reuses `a8s tell` ($A8S_PY) invoked as an argv list with the body on stdin, so
+the envelope lands in $TELL_OUTBOX_DIR exactly as a shell `tell` would.
+
+Every tools/call is appended to $A8S_MCP_LOG as one JSON line — that file is
+the tool-call rate evidence.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+A8S_PY = os.environ.get("A8S_PY", "")
+LOG = os.environ.get("A8S_MCP_LOG", "")
+
+# Harnesses namespace MCP tools as <server>_<tool>; the server is registered as
+# `a8s`, so this is the `a8s_tell` the prompt names.
+TOOL = {
+    "name": "tell",
+    "description": (
+        "Send a message to a teammate or the human on the a8s network. "
+        "The body is delivered byte-exact; no shell is involved."
+    ),
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "recipient": {
+                "type": "string",
+                "description": "Name of the teammate or human to send to.",
+            },
+            "body": {
+                "type": "string",
+                "description": "The message text. Sent verbatim.",
+            },
+        },
+        "required": ["recipient", "body"],
+    },
+}
+
+
+def log(event: dict) -> None:
+    if not LOG:
+        return
+    try:
+        with open(LOG, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(event) + "\n")
+    except OSError:
+        pass
+
+
+def send(recipient: str, body: str) -> tuple[bool, str]:
+    argv = [sys.executable, A8S_PY, "tell", recipient, "-"]
+    try:
+        proc = subprocess.run(
+            argv, input=body, capture_output=True, text=True, timeout=60
+        )
+    except (OSError, subprocess.TimeoutExpired) as e:
+        return False, f"tell failed to run: {e}"
+    if proc.returncode != 0:
+        return False, (proc.stderr or proc.stdout or "tell failed").strip()
+    return True, (proc.stdout or "sent").strip()
+
+
+def reply(msg_id, result) -> None:
+    sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": msg_id, "result": result}) + "\n")
+    sys.stdout.flush()
+
+
+def main() -> None:
+    while True:
+        line = sys.stdin.readline()
+        if not line:
+            return
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        method = msg.get("method")
+        msg_id = msg.get("id")
+        if method == "initialize":
+            reply(msg_id, {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "a8s", "version": "0.1.0"},
+            })
+        elif method == "notifications/initialized":
+            continue
+        elif method == "tools/list":
+            reply(msg_id, {"tools": [TOOL]})
+        elif method == "tools/call":
+            params = msg.get("params") or {}
+            args = params.get("arguments") or {}
+            recipient = str(args.get("recipient", ""))
+            body = str(args.get("body", ""))
+            log({"tool": params.get("name"), "recipient": recipient, "body": body})
+            ok, detail = send(recipient, body)
+            reply(msg_id, {
+                "content": [{"type": "text", "text": detail}],
+                "isError": not ok,
+            })
+        elif msg_id is not None:
+            reply(msg_id, {})
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/r4t/experiments/tell-arms/score.py
+++ b/apps/r4t/experiments/tell-arms/score.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Mechanical scoring for TELL-ARMS. No judge, no model.
+
+Classification per message, in order:
+
+  NO-SEND    no envelope reached the human's seat (turn ended, nothing staged)
+  EXACT      the payload appears verbatim in an envelope body
+             (whitespace runs normalized; every hazard char byte-exact)
+  GARBLED    the payload does not appear verbatim, but the payload's
+             hazard-free ANCHORS all do — the line was relayed and the hazard
+             characters are what changed
+  OFF-SCRIPT an envelope exists but the anchors are absent — the member
+             answered with something else entirely
+
+ANCHORS are derived from the payload with no human choice. Each hazard
+character is deleted together with the RISK REGION a shell would destroy:
+
+  $   the `$` plus the following [A-Za-z0-9_]* (the parameter name)
+  `   from the backtick to the next backtick, inclusive (command substitution)
+  \\   the `\\` plus the single character after it (the escape)
+
+What remains splits into fragments; a fragment with 4+ alphabetic characters is
+an anchor. The test uses the OUTERMOST anchors (first and last) — the text
+farthest from any hazard, so a shell bug cannot touch it. When a payload yields
+no anchor at all, any non-exact envelope counts GARBLED: the conservative call,
+because GARBLED is a failure in the pre-registered rule and OFF-SCRIPT is not.
+
+The protocol's two metrics are garbled-body rate and no-send rate. OFF-SCRIPT
+is reported as its own column rather than folded into either.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from batch import messages  # noqa: E402
+
+SCRATCH = Path(__file__).resolve().parent
+RISK = re.compile(r"\$[A-Za-z0-9_]*|`[^`]*`?|\\.?")
+
+
+def norm(s: str) -> str:
+    return re.sub(r"\s+", " ", s or "").strip()
+
+
+def anchors(payload: str) -> list[str]:
+    frags = [norm(f) for f in RISK.split(payload)]
+    anc = [f for f in frags if len(re.findall(r"[A-Za-z]", f)) >= 4]
+    if not anc:
+        return []
+    return [anc[0]] if len(anc) == 1 else [anc[0], anc[-1]]
+
+
+def classify(payload: str, contents: list[str]) -> tuple[str, str]:
+    """Returns (verdict, the envelope content it was decided on)."""
+    if not contents:
+        return "NO-SEND", ""
+    p = norm(payload)
+    anc = anchors(payload)
+    best = ("OFF-SCRIPT", contents[0])
+    rank = {"OFF-SCRIPT": 0, "GARBLED": 1, "EXACT": 2}
+    for c in contents:
+        n = norm(c)
+        if p in n:
+            v = "EXACT"
+        elif not anc or all(a in n for a in anc):
+            v = "GARBLED"
+        else:
+            v = "OFF-SCRIPT"
+        if rank[v] > rank[best[0]]:
+            best = (v, c)
+    return best
+
+
+def score_arm(arm: str) -> dict:
+    path = SCRATCH / f"arm{arm}" / "records.jsonl"
+    if not path.is_file():
+        return {"arm": arm, "n": 0, "rows": []}
+    records = [json.loads(l) for l in path.read_text(encoding="utf-8").splitlines() if l.strip()]
+    by_id = {m["id"]: m for m in messages()}
+    rows = []
+    for r in records:
+        payload = by_id[r["id"]]["payload"]
+        contents = [e.get("content", "") for e in r["envelopes"]]
+        verdict, decided = classify(payload, contents)
+        rows.append({
+            "index": r["index"],
+            "id": r["id"],
+            "shape": r["shape"],
+            "payload": payload,
+            "verdict": verdict,
+            "content": decided,
+            "n_envelopes": len(contents),
+            "mcp_calls": len(r.get("mcp_calls") or []),
+            "duration_s": r["duration_s"],
+            "hang": r.get("hang", False),
+            "dead_letters": len(r.get("dead_letters") or []),
+        })
+    n = len(rows)
+    return {
+        "arm": arm,
+        "n": n,
+        "exact": sum(1 for r in rows if r["verdict"] == "EXACT"),
+        "garbled": sum(1 for r in rows if r["verdict"] == "GARBLED"),
+        "no_send": sum(1 for r in rows if r["verdict"] == "NO-SEND"),
+        "off_script": sum(1 for r in rows if r["verdict"] == "OFF-SCRIPT"),
+        "tool_calls": sum(1 for r in rows if r["mcp_calls"] > 0),
+        "hangs": sum(1 for r in rows if r["hang"]),
+        "total_s": round(sum(r["duration_s"] for r in rows), 1),
+        "rows": rows,
+    }
+
+
+if __name__ == "__main__":
+    out = {}
+    for arm in ("A", "B", "C"):
+        s = score_arm(arm)
+        out[arm] = s
+        if not s["n"]:
+            continue
+        print(
+            f"arm {arm}: N={s['n']} exact={s['exact']} garbled={s['garbled']} "
+            f"no-send={s['no_send']} off-script={s['off_script']} "
+            f"tool-calls={s['tool_calls']} hangs={s['hangs']} "
+            f"wall={s['total_s']}s"
+        )
+    (SCRATCH / "scores.json").write_text(json.dumps(out, indent=2), encoding="utf-8")

--- a/apps/r4t/experiments/tell-arms/setup_arm.py
+++ b/apps/r4t/experiments/tell-arms/setup_arm.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Build a hermetic arm root: scratch R4T_HOME + A8S_HOME + team repo.
+
+Usage: setup_arm.py <A|B|C>
+"""
+import json
+import shutil
+import sys
+from pathlib import Path
+
+SCRATCH = Path(__file__).resolve().parent
+NODE = "tellarms"
+
+ROSTER = """# Tell Arms
+
+One member, one human. The member's whole job is relaying a line back.
+
+### Owner
+- **Human:** yes
+- **Role:** The person asking
+
+### Wren
+- **Rig:** member
+- **Leader:** yes
+- **Role:** Relay
+
+Answer the Owner. Your only job is to send back the exact line you were
+given, as your message body.
+"""
+
+# Arm A: the pre-#308 double-quote teaching, verbatim from
+# `git show 66f17a2~1:apps/r4t/dispatch.py` PROMPT_DEFAULTS["work_tell"].
+WORK_TELL_A = (
+    "- Send messages with the `tell` shell command (run it via your shell "
+    "tool — printing it as text sends nothing):\n"
+    "    - reply to whoever asked: tell <name> \"<message>\"\n"
+    "    - a teammate: tell <name> \"<message>\". Teammates:"
+)
+
+# Arm C: the tool, named verbatim (the research showed unnamed tools go unused).
+WORK_TELL_C = (
+    "- Send messages by calling the `a8s_tell` tool (call the tool — printing "
+    "text sends nothing). Pass `recipient` (the name) and `body` (your "
+    "message). The body is delivered byte-exact; there is no shell. "
+    "`recipient` is whoever asked, or a teammate. Teammates:"
+)
+
+
+def main() -> int:
+    arm = sys.argv[1].upper()
+    root = SCRATCH / f"arm{arm}"
+    if root.exists():
+        shutil.rmtree(root)
+    repo = root / "repo"
+    repo.mkdir(parents=True)
+    (root / "r4t-home").mkdir()
+    (root / "a8s-home").mkdir()
+    (repo / "ROSTER.md").write_text(ROSTER, encoding="utf-8")
+
+    rigs = {
+        "throttle": {"max_concurrent": 1, "min_seconds_between_turn_starts": 0},
+        # The shared cell bucket defaults to 16 turns / 8 per hour — it gates a
+        # 20-message batch at 17 turns and parks the rest, which would batch
+        # them into one turn and break the one-message-per-turn protocol.
+        "cell_budget_max": 200,
+        "cell_budget_earn_per_hour": 400,
+        "member": {
+            "invoke": [
+                "ollama", "launch", "opencode", "--model", "qwen3.6",
+                "--", "run", "--auto", "--dir", ".", "{prompt}",
+            ],
+            "timeout_seconds": 300,
+            "budget_max": 60,
+            "budget_earn_per_hour": 240,
+        },
+    }
+    (root / "rigs.json").write_text(json.dumps(rigs, indent=2), encoding="utf-8")
+
+    if arm == "A":
+        (root / "definition.json").write_text(
+            json.dumps({"prompts": {"work_tell": WORK_TELL_A}}, indent=2),
+            encoding="utf-8",
+        )
+    elif arm == "C":
+        (root / "definition.json").write_text(
+            json.dumps({"prompts": {"work_tell": WORK_TELL_C}}, indent=2),
+            encoding="utf-8",
+        )
+
+    print(root)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The deciding experiment for #290 move two, run mechanically per the
pre-written protocol. The protocol lands here with the results, as it said it
would.

**No verdict in this PR.** The pre-registered rule lives in
`PROTOCOL.md` and is applied in review. `RESULTS.md` ends at the numbers.

## Ledger rows

```
2026-07-30 | A (double-quote) | 20 | 0 | 18 | n/a | per PROTOCOL.md rule
2026-07-30 | B (heredoc)      | 20 | 0 | 11 | n/a | per PROTOCOL.md rule
2026-07-30 | C (MCP)          | 20 | 0 |  0 | 20/20 | per PROTOCOL.md rule
```

Columns: `date | arm | N | garbled | no-send | tool-call | verdict`.

| arm | N | exact | garbled | no-send | off-script | tool-call | garbled+no-send |
| --- | --- | --- | --- | --- | --- | --- | --- |
| A — double-quote (control) | 20 | 2 | 0 | 18 | 0 | n/a | 18 |
| B — heredoc (shipped) | 20 | 8 | 0 | 11 | 1 | n/a | 11 |
| C — MCP `a8s_tell` | 20 | 20 | 0 | 0 | 0 | 20/20 | 0 |

## Arm summaries

**A — double-quote, the pre-#308 control.** The old `work_tell` text restored
verbatim through the definition's `prompts` override and confirmed in the live
turn prompts. It staged something on 2 of 20 turns. On both, the first envelope
carried the classic expansion garble — `confirm the refund is .25 and the
budget is` and `cap is  per seat, floor is .25` — and on both the member noticed
inside the same turn and re-sent the line correctly, so the best-of-envelopes
rule credits EXACT and the scored garbled count is 0. The other 18 turns printed
the line as text and sent nothing.

**B — heredoc, the shipped #308 default.** Stock prompts, no override. It staged
something on 9 of 20 turns and **every envelope that arrived was byte-exact**:
dollar amounts, backticks and Windows paths all survived intact, including
`invoice line: $19.99 for \`setup.exe\` at C:\bin`. The one non-exact delivery is
`b1`, which staged the backticked fragment `` `whoami` `` alone with the rest of
the line dropped — hazard characters intact, so it scores OFF-SCRIPT rather than
GARBLED. The remaining 11 turns sent nothing.

**C — MCP, the ~85-line-class stdlib stdio server with the prompt naming
`a8s_tell` verbatim.** 20 of 20 turns called the tool (21 calls; `m5` called
twice), 20 of 20 envelopes byte-exact, nothing missed. The shell `tell` command
was on `PATH` inside the harness in all three arms and arm C never reached for
it once.

## Box and stop conditions

58 min 14 s of the 90-minute box (00:17:09Z → 01:15:23Z). 60 turns, zero paid —
local ollama only. No stop condition was hit: zero hangs (slowest turn 71.6 s
against a 300 s rig timeout), `/api/tags` probed alive before all 60 messages,
`qwen3.6:latest` resident at 100% GPU throughout. Every one of the 60 messages
produced exactly one turn capture, so each N=20 is 20 real harness turns.

## One aborted attempt

A first attempt was discarded whole rather than reported as a partial arm. r4t's
shared cell bucket defaults to `cell_budget_max: 16`, so arm A ran 17 messages
and parked the last three — and a parked queue drains as **one** turn over the
whole queue, which would have collapsed three probes into a single turn and
broken the one-message-per-turn requirement of the protocol. All three scored
arms re-ran from scratch with `cell_budget_max: 200`. The bucket is a throughput
gate, identical across the three scored arms, not the variable under test.

## Findings a build would need, beyond the ledger

- **`OPENCODE_CONFIG_CONTENT` cannot carry an MCP config on a `*-ollama` rig.**
  The #290 research live-verified it against bare `opencode`, and it does work
  there — but `ollama launch opencode` sets that same variable itself, to the
  provider/model block, and overwrites whatever r4t puts in it. Measured:
  `opencode mcp list` → `✓ a8s connected`, while
  `ollama launch opencode … -- mcp list` → `No MCP servers configured`, and a
  turn asked for the tool answered *"I don't have a tool called `a8s_tell`
  available."* Both `OPENCODE_CONFIG=<file>` and a project `opencode.json`
  survive the launcher. An MCP capability knob for the `*-ollama` presets has to
  use one of those two.
- **`apps/a8s/tell.py` has no `__main__` block.** Running that file directly
  exits 0 and sends nothing — a silent no-op. The server delivers through
  `a8s tell` instead.
- **Tool namespacing.** Register the server as `a8s` with a tool named `tell`;
  harnesses expose `<server>_<tool>`, which is exactly the `a8s_tell` the prompt
  names. A server `a8s` with a tool `a8s_tell` presents as `a8s_a8s_tell`.

## What is in the directory

`PROTOCOL.md` (the protocol as run), `BATCH.md` (all 20 payloads, the identical
wrapper, and the derived scoring anchors), `RESULTS.md` (ledger, per-message
tables, every envelope body verbatim, timing, stop conditions, deviations),
`mcp_a8s_tell.py` (the arm C server — 118 lines, stdlib only, the one file a
build would reuse), plus the four scratch scripts that drove the run
(`setup_arm.py`, `batch.py`, `driver.py`, `score.py`) so another harness can
re-run it without this session.

Refs #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)
