### PR TITLE
feat(a8s): a namespace node egresses as the bare prefix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,9 @@ apply on top.
 
 The router (`mailbox.py:_process_pending`) force-overwrites `from` based on
 which agent owns the enclosing root — the filesystem is the unforgeable
-identity.
+identity. A namespace bound to that agent changes only how the identity
+presents: mail leaving the namespace goes out as the bare prefix, mail inside
+it keeps `<prefix>:<sub-sender>`.
 
 a8s plants no skill files in an agent's repo: `tell` reads `TELL_OUTBOX_DIR`
 from the environment a8s injects on wake. Top-level doc skills for the user's

--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -170,11 +170,23 @@ tell acme:phil "lunch at noon?"      # delivered to acme-node with to = "acme:ph
 tell acme:team:ops "deploy done"     # same node; sub-address opaque to a8s
 ```
 
+A bound prefix is also the node's outward identity. Mail leaving the namespace
+presents `from` as the bare prefix — `acme`, not the `acme-node` registration
+name and not the `acme:phil` sub-sender that wrote it — so a namespace is one
+opaque address on the network whether it fronts one agent, a human, or a whole
+roster, and a reply to that name routes back in through the binding. Mail
+addressed *inside* the prefix keeps sub-sender attribution: an envelope to
+`acme:jane` claiming `from: acme:phil` keeps that `from`, since only the bound
+node writes that outbox and a claim under its own prefix carries its own
+authority. Ownership is still settled by the filesystem, not the JSON: a claim
+the sender's own namespaces don't back is discarded. A node with several
+prefixes bound has no unambiguous outward name, so its agent name stands for
+anything but a claim under one of them.
+
 Prefixes share the agent/alias name grammar (lowercase canonical form,
 case-insensitive match). A prefix may match the name of the agent it binds to
 — a node owning its own namespace, so `s1l` registers as agent `s1l` and binds
-prefix `s1l` to itself, and cross-wall traffic is attributed to `s1l` rather
-than a `s1l-node` stand-in. A prefix still can't collide with an alias or with
+prefix `s1l` to itself. A prefix still can't collide with an alias or with
 a *different* agent's name (a bare `tell <prefix>` resolves to the namespace,
 which would otherwise silently shadow that agent). An unknown prefix behaves
 like any unknown recipient: published to configured remotes (another cluster
@@ -425,7 +437,7 @@ The state root resolves as follows when `A8S_HOME` is unset: use `~/.config/a8s`
 
 The outbox lives in the agent's own dir because some sandboxes (codex `--full-auto`) only let the agent write inside its workspace. Inbox/trash/pending live under `~/.a8s/` where the agent can't see them — and per the agent-directory invariant, a8s never sidecars or rewrites in `.outbox/`. New outbox files are atomically renamed to `pending/` on every routing pass; everything from there (sidecars, retries, trash, remote publishes) happens in `~/.a8s/`.
 
-`from` is force-overwritten at routing time. An agent that hand-writes a JSON with `from: "VICTIM"` doesn't get to spoof — the file's outbox location is the unforgeable identity.
+`from` is force-overwritten at routing time. An agent that hand-writes a JSON with `from: "VICTIM"` doesn't get to spoof — the file's outbox location is the unforgeable identity. A namespace bound to that agent changes what the identity *presents as*, never whose it is: see [Namespaces](#namespaces).
 
 ## Connectors
 

--- a/apps/a8s/docs/tell.md
+++ b/apps/a8s/docs/tell.md
@@ -46,7 +46,7 @@ On disk alongside the JSON:
     avatar.jpg
 ```
 
-`from` is omitted when registry is unreachable; the router **force-overwrites** `from` based on which agent owns the outbox directory.
+`from` is omitted when registry is unreachable; the router **force-overwrites** `from` based on which agent owns the outbox directory. When a namespace is bound to that agent, mail leaving the namespace presents as the bare prefix (`acme`) and mail inside it keeps `acme:<sub-sender>`.
 
 4. **Ingest** — move `<msg_id>.json` and `<outbox>/<msg_id>/` together into `~/.a8s/agents/<SENDER>/pending/`.
 5. **Route** — copy pending bundle bytes into each recipient's `<files_dir>/<msg_id>/` (default `.files`). Inbox JSON keeps filename-only `files`. Wake `$MESSAGE` appends absolute `ATTACHED FILE:` lines.

--- a/apps/a8s/mailbox.py
+++ b/apps/a8s/mailbox.py
@@ -490,6 +490,38 @@ def _download_files_to_recipient(
     return out_msg
 
 
+def _stamp_from(
+    sender_name: str,
+    claimed: str,
+    recipient: str,
+    owned_prefixes: dict[str, str],
+) -> str:
+    """The `from` a routed message carries, keyed by the namespace prefixes bound
+    to the sender (lowercase key -> registry spelling).
+
+    The outbox is agent-writable, so its JSON can lie about `from`. Ownership is
+    settled by the filesystem — a claim the sender's own namespaces don't back is
+    discarded — and a namespace decides only how that owner *presents*: the
+    prefix is one address on the network and the agent behind it is registration
+    plumbing (`acme-node`), so a node with one bound prefix speaks as the prefix.
+    Whatever it fronts (one agent, a human, a whole roster) is one opaque name
+    outside, and a reply to that name routes back in through the binding.
+
+    Inside the prefix, a sub-sender claim stands (`acme:phil` to `acme:jane`):
+    only the bound node writes this outbox, so a claim under its own prefix
+    carries the node's own authority. Several bound prefixes leave the outward
+    name ambiguous for anything but a claim under one of them, so the agent name
+    stands."""
+    prefix = owned_prefixes.get(claimed.partition(":")[0].strip().lower())
+    if prefix is None:
+        if len(owned_prefixes) != 1:
+            return sender_name
+        return next(iter(owned_prefixes.values()))
+    if recipient.partition(":")[0].strip().lower() == prefix.lower():
+        return claimed if ":" in claimed else prefix
+    return prefix
+
+
 def _process_pending(
     sender: Participant,
     by_name: dict[str, Participant],
@@ -508,7 +540,7 @@ def _process_pending(
     if not pending.is_dir():
         return 0
     owned_prefixes = {
-        p.lower() for p, a in load_namespaces().items()
+        p.lower(): p for p, a in load_namespaces().items()
         if a.lower() == sender.name.lower()
     }
     now = datetime.now(timezone.utc)
@@ -534,16 +566,11 @@ def _process_pending(
             _trash_pending(sender, f)
             _drop_sidecar(f)
             continue
-        # Defense: the outbox was agent-writable, so the JSON could lie about
-        # `from`. The unforgeable identity is the enclosing sender — overwrite,
-        # except a sub-sender claim inside a namespace bound to this sender
-        # (`s1l:gerry` from the node bound to `s1l`): only that node writes
-        # this outbox, so the claim carries the node's own authority.
-        claimed = str(msg.get("from") or "").strip()
-        msg["from"] = sender.name
-        if ":" in claimed and claimed.partition(":")[0].strip().lower() in owned_prefixes:
-            msg["from"] = claimed
         recipient_name = (msg.get("to") or "").strip()
+        msg["from"] = _stamp_from(
+            sender.name, str(msg.get("from") or "").strip(),
+            recipient_name, owned_prefixes,
+        )
         preview = _preview(msg.get("content", ""))
         msg_files = [e.get("filename", "") for e in (msg.get("files") or []) if e.get("filename")]
         if not recipient_name:

--- a/apps/a8s/network.py
+++ b/apps/a8s/network.py
@@ -572,6 +572,21 @@ def receive_envelope(
         _publish_delivery_receipt(msg, delivered_names, publish_control, remote_id)
 
 
+def _receipt_sender(sender: str, all_agents: list[Participant]) -> Participant | None:
+    """The local agent a receipt belongs to. A node that owns a namespace sends
+    under the bare prefix, so the name on the wire is an address, not an agent —
+    resolve it through the binding before giving up on the confirmation."""
+    by_name = {agent.name.lower(): agent for agent in all_agents}
+    local = by_name.get(sender.lower())
+    if local is not None:
+        return local
+    try:
+        kind, bound = resolve_name(sender)
+    except (KeyError, ValueError):
+        return None
+    return by_name.get(bound[0].lower()) if kind == "namespace" else None
+
+
 def _receive_control_envelope(
     message: dict,
     all_agents: list[Participant],
@@ -586,10 +601,7 @@ def _receive_control_envelope(
             remote_id,
         )
         return
-    local_sender = next(
-        (agent for agent in all_agents if agent.name.lower() == receipt.sender.lower()),
-        None,
-    )
+    local_sender = _receipt_sender(receipt.sender, all_agents)
     if local_sender is None:
         return
     recipients = ",".join(receipt.recipients)

--- a/apps/a8s/tests/test_mailbox.py
+++ b/apps/a8s/tests/test_mailbox.py
@@ -312,21 +312,6 @@ class TestRouteOutboxes:
         # Routing forces from = sender's actual name, regardless of the JSON.
         assert delivered["from"] == "A"
 
-    def test_from_within_owned_namespace_is_preserved(self, two_agents):
-        a, b = two_agents
-        save_namespaces({"crew": "A"})
-        outbox = outbox_dir(a.root)
-        f = outbox / "20260101T000000_A.json"
-        f.write_text(json.dumps({
-            "from": "crew:gerry",  # sub-sender inside A's own namespace
-            "to": "B",
-            "content": "report",
-            "files": [],
-        }))
-        route_outboxes([a, b], all_agents=[a, b])
-        delivered = json.loads(next(inbox_dir("B").iterdir()).read_text())
-        assert delivered["from"] == "crew:gerry"
-
     def test_from_in_foreign_namespace_is_overwritten(self, two_agents):
         a, b = two_agents
         save_namespaces({"crew": "B"})  # bound to someone else
@@ -471,6 +456,107 @@ class TestNamespaceRouting:
         log = agent_log_path("A").read_text()
         assert "acme:phil" in log
         assert "namespace via NODE" in log
+
+
+class TestNamespaceEgressIdentity:
+    """Issue #315 — a bound prefix is the node's name on the network. Mail
+    leaving the namespace presents `from` as the bare prefix, so whatever the
+    prefix fronts is one opaque address outside it; mail addressed inside the
+    prefix keeps sub-sender attribution. Presentation is all a namespace
+    changes — the enclosing outbox still settles whose message it is."""
+
+    @pytest.fixture
+    def node_and_outsider(self, fake_home, tmp_path):
+        node_root = tmp_path / "node"; node_root.mkdir()
+        outsider_root = tmp_path / "outsider"; outsider_root.mkdir()
+        save_registry({
+            "acme-node": {"root": str(node_root)},
+            "B": {"root": str(outsider_root)},
+        })
+        save_namespaces({"acme": "acme-node"})
+        node = Participant("acme-node", node_root)
+        outsider = Participant("B", outsider_root)
+        ensure_mailboxes(node)
+        ensure_mailboxes(outsider)
+        return node, outsider
+
+    def _stage(self, node: Participant, claimed: str, to: str) -> None:
+        f = outbox_dir(node.root) / "20260101T000000_NODE.json"
+        f.write_text(json.dumps({
+            "from": claimed, "to": to, "content": "status green", "files": [],
+        }))
+
+    def _delivered_from(self, node, outsider) -> str:
+        route_outboxes([node, outsider], all_agents=[node, outsider])
+        return json.loads(next(inbox_dir("B").iterdir()).read_text())["from"]
+
+    def test_member_egress_presents_the_bare_namespace(self, node_and_outsider):
+        node, outsider = node_and_outsider
+        self._stage(node, "acme:lead", "B")
+        assert self._delivered_from(node, outsider) == "acme"
+
+    def test_node_name_egresses_as_its_sole_namespace(self, node_and_outsider):
+        # A plain `tell` from the node root: `acme-node` is the registration
+        # name a prefix can't share, not the node's identity on the network.
+        node, outsider = node_and_outsider
+        self._stage(node, "acme-node", "B")
+        assert self._delivered_from(node, outsider) == "acme"
+
+    def test_presented_prefix_uses_the_registry_spelling(self, node_and_outsider):
+        node, outsider = node_and_outsider
+        save_namespaces({"Acme": "acme-node"})
+        self._stage(node, "ACME:lead", "B")
+        assert self._delivered_from(node, outsider) == "Acme"
+
+    def test_spoofed_claim_is_discarded_not_carried_out(self, node_and_outsider):
+        # The claim buys nothing — the node presents as its own namespace, and
+        # `VICTIM` is gone.
+        node, outsider = node_and_outsider
+        self._stage(node, "VICTIM", "B")
+        assert self._delivered_from(node, outsider) == "acme"
+
+    def test_several_prefixes_leave_the_agent_name_standing(self, node_and_outsider):
+        node, outsider = node_and_outsider
+        save_namespaces({"acme": "acme-node", "ops": "acme-node"})
+        self._stage(node, "acme-node", "B")
+        assert self._delivered_from(node, outsider) == "acme-node"
+
+    def test_several_prefixes_still_honor_a_claim_under_one(self, node_and_outsider):
+        node, outsider = node_and_outsider
+        save_namespaces({"acme": "acme-node", "ops": "acme-node"})
+        self._stage(node, "ops:lead", "B")
+        assert self._delivered_from(node, outsider) == "ops"
+
+    def test_traffic_inside_the_prefix_keeps_the_sub_sender(self, node_and_outsider):
+        # The recipient is the node itself, so there is no local delivery to
+        # read — the remote publish carries the envelope that would go out.
+        node, outsider = node_and_outsider
+        published: list[dict] = []
+
+        def publish(msg, sender_name, succeeded_so_far, attempt_count):
+            published.append(msg)
+            return ["hub"]
+
+        self._stage(node, "acme:phil", "acme:jane")
+        route_outboxes(
+            [node, outsider], all_agents=[node, outsider],
+            publish_remotes=publish, configured_remote_ids=["hub"],
+        )
+        assert [m["from"] for m in published] == ["acme:phil"]
+
+    def test_reply_to_the_bare_namespace_routes_in_through_the_binding(
+        self, node_and_outsider
+    ):
+        # The round trip the presentation depends on: the outsider answers the
+        # name it saw, and the message enters at the bound node with `to` intact
+        # for the node to self-route.
+        node, outsider = node_and_outsider
+        _write_outbox("B", outsider.root, "acme", "thanks", [])
+        n = route_outboxes([node, outsider], all_agents=[node, outsider])
+        assert n == 1
+        delivered = json.loads(next(inbox_dir("acme-node").iterdir()).read_text())
+        assert delivered["to"] == "acme"
+        assert delivered["from"] == "B"
 
 
 class TestAtomicFanout:

--- a/apps/a8s/tests/test_network.py
+++ b/apps/a8s/tests/test_network.py
@@ -379,6 +379,20 @@ class TestReceiveEnvelope:
         assert republished == []
         assert all(not inbox_dir(name).exists() for name in ("A", "B"))
 
+    def test_receipt_for_a_bare_namespace_lands_on_the_bound_node(
+        self, two_local_agents, monkeypatch,
+    ):
+        # A node that owns a namespace sends under the bare prefix (#315), so
+        # the name on a returning receipt is an address — resolve it through the
+        # binding or the confirmation never reaches the node that sent.
+        events = []
+        monkeypatch.setattr(network.txlog, "log", lambda event, **fields: events.append((event, fields)))
+        save_namespaces({"crew": "A"})
+        envelope = build_delivery_receipt({"id": new_ulid(), "from": "crew"}, ["B"])
+        receive_envelope(json.dumps(envelope).encode(), two_local_agents)
+        receipts = [fields for event, fields in events if event == "DELIVERY_RECEIPT"]
+        assert [r["sender"] for r in receipts] == ["A"]
+
     def test_receipt_for_nonlocal_sender_is_ignored_without_loop(self, two_local_agents):
         envelope = build_delivery_receipt(
             {"id": new_ulid(), "from": "REMOTE_SENDER"},

--- a/apps/r4t/docs/message-flow.md
+++ b/apps/r4t/docs/message-flow.md
@@ -83,3 +83,12 @@ to know whether a name is one agent, a human, a device, or a whole roster.
 Symmetrically, external ingress is untrusted: a sub-address can't pick a member
 and nothing is parsed out of the body — everything from outside enters at the
 top lead on a fresh thread. One ingress point means one thing to reason about.
+
+The sender the outside sees is the bare namespace. Dispatch releases with
+`from: <node>:<member>`, and the a8s router — which owns `from`, because the
+outbox is agent-writable — presents that as the bound prefix on the way out:
+mail from the org arrives as `acme`, never `acme:lead` or `acme-node`. So the
+org speaks with one mouth (only the topmost leader originates external mail)
+under one name, and a reply to `acme` re-enters at the top lead. Inside the
+walls attribution stays member-level; the collapse is presentation at the wall,
+not a loss of who said what.

--- a/apps/r4t/docs/org.md
+++ b/apps/r4t/docs/org.md
@@ -116,7 +116,7 @@ config without a `repo` key is an in-repo org that just wants settings.
 |---|---|---|
 | `comms` | `open` | `open` delivers a tell to any valid member (learned addresses); `closed` reroutes non-adjacent tells through the sender's lead |
 | `leader_sees_lateral` | `false` | when `true`, a lateral (peer) delivery lands a read-only copy in the lead's history — no turn burned |
-| `egress` | `true` | only the topmost leader may message outside the garden; a non-top member's external tell redirects up to it. `false` keeps the org silent outward |
+| `egress` | `true` | only the topmost leader may message outside the garden; a non-top member's external tell redirects up to it. `false` keeps the org silent outward. What leaves is stamped with the bare namespace prefix, so the org is one name outside its walls (see [message-flow.md](message-flow.md)) |
 | `doorbell_check` | *absent* | a shell command that gates every ring of an absent human's doorbell (see [verification.md](verification.md)); absent or empty means no gate |
 | `run_as` | *absent* | OS-level isolation: wrap every member turn in `sudo -u <username>`. One user serves the whole roster (see [isolation.md](isolation.md)) |
 | `container` | *absent* | OS-level isolation: run every member turn under `docker run --rm <image>`; mutually exclusive with `run_as` (see [isolation.md](isolation.md)) |

--- a/apps/r4t/sandbox.py
+++ b/apps/r4t/sandbox.py
@@ -172,7 +172,10 @@ def _agent_messages(a8s_home: Path, agent: str) -> list[dict]:
 def _final_answer(a8s_home: Path) -> dict | None:
     for msg in _agent_messages(a8s_home, "human"):
         sender = str(msg.get("from", ""))
-        if sender != NODE and not sender.startswith(f"{TEAM}:"):
+        # The human seat is outside the walls, so the router presents the org's
+        # answer as the bare prefix; NODE and `TEAM:member` are the shapes a
+        # message takes before it crosses.
+        if sender not in (TEAM, NODE) and not sender.startswith(f"{TEAM}:"):
             continue
         if str(msg.get("content", "")).strip():
             return msg


### PR DESCRIPTION
Closes #315.

An org already speaks through one mouth (#183); now it speaks under one name.
External recipients saw `acme:lead` — which leaks the roster's shape and the
member behind the message. A namespace is one address on the network, so mail
leaving it now presents `from` as the bare prefix.

### Where it lands

The router owns `from` (the outbox is agent-writable, so the enclosing agent
root is the unforgeable identity), and the node cannot simply be *named* `acme`
because a prefix can't shadow a different agent — hence `<team>-node`. So the
stamp itself is where the change belongs: `mailbox._stamp_from` now decides how
a settled identity **presents**, never whose it is.

| envelope `from` | `to` | delivered `from` |
|---|---|---|
| `acme:lead` | `bob` (outside) | `acme` |
| `acme:phil` | `acme:jane` (inside) | `acme:phil` |
| `acme-node` | `bob` | `acme` (sole bound prefix; `-node` is plumbing) |
| `acme-node` | `bob`, two prefixes bound | `acme-node` (ambiguous outward name) |
| `VICTIM` | `bob` | the sender's own name or prefix — the claim is discarded |

Inside the walls nothing changes: r4t releases intra-team traffic to member
queues and never to the outbox, and member-level attribution is intact in
history, logs, and threads.

### Round trip

Bare-prefix ingress already resolves through the binding, and r4t enters every
external message at the top leader on a fresh thread — so a reply to the name
the outsider saw lands exactly where a reply to `acme:lead` used to. Covered by
a test rather than assumed.

Two call sites had to follow the presented name:

- **Cross-cluster delivery receipts** — a returning receipt was matched to a
  local agent by exact name, so `acme` would have found nobody and the node
  would silently lose its confirmation line. It now resolves a bare prefix
  through the binding.
- **`r4t sandbox`** — the answer detector accepted `crew-node` / `crew:member`;
  the human seat is outside the walls, so the org's answer now arrives as
  `crew`.

### No knob

The issue left the default open. Showing the roster's inside to the outside is
the leak the namespace exists to prevent, and the `-node` suffix is
registration plumbing rather than identity — so this is unconditional. The
moment a namespace node genuinely needs externally addressable sub-senders
(a connector fronting several channels, say) is the moment to add the setting;
none exists today.

### Tests

- `apps/a8s/tests/test_mailbox.py::TestNamespaceEgressIdentity` — 8 tests:
  member egress, node-name egress, registry spelling of the presented prefix,
  discarded spoof, both multi-prefix cases, intra-prefix fidelity (observed on
  the remote publish, since the recipient is the node itself), and the
  bare-namespace reply routing back in through the binding.
- `apps/a8s/tests/test_network.py` — receipt for a bare namespace lands on the
  bound node.
- The old `test_from_within_owned_namespace_is_preserved` asserted the leak;
  it is replaced by the egress cases.

`apps/a8s/tests/` 800 passed · `apps/r4t/tests/` 735 passed (run separately —
`apps/r4t/ulid.py` shadows a8s's `ulid` in a shared pytest session).

Refs #183, #175/#176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
