### PR TITLE
docs(a8s): tell teaching leads with the quoted-heredoc stdin form

### DIFF
--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -99,9 +99,12 @@ a8s ps
 # Send messages. Woken agents get `TELL_OUTBOX_DIR` from a8s. Manual / desktop
 # tell uses that env var, or a unique CWD-matched configured outbox
 # (see docs/filedrop.md / docs/tell.md).
+# Body on stdin with a quoted delimiter: $, backticks, and backslashes survive.
 cd ~/projects/code-review
-tell GEMINI "look at lines 40-80 of foo.py"
-tell devs   "stand-up at 3pm"
+tell GEMINI - <<'EOF'
+look at lines 40-80 of foo.py
+EOF
+tell devs "stand-up at 3pm"   # trailing argument: short plain bodies only
 
 # Read what each agent is doing.
 a8s logs CLAUDE GEMINI --tail 20
@@ -202,8 +205,8 @@ any prefixes pointing at it.
 
 |                                                                             |                                                                                                                                                                                                                                                                                                                           |
 | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `a8s tell <name> <msg>`                                                     | Routed message via `_write_outbox` into the sender's configured outbox. `<name>` may be an agent or alias (fans out at routing time). Sender = agent whose root encloses CWD; router force-stamps `from` from outbox ownership.                                                                                           |
-| `tell <name> <msg>` (top-level shim, `[~/bin/tell](/Users/neilo/bin/tell)`) | Delegates to `a8s tell` (`apps/a8s/tell.py`). Outbox: `TELL_OUTBOX_DIR` if set, else a unique configured outbox matched from CWD when `~/.a8s` is readable (see [filedrop.md](docs/filedrop.md)). Drops a JSON envelope. When the registry is reachable, recipient validation and `from` stamping apply. Windows: `tell.cmd`. Operator internals: `[docs/tell.md](docs/tell.md)`. |
+| `a8s tell <name> [<msg>\|-]`                                                | Routed message via `_write_outbox` into the sender's configured outbox. `-` reads the body from stdin (`- <<'EOF'` / `- < file.md`), which keeps shell expansion out of it. `<name>` may be an agent or alias (fans out at routing time). Sender = agent whose root encloses CWD; router force-stamps `from` from outbox ownership.                                                                                           |
+| `tell <name> [<msg>\|-]` (top-level shim, `[~/bin/tell](/Users/neilo/bin/tell)`) | Delegates to `a8s tell` (`apps/a8s/tell.py`). Outbox: `TELL_OUTBOX_DIR` if set, else a unique configured outbox matched from CWD when `~/.a8s` is readable (see [filedrop.md](docs/filedrop.md)). Drops a JSON envelope. When the registry is reachable, recipient validation and `from` stamping apply. Windows: `tell.cmd`. Operator internals: `[docs/tell.md](docs/tell.md)`. |
 | `tells [-f] [--timeout SEC] [--body-max N] [--glow [theme]]` (shim `[~/bin/tells](/Users/neilo/bin/tells)`) | Receive-side complement of `tell` (`apps/a8s/tells.py`). Same outbox resolution as `tell`; watches `.inbox` beside it. Default: wait up to 5s for a burst. `-f` / `--timeout 0`: follow until Ctrl+C. Bodies over `--body-max` / `TELLS_BODY_MAX` (default 16000; `0` = unlimited) print a `python3 -c` recovery command for the inbox JSON. `--glow` / headings share convo's markdown formatting. Non-destructive. Prefer over `convo -f` for filedrop inbound-only loops. |
 | `a8s logs <name>... [--tail N] [-f]`                                        | Read per-agent log files; one agent in append order, multiple merge by ISO timestamp. `-f` follows.                                                                                                                                                                                                                       |
 | `a8s convo <name> [--limit N] [-f] [--glow [theme]]`                        | Markdown history of messages to or from an agent. Default `--limit 10`; this controls display only. `-f` follows sequence-numbered rows in `conversations.sqlite3` (shows outbound too — use `tells -f` for filedrop inbound-only). `a8s update` retains `convo_max_rows` rows (default 50000). |

--- a/apps/a8s/definitions.py
+++ b/apps/a8s/definitions.py
@@ -532,8 +532,14 @@ def build_batch_prompt(recipient: str, entries: list[BatchEntry]) -> str:
     silently broke batch delivery. Composing the prompt here means there is
     only one place in the pipeline that understands the envelope schema."""
     header = (
-        f"You are receiving messages as '{recipient}'. Use bash CLI "
-        "`tell [--attach /path/to/file] <recipient> <message>` to send asynchronously."
+        f"You are receiving messages as '{recipient}'. Send with the bash CLI "
+        "`tell`, body on stdin with the delimiter quoted so nothing expands "
+        "($ ` \\ arrive byte-exact):\n"
+        "    tell <recipient> - <<'EOF'\n"
+        "    <your message>\n"
+        "    EOF\n"
+        "Attach files with `tell --attach /path/to/file <recipient> -`. "
+        "Delivery is asynchronous; do not wait for a reply."
     )
     blocks = [header]
     for entry in entries:

--- a/apps/a8s/docs/filedrop.md
+++ b/apps/a8s/docs/filedrop.md
@@ -48,7 +48,9 @@ default. Otherwise outbound mail is stamped from the wrong seat (classic
 ```bash
 export TELL_OUTBOX_DIR=~/filedrops/cursor-drop/.outbox
 tells -f          # background OK; .inbox still fills when this is down
-tell neil-macbook "done with the refactor"
+tell neil-macbook - <<'EOF'
+done with the refactor
+EOF
 ```
 
 When CWD is inside a unique registered filedrop root, `tell` / `tells` can

--- a/apps/a8s/docs/tell.md
+++ b/apps/a8s/docs/tell.md
@@ -4,6 +4,12 @@ Operator documentation for how `tell` works under the hood. Agent-facing usage
 lives in [`skills/tell/SKILL.md`](../skills/tell/SKILL.md) (send-only). Desktop /
 filedrop setup: [filedrop.md](filedrop.md).
 
+Bodies ride in on stdin — `tell <name> - <<'EOF' … EOF` with the delimiter
+quoted, or `tell <name> - < body.md`. That is what every teaching surface shows,
+because the shell never touches the text: `$`, backticks, and backslashes land
+byte-exact. The trailing-argv form covers short plain bodies; inside double
+quotes the shell expands `$…` and runs backticks before `tell` is reached.
+
 ## Surface
 
 | Entry | Path |

--- a/apps/a8s/skills/tell/SKILL.md
+++ b/apps/a8s/skills/tell/SKILL.md
@@ -5,14 +5,28 @@ description: "Send an asynchronous message with the `tell` CLI. Delivery is not 
 
 # tell
 
-Send messages via the shell (not by printing the command as text):
+Send messages via the shell (not by printing the command as text). Put the body
+on stdin with the heredoc delimiter quoted, so the shell expands nothing and
+`$`, backticks, and backslashes arrive byte-exact:
 
 ```
-tell [--attach PATH ...] [--split] <recipient> [<message...>]
+tell <recipient> - <<'EOF'
+<your message>
+EOF
+```
+
+Or point stdin at a file you wrote: `tell <recipient> - < message.md`.
+
+Full surface:
+
+```
+tell [--attach PATH ...] [--split] <recipient> [<message...>|-]
 ```
 
 - `<recipient>` is an opaque name — do not guess who/what it is or change tone.
-- Omit `<message>` when piping stdin (`echo hi | tell BOB`, or `tell BOB -`).
+- A trailing `<message...>` argument suits a short plain body. Anything holding
+  `$`, backticks, backslashes, quotes, or newlines goes on stdin — inside double
+  quotes the shell eats it (`"$1.25"` sends `.25`).
 - `--attach` / `--file` may repeat (or list existing paths after one flag); `--attach=PATH` works.
 - Oversized attachments fail immediately unless `--split` chunks them under the size limit.
 - Returns immediately. Delivery may take seconds or longer; do not expect a reply in-session.

--- a/apps/a8s/tell.py
+++ b/apps/a8s/tell.py
@@ -466,7 +466,7 @@ class TellHelp(Exception):
     pass
 
 
-_USAGE = "usage: tell [--attach PATH ...] [--split] <name> [<message...>]"
+_USAGE = "usage: tell [--attach PATH ...] [--split] <name> [<message...>|-]"
 
 
 def _print_usage() -> None:
@@ -474,6 +474,7 @@ def _print_usage() -> None:
     print("       --attach/--file may repeat; multiple paths after one flag OK if they exist", file=sys.stderr)
     print("       --split: chunk attachments over the size limit into .partNNNofMMM files", file=sys.stderr)
     print(f"       size limit: {TELL_FILE_MAX_ENV} (bytes or 50m), else max_file_bytes / 50MiB", file=sys.stderr)
+    print("       body on stdin keeps the shell out of it: - <<'EOF' … EOF, or - < body.md", file=sys.stderr)
     print("       message may be `-` to read stdin; stdin is used when piped", file=sys.stderr)
 
 

--- a/playbooks/a8s-filedrop-agent.md
+++ b/playbooks/a8s-filedrop-agent.md
@@ -95,7 +95,9 @@ After send, check for a new ULID `.json` under `$TELL_OUTBOX_DIR` (and a
 sibling directory when using `--attach`):
 
 ```bash
-tell someone "ping"
+tell someone - <<'EOF'
+ping
+EOF
 ls -1 "$TELL_OUTBOX_DIR" | tail -3
 ```
 
@@ -129,21 +131,26 @@ One-shot check without follow: `tells` (waits ~5s for a burst, then exits).
 ## Send
 
 ```bash
-tell --attach /abs/path/detail.md <recipient> "Headline. Ask: <one line>."
+tell --attach /abs/path/detail.md <recipient> - <<'EOF'
+Headline. Ask: <one line>.
+EOF
 ```
 
+- **Body on stdin, delimiter quoted.** `<<'EOF'` (quotes on the delimiter) stops
+  every expansion, so `$`, backticks, and backslashes reach the recipient
+  byte-exact. A body written to a file works the same way:
+  `tell <recipient> - < /abs/path/body.md`.
+- A trailing `"quoted message"` argument suits a short plain body only. Inside
+  double quotes bash eats `$…` and runs backticks — `"$1.25 fix"` arrives as
+  `.25 fix`.
 - Short body: headlines + the ask. Detail in `--attach` / `--file` (repeatable).
-- If content is long enough to need a file, **attach it** — do not use stdin
-  `-` as a way to sneak a long body past the shell.
-- **Shell metacharacters:** bash expands `$…` and backticks inside double quotes
-  (an unescaped `$value` vanishes from the body). Prefer single quotes, escape,
-  or pipe a **short** body on stdin so the shell never sees the text:
-  `printf '%s\n' '…' | tell <recipient> -`
+- If content is long enough to need a file, **attach it** — stdin carries the
+  headline and the ask, not a smuggled essay.
 - Prefer absolute paths (or a short variable). Avoid `cd … && tell …` compounds
   when your host's command classifier is strict.
 - Delivery may take **minutes**. Arm the monitor and continue other work.
 
-Flag reference: [tell.md](tell.md).
+Flag reference: [`apps/a8s/skills/tell/SKILL.md`](../apps/a8s/skills/tell/SKILL.md).
 
 ## Opaque peers and trust
 
@@ -178,8 +185,10 @@ When sending substantial work to a peer:
 ```bash
 export TELL_OUTBOX_DIR=<root>/.outbox
 
-# Send — short body, detail attached; then verify landing
-tell --attach /abs/a.md <recipient> "headline + ask"
+# Send — body on stdin, detail attached; then verify landing
+tell --attach /abs/a.md <recipient> - <<'EOF'
+headline + ask
+EOF
 ls -1 "$TELL_OUTBOX_DIR" | tail -3
 
 # Follow (CLI) or watch <root>/.inbox/*.json (files only)


### PR DESCRIPTION
Closes #309.

The double-quoted argv form hands the body to the shell before `tell` sees it — `$1.25` arrives as `.25`, backticks execute, backslashes vanish. Every a8s-side send surface now leads with the body on stdin and a quoted delimiter, matching r4t's `PROMPT_DEFAULTS` at each surface's own altitude:

```
tell <name> - <<'EOF'
<body>
EOF
```

plus the file variant `tell <name> - < body.md`. The trailing-argv form stays as a mention for short plain bodies.

Surfaces swept:

| Surface | Change |
|---|---|
| `apps/a8s/definitions.py` (`build_batch_prompt`) | Batch prompt header teaches the heredoc; attachments shown as `--attach … <recipient> -` |
| `apps/a8s/skills/tell/SKILL.md` (symlinked as `docs/tell.md`) | Leads with the stdin form; argv form scoped to short plain bodies, with the `"$1.25"` → `.25` failure named |
| `playbooks/a8s-filedrop-agent.md` | Send section + quick reference + landing-check example on heredoc; the `printf … \| tell -` workaround is gone; broken `[tell.md](tell.md)` link now points at the skill |
| `apps/a8s/README.md` | Quickstart send example; command table shows `[<msg>\|-]` for both `a8s tell` and the shim |
| `apps/a8s/tell.py` | Usage line `[<message...>\|-]` and a help line naming the stdin form |
| `apps/a8s/docs/tell.md`, `docs/filedrop.md` | Operator note on why stdin is the taught form; agent-seat example converted |

`apps/h4l/` left alone (own tell shape, out of scope per the issue).

Tests: `apps/a8s/tests/` — 792 passed. Batch header rendering spot-checked via `build_batch_prompt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
