### PR TITLE
feat(r4t): mcp defaults on per preset where the harness idiom is invocation-scoped

### DIFF
--- a/apps/r4t/dispatch.py
+++ b/apps/r4t/dispatch.py
@@ -586,7 +586,7 @@ def build_prompt(
         "## How to work",
         ctx.prompt("work_batch"),
         ctx.prompt("work_never_wait"),
-        ctx.prompt("work_tell_mcp" if rig.mcp else "work_tell"),
+        ctx.prompt("work_tell_mcp" if rig.mcp_on else "work_tell"),
         *(teammates or ["    - (none)"]),
         ctx.prompt("work_direct"),
         ctx.prompt("work_no_ack"),
@@ -643,7 +643,7 @@ def run_harness(
     # cross when the wrapper is told to carry them — so the injection states its
     # needs and the wrapper below honours them.
     mcp = McpPlan(argv=argv)
-    if rig.mcp and env is not None:
+    if rig.mcp_on and env is not None:
         mcp = apply_mcp(rig, argv, env, cwd, isolation)
         argv = mcp.argv
 

--- a/apps/r4t/docs/isolation.md
+++ b/apps/r4t/docs/isolation.md
@@ -171,8 +171,9 @@ deterministic name and lets `--rm` reap it.
 
 ## The `a8s_tell` tool behind the boundary
 
-`r4t rig set <rig> mcp on` ([rigs](rigs.md#the-a8s_tell-tool-mcp)) injects the
-a8s MCP server into every turn, and each harness takes it a different way:
+The `mcp` knob ([rigs](rigs.md#the-a8s_tell-tool-mcp)) — on by default on most
+presets — injects the a8s MCP server into every turn, and each harness takes it
+a different way:
 claude, codex and copilot read a flag, so it rides argv through both wrappers
 untouched; opencode reads a file named by `OPENCODE_CONFIG`; cursor reads
 `.cursor/mcp.json` in the workdir. A boundary keeps only what it is told to keep,

--- a/apps/r4t/docs/rigs.md
+++ b/apps/r4t/docs/rigs.md
@@ -187,19 +187,28 @@ mixing r4t's prompt with a real message still replies to the real sender.
 
 ## The `a8s_tell` tool (`mcp`)
 
-`r4t rig set <rig> mcp on` gives the rig's members a real tool instead of a
-shell command: every turn spawns `a8s mcp serve` through the harness's own
-config, and the prompt teaches the `a8s_tell` tool by name. The message body
-travels as a tool argument, so `$1.25`, backticks and Windows paths reach the
-recipient byte-exact with no quoting for the model to get right — and on a
-small local model that also lifts the "said it, never sent it" rate, which is
-what the tool buys over the heredoc teaching. Default is off, and off is the
-shell teaching unchanged. Two presets refuse the knob and say so: `agy` reads
-MCP config only from `~/.gemini`, and bare `ollama` has no tool use at all, so
-`rig set` errors with a `(try: r4t rig swap <rig> ...)` hint rather than
-running turns whose tool never appears. Under an org boundary (`run_as` /
-`container`) r4t carries each harness's idiom across and fails the turn closed
-when it cannot — see [isolation](isolation.md#the-a8s_tell-tool-behind-the-boundary).
+The `mcp` knob gives the rig's members a real tool instead of a shell command:
+every turn spawns `a8s mcp serve` through the harness's own config, and the
+prompt teaches the `a8s_tell` tool by name. The message body travels as a tool
+argument, so `$1.25`, backticks and Windows paths reach the recipient byte-exact
+with no quoting for the model to get right — and on a small local model that
+also lifts the "said it, never sent it" rate, which is what the tool buys over
+the heredoc teaching.
+
+It is **on by default** on `claude`, `codex`, `copilot` and `opencode` (and
+their `ollama launch` variants): their idioms are a flag, a `-c` override or a
+config file under the member's own state dir, so nothing lands in the team repo.
+`cursor` is **opt-in** — its only idiom writes `.cursor/mcp.json` into the
+working tree, and writing a file into your repo is a different consent level
+than passing a flag. `r4t rig set <rig> mcp off` is the escape hatch on any rig,
+and `r4t rig get <rig> mcp` says whether the value is `explicit` or came `from
+preset <name>`. Two presets have no per-turn path at all — `agy` reads MCP
+config only from `~/.gemini`, bare `ollama` has no tool use — so they resolve
+off silently and `rig set <rig> mcp on` errors there with a
+`(try: r4t rig swap <rig> ...)` hint rather than running turns whose tool never
+appears. Under an org boundary (`run_as` / `container`) r4t carries each
+harness's idiom across and fails the turn closed when it cannot — see
+[isolation](isolation.md#the-a8s_tell-tool-behind-the-boundary).
 
 ## The economics: budgets, not cuts
 
@@ -239,7 +248,7 @@ invoke lines is a fully governed team. Rationale and prior art per layer:
 | `max_sends_per_turn` (rig) | 6 | Envelopes released per turn; excess dead-letters | Runaway fan-out width |
 | `history_max_bytes` / `history_body_max` / `prompt_body_max` (rig) | by preset tier — big (agy/codex/claude) 50k/12k/24k · moderate (cursor/opencode/copilot) 25k/6k/12k · small (ollama variants, or no preset) 8192/2000/4000 | Context sizing on the rig: rolling-history budget, per-entry history clip, and per-message prompt clip. `rig add`/`swap` record the preset; explicit values override the tier | A weak rig drowning in context, or a strong one starved of it |
 | `echo` / `echo_max_chars` (rig) | false / 1500 | Stdout-only members (see [Echo rigs](#echo-rigs)): no messaging scaffolding in the prompt, cleaned stdout staged as the one reply, bodies past the cap truncated with the full text attached | A model that misuses `tell`, looping "I did it" messages instead of answering |
-| `mcp` (rig) | false | Members send with the `a8s_tell` tool instead of the `tell` shell command (see [The `a8s_tell` tool](#the-a8s_tell-tool-mcp)): `a8s mcp serve` is injected per turn through the harness's own idiom and the prompt names the tool. `agy` and bare `ollama` refuse it | Shell quoting mangling a body, and a member that describes a message instead of sending one |
+| `mcp` (rig) | by preset — **on** for claude/codex/copilot/opencode and their `ollama launch` variants; **off** for cursor (its idiom writes `.cursor/mcp.json` into your repo) and for agy / bare ollama (no per-turn idiom) | Members send with the `a8s_tell` tool instead of the `tell` shell command (see [The `a8s_tell` tool](#the-a8s_tell-tool-mcp)): `a8s mcp serve` is injected per turn through the harness's own idiom and the prompt names the tool. `mcp off` is the escape hatch anywhere; `mcp on` errors on agy and bare ollama | Shell quoting mangling a body, and a member that describes a message instead of sending one |
 | `timeout_seconds` (rig) | 900 | Harness wall clock; the process group is killed | Hung harnesses |
 | `concurrency` (rig) | 1 | Live turns within one rig | Rig-wide pile-ups |
 | `cell_budget_max` / `cell_budget_earn_per_hour` | 16 / 8 | Shared cell spend bucket; a turn also costs 1 cell unit. When empty, everyone rests | Whole-cell money burn |

--- a/apps/r4t/rig.py
+++ b/apps/r4t/rig.py
@@ -32,11 +32,14 @@ plan always declares a refill rate.
 
 `mcp` — inject the a8s MCP server (`a8s mcp serve`) into every turn on this
 rig, using the harness's own per-invocation idiom, and teach the member the
-`a8s_tell` tool instead of the shell command. Default off: the shell teaching
-stays. Presets whose CLI takes MCP config only globally (agy) or has no tools
-at all (bare ollama) refuse the knob. Each idiom rides a different channel, so
-`apply_mcp` states what an org's isolation boundary has to carry across
-(`McpPlan`) and the wrapper in isolate.py honours it.
+`a8s_tell` tool instead of the shell command. Tri-state: unset takes the
+preset's default (on wherever the idiom is invisible to the team repo — see
+`MCP_DEFAULT_ON_IDIOMS`, off for cursor and for presets with no idiom at all),
+and an explicit true/false in rigs.json always wins. Presets whose CLI takes
+MCP config only globally (agy) or has no tools at all (bare ollama) refuse an
+explicit on. Each idiom rides a different channel, so `apply_mcp` states what an
+org's isolation boundary has to carry across (`McpPlan`) and the wrapper in
+isolate.py honours it.
 
 `echo` — the rig's members never see `tell` or any messaging instructions:
 they are simply prompted with the message content and their cleaned stdout is
@@ -417,7 +420,7 @@ class Rig:
     preset: str | None = None
     echo: bool = False
     echo_max_chars: int = DEFAULT_ECHO_MAX_CHARS
-    mcp: bool = False
+    mcp: bool | None = None
     error: str | None = None
 
     @property
@@ -426,6 +429,11 @@ class Rig:
         means there is no per-turn path (agy configures MCP only in ~/.gemini;
         bare ollama has no tool use), and the knob refuses to turn on."""
         return HARNESS_PRESETS.get(self.preset or "", {}).get("mcp")
+
+    @property
+    def mcp_on(self) -> bool:
+        """The effective `mcp` knob — what dispatch acts on."""
+        return mcp_enabled(self.mcp, self.preset)
 
     @property
     def continue_argv(self) -> list[str]:
@@ -601,6 +609,34 @@ class McpPlan:
 def mcp_presets() -> list[str]:
     """Presets that can take the MCP server for a single invocation."""
     return [n for n in preset_names() if HARNESS_PRESETS[n].get("mcp")]
+
+
+# Idioms the team repo never sees: a flag, a `-c` override, or a config file
+# under the member's own state dir. Those default the knob ON — the tell-arms
+# experiment measured the tool eliminating the no-send failure class outright
+# (20/20 against 9/20), so an untouched rig has to be the one that sends.
+# `cursor-file` writes `.cursor/mcp.json` into the working tree: writing a file
+# into the user's repo is a different consent level than passing a flag, so
+# cursor stays opt-in.
+MCP_DEFAULT_ON_IDIOMS = frozenset({
+    "claude-flag",
+    "codex-config",
+    "copilot-flag",
+    "opencode-env",
+})
+
+
+def mcp_default(preset: str | None) -> bool:
+    """Whether the knob is on for a preset whose rig says nothing about it."""
+    return HARNESS_PRESETS.get(preset or "", {}).get("mcp") in MCP_DEFAULT_ON_IDIOMS
+
+
+def mcp_enabled(mcp: bool | None, preset: str | None) -> bool:
+    """Where the tri-state resolves, for dispatch and for the CLI's display
+    alike: an explicit true/false in rigs.json wins, unset takes the preset's
+    default. A preset with no idiom resolves off silently — only an explicit on
+    is an error (see `mcp_unsupported_reason`)."""
+    return mcp_default(preset) if mcp is None else mcp
 
 
 def mcp_unsupported_reason(preset: str | None) -> str:
@@ -1205,6 +1241,15 @@ def _resolve_setting(entry: dict, key: str) -> RigSetting:
         if "concurrency" in entry:
             return RigSetting(key, int(entry["concurrency"]), "explicit", True)
         return RigSetting(key, DEFAULT_CONCURRENCY, "built-in default", False)
+    if key == "mcp":
+        if key in entry:
+            return RigSetting(key, bool(entry[key]), "explicit", True)
+        return RigSetting(
+            key,
+            mcp_enabled(None, preset),
+            f"from preset {preset}" if preset else "built-in default",
+            False,
+        )
     if key in CONFIGURABLE_BOOL_KEYS:
         if key in entry:
             return RigSetting(key, bool(entry[key]), "explicit", True)

--- a/apps/r4t/tests/test_dispatch.py
+++ b/apps/r4t/tests/test_dispatch.py
@@ -2821,10 +2821,15 @@ class TestMcpKnob:
         roster = load_roster(ctx.roster_path)
         return dispatch.build_prompt(ctx, roster, roster.find("phil"), [], rig)
 
-    def test_knob_off_keeps_the_heredoc_teaching(self, ctx):
-        prompt = self._prompt(ctx, Rig(name="t", preset="opencode"))
+    def test_explicit_off_keeps_the_heredoc_teaching(self, ctx):
+        prompt = self._prompt(ctx, Rig(name="t", preset="opencode", mcp=False))
         assert HEREDOC_TEACHING in prompt
         assert "a8s_tell" not in prompt
+
+    def test_unset_follows_the_preset_default(self, ctx):
+        assert "`a8s_tell` tool" in self._prompt(ctx, Rig(name="t", preset="opencode"))
+        assert HEREDOC_TEACHING in self._prompt(ctx, Rig(name="t", preset="cursor"))
+        assert HEREDOC_TEACHING in self._prompt(ctx, Rig(name="t", preset="agy"))
 
     def test_knob_on_names_the_tool_instead(self, ctx):
         prompt = self._prompt(ctx, Rig(name="t", preset="opencode", mcp=True))
@@ -2860,7 +2865,7 @@ class TestMcpKnob:
     def test_turn_env_untouched_when_off(self, tmp_path):
         staging = tmp_path / "agents" / "phil" / "staging"
         staging.mkdir(parents=True)
-        rig = self._echo_env_rig(tmp_path, preset="opencode")
+        rig = self._echo_env_rig(tmp_path, preset="opencode", mcp=False)
         env = {k: v for k, v in os.environ.items() if k != "OPENCODE_CONFIG"}
         env["TELL_OUTBOX_DIR"] = str(staging)
 
@@ -2875,12 +2880,20 @@ class TestMcpKnob:
             "apply_mcp",
             lambda rig, argv, env, cwd, iso: calls.append(rig) or McpPlan(argv=argv),
         )
-        rig = self._echo_env_rig(tmp_path, preset="opencode")
+        rig = self._echo_env_rig(tmp_path, preset="opencode", mcp=False)
         run_harness(rig, "x", tmp_path, env=dict(os.environ))
         assert calls == []
 
         run_harness(
-            self._echo_env_rig(tmp_path, preset="opencode", mcp=True),
+            self._echo_env_rig(tmp_path, preset="cursor"),
+            "x",
+            tmp_path,
+            env=dict(os.environ),
+        )
+        assert calls == []
+
+        run_harness(
+            self._echo_env_rig(tmp_path, preset="opencode"),
             "x",
             tmp_path,
             env=dict(os.environ),

--- a/apps/r4t/tests/test_rig.py
+++ b/apps/r4t/tests/test_rig.py
@@ -1292,15 +1292,63 @@ def _mcp_rig(tmp_path, preset, model=None):
 
 
 class TestMcpSetting:
-    def test_default_off_everywhere(self, tmp_path):
+    @pytest.mark.parametrize("preset", ["claude", "codex", "copilot", "opencode"])
+    def test_unset_defaults_on_where_the_idiom_is_invisible_to_the_repo(
+        self, tmp_path, preset
+    ):
         path = tmp_path / "rigs.json"
-        add_preset_rig(path, "worker", "opencode")
+        add_preset_rig(path, "worker", preset)
         rig = load_rig_config(path).rigs["worker"]
-        assert rig.mcp is False
+        assert rig.mcp is None
+        assert rig.mcp_on is True
         s = rig_setting(path, "worker", "mcp")
         assert (s.value, s.explicit, s.source, s.display()) == (
-            False, False, "built-in default", "false"
+            True, False, f"from preset {preset}", "true"
         )
+
+    def test_unset_defaults_off_for_cursor_which_would_write_into_the_repo(
+        self, tmp_path
+    ):
+        path = tmp_path / "rigs.json"
+        add_preset_rig(path, "worker", "cursor")
+        rig = load_rig_config(path).rigs["worker"]
+        assert (rig.mcp, rig.mcp_on) == (None, False)
+        s = rig_setting(path, "worker", "mcp")
+        assert (s.value, s.explicit, s.source) == (False, False, "from preset cursor")
+
+    @pytest.mark.parametrize("preset,model", [("agy", None), ("ollama", "tiny")])
+    def test_unset_resolves_off_silently_without_an_idiom(self, tmp_path, preset, model):
+        path = tmp_path / "rigs.json"
+        add_preset_rig(path, "worker", preset, model=model)
+        rig = load_rig_config(path).rigs["worker"]
+        assert (rig.mcp, rig.mcp_on, rig.error) == (None, False, None)
+
+    def test_presetless_rig_resolves_off(self, tmp_path):
+        path = write_config(tmp_path, {"worker": {"invoke": ["x", "{prompt}"]}})
+        rig = load_rig_config(path).rigs["worker"]
+        assert (rig.mcp, rig.mcp_on) == (None, False)
+        s = rig_setting(path, "worker", "mcp")
+        assert (s.value, s.explicit, s.source) == (False, False, "built-in default")
+
+    def test_explicit_off_beats_a_default_on_preset(self, tmp_path):
+        path = tmp_path / "rigs.json"
+        add_preset_rig(path, "worker", "claude")
+        set_rig_value(path, "worker", "mcp", "off")
+        rig = load_rig_config(path).rigs["worker"]
+        assert (rig.mcp, rig.mcp_on) == (False, False)
+        s = rig_setting(path, "worker", "mcp")
+        assert (s.value, s.explicit, s.source) == (False, True, "explicit")
+        assert unset_rig_value(path, "worker", "mcp") is True
+        assert load_rig_config(path).rigs["worker"].mcp_on is True
+
+    def test_a_fresh_rig_carries_no_mcp_key(self, tmp_path):
+        path = tmp_path / "rigs.json"
+        add_preset_rig(path, "worker", "claude")
+        assert "mcp" not in json.loads(path.read_text(encoding="utf-8"))["worker"]
+        set_rig_value(path, "worker", "mcp", "off")
+        assert json.loads(path.read_text(encoding="utf-8"))["worker"]["mcp"] is False
+        unset_rig_value(path, "worker", "mcp")
+        assert "mcp" not in json.loads(path.read_text(encoding="utf-8"))["worker"]
 
     def test_set_get_unset_round_trip(self, tmp_path):
         path = tmp_path / "rigs.json"
@@ -1369,7 +1417,7 @@ class TestMcpSetting:
         )
         rig = load_rig_config(path).rigs["worker"]
         assert rig.error and "~/.gemini" in rig.error
-        assert rig.mcp is False
+        assert (rig.mcp, rig.mcp_on) == (None, False)
         assert load_rig_config(path).rig_for(member(rig="worker"))[0] is None
 
     def test_parse_rejects_non_boolean_json(self, tmp_path):


### PR DESCRIPTION
Closes #316. Builds on #314 (isolation-aware idioms), so an isolated org's default is not a prompt naming a tool the harness never got.

## What changed

`Rig.mcp` is tri-state:

- **unset** → the preset's default
- **explicit `true`/`false`** → always wins; `r4t rig set <rig> mcp off` is the escape hatch on any rig
- **explicit `on`** on a preset with no idiom (agy, bare ollama) → still errors with the `rig swap` hint, unchanged

| preset | unset resolves to | why |
|---|---|---|
| claude, codex, copilot, opencode (+ `ollama launch` variants) | **on** | flag / `-c` override / config file under the member's own state dir — the team repo never sees it |
| cursor | **off** | its only idiom writes `.cursor/mcp.json` into the working tree; writing into the user's repo is a different consent level than passing a flag |
| agy, bare ollama, presetless rigs | **off** (silently) | no per-turn idiom exists |

The tri-state resolves in exactly one place — `rig.mcp_enabled()`, which both `Rig.mcp_on` (dispatch) and `_resolve_setting` (`rig get` / `rig configure`) call, so the two surfaces cannot drift. `rig get` shows the effective value with its provenance in the existing `(source)` style:

```
mcp   true  (from preset claude)
mcp   false (from preset cursor)
mcp   false (explicit)
```

A fresh `rig add` writes no `mcp` key, and `rig unset` removes it — no `mcp: null` noise on disk.

## Why

The tell-arms verdict: the MCP tool eliminated the no-send failure class outright, 20/20 sends against 9/20 for the shell heredoc on the same small model. A knob you have to find and flip contradicts defaults doing the right thing.

## Verification

- Full r4t suite: **764 passed** (754 before; new coverage for unset→preset default per preset class, explicit off beating a default-on preset, explicit on still failing closed on agy/ollama, and the keyless serialization round-trip).
- `r4t sandbox --fake`: all mechanical checks pass, 4 turns. The sandbox rigs record no preset (their invoke is the scripted agent), so they resolve off and keep the shell teaching the fake harness implements — no pin needed, and the sandbox still reflects what a presetless custom-CLI rig really does.

Docs: `docs/rigs.md` knob table and the `a8s_tell` section state the per-preset default; `docs/isolation.md`'s reference stops implying the knob is off until set. `README.md` untouched — a held PR owns it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)