### PR TITLE
fix(r4t): opencode rigs anchor on the member's Workdir, not the caller's PWD

### DIFF
--- a/apps/r4t/dispatch.py
+++ b/apps/r4t/dispatch.py
@@ -605,10 +605,13 @@ def run_harness(
     variant: int = 0,
 ) -> tuple[int, str, float, bool]:
     """Run the rig's argv (pool variant `variant`) with {prompt} substituted
-    as a single argv element — never a shell. Returns (exit_code, output,
-    duration_seconds, timed_out). When the env carries `R4T_LIVE_LOG`, the
-    harness output is teed there line by line as it arrives, so a gemba attach
-    can tail the turn live; the full output is still returned for staging.
+    as a single argv element — never a shell — and {workdir} with `cwd`, for a
+    harness that takes its working directory as an argument. Returns
+    (exit_code, output, duration_seconds, timed_out). `PWD` in the turn env is
+    pinned to `cwd`, because a spawned process otherwise inherits the caller's.
+    When the env carries `R4T_LIVE_LOG`, the harness output is teed there line
+    by line as it arrives, so a gemba attach can tail the turn live; the full
+    output is still returned for staging.
 
     When the org sets `run_as` or `container` (org.py; plans/ISOLATE-SPEC.md)
     the choice rides in via the turn env and the argv is wrapped in the OS-level
@@ -621,7 +624,10 @@ def run_harness(
     `cwd`. It rides the env for the same reason isolation does: the run_fn
     contract stays narrow."""
     argv = rig.argv(
-        prompt, variant, continue_conversation=(env or {}).get("R4T_CONTINUE") == "1"
+        prompt,
+        variant,
+        continue_conversation=(env or {}).get("R4T_CONTINUE") == "1",
+        workdir=cwd,
     )
     if rig.model_resolver == "agy-live":
         # Resolve the friendly --model against the live `agy models` list before
@@ -680,6 +686,11 @@ def run_harness(
         )
 
     live_log = (env or {}).get("R4T_LIVE_LOG")
+    # PWD is a shell convention no kernel maintains, so a spawned harness
+    # inherits the PWD of whoever started r4t however `cwd` is set. A harness
+    # that resolves its own paths against it (opencode does, for --dir) would
+    # anchor them outside the member's workdir (#273).
+    turn_env = dict(env if env is not None else os.environ, PWD=str(cwd))
     start = time.monotonic()
     try:
         proc = subprocess.Popen(
@@ -689,7 +700,7 @@ def run_harness(
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
-            env=env,
+            env=turn_env,
             start_new_session=True,
         )
     except OSError as e:

--- a/apps/r4t/docs/harness-ollama-launch.md
+++ b/apps/r4t/docs/harness-ollama-launch.md
@@ -29,7 +29,10 @@ ollama launch <integration> --model <tag> -y -- <the harness's own headless argv
   by spawning each wrapped integration with a cwd of its own and reading the
   OS-reported cwd of every descendant: launcher, harness, and the node/codex
   helpers underneath all sat in the spawn directory. That is what makes
-  `Workdir:` work on the `*-ollama` presets (issue #289).
+  `Workdir:` work on the `*-ollama` presets (issue #289). A harness that reads
+  something other than its cwd needs more than the hop: opencode resolves
+  `--dir` against `$PWD`, so r4t pins `PWD` to the turn directory and the
+  opencode presets pass the workdir absolutely (issue #273).
 
 ## What the launcher persists, per integration
 

--- a/apps/r4t/docs/rigs.md
+++ b/apps/r4t/docs/rigs.md
@@ -77,16 +77,27 @@ because there the refound is meant to carry rolling context forward.
 `- **Workdir:** <path>` in the roster runs a member's turns from its own
 directory (relative paths resolve against the workplace; absolute and `~`
 paths may live outside the repo). r4t sets the harness subprocess cwd to it,
-and the member's prompt names it as the absolute root everything it writes
-belongs under.
+states it in the prompt as the absolute root everything the member writes
+belongs under, and hands it to any harness that takes its working directory as
+an argument — `{workdir}` anywhere in an `invoke` is substituted with the
+member's resolved absolute path (the opencode presets pass it as `--dir`).
 
-**Rigs do not all treat that directory as the project root.** The
-opencode-family presets keep two paths: the working directory and a separate
-*workspace root* discovered by walking up for a `.git` — the enclosing repo.
-Both are shown to the model, and a model that takes the advertised root at its
-word writes there by absolute path. `claude`/`cursor` advertise no competing
-root, so their members stay in the workdir. No opencode flag or env var pins
-the root; `--dir` does not.
+Two knobs, because the cwd alone does not reach every harness. `PWD` is a shell
+convention no kernel maintains, so a spawned process inherits the `PWD` of
+whoever started r4t however its cwd is set, and a harness that resolves paths
+against `PWD` lands outside the workdir. r4t pins `PWD` to the workdir in every
+turn env for that reason; `{workdir}` is the belt to that braces, since an
+absolute path in the argv depends on no environment at all.
+
+**Rigs still do not all treat that directory as the project root.** The
+opencode-family presets keep two paths: the working directory (which their file
+tools anchor on, and which `--dir` pins) and a separate *workspace root*
+discovered by walking up for a `.git` — the enclosing repo. Both are shown to
+the model, and a model that takes the advertised root at its word writes there
+by absolute path. `claude`/`cursor` advertise no competing root, so their
+members stay in the workdir. No opencode flag or env var pins that root:
+`--dir` sets the working directory, and the root is always the git walk-up from
+it.
 
 The `ollama launch`-wrapped presets inherit their parent's behavior and nothing
 worse: the launcher execs the integration in the directory r4t spawned it in,

--- a/apps/r4t/docs/rigs.md
+++ b/apps/r4t/docs/rigs.md
@@ -86,8 +86,8 @@ Two knobs, because the cwd alone does not reach every harness. `PWD` is a shell
 convention no kernel maintains, so a spawned process inherits the `PWD` of
 whoever started r4t however its cwd is set, and a harness that resolves paths
 against `PWD` lands outside the workdir. r4t pins `PWD` to the workdir in every
-turn env for that reason; `{workdir}` is the belt to that braces, since an
-absolute path in the argv depends on no environment at all.
+turn env for that reason; `{workdir}` is the second pin, an absolute path in
+the argv that depends on no environment at all.
 
 **Rigs still do not all treat that directory as the project root.** The
 opencode-family presets keep two paths: the working directory (which their file

--- a/apps/r4t/docs/tutorial.md
+++ b/apps/r4t/docs/tutorial.md
@@ -45,7 +45,7 @@ r4t init
 - **`ROSTER.md`** — a Human owner, an AI Lead on rig `leader`, an AI Dev on
   rig `member`
 - **`~/.config/r4t/rigs.json`** — matching `leader` and `member` rig
-  definitions (default invoke: `opencode run --auto --dir .`)
+  definitions (default invoke: `opencode run --auto --dir {workdir}`)
 
 It then prints the exact **a8s registration** sequence for your repo name:
 

--- a/apps/r4t/example-rigs.json
+++ b/apps/r4t/example-rigs.json
@@ -5,6 +5,8 @@
     "defined here can run. A roster Harness naming a rig absent from this file fails",
     "closed. Keys starting with _ are ignored everywhere.",
     "{prompt} is replaced with the built prompt as a single argv element — never a shell.",
+    "{workdir} is replaced with the member's absolute working directory, for a CLI that",
+    "takes one as an argument (opencode: --dir {workdir}).",
     "Every key below is optional; the values shown for the governance knobs are the",
     "defaults. See README.md for the knob table and docs/governance.md for why."
   ],
@@ -31,8 +33,8 @@
   "junior-dev": {
     "_notes": "Cheap worker rig — OpenCode with whatever model the repo's opencode.json picks. A local model runs almost freely, so a generous budget. invoke may also be a POOL (list of argvs) rotated round-robin per turn — agents never know which variant ran them.",
     "invoke": [
-      ["opencode", "run", "--auto", "{prompt}"],
-      ["opencode", "run", "--auto", "--model", "ollama/gpt-oss:20b", "{prompt}"]
+      ["opencode", "run", "--auto", "--dir", "{workdir}", "{prompt}"],
+      ["opencode", "run", "--auto", "--dir", "{workdir}", "--model", "ollama/gpt-oss:20b", "{prompt}"]
     ],
     "timeout_seconds": 900,
     "budget_max": 40,

--- a/apps/r4t/rig.py
+++ b/apps/r4t/rig.py
@@ -76,6 +76,10 @@ from roster import Member, Roster
 from state import atomic_write_json, r4t_home
 
 PROMPT_PLACEHOLDER = "{prompt}"
+# The directory the turn runs from, for harnesses that take it as an argument
+# rather than reading their own cwd. dispatch.run_harness fills it with the
+# member's resolved `Workdir:`.
+WORKDIR_PLACEHOLDER = "{workdir}"
 
 RESERVED_CONFIG_KEYS = frozenset({
     "pins",
@@ -171,12 +175,17 @@ HARNESS_PRESETS: dict[str, dict] = {
         "a8s_definition": "opencode.json",
         "headless": "run --auto (positional prompt)",
         "mcp": "opencode-env",
+        # --dir takes the workdir as an ABSOLUTE path. opencode resolves a
+        # relative --dir against $PWD, falling back to its real cwd only when
+        # PWD is unset, and a spawned process inherits the PWD of whoever
+        # started r4t — so `--dir .` anchored the file tools wherever r4t was
+        # invoked from, not the member's `Workdir:` (#273).
         "invoke": [
             "opencode",
             "run",
             "--auto",
             "--dir",
-            ".",
+            "{workdir}",
             "{prompt}",
         ],
         "model_argv": ["-m", "{model}"],
@@ -202,7 +211,7 @@ HARNESS_PRESETS: dict[str, dict] = {
             "run",
             "--auto",
             "--dir",
-            ".",
+            "{workdir}",
             "{prompt}",
         ],
         # `ollama launch` passes the appended flag through to opencode, whose
@@ -482,10 +491,20 @@ class Rig:
         return len(self.pool())
 
     def argv(
-        self, prompt: str, index: int = 0, *, continue_conversation: bool = False
+        self,
+        prompt: str,
+        index: int = 0,
+        *,
+        continue_conversation: bool = False,
+        workdir: str | Path | None = None,
     ) -> list[str]:
         pool = self.pool()
         chosen = pool[index % len(pool)]
+        # {workdir} goes in first: the prompt carries message text, so
+        # substituting it last keeps a `{workdir}` a teammate typed from being
+        # read as a placeholder.
+        if workdir is not None:
+            chosen = [a.replace(WORKDIR_PLACEHOLDER, str(workdir)) for a in chosen]
         argv = [a.replace(PROMPT_PLACEHOLDER, prompt) for a in chosen]
         if continue_conversation and self.continue_argv:
             anchor = self.continue_anchor
@@ -1572,9 +1591,9 @@ def default_config_payload() -> dict:
             "All governance knobs default sanely; see apps/r4t/docs/rigs.md.",
         ],
         "leader": {
-            "invoke": ["opencode", "run", "--auto", "--dir", ".", "{prompt}"],
+            "invoke": ["opencode", "run", "--auto", "--dir", "{workdir}", "{prompt}"],
         },
         "member": {
-            "invoke": ["opencode", "run", "--auto", "--dir", ".", "{prompt}"],
+            "invoke": ["opencode", "run", "--auto", "--dir", "{workdir}", "{prompt}"],
         },
     }

--- a/apps/r4t/roster.py
+++ b/apps/r4t/roster.py
@@ -35,11 +35,12 @@ directory for turns. Relative paths resolve against the org workplace
 outside the repo entirely. Absent means the member runs from the workplace
 root. The directory is created on demand at the start of a turn.
 It sets the turn's cwd — which every rig receives, `ollama launch` wrappers
-included — and the prompt names it as the member's root, but no harness is
-obliged to treat it as the project root: opencode-family rigs also advertise
-the enclosing git root to the model as a "workspace root". A workdir nested in
-a repo can therefore still attract writes to the repo root (issue #273; see
-docs/rigs.md).
+included — fills a `{workdir}` in the rig's invoke for a CLI that takes its
+working directory as an argument, and the prompt names it as the member's root.
+No harness is obliged to treat it as the project root, though:
+opencode-family rigs also advertise the enclosing git root to the model as a
+"workspace root". A workdir nested in a repo can therefore still attract writes
+to the repo root (issue #273; see docs/rigs.md).
 """
 from __future__ import annotations
 

--- a/apps/r4t/tests/test_dispatch.py
+++ b/apps/r4t/tests/test_dispatch.py
@@ -1901,7 +1901,52 @@ class TestRunHarness:
         code, out, _dur, timed_out = run_harness(rig, "x", workdir, env=dict(os.environ))
         assert code == 0 and not timed_out
         assert f"harness cwd: {workdir}" in out
-        assert "harness argv: run --auto --dir . x" in out
+        # The cwd survives the hop, and the workdir also rides the argv, because
+        # opencode reads --dir rather than its own cwd (#273).
+        assert f"harness argv: run --auto --dir {workdir} x" in out
+
+    def _pwd_probe(self, tmp_path):
+        script = tmp_path / "where.py"
+        script.write_text(
+            "import os\nprint('PWD=' + os.environ.get('PWD', ''))\n"
+            "print('CWD=' + os.getcwd())\n",
+            encoding="utf-8",
+        )
+        return script
+
+    def test_workdir_placeholder_becomes_the_turn_directory(self, tmp_path):
+        # opencode takes its working directory as an argument, so the resolved
+        # Workdir has to reach the argv and not only the subprocess cwd (#273).
+        workdir = tmp_path / "agents" / "bob"
+        workdir.mkdir(parents=True)
+        rig = Rig(name="oc", invoke=["printf", "%s\\n", "--dir", "{workdir}", "{prompt}"])
+        code, out, _dur, timed_out = run_harness(rig, "hi", workdir)
+        assert code == 0 and not timed_out
+        assert str(workdir) in out
+        assert "{workdir}" not in out
+
+    def test_pwd_names_the_turn_directory_not_the_caller(self, tmp_path, monkeypatch):
+        # PWD is inherited, never updated for a subprocess cwd, and opencode
+        # resolves a relative --dir against it (#273).
+        monkeypatch.setenv("PWD", str(tmp_path / "invoked-from"))
+        workdir = tmp_path / "agents" / "bob"
+        workdir.mkdir(parents=True)
+        rig = Rig(name="t", invoke=[sys.executable, str(self._pwd_probe(tmp_path)), "{prompt}"])
+        code, out, _dur, _timed = run_harness(rig, "x", workdir)
+        assert code == 0
+        assert f"PWD={workdir}" in out
+        assert "invoked-from" not in out
+
+    def test_pwd_pinned_over_an_explicit_turn_env(self, tmp_path):
+        workdir = tmp_path / "agents" / "bob"
+        workdir.mkdir(parents=True)
+        env = dict(os.environ, PWD=str(tmp_path / "invoked-from"))
+        rig = Rig(name="t", invoke=[sys.executable, str(self._pwd_probe(tmp_path)), "{prompt}"])
+        code, out, _dur, _timed = run_harness(rig, "x", workdir, env=env)
+        assert code == 0
+        assert f"PWD={workdir}" in out
+        # The caller's env dict is the turn's record; run_harness leaves it be.
+        assert env["PWD"] == str(tmp_path / "invoked-from")
 
     def test_agy_model_resolved_live_before_turn(self, tmp_path, monkeypatch):
         # The stored argv carries a {model} placeholder; run_harness resolves it
@@ -2861,6 +2906,27 @@ class TestWorkdir:
         run_one(ctx, "acme:bob", "acme:gerry", "hi", run_fn=self.recording_run(turns))
         prompt, _cwd = turns[0]
         assert "org workplace" not in prompt
+
+    def test_real_turn_hands_the_workdir_to_an_opencode_shaped_rig(
+        self, r4t_home, tmp_path, rig_config, tells
+    ):
+        # The whole path: roster Workdir -> resolve_workdir -> run_harness ->
+        # `--dir <absolute workdir>` in the argv the CLI actually sees (#273).
+        seen = tmp_path / "argv.txt"
+        script = tmp_path / "argv-probe.py"
+        script.write_text(
+            "import sys\n"
+            f"open({str(seen)!r}, 'w').write(' '.join(sys.argv[1:]))\n",
+            encoding="utf-8",
+        )
+        config = json.loads(rig_config.read_text(encoding="utf-8"))
+        config["junior-dev"]["invoke"] = [
+            sys.executable, str(script), "--dir", "{workdir}", "{prompt}",
+        ]
+        rig_config.write_text(json.dumps(config), encoding="utf-8")
+        ctx = self.make_ctx(tmp_path, rig_config, tells, "agents/bob")
+        assert run_one(ctx, "acme:gerry", "acme:bob", "hi") == 1
+        assert f"--dir {ctx.root / 'agents' / 'bob'}" in seen.read_text(encoding="utf-8")
 
 
 HEREDOC_TEACHING = "tell <name> - <<'EOF'"

--- a/apps/r4t/tests/test_rig.py
+++ b/apps/r4t/tests/test_rig.py
@@ -272,6 +272,62 @@ class TestArgv:
         assert config.rigs["t"].argv("X") == ["run", "prompt=X"]
 
 
+class TestWorkdirPlaceholder:
+    """`{workdir}` carries the member's resolved `Workdir:` into the argv, for a
+    harness that takes its working directory as an argument (#273)."""
+
+    def _rig(self, tmp_path, argv):
+        return load_rig_config(write_config(tmp_path, {"t": {"invoke": argv}})).rigs["t"]
+
+    def test_substituted_when_given(self, tmp_path):
+        rig = self._rig(tmp_path, ["oc", "--dir", "{workdir}", "{prompt}"])
+        assert rig.argv("hi", workdir="/repo/agents/bob") == [
+            "oc", "--dir", "/repo/agents/bob", "hi",
+        ]
+
+    def test_accepts_a_path(self, tmp_path):
+        rig = self._rig(tmp_path, ["oc", "--dir", "{workdir}", "{prompt}"])
+        assert rig.argv("hi", workdir=Path("/repo/agents/bob"))[2] == "/repo/agents/bob"
+
+    def test_left_alone_when_not_given(self, tmp_path):
+        rig = self._rig(tmp_path, ["oc", "--dir", "{workdir}", "{prompt}"])
+        assert rig.argv("hi") == ["oc", "--dir", "{workdir}", "hi"]
+
+    def test_prompt_text_is_never_read_as_a_placeholder(self, tmp_path):
+        # A teammate may write "{workdir}" in a message; the prompt is data.
+        rig = self._rig(tmp_path, ["oc", "--dir", "{workdir}", "{prompt}"])
+        argv = rig.argv("put it in {workdir}", workdir="/repo/agents/bob")
+        assert argv == ["oc", "--dir", "/repo/agents/bob", "put it in {workdir}"]
+
+    def test_embedded_in_a_token(self, tmp_path):
+        rig = self._rig(tmp_path, ["oc", "--dir={workdir}", "{prompt}"])
+        assert rig.argv("hi", workdir="/w")[1] == "--dir=/w"
+
+    def test_substituted_in_every_pool_variant(self, tmp_path):
+        rig = self._rig(tmp_path, [
+            ["oc", "--dir", "{workdir}", "{prompt}"],
+            ["oc", "--dir", "{workdir}", "-m", "local", "{prompt}"],
+        ])
+        assert rig.argv("hi", 0, workdir="/w")[2] == "/w"
+        assert rig.argv("hi", 1, workdir="/w")[2] == "/w"
+
+    def test_opencode_presets_pin_the_workdir_absolutely(self):
+        # opencode resolves a RELATIVE --dir against $PWD (its real cwd only as
+        # a fallback), and a spawned harness inherits the PWD of whoever started
+        # r4t — so `--dir .` anchored the file tools outside the workdir.
+        for preset in ("opencode", "opencode-ollama"):
+            argv = HARNESS_PRESETS[preset]["invoke"]
+            assert "--dir" in argv
+            assert argv[argv.index("--dir") + 1] == "{workdir}"
+            assert "." not in argv
+
+    def test_init_starter_rigs_pin_the_workdir(self):
+        for entry in default_config_payload().values():
+            if not isinstance(entry, dict) or "invoke" not in entry:
+                continue
+            assert "{workdir}" in entry["invoke"]
+
+
 class TestContinue:
     def test_only_verified_presets_declare_continue(self):
         # Each of these was verified against the installed CLI's own --help and


### PR DESCRIPTION
Fixes the `Workdir:` half of #273 at the invoke layer, with opencode's own
flag. The issue's writeup concluded there was no invoke-level fix; a re-read of
the 1.18.3 binary found the mechanism it was missing, and that mechanism is
fixable.

## Root cause: opencode resolves `--dir` against `$PWD`, not its cwd

```js
function U1(D, u = process.env.PWD, F = process.cwd()) {
  let C = BD.resolve(u ?? F)
  if (D) return BD.resolve(isAbsolute(D) ? D : join(C, D))
  return BD.resolve(F)
}
```

A **relative** `--dir` is joined onto `process.env.PWD`; the real cwd is only
the fallback for when PWD is unset. `PWD` is a shell convention no kernel
maintains — `Popen(cwd=...)` does not touch it — so the harness inherited the
PWD of whoever started r4t, and the preset's `--dir .` resolved *there*. The
file tools then anchor a relative path on that same value:

```js
u = isAbsolute(i.filePath) ? i.filePath : join(y.directory, i.filePath)
```

This is the upstream cause of the symptom in the issue's second comment
(`Working directory: /private/tmp`, `Workspace root folder: /`). The
`ollama launch` wrapper was not to blame — it does carry the cwd through
(`lsof -d cwd` on the spawned `opencode` shows the workdir), which #322
independently measured across all four wrapped integrations. PWD was the leak.
Rebased onto #322, so its paragraph stands and this adds the reason the cwd
alone was not enough for opencode.

## Repro, deterministic and model-free

Fresh `git init` sandbox with a workdir at `agents/w`, isolated `OPENCODE_DB`,
opencode 1.18.3, reading `session.directory` / `project.worktree` back out of
the DB — no dependence on model behavior:

| trial | real cwd | `PWD` | `--dir` | `session.directory` |
|---|---|---|---|---|
| E | workdir | workdir | `.` | workdir ✅ |
| **F** | **workdir** | **`/private/tmp`** | **`.`** | **`/private/tmp`** ❌ (`worktree` = `/`) |
| G | workdir | `/private/tmp` | **absolute workdir** | workdir ✅ |
| H | `/private/tmp` | workdir | `.` | workdir ✅ |

F is the shipped state: cwd correct, PWD stale, anchor lost. G and H are the
two pins below, each sufficient on its own.

## The fix

- **`--dir {workdir}`** in the `opencode` and `opencode-ollama` presets.
  `{workdir}` is a new invoke placeholder that `run_harness` substitutes with
  the member's resolved absolute `Workdir:`, for any harness that takes its
  working directory as an argument. An absolute path depends on no environment
  at all (trial G).
- **`PWD` pinned to the turn cwd** in the env every harness gets. A stale PWD
  is simply wrong about the process it describes, whatever CLI reads it. This
  also fixes rigs already on disk that keep their `--dir .` (trial H) — pre-v1
  writes no migration, and none is needed.

Each covers where the other cannot. An isolated turn is the clearest case: past
a `run_as` or container boundary the turn env does not cross intact (sudoers
`env_reset`, and `docker run` sees only what #321's `McpPlan` says to pass), so
there the absolute path in the argv is the pin that survives.

Substitution order is workdir first, then prompt, so a `{workdir}` a teammate
types into a message stays data.

## What this does not fix

opencode's separate **workspace root** — the git walk-up from `directory`,
which it advertises to the model next to the working directory. No flag and no
env var pins it: `--dir` moves the working directory and the root follows the
enclosing repo (`Git.repo.discover` walks up for `.git`, then
`rev-parse --show-toplevel`). `OPENCODE_FAKE_VCS` sets the vcs *type*;
`OPENCODE_WORKSPACE_ID` / `OPENCODE_EXPERIMENTAL_WORKSPACES` belong to the
experimental server-side workspace routing, not to `run`. So the prompt
doctrine from #288 stays the mitigation for a model that believes the
advertised root, and `docs/rigs.md` keeps saying so. What changes is that the
directory the tools actually anchor on is now the member's workdir, whatever
the environment.

Suggest keeping #273 open for the advertised-root half, or closing it with the
mitigation-1 note carried to #153.

## Tests

`apps/r4t/tests/` — **767 passed** (755 on main; +12):

- `TestWorkdirPlaceholder` (8) — substitution, `Path` input, left alone when
  absent, prompt text never read as a placeholder, embedded in a token, every
  pool variant, both opencode presets pin absolutely, `r4t init` starter rigs.
- `TestRunHarness` (3) — `{workdir}` becomes the turn directory; `PWD` names
  the turn directory not the caller, both for an inherited env and an explicit
  turn env dict (which is left unmutated).
- `TestWorkdir` (1) — the whole path, roster `Workdir:` through to the `--dir`
  the CLI actually receives.

#322's `test_turn_cwd_reaches_a_launcher_wrapped_harness` now asserts
`run --auto --dir <absolute workdir> x`, so it pins both halves of the contract
through the launcher hop: the cwd it was written for, and the argv this adds.

Also smoke-checked `r4t rig presets` / `rig add`, which render
`opencode run --auto --dir {workdir} {prompt}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
