### PR TITLE
fix(r4t): carry the mcp knob's env and file idioms across the isolation boundary

### DIFF
--- a/apps/r4t/dispatch.py
+++ b/apps/r4t/dispatch.py
@@ -51,7 +51,15 @@ from pathlib import Path
 import isolate
 import state
 import tasks
-from rig import RigConfig, RigError, Rig, apply_mcp, load_rig_config, resolve_agy_model
+from rig import (
+    McpPlan,
+    RigConfig,
+    RigError,
+    Rig,
+    apply_mcp,
+    load_rig_config,
+    resolve_agy_model,
+)
 from notify import TellFn
 from roster import Member, Roster, RosterError, load_roster
 
@@ -626,21 +634,35 @@ def run_harness(
             return 127, f"agy --model {rig.model!r} did not resolve: {e}", 0.0, False
         argv = [resolved if a == "{model}" else a for a in argv]
 
-    # The `mcp` knob: splice the a8s MCP server in with this harness's own
-    # idiom, before any isolation wrapper takes the argv over.
-    if rig.mcp and env is not None:
-        argv = apply_mcp(rig, argv, env, cwd)
-
     staging = (env or {}).get("TELL_OUTBOX_DIR", "")
     isolation = isolate.isolation_from_env(env)
+
+    # The `mcp` knob: splice the a8s MCP server in with this harness's own
+    # idiom, before any isolation wrapper takes the argv over. The idioms ride
+    # different channels — argv survives a boundary, environment and files only
+    # cross when the wrapper is told to carry them — so the injection states its
+    # needs and the wrapper below honours them.
+    mcp = McpPlan(argv=argv)
+    if rig.mcp and env is not None:
+        mcp = apply_mcp(rig, argv, env, cwd, isolation)
+        argv = mcp.argv
+
     kill_container_name: str | None = None
     if isolation.run_as:
         probe_error = isolate.probe_run_as(isolation.run_as, cwd)
         if probe_error:
             return 126, f"run_as {isolation.run_as!r} isolation failed: {probe_error}", 0.0, False
+        # A prompt that teaches `a8s_tell` against a server the boundary's user
+        # cannot start leaves the member with no way to send at all, so an
+        # unreadable server fails the turn rather than degrading it.
+        mcp_error = isolate.probe_readable_as(isolation.run_as, mcp.read_paths)
+        if mcp_error:
+            return 126, f"rig {rig.name!r} has mcp on but {mcp_error}", 0.0, False
         if staging:
             isolate.assert_writable_shared_dir(staging, isolate.agent_gid(isolation.run_as))
-        argv = isolate.wrap_run_as(argv, isolation.run_as, staging, cwd)
+        argv = isolate.wrap_run_as(
+            argv, isolation.run_as, staging, cwd, env_pass=mcp.env_pass
+        )
     elif isolation.container:
         kill_container_name = isolate.container_name(
             (env or {}).get("R4T_NODE", ""), (env or {}).get("R4T_MEMBER", "")
@@ -653,6 +675,8 @@ def run_harness(
             workplace=cwd,
             tell_outbox=staging,
             container_args=isolation.container_args,
+            extra_env=mcp.env_pass,
+            extra_ro_dirs=mcp.mount_dirs,
         )
 
     live_log = (env or {}).get("R4T_LIVE_LOG")

--- a/apps/r4t/docs/isolation.md
+++ b/apps/r4t/docs/isolation.md
@@ -112,15 +112,18 @@ read, alter, or erase the audit trail.
 
 ```
 sudo -u <user> bash --login -c \
-  'export TELL_OUTBOX_DIR="$1"; cd "$2"; shift 2; exec "$@"' \
-  _ <staging-dir> <workplace> <argv...>
+  'export TELL_OUTBOX_DIR="$1"; cd "$2"; n="$3"; shift 3;
+   while [ "$n" -gt 0 ]; do export "$1"; shift; n=$((n - 1)); done; exec "$@"' \
+  _ <staging-dir> <workplace> <count> <NAME=value...> <argv...>
 ```
 
 `bash --login` so the agent user's own profile resolves its per-user tool
 installs. The environment cannot survive sudoers `env_reset`, so
-`TELL_OUTBOX_DIR` and the workplace ride as positional arguments; `exec "$@"`
-hands the harness argv through untouched, so quoting bugs are impossible. The
-rig's wall-clock timeout wraps the whole `sudo`.
+`TELL_OUTBOX_DIR`, the workplace, and any further variables the turn needs ride
+as positional arguments — `<count>` says how many `NAME=value` words follow, and
+each is one word, so a value with spaces cannot re-split. `exec "$@"` hands the
+harness argv through untouched, so quoting bugs are impossible. The rig's
+wall-clock timeout wraps the whole `sudo`.
 
 ## `container` — prerequisites and contract
 
@@ -165,6 +168,34 @@ Interactive and browser-based auth flows are an explicit non-goal: a harness
 that cannot authenticate headlessly from mounted files does not belong in a
 container rig. On rig-timeout expiry r4t kills the container by its
 deterministic name and lets `--rm` reap it.
+
+## The `a8s_tell` tool behind the boundary
+
+`r4t rig set <rig> mcp on` ([rigs](rigs.md#the-a8s_tell-tool-mcp)) injects the
+a8s MCP server into every turn, and each harness takes it a different way:
+claude, codex and copilot read a flag, so it rides argv through both wrappers
+untouched; opencode reads a file named by `OPENCODE_CONFIG`; cursor reads
+`.cursor/mcp.json` in the workdir. A boundary keeps only what it is told to keep,
+so r4t carries each idiom across:
+
+- **`run_as`** re-exports `OPENCODE_CONFIG` through the wrapper's counted
+  positionals and writes the config into `agents/<member>/mcp/`, beside the
+  staging outbox and readable by the agent user. cursor's file lands in the
+  workplace, which the agent user already has.
+- **`container`** mounts that one config dir read-only, passes the matching
+  `-e`, and names the image's own `python3` for the server — the router's
+  interpreter path is not in the image, while the a8s client dir is mounted at
+  its real path. So the image contract gains one line when the knob is on:
+  `python3` on PATH, which the `tell` shim already wants.
+- **Before a `run_as` turn** r4t probes that the agent user can read the server
+  script, its interpreter, and the config. If it cannot, the turn fails closed
+  with the fix (`chmod -R a+rX` on the checkout, or the knob off). A member whose
+  prompt teaches `a8s_tell` against a server that never starts has no way to send
+  at all, so that outcome is worth refusing rather than degrading into.
+
+Behind either boundary the server is told the outbox and nothing else: the
+router's `HOME` and `A8S_HOME` are another user's home, or absent from the image,
+and `tell` writes the envelope from `TELL_OUTBOX_DIR` alone.
 
 ## What this boundary does not do
 

--- a/apps/r4t/docs/rigs.md
+++ b/apps/r4t/docs/rigs.md
@@ -197,7 +197,9 @@ what the tool buys over the heredoc teaching. Default is off, and off is the
 shell teaching unchanged. Two presets refuse the knob and say so: `agy` reads
 MCP config only from `~/.gemini`, and bare `ollama` has no tool use at all, so
 `rig set` errors with a `(try: r4t rig swap <rig> ...)` hint rather than
-running turns whose tool never appears.
+running turns whose tool never appears. Under an org boundary (`run_as` /
+`container`) r4t carries each harness's idiom across and fails the turn closed
+when it cannot — see [isolation](isolation.md#the-a8s_tell-tool-behind-the-boundary).
 
 ## The economics: budgets, not cuts
 

--- a/apps/r4t/isolate.py
+++ b/apps/r4t/isolate.py
@@ -37,10 +37,15 @@ ENV_CONTAINER = "R4T_CONTAINER"
 ENV_CONTAINER_ARGS = "R4T_CONTAINER_ARGS"
 
 # The bash the wrapped `sudo` runs: env cannot survive sudoers env_reset, so
-# TELL_OUTBOX_DIR rides as $1 and the workplace as $2; `exec "$@"` hands the
+# TELL_OUTBOX_DIR rides as $1 and the workplace as $2; $3 counts the further
+# `NAME=value` positionals to re-export (the `mcp` knob's env idioms), each one
+# a single word so a value with spaces cannot re-split; `exec "$@"` hands the
 # remaining positionals to the harness verbatim — no quoted command string, so
 # quoting bugs are structurally impossible.
-_RUN_AS_BOOTSTRAP = 'export TELL_OUTBOX_DIR="$1"; cd "$2"; shift 2; exec "$@"'
+_RUN_AS_BOOTSTRAP = (
+    'export TELL_OUTBOX_DIR="$1"; cd "$2"; n="$3"; shift 3; '
+    'while [ "$n" -gt 0 ]; do export "$1"; shift; n=$((n - 1)); done; exec "$@"'
+)
 
 # A standard system PATH the container shim prepends the a8s client dir to, so
 # an unmodified `tell` resolves inside the image. Operators can override with a
@@ -113,11 +118,21 @@ def a8s_client_dir() -> Path:
 # ---------- run_as ----------
 
 def wrap_run_as(
-    argv: list[str], user: str, staging_dir: str | Path, workplace: str | Path
+    argv: list[str],
+    user: str,
+    staging_dir: str | Path,
+    workplace: str | Path,
+    *,
+    env_pass: dict[str, str] | None = None,
 ) -> list[str]:
+    """Wrap one harness argv in `sudo -u <user>`. `env_pass` names the extra
+    environment the harness itself needs across the boundary — anything not
+    listed is gone, because sudoers `env_reset` keeps nothing."""
+    pairs = [f"{k}={v}" for k, v in (env_pass or {}).items()]
     return [
         "sudo", "-u", user, "bash", "--login", "-c",
-        _RUN_AS_BOOTSTRAP, "_", str(staging_dir), str(workplace), *argv,
+        _RUN_AS_BOOTSTRAP, "_", str(staging_dir), str(workplace),
+        str(len(pairs)), *pairs, *argv,
     ]
 
 
@@ -163,6 +178,33 @@ def probe_run_as(user: str, workplace: str | Path) -> str | None:
             + (f": {detail}" if detail else "")
             + " (try: give the agent user's group g+ws on the workplace — see "
             "apps/r4t/docs/isolation.md)"
+        )
+    return None
+
+
+def probe_readable_as(user: str, paths: list[str | Path]) -> str | None:
+    """Verify the agent user can read every path a per-turn injection depends on
+    (the `mcp` knob's server script, its interpreter, its config file). Returns
+    None when all pass, else an action-first error naming the first path that
+    does not. A tool the prompt teaches but the boundary cannot start is worse
+    than no tool at all, so this fails the turn instead of degrading it."""
+    if not paths:
+        return None
+    args = [str(p) for p in paths]
+    try:
+        probe = _run_probe([
+            "sudo", "-n", "-u", user, "bash", "--login", "-c",
+            'for p; do [ -r "$p" ] || { echo "$p"; exit 1; }; done', "_", *args,
+        ])
+    except (OSError, subprocess.TimeoutExpired) as e:
+        return f"cannot probe read access as {user!r}: {e}"
+    if probe.returncode != 0:
+        blocked = (probe.stdout or "").strip().splitlines()
+        first = blocked[-1] if blocked else args[0]
+        return (
+            f"user {user!r} cannot read {first} "
+            f"(try: chmod -R a+rX on the r4t checkout and its python, or turn "
+            f"the rig's mcp knob off — see apps/r4t/docs/isolation.md)"
         )
     return None
 
@@ -225,13 +267,17 @@ def build_container_argv(
     container_args: list[str] | None = None,
     delivered_dir: str | Path | None = None,
     client_dir: str | Path | None = None,
+    extra_env: dict[str, str] | None = None,
+    extra_ro_dirs: list[str | Path] | None = None,
 ) -> list[str]:
     """`docker run --rm` with the workplace bind-mounted rw at the same path and
     used as workdir, the staging dir rw at the same path with TELL_OUTBOX_DIR
     injected (no env_reset inside a container), the a8s client ro with a PATH
-    shim, an optional delivered-files dir ro, then the org's container_args
-    verbatim, then the image and the harness argv. r4t never builds, pulls, or
-    inspects the image — a missing image is an ordinary turn failure."""
+    shim, an optional delivered-files dir ro, `extra_env`/`extra_ro_dirs` for
+    what a per-turn injection needs to see inside (the `mcp` knob), then the
+    org's container_args verbatim, then the image and the harness argv. r4t
+    never builds, pulls, or inspects the image — a missing image is an ordinary
+    turn failure."""
     client = Path(client_dir) if client_dir is not None else a8s_client_dir()
     cmd = [
         "docker", "run", "--rm", "--name", name,
@@ -244,6 +290,12 @@ def build_container_argv(
     ]
     if delivered_dir is not None:
         cmd += ["-v", f"{delivered_dir}:{delivered_dir}:ro"]
+    for d in extra_ro_dirs or []:
+        cmd += ["-v", f"{d}:{d}:ro"]
+    for key, value in (extra_env or {}).items():
+        cmd += ["-e", f"{key}={value}"]
+    # Last flag wins in docker, so the org's own args can still override any of
+    # the above (the option-passthrough principle).
     cmd += list(container_args or [])
     cmd += [image, *argv]
     return cmd

--- a/apps/r4t/plans/ISOLATE-SPEC.md
+++ b/apps/r4t/plans/ISOLATE-SPEC.md
@@ -80,8 +80,9 @@ When `run_as` is set, the rig's resolved argv is wrapped:
 
 ```
 sudo -u <user> bash --login -c \
-  'export TELL_OUTBOX_DIR="$1"; cd "$2"; shift 2; exec "$@"' \
-  _ <staging-dir> <workplace> <argv...>
+  'export TELL_OUTBOX_DIR="$1"; cd "$2"; n="$3"; shift 3;
+   while [ "$n" -gt 0 ]; do export "$1"; shift; n=$((n - 1)); done; exec "$@"' \
+  _ <staging-dir> <workplace> <count> <NAME=value...> <argv...>
 ```
 
 - `bash --login` so the agent user's own profile/PATH resolves its own
@@ -91,6 +92,9 @@ sudo -u <user> bash --login -c \
   exported vars from dispatch never survive the boundary. DECIDED: the
   `exec "$@"` form, not a quoted command string — argv passes through
   untouched and quoting bugs are structurally impossible.
+- A per-turn injection that rides the environment (the `mcp` knob's
+  `OPENCODE_CONFIG`) states what it needs; `<count>` `NAME=value` words
+  follow the workplace and the bootstrap re-exports each one.
 - cwd is the org workplace (r4t members work in the shared repo; this
   deliberately differs from the production precedent, whose agent works
   in its own home).

--- a/apps/r4t/rig.py
+++ b/apps/r4t/rig.py
@@ -34,7 +34,9 @@ plan always declares a refill rate.
 rig, using the harness's own per-invocation idiom, and teach the member the
 `a8s_tell` tool instead of the shell command. Default off: the shell teaching
 stays. Presets whose CLI takes MCP config only globally (agy) or has no tools
-at all (bare ollama) refuse the knob.
+at all (bare ollama) refuse the knob. Each idiom rides a different channel, so
+`apply_mcp` states what an org's isolation boundary has to carry across
+(`McpPlan`) and the wrapper in isolate.py honours it.
 
 `echo` — the rig's members never see `tell` or any messaging instructions:
 they are simply prompted with the message content and their cleaned stdout is
@@ -63,11 +65,13 @@ from __future__ import annotations
 
 import json
 import re
+import stat
 import subprocess
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from isolate import Isolation
 from roster import Member, Roster
 from state import atomic_write_json, r4t_home
 
@@ -560,6 +564,12 @@ def continue_presets() -> list[str]:
 # TELL_OUTBOX_DIR, so one blob serves every member on every node. Where the
 # idiom accepts `env`/`cwd` they are pinned anyway, so the outbox is stated
 # rather than inferred (#289).
+#
+# Each idiom rides a different channel, and an OS boundary (isolate.py) keeps
+# only what it is told to keep: argv passes through untouched, environment and
+# files do not. So the injection is boundary-aware — it states what has to cross
+# in an McpPlan the wrapper consumes, and names the image's own interpreter when
+# the turn runs in a container, where the router's is not on the filesystem.
 
 A8S_PY = Path(__file__).resolve().parent.parent / "a8s" / "a8s.py"
 
@@ -567,6 +577,25 @@ MCP_SERVER_NAME = "a8s"
 # What claude's permission layer calls the tool the model sees as `a8s_tell`.
 MCP_CLAUDE_TOOL = "mcp__a8s__tell"
 OPENCODE_CONFIG_BASENAME = "mcp-opencode.json"
+# Per-member dir the file idioms write into: a sibling of the turn's staging
+# outbox rather than the member state dir itself, so a container can mount it
+# read-only without exposing history or turn transcripts, and so a `.json`
+# config is never mistaken for a staged envelope.
+MCP_CONFIG_DIRNAME = "mcp"
+
+
+@dataclass
+class McpPlan:
+    """One turn's injection, plus what it needs from the isolation boundary:
+    `env_pass` are the variables the harness must still have on the far side of
+    an `env_reset`/container, `mount_dirs` what a container has to see, and
+    `read_paths` what the boundary's user must be able to read for the server to
+    start at all."""
+
+    argv: list[str]
+    env_pass: dict[str, str] = field(default_factory=dict)
+    mount_dirs: list[Path] = field(default_factory=list)
+    read_paths: list[Path] = field(default_factory=list)
 
 
 def mcp_presets() -> list[str]:
@@ -584,41 +613,61 @@ def mcp_unsupported_reason(preset: str | None) -> str:
     return "the rig records no preset, so there is no idiom to inject with"
 
 
-def _mcp_command() -> list[str]:
-    return [sys.executable, str(A8S_PY), "mcp", "serve"]
+def _mcp_command(*, in_container: bool = False) -> list[str]:
+    """How to start the server. A container has its own filesystem: the router's
+    interpreter path is not in the image, but the a8s client dir is mounted at
+    the same absolute path and the image already needs a `python3` for the `tell`
+    shim, so inside one the interpreter resolves from the image's PATH."""
+    python = "python3" if in_container else sys.executable
+    return [python, str(A8S_PY), "mcp", "serve"]
 
 
-def _mcp_server_env(env: dict) -> dict[str, str]:
+_MCP_SERVER_ENV_KEYS = ("TELL_OUTBOX_DIR", "HOME", "A8S_HOME", "A8S_MCP_LOG")
+# Behind an OS boundary the router's HOME and A8S_HOME are another user's home or
+# absent from the image: pinning them points the server at paths it cannot read
+# and promises a registry it will not find. The outbox is the one path the
+# boundary does carry across, and `tell` writes the envelope from that alone.
+_MCP_ISOLATED_SERVER_ENV_KEYS = ("TELL_OUTBOX_DIR", "A8S_MCP_LOG")
+
+
+def _mcp_server_env(env: dict, *, isolated: bool = False) -> dict[str, str]:
     """What the server needs whatever the client's env policy. Clients differ
     on how much of their own environment they hand a stdio child, so the outbox
     it must write into is stated explicitly."""
-    pinned = {k: env.get(k, "") for k in ("TELL_OUTBOX_DIR", "HOME", "A8S_HOME", "A8S_MCP_LOG")}
+    keys = _MCP_ISOLATED_SERVER_ENV_KEYS if isolated else _MCP_SERVER_ENV_KEYS
+    pinned = {k: env.get(k, "") for k in keys}
     return {k: v for k, v in pinned.items() if v}
 
 
-def _mcp_server_entry(env: dict) -> dict:
-    argv = _mcp_command()
-    return {"command": argv[0], "args": argv[1:], "env": _mcp_server_env(env)}
+def _mcp_server_entry(env: dict, command: list[str], *, isolated: bool = False) -> dict:
+    return {
+        "command": command[0],
+        "args": command[1:],
+        "env": _mcp_server_env(env, isolated=isolated),
+    }
 
 
-def _mcp_servers_json(env: dict) -> str:
+def _mcp_servers_json(env: dict, command: list[str], *, isolated: bool = False) -> str:
     """The `mcpServers` object claude, copilot and cursor all read."""
-    return json.dumps({"mcpServers": {MCP_SERVER_NAME: _mcp_server_entry(env)}})
+    entry = _mcp_server_entry(env, command, isolated=isolated)
+    return json.dumps({"mcpServers": {MCP_SERVER_NAME: entry}})
 
 
 def _toml_string(value: str) -> str:
     return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
 
 
-def _mcp_codex_override(env: dict, cwd: Path) -> str:
+def _mcp_codex_override(
+    env: dict, cwd: Path, command: list[str], *, isolated: bool = False
+) -> str:
     """codex takes config as `-c key=<TOML value>`, and its server table is the
     one idiom that also accepts an explicit cwd."""
-    argv = _mcp_command()
-    args = ", ".join(_toml_string(a) for a in argv[1:])
-    pinned = ", ".join(f"{k} = {_toml_string(v)}" for k, v in _mcp_server_env(env).items())
+    args = ", ".join(_toml_string(a) for a in command[1:])
+    server_env = _mcp_server_env(env, isolated=isolated)
+    pinned = ", ".join(f"{k} = {_toml_string(v)}" for k, v in server_env.items())
     return (
         f"mcp_servers.{MCP_SERVER_NAME}={{"
-        f"command = {_toml_string(argv[0])}, "
+        f"command = {_toml_string(command[0])}, "
         f"args = [{args}], "
         f"env = {{{pinned}}}, "
         f"cwd = {_toml_string(str(cwd))}"
@@ -626,16 +675,16 @@ def _mcp_codex_override(env: dict, cwd: Path) -> str:
     )
 
 
-def _mcp_opencode_config(env: dict) -> str:
+def _mcp_opencode_config(env: dict, command: list[str], *, isolated: bool = False) -> str:
     return json.dumps(
         {
             "$schema": "https://opencode.ai/config.json",
             "mcp": {
                 MCP_SERVER_NAME: {
                     "type": "local",
-                    "command": _mcp_command(),
+                    "command": command,
                     "enabled": True,
-                    "environment": _mcp_server_env(env),
+                    "environment": _mcp_server_env(env, isolated=isolated),
                 }
             },
         },
@@ -643,14 +692,28 @@ def _mcp_opencode_config(env: dict) -> str:
     )
 
 
+def _add_read_bits(path: Path, extra: int) -> None:
+    """Grant read (and for a dir, traverse) to group and other without touching
+    any other bit the operator set — setgid on a shared workplace survives."""
+    mode = stat.S_IMODE(path.stat().st_mode)
+    if mode | extra != mode:
+        path.chmod(mode | extra)
+
+
 def _write_if_changed(path: Path, text: str) -> None:
+    """Write a config a harness reads back. The reader may be another Unix user
+    (`run_as`) or root inside a container, so the file does not stay at the
+    router's umask — it carries paths and a command, never a secret."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    if path.is_file() and path.read_text(encoding="utf-8") == text:
-        return
-    path.write_text(text, encoding="utf-8")
+    _add_read_bits(path.parent, 0o055)
+    if not (path.is_file() and path.read_text(encoding="utf-8") == text):
+        path.write_text(text, encoding="utf-8")
+    _add_read_bits(path, 0o044)
 
 
-def _write_cursor_mcp(cwd: Path, env: dict) -> Path:
+def _write_cursor_mcp(
+    cwd: Path, env: dict, command: list[str], *, isolated: bool = False
+) -> Path:
     """cursor has no per-invocation flag, so the server rides a file in the
     effective cwd. Any other server already configured there is preserved."""
     path = cwd / ".cursor" / "mcp.json"
@@ -663,18 +726,20 @@ def _write_cursor_mcp(cwd: Path, env: dict) -> Path:
         if isinstance(loaded, dict):
             payload = loaded
     servers = payload.get("mcpServers")
-    payload["mcpServers"] = {**(servers if isinstance(servers, dict) else {}),
-                             MCP_SERVER_NAME: _mcp_server_entry(env)}
+    payload["mcpServers"] = {
+        **(servers if isinstance(servers, dict) else {}),
+        MCP_SERVER_NAME: _mcp_server_entry(env, command, isolated=isolated),
+    }
     _write_if_changed(path, json.dumps(payload, indent=2))
     return path
 
 
 def _mcp_config_dir(env: dict, cwd: Path) -> Path:
-    """Where a config file the harness reads from disk goes: the member's own
-    r4t state dir (parent of the per-turn staging outbox), so the knob writes
-    nothing into the team repo."""
+    """Where a config file the harness reads from disk goes: an `mcp` dir beside
+    the member's per-turn staging outbox, so the knob writes nothing into the
+    team repo and a container mounts one dir that holds nothing else."""
     staging = env.get("TELL_OUTBOX_DIR", "")
-    return Path(staging).parent if staging else cwd
+    return Path(staging).parent / MCP_CONFIG_DIRNAME if staging else cwd
 
 
 def _mcp_splice_at(argv: list[str]) -> int:
@@ -683,17 +748,29 @@ def _mcp_splice_at(argv: list[str]) -> int:
     return argv.index("--") + 1 if "--" in argv else 1
 
 
-def apply_mcp(rig: Rig, argv: list[str], env: dict, cwd: Path) -> list[str]:
+def apply_mcp(
+    rig: Rig, argv: list[str], env: dict, cwd: Path, isolation: Isolation | None = None
+) -> McpPlan:
     """Inject the a8s MCP server into one turn with the harness's own idiom.
-    Returns the argv to run; `env` is updated in place and whatever config file
-    the idiom needs is written."""
+    `env` is updated in place and whatever config file the idiom needs is
+    written; the returned plan carries the argv to run plus what the org's
+    isolation boundary has to let through for the server to actually start."""
     idiom = rig.mcp_idiom
     if not idiom:
-        return argv
-    argv = list(argv)
+        return McpPlan(argv=argv)
+    in_container = bool(isolation and isolation.container)
+    isolated = bool(isolation and isolation.active)
+    command = _mcp_command(in_container=in_container)
+    plan = McpPlan(argv=list(argv))
+    argv = plan.argv
+    if not in_container:
+        # Inside a container the interpreter comes from the image and the script
+        # from a mount r4t already makes; outside one, both are the router's own
+        # files and the boundary's user has to be able to read them.
+        plan.read_paths += [Path(command[0]), A8S_PY]
     at = _mcp_splice_at(argv)
     if idiom == "claude-flag":
-        argv[at:at] = ["--mcp-config", _mcp_servers_json(env)]
+        argv[at:at] = ["--mcp-config", _mcp_servers_json(env, command, isolated=isolated)]
         # `dontAsk` never prompts, so a tool missing from --allowedTools is
         # silently denied — the MCP tool has to be named there too.
         for i, token in enumerate(argv):
@@ -702,18 +779,27 @@ def apply_mcp(rig: Rig, argv: list[str], env: dict, cwd: Path) -> list[str]:
                     argv[i + 1] = f"{argv[i + 1]} {MCP_CLAUDE_TOOL}".strip()
                 break
     elif idiom == "codex-config":
-        argv[at:at] = ["-c", _mcp_codex_override(env, cwd)]
+        argv[at:at] = ["-c", _mcp_codex_override(env, cwd, command, isolated=isolated)]
     elif idiom == "copilot-flag":
-        argv[at:at] = ["--additional-mcp-config", _mcp_servers_json(env)]
+        argv[at:at] = [
+            "--additional-mcp-config", _mcp_servers_json(env, command, isolated=isolated)
+        ]
     elif idiom == "opencode-env":
         path = _mcp_config_dir(env, cwd) / OPENCODE_CONFIG_BASENAME
-        _write_if_changed(path, _mcp_opencode_config(env))
+        _write_if_changed(path, _mcp_opencode_config(env, command, isolated=isolated))
         # OPENCODE_CONFIG_CONTENT is not an option: `ollama launch` sets it for
         # provider+model and clobbers anything r4t puts there (measured, #310).
         env["OPENCODE_CONFIG"] = str(path)
+        # The variable is the whole idiom: a boundary that resets the environment
+        # must re-export it, and a container must be able to see the file.
+        plan.env_pass["OPENCODE_CONFIG"] = str(path)
+        plan.mount_dirs.append(path.parent)
+        plan.read_paths.append(path)
     elif idiom == "cursor-file":
-        _write_cursor_mcp(cwd, env)
-    return argv
+        # The file lands in the effective cwd — the workplace, which both
+        # wrappers already give the harness — so only its mode has to hold.
+        plan.read_paths.append(_write_cursor_mcp(cwd, env, command, isolated=isolated))
+    return plan
 
 
 def _effective_cwd(member: Member, workplace: Path) -> Path:

--- a/apps/r4t/state.py
+++ b/apps/r4t/state.py
@@ -12,6 +12,9 @@ honors A8S_HOME).
     ├── agents/<name>/meta.json    last inbound / last completed turn bookkeeping
     ├── agents/<name>/staging/     per-turn $TELL_OUTBOX_DIR — envelopes the agent
     │                              sent this turn, released by dispatch afterwards
+    ├── agents/<name>/mcp/         config the `mcp` knob hands the harness to read
+    │                              (rig.py); readable behind an isolation boundary,
+    │                              and the one dir a container mounts for it
     ├── agents/<name>/live.log     the running turn's harness output, teed live
     │                              (truncated at turn start; a gemba attach tails it)
     ├── agents/<name>/turns/       per-turn capture — one markdown file per turn

--- a/apps/r4t/tests/test_dispatch.py
+++ b/apps/r4t/tests/test_dispatch.py
@@ -24,7 +24,7 @@ from dispatch import (
     run_idle,
     split_recipient,
 )
-from rig import Rig, RigError, load_rig_config
+from rig import McpPlan, Rig, RigError, load_rig_config
 from roster import load_roster
 from r4t import main as r4t_main
 from ulid import new as new_ulid
@@ -2854,7 +2854,7 @@ class TestMcpKnob:
         code, out, _dur, _timed = run_harness(rig, "x", tmp_path, env=env)
         assert code == 0
         config = Path(out.strip())
-        assert config.parent == staging.parent
+        assert config.parent == staging.parent / "mcp"
         assert json.loads(config.read_text(encoding="utf-8"))["mcp"]["a8s"]["enabled"]
 
     def test_turn_env_untouched_when_off(self, tmp_path):
@@ -2871,7 +2871,9 @@ class TestMcpKnob:
     def test_injection_is_skipped_entirely_when_off(self, tmp_path, monkeypatch):
         calls = []
         monkeypatch.setattr(
-            dispatch, "apply_mcp", lambda rig, argv, env, cwd: calls.append(rig) or argv
+            dispatch,
+            "apply_mcp",
+            lambda rig, argv, env, cwd, iso: calls.append(rig) or McpPlan(argv=argv),
         )
         rig = self._echo_env_rig(tmp_path, preset="opencode")
         run_harness(rig, "x", tmp_path, env=dict(os.environ))

--- a/apps/r4t/tests/test_isolate.py
+++ b/apps/r4t/tests/test_isolate.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import json
 import os
 import stat
+import subprocess
 import sys
 import textwrap
 from pathlib import Path
@@ -25,7 +26,14 @@ import state
 from dispatch import DispatchContext, drain, handle_message, run_harness
 from isolate import Isolation
 from org import ORG_CONFIG_NAME, check_org, load_org
-from rig import Rig, load_rig_config
+from rig import (
+    A8S_PY,
+    Rig,
+    add_preset_rig,
+    apply_mcp,
+    load_rig_config,
+    set_rig_value,
+)
 from roster import Member
 
 NODE = "acme"
@@ -47,23 +55,62 @@ def fakebin(tmp_path, monkeypatch):
     return d
 
 
+BOOTSTRAP = (
+    'export TELL_OUTBOX_DIR="$1"; cd "$2"; n="$3"; shift 3; '
+    'while [ "$n" -gt 0 ]; do export "$1"; shift; n=$((n - 1)); done; exec "$@"'
+)
+
+
 class TestWrapRunAs:
     def test_exact_argv(self):
         argv = isolate.wrap_run_as(
             ["claude", "-p", "{hi}"], "agent-x", "/stg/dir", "/work/place"
         )
         assert argv == [
-            "sudo", "-u", "agent-x", "bash", "--login", "-c",
-            'export TELL_OUTBOX_DIR="$1"; cd "$2"; shift 2; exec "$@"',
-            "_", "/stg/dir", "/work/place", "claude", "-p", "{hi}",
+            "sudo", "-u", "agent-x", "bash", "--login", "-c", BOOTSTRAP,
+            "_", "/stg/dir", "/work/place", "0", "claude", "-p", "{hi}",
         ]
 
     def test_env_rides_as_positionals_not_a_command_string(self):
         argv = isolate.wrap_run_as(["h", "a b"], "u", "/s", "/w")
         # The bootstrap is a single -c argument; the harness argv follows as
         # discrete positionals, so a space in an arg can never re-split.
-        assert argv[6] == 'export TELL_OUTBOX_DIR="$1"; cd "$2"; shift 2; exec "$@"'
+        assert argv[6] == BOOTSTRAP
         assert argv[-2:] == ["h", "a b"]
+
+    def test_env_pass_rides_as_counted_positionals(self):
+        argv = isolate.wrap_run_as(
+            ["h", "{p}"], "u", "/s", "/w",
+            env_pass={"OPENCODE_CONFIG": "/state/mcp/c.json", "K": "a b"},
+        )
+        assert argv[7:] == [
+            "_", "/s", "/w", "2",
+            "OPENCODE_CONFIG=/state/mcp/c.json", "K=a b", "h", "{p}",
+        ]
+
+    def test_bootstrap_really_exports_what_it_is_handed(self, tmp_path):
+        # Functional, not shape: run the bootstrap under a real bash (no sudo)
+        # and have the "harness" report the environment it was handed.
+        script = tmp_path / "show.py"
+        script.write_text(
+            "import os\nprint(os.environ.get('OPENCODE_CONFIG', 'unset'))\n"
+            "print(os.environ.get('A8S_MCP_LOG', 'unset'))\n"
+            "print(os.environ['TELL_OUTBOX_DIR'])\nprint(os.getcwd())\n",
+            encoding="utf-8",
+        )
+        argv = isolate.wrap_run_as(
+            [sys.executable, str(script)], "u", tmp_path, tmp_path,
+            # A value with a space is the case a quoted command string mangles.
+            env_pass={"OPENCODE_CONFIG": "/state/mcp/c.json", "A8S_MCP_LOG": "x y"},
+        )
+        out = subprocess.run(
+            ["bash", "-c", *argv[6:]], capture_output=True, text=True,
+            env={"PATH": os.environ["PATH"]},
+        )
+        assert out.returncode == 0, out.stderr
+        assert out.stdout.splitlines() == [
+            "/state/mcp/c.json", "x y", str(tmp_path), str(tmp_path),
+        ]
 
 
 class TestBuildContainer:
@@ -368,6 +415,288 @@ class TestContainerTimeoutKill:
         killed = record.read_text(encoding="utf-8").split()
         assert len(killed) == 1
         assert killed[0].startswith("r4t-acme-phil-")
+
+
+# ---------- the `mcp` knob has to cross the boundary too (#314) ----------
+
+
+def _mcp_rig(tmp_path, preset: str) -> Rig:
+    path = tmp_path / f"mcp-rigs-{preset}.json"
+    add_preset_rig(path, "worker", preset, force=True)
+    set_rig_value(path, "worker", "mcp", "on")
+    return load_rig_config(path).rigs["worker"]
+
+
+def _mcp_turn_env(tmp_path, isolation: Isolation) -> tuple[dict, Path, Path]:
+    """A turn env shaped like dispatch's: a per-member staging outbox, a
+    workplace, the router's HOME, and the org's isolation choice."""
+    staging = tmp_path / "state" / "worker" / "staging"
+    staging.mkdir(parents=True, exist_ok=True)
+    workplace = tmp_path / "work"
+    workplace.mkdir(exist_ok=True)
+    env = dict(os.environ)  # keep PATH so the fake sudo/docker resolve
+    env["TELL_OUTBOX_DIR"] = str(staging)
+    env["HOME"] = str(tmp_path / "router-home")
+    env["R4T_NODE"] = NODE
+    env["R4T_MEMBER"] = "worker"
+    env.update(isolation.to_env())
+    return env, workplace, staging
+
+
+def _recording_sudo(fakebin, record: Path, *, unreadable: str = "") -> None:
+    """A `sudo` stub that answers the prereq probes, optionally fails the
+    read-access probe, and records the wrapped invoke instead of running it."""
+    _fake_bin(
+        fakebin, "sudo",
+        f"""
+        import sys
+        a = sys.argv[1:]
+        script = a[a.index("-c") + 1] if "-c" in a else ""
+        if script.startswith("for p;"):
+            if {unreadable!r}:
+                print({unreadable!r})
+                sys.exit(1)
+            sys.exit(0)
+        if script.startswith("export TELL_OUTBOX_DIR"):
+            open({str(record)!r}, "w").write(repr(a))
+        sys.exit(0)
+        """,
+    )
+
+
+def _recording_docker(fakebin, record: Path) -> None:
+    _fake_bin(
+        fakebin, "docker",
+        f"""
+        import sys
+        a = sys.argv[1:]
+        if a and a[0] == "run":
+            open({str(record)!r}, "w").write(repr(a))
+        """,
+    )
+
+
+def _wrapped_argv(record: Path) -> list[str]:
+    return eval(record.read_text(encoding="utf-8"))  # noqa: S307 — test-owned stub
+
+
+def _server_from_flag(argv: list[str], flag: str) -> dict:
+    """The server the wrapped argv carries. codex speaks TOML, and its `-c` has
+    to be told apart from the wrapper's own `bash -c`."""
+    payloads = [
+        argv[i + 1] for i, token in enumerate(argv[:-1])
+        if token == flag and ("a8s" in argv[i + 1])
+    ]
+    assert len(payloads) == 1, f"{flag} payload not carried across: {argv}"
+    if flag == "-c":
+        return {"toml": payloads[0]}
+    return json.loads(payloads[0])["mcpServers"]["a8s"]
+
+
+FLAG_IDIOMS = {
+    "claude": "--mcp-config",
+    "codex": "-c",
+    "copilot": "--additional-mcp-config",
+}
+
+
+class TestMcpCrossesRunAs:
+    """Every idiom the knob supports either reaches the harness behind
+    `sudo`/`env_reset` or fails the turn — a prompt that teaches `a8s_tell`
+    against a server that never started is the one outcome worth refusing."""
+
+    @pytest.mark.parametrize("preset,flag", sorted(FLAG_IDIOMS.items()))
+    def test_flag_idioms_ride_argv_through_the_bootstrap(
+        self, tmp_path, fakebin, preset, flag
+    ):
+        record = tmp_path / f"sudo-{preset}.txt"
+        _recording_sudo(fakebin, record)
+        rig = _mcp_rig(tmp_path, preset)
+        env, workplace, _staging = _mcp_turn_env(tmp_path, Isolation(run_as="agent-x"))
+
+        run_harness(rig, "P", workplace, env=env)
+
+        argv = _wrapped_argv(record)
+        assert argv[:5] == ["-u", "agent-x", "bash", "--login", "-c"]
+        assert flag in argv
+        server = _server_from_flag(argv, flag)
+        # The router's own interpreter: same filesystem on this side of sudo.
+        assert sys.executable in (server.get("command") or server["toml"])
+
+    def test_opencode_env_rides_as_a_re_exported_positional(self, tmp_path, fakebin):
+        record = tmp_path / "sudo-opencode.txt"
+        _recording_sudo(fakebin, record)
+        rig = _mcp_rig(tmp_path, "opencode")
+        env, workplace, staging = _mcp_turn_env(tmp_path, Isolation(run_as="agent-x"))
+
+        run_harness(rig, "P", workplace, env=env)
+
+        config = staging.parent / "mcp" / "mcp-opencode.json"
+        argv = _wrapped_argv(record)
+        # _ staging workplace <count> <NAME=value>... then the harness argv.
+        assert argv[6:10] == [
+            "_", str(staging), str(workplace), "1"
+        ]
+        assert argv[10] == f"OPENCODE_CONFIG={config}"
+        assert config.is_file()
+
+    def test_config_file_is_readable_by_another_user(self, tmp_path, fakebin):
+        _recording_sudo(fakebin, tmp_path / "sudo.txt")
+        rig = _mcp_rig(tmp_path, "opencode")
+        env, workplace, staging = _mcp_turn_env(tmp_path, Isolation(run_as="agent-x"))
+        (staging.parent).chmod(0o700)  # a narrow umask, or drift
+
+        run_harness(rig, "P", workplace, env=env)
+
+        config = staging.parent / "mcp" / "mcp-opencode.json"
+        assert stat.S_IMODE(config.stat().st_mode) & 0o044 == 0o044
+        assert stat.S_IMODE(config.parent.stat().st_mode) & 0o055 == 0o055
+
+    def test_cursor_file_lands_in_the_workplace_and_is_readable(self, tmp_path, fakebin):
+        _recording_sudo(fakebin, tmp_path / "sudo.txt")
+        rig = _mcp_rig(tmp_path, "cursor")
+        env, workplace, _staging = _mcp_turn_env(tmp_path, Isolation(run_as="agent-x"))
+
+        run_harness(rig, "P", workplace, env=env)
+
+        # The workplace is the one dir both wrappers already give the harness.
+        config = workplace / ".cursor" / "mcp.json"
+        assert stat.S_IMODE(config.stat().st_mode) & 0o044 == 0o044
+        assert json.loads(config.read_text(encoding="utf-8"))["mcpServers"]["a8s"]
+
+    def test_setgid_on_a_shared_workplace_survives_the_mode_fix(self, tmp_path, fakebin):
+        _recording_sudo(fakebin, tmp_path / "sudo.txt")
+        rig = _mcp_rig(tmp_path, "cursor")
+        env, workplace, _staging = _mcp_turn_env(tmp_path, Isolation(run_as="agent-x"))
+        (workplace / ".cursor").mkdir()
+        (workplace / ".cursor").chmod(0o2770)  # the shared-group workplace
+
+        run_harness(rig, "P", workplace, env=env)
+
+        assert stat.S_IMODE((workplace / ".cursor").stat().st_mode) & 0o2000
+
+    def test_unreadable_server_fails_the_turn_closed(self, tmp_path, fakebin):
+        record = tmp_path / "sudo.txt"
+        _recording_sudo(fakebin, record, unreadable=str(A8S_PY))
+        rig = _mcp_rig(tmp_path, "claude")
+        env, workplace, _staging = _mcp_turn_env(tmp_path, Isolation(run_as="agent-x"))
+
+        code, out, _dur, timed = run_harness(rig, "P", workplace, env=env)
+
+        assert code == 126 and not timed
+        assert "mcp on" in out and "cannot read" in out and str(A8S_PY) in out
+        assert "docs/isolation.md" in out
+        assert not record.exists()  # the harness never ran taught-but-toolless
+
+    def test_router_home_is_not_promised_to_the_server(self, tmp_path, fakebin):
+        record = tmp_path / "sudo.txt"
+        _recording_sudo(fakebin, record)
+        rig = _mcp_rig(tmp_path, "claude")
+        env, workplace, staging = _mcp_turn_env(tmp_path, Isolation(run_as="agent-x"))
+
+        run_harness(rig, "P", workplace, env=env)
+
+        server = _server_from_flag(_wrapped_argv(record), "--mcp-config")
+        # HOME belongs to the router and is unreachable behind the boundary; the
+        # outbox is what crosses, and `tell` needs nothing else.
+        assert server["env"] == {"TELL_OUTBOX_DIR": str(staging)}
+
+
+class TestMcpCrossesContainer:
+    """A container keeps only what `docker run` is told to carry, and its
+    filesystem is the image's — the injection has to name both."""
+
+    @pytest.mark.parametrize("preset,flag", sorted(FLAG_IDIOMS.items()))
+    def test_flag_idioms_name_the_image_interpreter(self, tmp_path, fakebin, preset, flag):
+        record = tmp_path / f"docker-{preset}.txt"
+        _recording_docker(fakebin, record)
+        rig = _mcp_rig(tmp_path, preset)
+        env, workplace, _staging = _mcp_turn_env(tmp_path, Isolation(container="img"))
+
+        run_harness(rig, "P", workplace, env=env)
+
+        argv = _wrapped_argv(record)
+        assert flag in argv
+        server = _server_from_flag(argv, flag)
+        command = server.get("command") or server["toml"]
+        # The router's interpreter path is not in the image; the a8s client dir
+        # is mounted at the same path, and `python3` resolves from the image.
+        assert sys.executable not in command
+        assert "python3" in command
+        assert str(A8S_PY) in str(server.get("args") or server["toml"])
+
+    def test_opencode_gets_the_env_and_a_mount_of_its_own_dir(self, tmp_path, fakebin):
+        record = tmp_path / "docker-opencode.txt"
+        _recording_docker(fakebin, record)
+        rig = _mcp_rig(tmp_path, "opencode")
+        env, workplace, staging = _mcp_turn_env(tmp_path, Isolation(container="img"))
+
+        run_harness(rig, "P", workplace, env=env)
+
+        config = staging.parent / "mcp" / "mcp-opencode.json"
+        argv = _wrapped_argv(record)
+        assert f"OPENCODE_CONFIG={config}" in argv
+        assert argv[argv.index(f"OPENCODE_CONFIG={config}") - 1] == "-e"
+        mount = f"{config.parent}:{config.parent}:ro"
+        assert mount in argv and argv[argv.index(mount) - 1] == "-v"
+        # The mount carries the config and nothing else — no history, no
+        # transcripts from the member state dir above it.
+        assert f"{staging.parent}:{staging.parent}:ro" not in argv
+        assert list(config.parent.iterdir()) == [config]
+
+    def test_org_container_args_still_win(self, tmp_path, fakebin):
+        record = tmp_path / "docker-args.txt"
+        _recording_docker(fakebin, record)
+        rig = _mcp_rig(tmp_path, "opencode")
+        env, workplace, _staging = _mcp_turn_env(
+            tmp_path,
+            Isolation(container="img", container_args=["-e", "OPENCODE_CONFIG=/theirs"]),
+        )
+
+        run_harness(rig, "P", workplace, env=env)
+
+        argv = _wrapped_argv(record)
+        ours = next(a for a in argv if a.startswith("OPENCODE_CONFIG=") and a != "OPENCODE_CONFIG=/theirs")
+        # docker takes the last value, so the org's own args are still the
+        # override of last resort.
+        assert argv.index(ours) < argv.index("OPENCODE_CONFIG=/theirs") < argv.index("img")
+        assert argv[argv.index("img") - 2:argv.index("img")] == [
+            "-e", "OPENCODE_CONFIG=/theirs"
+        ]
+
+    def test_cursor_file_rides_the_workplace_mount(self, tmp_path, fakebin):
+        record = tmp_path / "docker-cursor.txt"
+        _recording_docker(fakebin, record)
+        rig = _mcp_rig(tmp_path, "cursor")
+        env, workplace, _staging = _mcp_turn_env(tmp_path, Isolation(container="img"))
+
+        run_harness(rig, "P", workplace, env=env)
+
+        assert (workplace / ".cursor" / "mcp.json").is_file()
+        assert f"{workplace}:{workplace}" in _wrapped_argv(record)
+
+
+class TestMcpWithoutIsolation:
+    """A bare org keeps the plain shape: the router's interpreter, its HOME
+    pinned, and nothing extra asked of any wrapper."""
+
+    def test_plain_turn_pins_home_and_the_router_interpreter(self, tmp_path):
+        rig = _mcp_rig(tmp_path, "claude")
+        env, workplace, _staging = _mcp_turn_env(tmp_path, Isolation())
+        plan = apply_mcp(rig, rig.argv("P"), env, workplace, Isolation())
+
+        server = _server_from_flag(plan.argv, "--mcp-config")
+        assert server["command"] == sys.executable
+        assert server["env"]["HOME"] == env["HOME"]
+        assert plan.env_pass == {} and plan.mount_dirs == []
+
+    def test_a_preset_without_an_idiom_asks_nothing_of_the_boundary(self, tmp_path):
+        rig = Rig(name="agy-rig", invoke=["agy", "{prompt}"], preset="agy", mcp=True)
+        env, workplace, _staging = _mcp_turn_env(tmp_path, Isolation(run_as="agent-x"))
+        plan = apply_mcp(rig, rig.argv("P"), env, workplace, Isolation(run_as="agent-x"))
+
+        assert plan.argv == rig.argv("P")
+        assert not plan.env_pass and not plan.mount_dirs and not plan.read_paths
 
 
 class TestStatusRowRendering:

--- a/apps/r4t/tests/test_rig.py
+++ b/apps/r4t/tests/test_rig.py
@@ -1408,7 +1408,7 @@ class TestMcpInjection:
     def test_claude_gets_mcp_config_and_an_allowlisted_tool(self, tmp_path):
         rig = _mcp_rig(tmp_path, "claude")
         env, cwd = self._turn(tmp_path)
-        argv = apply_mcp(rig, rig.argv("PROMPT"), env, cwd)
+        argv = apply_mcp(rig, rig.argv("PROMPT"), env, cwd).argv
 
         assert argv[1] == "--mcp-config"
         server = json.loads(argv[2])["mcpServers"]["a8s"]
@@ -1421,7 +1421,7 @@ class TestMcpInjection:
     def test_claude_ollama_splices_after_the_launcher_separator(self, tmp_path):
         rig = _mcp_rig(tmp_path, "claude-ollama", model="qwen3.6")
         env, cwd = self._turn(tmp_path)
-        argv = apply_mcp(rig, rig.argv("PROMPT"), env, cwd)
+        argv = apply_mcp(rig, rig.argv("PROMPT"), env, cwd).argv
 
         assert argv[argv.index("--") + 1] == "--mcp-config"
         assert "mcp__a8s__tell" in argv[argv.index("--allowedTools") + 1]
@@ -1429,7 +1429,7 @@ class TestMcpInjection:
     def test_codex_gets_a_toml_override_with_cwd_pinned(self, tmp_path):
         rig = _mcp_rig(tmp_path, "codex")
         env, cwd = self._turn(tmp_path)
-        argv = apply_mcp(rig, rig.argv("PROMPT"), env, cwd)
+        argv = apply_mcp(rig, rig.argv("PROMPT"), env, cwd).argv
 
         assert argv[1] == "-c"
         override = argv[2]
@@ -1441,13 +1441,13 @@ class TestMcpInjection:
     def test_codex_ollama_splices_after_the_launcher_separator(self, tmp_path):
         rig = _mcp_rig(tmp_path, "codex-ollama", model="qwen3.6")
         env, cwd = self._turn(tmp_path)
-        argv = apply_mcp(rig, rig.argv("PROMPT"), env, cwd)
+        argv = apply_mcp(rig, rig.argv("PROMPT"), env, cwd).argv
         assert argv[argv.index("--") + 1] == "-c"
 
     def test_copilot_gets_an_additional_config(self, tmp_path):
         rig = _mcp_rig(tmp_path, "copilot")
         env, cwd = self._turn(tmp_path)
-        argv = apply_mcp(rig, rig.argv("PROMPT"), env, cwd)
+        argv = apply_mcp(rig, rig.argv("PROMPT"), env, cwd).argv
 
         assert argv[1] == "--additional-mcp-config"
         assert json.loads(argv[2])["mcpServers"]["a8s"]["command"]
@@ -1455,18 +1455,21 @@ class TestMcpInjection:
     def test_copilot_ollama_splices_after_the_launcher_separator(self, tmp_path):
         rig = _mcp_rig(tmp_path, "copilot-ollama", model="qwen3.6")
         env, cwd = self._turn(tmp_path)
-        argv = apply_mcp(rig, rig.argv("PROMPT"), env, cwd)
+        argv = apply_mcp(rig, rig.argv("PROMPT"), env, cwd).argv
         assert argv[argv.index("--") + 1] == "--additional-mcp-config"
 
     def test_opencode_rides_a_config_file_never_config_content(self, tmp_path):
         rig = _mcp_rig(tmp_path, "opencode")
         env, cwd = self._turn(tmp_path)
-        argv = apply_mcp(rig, rig.argv("PROMPT"), env, cwd)
+        argv = apply_mcp(rig, rig.argv("PROMPT"), env, cwd).argv
 
         assert argv == rig.argv("PROMPT")
         assert "OPENCODE_CONFIG_CONTENT" not in env
         config = Path(env["OPENCODE_CONFIG"])
-        assert config.parent == Path(env["TELL_OUTBOX_DIR"]).parent
+        # A dir of its own beside the staging outbox: nothing else lives there,
+        # so a container can mount it without exposing the member's transcripts,
+        # and a `.json` here is never mistaken for a staged envelope.
+        assert config.parent == Path(env["TELL_OUTBOX_DIR"]).parent / "mcp"
         assert cwd not in config.parents
         server = json.loads(config.read_text(encoding="utf-8"))["mcp"]["a8s"]
         assert server["type"] == "local"
@@ -1477,7 +1480,7 @@ class TestMcpInjection:
     def test_opencode_ollama_uses_the_same_file_idiom(self, tmp_path):
         rig = _mcp_rig(tmp_path, "opencode-ollama", model="qwen3.6")
         env, cwd = self._turn(tmp_path)
-        argv = apply_mcp(rig, rig.argv("PROMPT"), env, cwd)
+        argv = apply_mcp(rig, rig.argv("PROMPT"), env, cwd).argv
         assert argv == rig.argv("PROMPT")
         assert Path(env["OPENCODE_CONFIG"]).is_file()
         assert "OPENCODE_CONFIG_CONTENT" not in env
@@ -1491,7 +1494,7 @@ class TestMcpInjection:
             json.dumps({"mcpServers": {"theirs": {"command": "x"}}}), encoding="utf-8"
         )
 
-        argv = apply_mcp(rig, rig.argv("PROMPT"), env, cwd)
+        argv = apply_mcp(rig, rig.argv("PROMPT"), env, cwd).argv
         assert argv == rig.argv("PROMPT")
         servers = json.loads(existing.read_text(encoding="utf-8"))["mcpServers"]
         assert set(servers) == {"theirs", "a8s"}


### PR DESCRIPTION
Closes #314.

## The gap

`mcp on` gives a member the `a8s_tell` tool and rewrites its prompt to name it. Two of the five idioms rode channels an OS boundary discards, so an isolated org got the teaching and no tool:

- `apps/r4t/rig.py:713` (pre-fix) set `env["OPENCODE_CONFIG"]`, while `apps/r4t/isolate.py:43` re-exported only `TELL_OUTBOX_DIR` past sudoers `env_reset`, and `build_container_argv` passed only its own `-e` flags.
- The opencode and cursor config files landed in the member state dir / workdir with no guarantee the far side could read them, and no container mount for the state-dir path.
- The flag idioms (claude/codex/copilot) did ride argv through both wrappers, but named `sys.executable` — the router's interpreter path, which a container image does not have.

## The fix

`apply_mcp` takes the org's `Isolation` and returns an `McpPlan` (argv + `env_pass` + `mount_dirs` + `read_paths`); `run_harness` hands each part to the wrapper that can carry it.

- **run_as** — the bootstrap gained a counted `NAME=value` re-export (`<count>` positional, each pair one word, so a spaced value cannot re-split); `exec "$@"` is untouched.
- **container** — the config dir is mounted `:ro`, the `-e` is passed, and the server command is `python3` from the image (the a8s client dir is already mounted at its real path, and `tell` needs a `python3` there anyway). Org `container_args` still override, docker-last-wins.
- **File idioms** move to `agents/<member>/mcp/` — its own dir beside the staging outbox, so a container mount exposes no history or transcripts and a `.json` there is never read as a staged envelope. Modes gain read bits additively, so setgid on a shared workplace survives.
- **Server env** behind either boundary is the outbox alone: the router's `HOME`/`A8S_HOME` are another user's home or absent from the image.
- **Fail closed** — before a `run_as` turn, `probe_readable_as` checks the agent user can read the server script, its interpreter and the config; a miss returns 126 naming the path and the fix, so no turn runs taught-but-toolless.

Docs: `docs/isolation.md` gains the new wrapper shape and a section on the knob behind a boundary (including the one-line image-contract addition); `docs/rigs.md` and `plans/ISOLATE-SPEC.md` follow.

## Tests

`apps/r4t/tests/` — **754 passed** (735 before; +17 new in `test_isolate.py` covering each idiom × each wrapper, +2 on the bootstrap). New coverage includes a functional bash run of the bootstrap proving a spaced value survives, exact docker argv for the `-e`/mount, the mount holding the config and nothing else, and the fail-closed path asserting the harness never ran.

Also green: `r4t sandbox --fake` (all mechanical checks pass) and `apps/r4t/tests/docker/run-as.sh` — the real sudo boundary under `ubuntu:24.04` still holds with the new bootstrap.

Not in scope: extending `tests/docker/inside.sh` to drive a real `mcp on` turn behind the boundary would need the `apps/a8s` tree mounted beside `apps/r4t` inside the container (today only `apps/r4t` is), so it is left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)