### PR TITLE
fix(a8s): file-proxy delivery no longer queues behind an in-flight wake

### DIFF
--- a/apps/a8s/DEVELOPMENT.md
+++ b/apps/a8s/DEVELOPMENT.md
@@ -18,6 +18,10 @@ Read `README.md` first for concept and usage.
 - **Per-agent take-over via detach-request (no orphans).** Don't reintroduce
   process-level SIGTERM-and-wait in `acquire`.
 - **Per-agent kill via kill-request + SIGUSR1.** Handler checks at iteration top.
+- **File-proxy delivery is ungated.** `attached_loop` promotes a proxy's
+  envelopes every iteration, including while another handled agent's wake is
+  in flight — the move spawns nothing, and `tells` watches that inbox. Only
+  subprocess wakes queue behind the single in-flight slot.
 - **Agent-directory invariant — `.outbox/` is one-way.** a8s never reads or
   writes sidecars there. Ingest is atomic rename into `pending/`.
 - **Remote routing publishes to all configured remotes.** Receivers dedupe by ULID.

--- a/apps/a8s/daemon.py
+++ b/apps/a8s/daemon.py
@@ -879,7 +879,8 @@ def attached_loop(names: list[str], interval: float, *, single_pass: bool = Fals
         issue #68): release just the requested agent and keep serving the rest
       - reload registry (so newly-added agents become routable recipients)
       - drop any agent whose pid file no longer points at us (defense)
-      - route each handled agent's outbox; drain each handled agent's inbox
+      - route each handled agent's outbox; deliver every file proxy's inbox;
+        then wake one non-proxy agent if the wake slot is free
 
     On 1st signal: detach all currently-handled agents (graceful — finish the
     in-flight wake first). On 2nd signal: SIGTERM-then-SIGKILL the wake
@@ -997,34 +998,43 @@ def attached_loop(names: list[str], interval: float, *, single_pass: bool = Fals
                                 clear_inbox_waiting_since(p.name)
                                 break
                             _drain_one(p, msg)
-                elif not _wake_in_flight():
+                else:
+                    defined: list[tuple[Participant, dict]] = []
                     for p in handled:
-                        if _wake_in_flight():
-                            break
                         try:
-                            definition = load_definition(p.name)
+                            defined.append((p, load_definition(p.name)))
                         except (FileNotFoundError, RuntimeError) as e:
                             out_agent(p.name, f"[{p.name}] {e}")
-                            continue
-                        while not _STOP_EVENT.is_set():
+                    # A file proxy's delivery is a file move that spawns
+                    # nothing, so it has no reason to queue behind the single
+                    # wake slot (issue #163). Gating it froze proxy inboxes —
+                    # and `tells`, which watches them — for as long as some
+                    # other handled agent's turn ran, up to max_wake_seconds.
+                    for p, definition in defined:
+                        if is_file_proxy(definition):
+                            _dispatch_agent(p, definition, async_wake=False)
+                    if not _wake_in_flight():
+                        for p, definition in defined:
                             if _wake_in_flight():
                                 break
-                            started = _dispatch_agent(
-                                p, definition, async_wake=async_wake
-                            )
-                            if started:
-                                break
-                            if async_wake:
-                                break
-                            if not peek_inbox_messages(p, 1):
-                                break
-                            if (
-                                not is_file_proxy(definition)
-                                and not _pause_ready_for_wake(
-                                    p.name, pause_seconds(definition)
+                            if is_file_proxy(definition):
+                                continue
+                            while not _STOP_EVENT.is_set():
+                                if _wake_in_flight():
+                                    break
+                                started = _dispatch_agent(
+                                    p, definition, async_wake=async_wake
                                 )
-                            ):
-                                break
+                                if started:
+                                    break
+                                if async_wake:
+                                    break
+                                if not peek_inbox_messages(p, 1):
+                                    break
+                                if not _pause_ready_for_wake(
+                                    p.name, pause_seconds(definition)
+                                ):
+                                    break
                 if (
                     not _STOP_EVENT.is_set()
                     and drain_seconds == 0

--- a/apps/a8s/tests/test_daemon.py
+++ b/apps/a8s/tests/test_daemon.py
@@ -1079,3 +1079,105 @@ class TestAsyncAttachedLoop:
         log = _read_log("A")
         assert "max wake time" in log
         assert "0.25" in log
+
+
+class TestSharedHandlerStarvation:
+    """Issue #163 — one agent's in-flight wake must not freeze delivery to the
+    other agents a shared handler serves."""
+
+    def _queue(self, name: str, content: str) -> str:
+        from ulid import new as new_ulid
+
+        msg_id = new_ulid()
+        (inbox_dir(name) / f"{msg_id}.json").write_text(
+            json.dumps({
+                "id": msg_id,
+                "date": "2026-04-29T12:00:00Z",
+                "from": "Y",
+                "to": name,
+                "content": content,
+                "files": [],
+            })
+        )
+        return msg_id
+
+    def _setup(self, tmp_path, fixtures_dir, sibling_def: Path) -> Path:
+        for sub in ("a", "b"):
+            (tmp_path / sub).mkdir()
+        save_registry({
+            "A": {
+                "root": str(tmp_path / "a"),
+                "definition": str(fixtures_dir / "mock-slow.json"),
+            },
+            "B": {
+                "root": str(tmp_path / "b"),
+                "definition": str(sibling_def),
+            },
+        })
+        ensure_mailboxes(Participant("A", tmp_path / "a"))
+        ensure_mailboxes(Participant("B", tmp_path / "b"))
+        self._queue("A", "slow-wake")
+        return tmp_path / "b" / ".inbox"
+
+    def test_file_proxy_delivery_runs_during_in_flight_wake(
+        self, fake_home, tmp_path, fixtures_dir, monkeypatch
+    ):
+        import daemon as daemon_mod
+
+        monkeypatch.setenv("MOCK_SLEEP", "3")
+        defp = tmp_path / "proxy.json"
+        defp.write_text(json.dumps({"proxy": "file", "idle": {"timeout": 30}}))
+        proxy_inbox = self._setup(tmp_path, fixtures_dir, defp)
+
+        in_flight_at_delivery: list[bool] = []
+        sent = False
+        wait_calls = 0
+
+        def stop_when_delivered(self, timeout=None):
+            nonlocal sent, wait_calls
+            wait_calls += 1
+            if not sent:
+                if daemon_mod._wake_in_flight():
+                    _write_outbox("A", tmp_path / "a", "B", "mid-wake", [])
+                    sent = True
+            elif not in_flight_at_delivery and list(proxy_inbox.glob("*.json")):
+                in_flight_at_delivery.append(daemon_mod._wake_in_flight())
+                daemon_mod._STOP_EVENT.set()
+            if wait_calls >= 500:
+                daemon_mod._STOP_EVENT.set()
+            return True
+
+        monkeypatch.setattr(threading.Event, "wait", stop_when_delivered)
+        attached_loop(["A", "B"], 0.05, single_pass=False)
+
+        assert "exec:" in _read_log("A")
+        assert in_flight_at_delivery == [True]
+        bodies = [json.loads(f.read_text())["content"] for f in proxy_inbox.glob("*.json")]
+        assert bodies == ["mid-wake"]
+
+    def test_sibling_wake_still_waits_for_the_single_wake_slot(
+        self, fake_home, tmp_path, fixtures_dir, monkeypatch
+    ):
+        import daemon as daemon_mod
+
+        monkeypatch.setenv("MOCK_SLEEP", "3")
+        self._setup(tmp_path, fixtures_dir, fixtures_dir / "mock.json")
+        self._queue("B", "for-sibling")
+
+        saw_in_flight = False
+        wait_calls = 0
+
+        def stop_once_wake_started(self, timeout=None):
+            nonlocal saw_in_flight, wait_calls
+            wait_calls += 1
+            if daemon_mod._wake_in_flight():
+                saw_in_flight = True
+            if (saw_in_flight and wait_calls >= 5) or wait_calls >= 60:
+                daemon_mod._STOP_EVENT.set()
+            return True
+
+        monkeypatch.setattr(threading.Event, "wait", stop_once_wake_started)
+        attached_loop(["A", "B"], 0.05, single_pass=False)
+
+        assert saw_in_flight
+        assert "exec:" not in _read_log("B")


### PR DESCRIPTION
Fixes #163.

## Verified on current main (17e9d7c)

Still reproduces. `attached_loop` gates its entire inbox pass on the
handler-global wake slot — `apps/a8s/daemon.py:1000` (pre-fix)
`elif not _wake_in_flight():`. The only code path that promotes a file
proxy's envelopes into the agent's own inbox dir is `_dispatch_agent` →
`wake_once` → `_deliver_file_proxy` (`daemon.py:848` / `daemon.py:355` /
`daemon.py:292`), and it lives inside that gate. `route_outboxes` already
runs ungated at `daemon.py:984`, so mail lands in the internal inbox on time
and then stops there.

Log from the new regression test with the fix reverted — the envelope routes,
then nothing moves it for the rest of the wake:

```
[A] exec: .../mock-slow-cli 'FROM:Y|TO:A|MSG:slow-wake'
routed: A -> B: mid-wake
received from A: mid-wake
A> [21:59:55] MOCK-CLI: FROM:Y|TO:A|MSG:slow-wake      <- wake ends
[a8s] A: detached
```

No `proxy: delivered` line. With the fix it appears while the wake is still
in flight.

## Fix shape

The gate's job is keeping two LLM CLI subprocesses off each other. A file
proxy's delivery is a `shutil.move` that spawns nothing, so it never needed
the slot. The iteration now loads each handled agent's definition once,
delivers every proxy unconditionally, and only then reaches for the wake slot
on behalf of the non-proxy agents.

No threads, no async, no new daemon — a reordering of the pass that already
existed. Subprocess wakes stay serialized exactly as before (second test
guards that). The issue's "better" option, a per-agent wake slot, would mean
N tracked processes, N stdout pumps, N timeouts and per-agent SIGUSR1
routing; that stays with #152/#153, and running one handler per agent remains
the way to get wake concurrency today.

`tells` gets fixed by the same change — it watches the proxy `.inbox`, so it
was waiting out whatever sibling turn happened to be running.

## Tests

`apps/a8s/tests/test_daemon.py::TestSharedHandlerStarvation`

- `test_file_proxy_delivery_runs_during_in_flight_wake` — A runs a 3s wake;
  mid-wake a message is routed to proxy seat B; asserts it reaches B's
  `.inbox` **and** that `_wake_in_flight()` was still true at that moment.
  Fails on pre-fix code.
- `test_sibling_wake_still_waits_for_the_single_wake_slot` — same setup with
  B as a normal CLI agent; asserts B never execs while A's wake is in flight,
  so the fix didn't quietly allow concurrent wakes.

Full suite: 802 passed (including the sometimes-flaky remote e2e).

Also recorded the invariant in `DEVELOPMENT.md` so a future refactor doesn't
fold proxy delivery back behind the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
