### PR TITLE
fix(r4t): pin the turn cwd through the `ollama launch` wrappers

### DIFF
--- a/apps/r4t/docs/harness-ollama-launch.md
+++ b/apps/r4t/docs/harness-ollama-launch.md
@@ -24,6 +24,12 @@ ollama launch <integration> --model <tag> -y -- <the harness's own headless argv
 - `-y` auto-answers the launcher's own confirmation prompts. Required for
   unattended dispatch: a first-run or install confirmation would otherwise
   hang the turn.
+- The launcher execs the integration in its own working directory, so the cwd
+  r4t sets for a member's turn reaches the harness. Measured on ollama 0.32.5
+  by spawning each wrapped integration with a cwd of its own and reading the
+  OS-reported cwd of every descendant: launcher, harness, and the node/codex
+  helpers underneath all sat in the spawn directory. That is what makes
+  `Workdir:` work on the `*-ollama` presets (issue #289).
 
 ## What the launcher persists, per integration
 

--- a/apps/r4t/docs/rigs.md
+++ b/apps/r4t/docs/rigs.md
@@ -88,11 +88,13 @@ word writes there by absolute path. `claude`/`cursor` advertise no competing
 root, so their members stay in the workdir. No opencode flag or env var pins
 the root; `--dir` does not.
 
-The `ollama launch`-wrapped presets are worse: the wrapper does not carry the
-subprocess cwd through, so the harness runs in whatever directory invoked r4t
-(under a8s, the agent root) and never sees the workdir at all. A relative path
-from one of those members lands there, not in the workdir — measured, not
-inferred.
+The `ollama launch`-wrapped presets inherit their parent's behavior and nothing
+worse: the launcher execs the integration in the directory r4t spawned it in,
+so an `*-ollama` member's harness runs in the workdir (measured on ollama
+0.32.5 against all four wrapped integrations — the launcher, the harness, and
+every descendant report the workdir as their cwd). `opencode-ollama` therefore
+carries the same advertised-root caveat as `opencode`, and `claude-ollama` /
+`codex-ollama` / `copilot-ollama` stay in the workdir like their parents.
 
 So the prompt is the portable mitigation, and the only one that reaches every
 rig: the intro states the member's absolute working directory, tells it to

--- a/apps/r4t/roster.py
+++ b/apps/r4t/roster.py
@@ -33,12 +33,12 @@ An optional `- **Workdir:** <path>` gives the member its own working
 directory for turns. Relative paths resolve against the org workplace
 (`agents/bob/`, `.bob/`); absolute and `~` paths are allowed and may live
 outside the repo entirely. Absent means the member runs from the workplace
-root, as before. The directory is created on demand at the start of a turn.
-It sets the turn's cwd and the prompt names it as the member's root, but no
-harness is obliged to honor it: opencode-family rigs also advertise the
-enclosing git root to the model as a "workspace root", and the `ollama
-launch` wrappers do not carry the cwd through at all. A workdir nested in a
-repo can therefore still attract writes to the repo root (issue #273; see
+root. The directory is created on demand at the start of a turn.
+It sets the turn's cwd — which every rig receives, `ollama launch` wrappers
+included — and the prompt names it as the member's root, but no harness is
+obliged to treat it as the project root: opencode-family rigs also advertise
+the enclosing git root to the model as a "workspace root". A workdir nested in
+a repo can therefore still attract writes to the repo root (issue #273; see
 docs/rigs.md).
 """
 from __future__ import annotations

--- a/apps/r4t/tests/test_dispatch.py
+++ b/apps/r4t/tests/test_dispatch.py
@@ -24,7 +24,7 @@ from dispatch import (
     run_idle,
     split_recipient,
 )
-from rig import McpPlan, Rig, RigError, load_rig_config
+from rig import McpPlan, Rig, RigError, build_preset_invoke, load_rig_config
 from roster import load_roster
 from r4t import main as r4t_main
 from ulid import new as new_ulid
@@ -1852,6 +1852,56 @@ class TestRunHarness:
         assert code == 127
         assert "failed to spawn" in out
         assert not timed_out
+
+    def test_turn_cwd_reaches_a_launcher_wrapped_harness(self, tmp_path, monkeypatch):
+        """The `*-ollama` presets put `ollama launch <tool> -- <argv>` in front of
+        the harness. The turn's workdir has to survive that hop, or every relative
+        path a member writes lands wherever r4t itself was invoked (#289). Fake
+        launcher, fake harness: the wrapper execs the tool the way the real one
+        does, and the tool reports the directory it actually got."""
+        fakebin = tmp_path / "fakebin"
+        fakebin.mkdir()
+        launcher = fakebin / "ollama"
+        launcher.write_text(
+            f"#!{sys.executable}\n"
+            + textwrap.dedent(
+                """
+                import os, sys
+                argv = sys.argv[1:]
+                tool = argv[1]
+                passthrough = argv[argv.index("--") + 1:]
+                os.execvp(tool, [tool, *passthrough])
+                """
+            ),
+            encoding="utf-8",
+        )
+        launcher.chmod(0o755)
+        harness = fakebin / "opencode"
+        harness.write_text(
+            f"#!{sys.executable}\n"
+            + textwrap.dedent(
+                """
+                import os, sys
+                print("harness cwd:", os.getcwd())
+                print("harness argv:", " ".join(sys.argv[1:]))
+                """
+            ),
+            encoding="utf-8",
+        )
+        harness.chmod(0o755)
+        monkeypatch.setenv("PATH", str(fakebin) + os.pathsep + os.environ["PATH"])
+        workdir = tmp_path / "agents" / "bob"
+        workdir.mkdir(parents=True)
+        rig = Rig(
+            name="local",
+            preset="opencode-ollama",
+            invoke=build_preset_invoke("opencode-ollama", model="qwen3.6:latest"),
+            timeout_seconds=30,
+        )
+        code, out, _dur, timed_out = run_harness(rig, "x", workdir, env=dict(os.environ))
+        assert code == 0 and not timed_out
+        assert f"harness cwd: {workdir}" in out
+        assert "harness argv: run --auto --dir . x" in out
 
     def test_agy_model_resolved_live_before_turn(self, tmp_path, monkeypatch):
         # The stored argv carries a {model} placeholder; run_harness resolves it


### PR DESCRIPTION
Closes #289.

## What was believed

`*-ollama` rigs were documented as losing a member's `Workdir:` — the claim
being that `ollama launch` swallowed the subprocess cwd r4t sets, so the harness
ran in whatever directory invoked r4t (under a8s, the agent root) and a relative
write landed there. rigs.md called it "measured, not inferred", and #288's
prompt doctrine dropped its relative-path instruction because of it.

## What is measured now (ollama 0.32.5)

The launcher execs the integration in its own working directory. The cwd r4t
passes to `Popen` (`dispatch.py:663`, from `resolve_workdir` at
`dispatch.py:1419`) reaches the harness and everything under it.

Method: spawn `ollama launch <integration> ... -- <the shipped preset's
passthrough>` with its own cwd, then read the OS-reported cwd (`lsof -d cwd`)
of every descendant while the turn runs — no dependence on model behavior.

| integration | launcher cwd | harness cwd |
|---|---|---|
| opencode | spawn dir | spawn dir |
| claude | spawn dir | spawn dir |
| codex | spawn dir | spawn dir (plus its node/vendored children) |
| copilot | spawn dir | spawn dir |

Also confirmed end-to-end through r4t's own layers (`build_preset_invoke` →
`run_harness` → real `ollama launch` → a probe harness on PATH): the probe
reports the workdir as `getcwd()`.

So the invoke needs no change. The launcher does clobber
`OPENCODE_CONFIG_CONTENT` with its own config, which is exactly why the `mcp`
knob uses the `OPENCODE_CONFIG` file-path form — untouched here.

## What remains true

The narrower #273 finding, which is about the root a harness *advertises*
rather than the cwd it runs in: opencode-family rigs hand the model the
enclosing git root as a "workspace root", `opencode-ollama` included. That
paragraph stays; the lost-cwd claim goes.

## Changes

- `apps/r4t/docs/rigs.md`, `apps/r4t/roster.py`, `apps/r4t/docs/harness-ollama-launch.md` — present truth: the turn cwd reaches every rig, wrappers included; the advertised-root caveat is scoped to the opencode family.
- `apps/r4t/tests/test_dispatch.py` — regression test for the r4t-owned half of the contract: a fake launcher execs a fake harness the way the real one does, driven by the shipped `opencode-ollama` argv, and the harness reports the workdir it was given (also asserts the passthrough argv after `--`).

## Tests

`755 passed` — full `apps/r4t/tests/` suite on this branch's base (`origin/main` @ #321).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
