### PR TITLE
feat(a8s): retry delivery when a wake fails

### DIFF
--- a/apps/a8s/DEVELOPMENT.md
+++ b/apps/a8s/DEVELOPMENT.md
@@ -36,6 +36,15 @@ Read `README.md` first for concept and usage.
 - **`publish` waits for readiness event before raising.** Don't drop the
   disconnect handler.
 - **Per-message backoff retry.** BACKOFF_SCHEDULE drives `.retry` sidecars.
+- **Exit 0 is the only delivery ack.** Any other wake outcome — nonzero exit,
+  timeout kill, failed spawn, unexpanded vars — moves the envelopes back into
+  the inbox and arms the agent's `wake-retry` record, and after
+  MAX_WAKE_ATTEMPTS they stay in trash as logged dead letters.
+  `_wake_retry_ready` gates dispatch, so a permanently broken CLI backs off
+  instead of spinning the handler. Delivery is at-least-once: a wake command
+  must tolerate the same envelope twice. r4t dispatch already does — it
+  enqueues durably and returns 0 before any turn runs, so a8s retries
+  delivery without re-running turns.
 - **Local routing claims the ULID in `seen-ids`** to prevent MQTT round-trip dupes.
 - **`settings.json` is the stable operator config.** `a8s config set` persists
   machine-wide keys; `a8s config` (no args) catalogs every knob including

--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -402,6 +402,12 @@ Agents that can process multiple tells in one subprocess can declare a `batch` b
 
 Debounce mechanics: on the first inbox message, a8s stamps `~/.a8s/agents/<NAME>/inbox-waiting-since` and skips waking until `pause` seconds elapse. Each loop iteration re-routes outboxes, so messages that arrive during the wait window join the inbox before the wake decision. The stamp clears when the inbox drains or a wake fires.
 
+### Delivery ack and retry
+
+**Exit 0 is the only ack.** A wake that exits nonzero, gets killed for exceeding `max_wake_seconds`, fails to spawn, or aborts on an unset var puts its envelopes back in the agent's inbox and waits before trying again — 30s, then 2m, then 10m. After the 4th failed attempt the envelopes stay in trash as dead letters, logged in the agent log and recorded as `DROPPED` in `transactions.tsv`, so one poison message can't wedge the inbox shut. The backoff is per agent (`~/.a8s/agents/<NAME>/wake-retry`) and survives handler restarts, so a broken CLI backs off instead of burning a wake per loop iteration.
+
+Delivery is therefore at-least-once: **a wake command must tolerate seeing the same envelope twice.** The cheap way to guarantee that is to ack early — record the message durably, exit 0, and do the slow work afterwards. Reserve nonzero exits for "I did not receive this."
+
 ### Recipient transparency
 
 The default definitions follow the opacity rule — `$SENDER tells $RECIPIENT: $MESSAGE` works equally well whether `$RECIPIENT` is an LLM session, a Python script, or (someday) an SMS gateway. Customize at your own risk.
@@ -431,6 +437,8 @@ The state root resolves as follows when `A8S_HOME` is unset: use `~/.config/a8s`
         ├── log.txt            per-agent log (wakes, routing, subprocess output)
         ├── last-active        ISO timestamp; touched at wake start/end and
         │                     after every idle invoke (gates `idle.invoke`)
+        ├── wake-retry         backoff record after a failed wake: which
+        │                     envelopes, how many attempts, when to retry
         └── pid                handler attachment
 
 <agent-root>/

--- a/apps/a8s/core.py
+++ b/apps/a8s/core.py
@@ -11,6 +11,7 @@ Mutable module-level state:
 """
 from __future__ import annotations
 
+import json
 import os
 import re
 import sys
@@ -252,6 +253,51 @@ def clear_inbox_waiting_since(name: str) -> None:
         pass
 
 
+def wake_retry_path(name: str) -> Path:
+    """Per-agent wake-delivery retry record, written when a wake fails and its
+    envelopes go back into the inbox. JSON: `{"unit": [<inbox filenames>],
+    "attempts": N, "next_at": "<ISO-8601 UTC>"}`. `unit` identifies which
+    delivery the attempt count belongs to — a different message (or batch)
+    starts the count over. Cleared the moment a wake exits 0. Persists across
+    handler restarts so a restart can't reset the backoff and spin a
+    permanently broken CLI."""
+    return agent_dir(name) / "wake-retry"
+
+
+def read_wake_retry(name: str) -> dict | None:
+    p = wake_retry_path(name)
+    if not p.is_file():
+        return None
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def write_wake_retry(
+    name: str, unit: list[str], attempts: int, next_at: datetime
+) -> None:
+    p = wake_retry_path(name)
+    body = json.dumps({
+        "unit": sorted(unit),
+        "attempts": attempts,
+        "next_at": next_at.isoformat().replace("+00:00", "Z"),
+    })
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body, encoding="utf-8")
+    except OSError:
+        pass
+
+
+def clear_wake_retry(name: str) -> None:
+    try:
+        wake_retry_path(name).unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
 def pending_dir(name: str) -> Path:
     """Ingested-but-not-yet-fully-routed messages. `route_outboxes` atomically
     moves each new file from `<root>/.outbox/` into here on every pass before
@@ -383,6 +429,14 @@ MAX_SEEN_IDS = 10000
 # with a "discarded after backoff exhausted" log line.
 BACKOFF_SCHEDULE = [30, 60, 120, 300, 900, 1800, 3600, 21600, 86400]
 MAX_ATTEMPTS = len(BACKOFF_SCHEDULE)
+
+# Wake-delivery retry backoff. Index = number of failed wakes so far for the
+# same delivery. Deliberately shorter and shallower than BACKOFF_SCHEDULE: a
+# redelivered envelope costs an LLM turn, so duplicates are expensive and a
+# poison envelope must stop blocking the inbox quickly. MAX_WAKE_ATTEMPTS
+# counts the first attempt too, so the schedule holds the retry delays only.
+WAKE_RETRY_SCHEDULE = [30, 120, 600]
+MAX_WAKE_ATTEMPTS = len(WAKE_RETRY_SCHEDULE) + 1
 
 
 # ---------- general helpers ----------

--- a/apps/a8s/daemon.py
+++ b/apps/a8s/daemon.py
@@ -5,6 +5,7 @@ This module owns the runtime engine:
 - `run_with_prefix` spawns the wake subprocess in its own session group so
   SIGKILL can target the whole tree.
 - `wake_once` processes one inbox message (with read-time wipe for CLEAR).
+- `_settle_wake` acks (exit 0) or requeues-with-backoff every other outcome.
 - `attached_loop` is the daemon body — handles 1+ agents in one process.
 
 Module-level mutable state used by signal handlers:
@@ -29,13 +30,15 @@ import sys
 import threading
 import time as _time
 from collections.abc import Callable
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import core
 from core import (
+    MAX_WAKE_ATTEMPTS,
     Participant,
     TELL_OUTBOX_DIR_ENV,
+    WAKE_RETRY_SCHEDULE,
     _pid_alive,
     _preview,
     agent_dir,
@@ -45,12 +48,15 @@ from core import (
     out_agent,
     pid_path,
     clear_inbox_waiting_since,
+    clear_wake_retry,
     read_inbox_waiting_since,
     read_last_active,
+    read_wake_retry,
     touch_inbox_waiting_since,
     touch_last_active,
     trash_dir,
     unique_path,
+    write_wake_retry,
 )
 from definitions import (
     BatchEntry,
@@ -91,7 +97,7 @@ _CURRENT_WAKE_PROC: subprocess.Popen | None = None
 _CURRENT_WAKE_NAME: str | None = None
 _WAKE_STARTED_MONO: float | None = None
 _WAKE_MAX_SECONDS: float | None = None
-_WAKE_ON_COMPLETE: Callable[[], None] | None = None
+_WAKE_ON_COMPLETE: Callable[[int | None], None] | None = None
 
 
 def _wake_in_flight() -> bool:
@@ -99,7 +105,7 @@ def _wake_in_flight() -> bool:
     return proc is not None and proc.poll() is None
 
 
-def _clear_wake_state() -> None:
+def _clear_wake_state(rc: int | None = None) -> None:
     global _CURRENT_WAKE_PROC, _CURRENT_WAKE_NAME
     global _WAKE_STARTED_MONO, _WAKE_MAX_SECONDS, _WAKE_ON_COMPLETE
     _CURRENT_WAKE_PROC = None
@@ -109,7 +115,7 @@ def _clear_wake_state() -> None:
     on_complete = _WAKE_ON_COMPLETE
     _WAKE_ON_COMPLETE = None
     if on_complete is not None:
-        on_complete()
+        on_complete(rc)
 
 
 def _log_wake_line(name: str, line: str) -> None:
@@ -177,7 +183,7 @@ def _finish_wake_if_done() -> None:
         proc.wait(timeout=0)
     except subprocess.TimeoutExpired:
         pass
-    _clear_wake_state()
+    _clear_wake_state(rc)
 
 
 def _service_in_flight_wake() -> None:
@@ -195,9 +201,13 @@ def _start_wake_subprocess(
     *,
     env: dict[str, str] | None = None,
     max_seconds: float | None = None,
-    on_complete: Callable[[], None] | None = None,
+    on_complete: Callable[[int | None], None] | None = None,
 ) -> bool:
-    """Start a wake subprocess. Returns True iff the process was spawned."""
+    """Start a wake subprocess. Returns True iff the process was spawned.
+
+    `on_complete` fires from `_clear_wake_state` with the subprocess exit code
+    once the wake finishes. It does NOT fire when the spawn itself fails —
+    callers see that as a False return and settle the delivery themselves."""
     global _CURRENT_WAKE_PROC, _CURRENT_WAKE_NAME
     global _WAKE_STARTED_MONO, _WAKE_MAX_SECONDS, _WAKE_ON_COMPLETE
     if _wake_in_flight():
@@ -236,18 +246,22 @@ def run_with_prefix(
     *,
     env: dict[str, str] | None = None,
     max_seconds: float | None = None,
+    on_complete: Callable[[int | None], None] | None = None,
 ) -> int:
     """Run the wake subprocess in its own session so SIGKILL can target the
     whole process group (LLM CLI + any helpers it spawns). Tracks the live
     process in `_CURRENT_WAKE_PROC` and the agent in `_CURRENT_WAKE_NAME` so
     signal handlers can identify which agent's wake is in-flight."""
     if not _start_wake_subprocess(
-        name, cmd, cwd, env=env, max_seconds=max_seconds
+        name, cmd, cwd, env=env, max_seconds=max_seconds, on_complete=on_complete
     ):
+        if on_complete is not None:
+            on_complete(None)
         return 127
     proc = _CURRENT_WAKE_PROC
     assert proc is not None and proc.stdout is not None
     started = _WAKE_STARTED_MONO or _time.monotonic()
+    exited: int | None = None
     try:
         while True:
             if max_seconds is not None and _time.monotonic() - started >= max_seconds:
@@ -265,6 +279,7 @@ def run_with_prefix(
                 if rc != 0:
                     ts = datetime.now().strftime("%H:%M:%S")
                     out_agent(name, f"{name}> [{ts}] (exit {rc})")
+                exited = rc
                 return rc
             try:
                 ready, _, _ = select.select([proc.stdout], [], [], 0.05)
@@ -276,7 +291,7 @@ def run_with_prefix(
                     _log_wake_line(name, line)
     finally:
         if _CURRENT_WAKE_PROC is not None:
-            _clear_wake_state()
+            _clear_wake_state(exited)
 
 
 def _tell_outbox_env(p: Participant) -> dict[str, str]:
@@ -330,6 +345,97 @@ def _pause_ready_for_wake(
     return True
 
 
+def _settle_wake(
+    p: Participant,
+    envelopes: list[Path],
+    rc: int | None,
+    *,
+    reason: str | None = None,
+) -> None:
+    """Ack or requeue the envelopes a wake consumed (issue #152).
+
+    Exit 0 is the only ack: the envelopes stay in trash and the agent's retry
+    record clears. Any other outcome — nonzero exit, timeout kill, failed spawn,
+    unexpanded vars — moves them back into the inbox and arms a per-agent
+    backoff so the next attempt waits instead of hot-looping. Once
+    MAX_WAKE_ATTEMPTS attempts have failed they stay in trash as dead letters,
+    logged and recorded in the transaction log, so a poison envelope can't block
+    the inbox forever."""
+    if rc == 0:
+        clear_wake_retry(p.name)
+        return
+    if reason is None:
+        reason = "spawn failed" if rc is None else f"exit {rc}"
+    unit = sorted(f.name for f in envelopes)
+    record = read_wake_retry(p.name) or {}
+    attempts = (record.get("attempts", 0) if record.get("unit") == unit else 0) + 1
+
+    if attempts >= MAX_WAKE_ATTEMPTS:
+        clear_wake_retry(p.name)
+        for f in envelopes:
+            out_agent(
+                p.name,
+                f"[{p.name}] dead letter after {attempts} failed wakes "
+                f"({reason}): {f.name} left in trash",
+            )
+            txlog.log(
+                "DROPPED",
+                msg_id=f.stem,
+                recipient=p.name,
+                detail=f"wake failed {attempts}x ({reason}); envelope left in trash",
+            )
+        return
+
+    inbox = inbox_dir(p.name)
+    inbox.mkdir(parents=True, exist_ok=True)
+    requeued = 0
+    for f in envelopes:
+        try:
+            f.rename(inbox / f.name)
+        except OSError as e:
+            out_agent(p.name, f"[{p.name}] requeue failed for {f.name}: {e}")
+            continue
+        requeued += 1
+    if not requeued:
+        return
+    delay = WAKE_RETRY_SCHEDULE[attempts - 1]
+    write_wake_retry(
+        p.name, unit, attempts, datetime.now(timezone.utc) + timedelta(seconds=delay)
+    )
+    out_agent(
+        p.name,
+        f"[{p.name}] wake failed ({reason}) — requeued {requeued}; "
+        f"retry in {delay}s (attempt {attempts + 1}/{MAX_WAKE_ATTEMPTS})",
+    )
+
+
+def _wake_retry_ready(name: str, *, now: datetime | None = None) -> bool:
+    """False while a failed wake's backoff is still running. An unreadable or
+    unparseable record reads as ready — a corrupt sidecar must not wedge an
+    agent's inbox shut."""
+    record = read_wake_retry(name)
+    if not record:
+        return True
+    raw = record.get("next_at")
+    if not isinstance(raw, str):
+        return True
+    try:
+        next_at = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return True
+    return (now or datetime.now(timezone.utc)) >= next_at
+
+
+def _wake_completion(
+    p: Participant, envelopes: list[Path]
+) -> Callable[[int | None], None]:
+    def complete(rc: int | None) -> None:
+        touch_last_active(p.name)
+        _settle_wake(p, envelopes, rc)
+
+    return complete
+
+
 def wake_once(p: Participant, msg_path: Path, *, async_wake: bool = False) -> bool:
     # Mark activity before any work — covers the parse-error / load-error
     # exits below too. Without this, a bad inbox file in the only handled
@@ -371,22 +477,31 @@ def wake_once(p: Participant, msg_path: Path, *, async_wake: bool = False) -> bo
         )
     except UndefinedVarsError as e:
         out_agent(p.name, f"[{p.name}] wake aborted: {e}")
+        _settle_wake(p, [trashed], None, reason=str(e))
         return False
     out_agent(p.name, f"[{p.name}] exec: {shlex.join(cmd)}")
     max_sec = max_wake_seconds(definition)
+    complete = _wake_completion(p, [trashed])
     if async_wake:
-        return _start_wake_subprocess(
+        started = _start_wake_subprocess(
             p.name,
             cmd,
             p.root,
             env=_tell_outbox_env(p),
             max_seconds=max_sec,
-            on_complete=lambda: touch_last_active(p.name),
+            on_complete=complete,
         )
+        if not started:
+            complete(None)
+        return started
     run_with_prefix(
-        p.name, cmd, p.root, env=_tell_outbox_env(p), max_seconds=max_sec
+        p.name,
+        cmd,
+        p.root,
+        env=_tell_outbox_env(p),
+        max_seconds=max_sec,
+        on_complete=complete,
     )
-    touch_last_active(p.name)
     return False
 
 
@@ -437,22 +552,31 @@ def wake_batch(
         )
     except UndefinedVarsError as e:
         out_agent(p.name, f"[{p.name}] batch wake aborted: {e}")
+        _settle_wake(p, trashed, None, reason=str(e))
         return False
     out_agent(p.name, f"[{p.name}] batch exec: {shlex.join(cmd)}")
     max_sec = max_wake_seconds(definition)
+    complete = _wake_completion(p, trashed)
     if async_wake:
-        return _start_wake_subprocess(
+        started = _start_wake_subprocess(
             p.name,
             cmd,
             p.root,
             env=_tell_outbox_env(p),
             max_seconds=max_sec,
-            on_complete=lambda: touch_last_active(p.name),
+            on_complete=complete,
         )
+        if not started:
+            complete(None)
+        return started
     run_with_prefix(
-        p.name, cmd, p.root, env=_tell_outbox_env(p), max_seconds=max_sec
+        p.name,
+        cmd,
+        p.root,
+        env=_tell_outbox_env(p),
+        max_seconds=max_sec,
+        on_complete=complete,
     )
-    touch_last_active(p.name)
     return False
 
 
@@ -545,7 +669,7 @@ def maybe_run_idle(p: Participant, *, async_wake: bool = False) -> bool:
                 p.root,
                 env=_tell_outbox_env(p),
                 max_seconds=max_sec,
-                on_complete=lambda: touch_last_active(p.name),
+                on_complete=lambda _rc: touch_last_active(p.name),
             )
         run_with_prefix(
             p.name, cmd, p.root, env=_tell_outbox_env(p), max_seconds=max_sec
@@ -853,6 +977,9 @@ def _dispatch_agent(p: Participant, definition: dict, *, async_wake: bool) -> bo
         wake_once(p, msg, async_wake=False)
         return False
 
+    if not _wake_retry_ready(p.name):
+        return False
+
     if not _pause_ready_for_wake(p.name, pause_seconds(definition)):
         return False
 
@@ -1030,6 +1157,8 @@ def attached_loop(names: list[str], interval: float, *, single_pass: bool = Fals
                                 if async_wake:
                                     break
                                 if not peek_inbox_messages(p, 1):
+                                    break
+                                if not _wake_retry_ready(p.name):
                                     break
                                 if not _pause_ready_for_wake(
                                     p.name, pause_seconds(definition)

--- a/apps/a8s/settings.py
+++ b/apps/a8s/settings.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
-from core import BACKOFF_SCHEDULE, _a8s_dir
+from core import BACKOFF_SCHEDULE, MAX_WAKE_ATTEMPTS, WAKE_RETRY_SCHEDULE, _a8s_dir
 
 Group = Literal["machine", "definition", "registry", "network", "env", "constant"]
 
@@ -107,6 +107,16 @@ KNOBS: tuple[Knob, ...] = (
         "constant",
         False,
         note="Remote publish retry delays in seconds (fixed schedule)",
+    ),
+    Knob(
+        "wake.retry_schedule",
+        list(WAKE_RETRY_SCHEDULE),
+        "constant",
+        False,
+        note=(
+            "Delays in seconds before redelivering after a failed wake; "
+            f"{MAX_WAKE_ATTEMPTS} attempts then the envelope stays in trash as a dead letter"
+        ),
     ),
 )
 

--- a/apps/a8s/tests/fixtures/mock-flaky-cli
+++ b/apps/a8s/tests/fixtures/mock-flaky-cli
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Mock agent CLI that fails on purpose so wake-retry tests can exercise the
+# nonzero-exit path. Exits $MOCK_FAIL_RC (default 3) unless $MOCK_OK_FILE names
+# an existing file, in which case it behaves like mock-cli — that lets a test
+# flip a broken CLI into a working one mid-loop and watch delivery recover.
+if [ -n "${MOCK_OK_FILE:-}" ] && [ -e "$MOCK_OK_FILE" ]; then
+    for arg in "$@"; do
+        printf 'MOCK-CLI: %s\n' "$arg"
+    done
+    exit 0
+fi
+printf 'MOCK-CLI: deliberate failure\n'
+exit "${MOCK_FAIL_RC:-3}"

--- a/apps/a8s/tests/test_wake_retry.py
+++ b/apps/a8s/tests/test_wake_retry.py
@@ -1,0 +1,437 @@
+"""Wake-delivery retry (issue #152) — exit 0 is the only ack.
+
+Two layers here. `_settle_wake` / `_wake_retry_ready` are exercised directly
+because the schedule and the dead-letter cap are the semantics worth pinning
+exactly. The failure MODES (nonzero exit, timeout kill, missing binary,
+unexpanded vars) go through `attached_loop` with real subprocesses, because the
+whole point of the issue is that mail survives what the wake actually does.
+"""
+from __future__ import annotations
+
+import json
+import threading
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from core import (
+    MAX_WAKE_ATTEMPTS,
+    Participant,
+    WAKE_RETRY_SCHEDULE,
+    agent_log_path,
+    inbox_dir,
+    read_wake_retry,
+    trash_dir,
+    wake_retry_path,
+    write_wake_retry,
+)
+from daemon import _settle_wake, _wake_retry_ready, attached_loop
+from mailbox import ensure_mailboxes
+from registry import save_registry
+from ulid import new as new_ulid
+
+
+def _read_log(name: str) -> str:
+    p = agent_log_path(name)
+    return p.read_text() if p.is_file() else ""
+
+
+def _envelope(content: str) -> dict:
+    msg_id = new_ulid()
+    return {
+        "id": msg_id,
+        "date": "2026-04-29T12:00:00Z",
+        "from": "Y",
+        "to": "A",
+        "content": content,
+        "files": [],
+    }
+
+
+def _queue_inbox(name: str, content: str) -> Path:
+    env = _envelope(content)
+    path = inbox_dir(name) / f"{env['id']}.json"
+    path.write_text(json.dumps(env))
+    return path
+
+
+def _in_trash(name: str, content: str) -> Path:
+    """An envelope sitting in trash, as a wake that just consumed it leaves it."""
+    env = _envelope(content)
+    trash_dir(name).mkdir(parents=True, exist_ok=True)
+    path = trash_dir(name) / f"{env['id']}.json"
+    path.write_text(json.dumps(env))
+    return path
+
+
+@pytest.fixture
+def agent(fake_home, tmp_path):
+    root = tmp_path / "a"
+    root.mkdir()
+    p = Participant("A", root)
+    ensure_mailboxes(p)
+    return p
+
+
+# ---------- _settle_wake semantics ----------
+
+class TestSettleWake:
+    def test_exit_zero_acks_and_clears_the_record(self, agent):
+        env = _in_trash("A", "done")
+        write_wake_retry("A", [env.name], 2, datetime.now(timezone.utc))
+
+        _settle_wake(agent, [env], 0)
+
+        assert env.is_file()
+        assert not list(inbox_dir("A").glob("*.json"))
+        assert read_wake_retry("A") is None
+
+    def test_nonzero_exit_requeues_and_arms_backoff(self, agent):
+        env = _in_trash("A", "retry me")
+        before = datetime.now(timezone.utc)
+
+        _settle_wake(agent, [env], 3)
+
+        assert not env.exists()
+        requeued = list(inbox_dir("A").glob("*.json"))
+        assert [f.name for f in requeued] == [env.name]
+        assert json.loads(requeued[0].read_text())["content"] == "retry me"
+
+        record = read_wake_retry("A")
+        assert record["attempts"] == 1
+        assert record["unit"] == [env.name]
+        next_at = datetime.fromisoformat(record["next_at"].replace("Z", "+00:00"))
+        assert next_at >= before + timedelta(seconds=WAKE_RETRY_SCHEDULE[0])
+        assert "wake failed (exit 3)" in _read_log("A")
+
+    def test_spawn_failure_requeues(self, agent):
+        env = _in_trash("A", "never ran")
+
+        _settle_wake(agent, [env], None)
+
+        assert [f.name for f in inbox_dir("A").glob("*.json")] == [env.name]
+        assert "wake failed (spawn failed)" in _read_log("A")
+
+    def test_explicit_reason_reaches_the_log(self, agent):
+        env = _in_trash("A", "bad vars")
+
+        _settle_wake(agent, [env], None, reason="undefined a8s var: $MODEL")
+
+        assert "wake failed (undefined a8s var: $MODEL)" in _read_log("A")
+
+    def test_repeated_failures_walk_the_schedule(self, agent):
+        env = _in_trash("A", "flaky")
+        delays = []
+        for attempt in range(1, MAX_WAKE_ATTEMPTS):
+            before = datetime.now(timezone.utc)
+            _settle_wake(agent, [env], 3)
+            record = read_wake_retry("A")
+            assert record["attempts"] == attempt
+            next_at = datetime.fromisoformat(record["next_at"].replace("Z", "+00:00"))
+            delays.append(round((next_at - before).total_seconds()))
+            # Next attempt consumes it again, as a wake would.
+            env = inbox_dir("A") / env.name
+            env.rename(trash_dir("A") / env.name)
+            env = trash_dir("A") / env.name
+
+        assert delays == WAKE_RETRY_SCHEDULE
+
+    def test_cap_dead_letters_into_trash(self, agent):
+        env = _in_trash("A", "poison")
+        write_wake_retry("A", [env.name], MAX_WAKE_ATTEMPTS - 1, datetime.now(timezone.utc))
+
+        _settle_wake(agent, [env], 3)
+
+        assert env.is_file(), "dead letters stay in trash, inspectable"
+        assert not list(inbox_dir("A").glob("*.json"))
+        assert read_wake_retry("A") is None
+        log = _read_log("A")
+        assert f"dead letter after {MAX_WAKE_ATTEMPTS} failed wakes" in log
+
+        import txlog
+
+        events = txlog.read_events(env.stem)
+        assert [e["event"] for e in events] == ["DROPPED"]
+        assert "left in trash" in events[0]["detail"]
+
+    def test_a_different_delivery_restarts_the_count(self, agent):
+        first = _in_trash("A", "one")
+        write_wake_retry("A", [first.name], MAX_WAKE_ATTEMPTS - 1, datetime.now(timezone.utc))
+        second = _in_trash("A", "two")
+
+        _settle_wake(agent, [second], 3)
+
+        record = read_wake_retry("A")
+        assert record["attempts"] == 1
+        assert record["unit"] == [second.name]
+        assert (inbox_dir("A") / second.name).is_file()
+
+    def test_batch_failure_requeues_every_envelope(self, agent):
+        envs = [_in_trash("A", f"batch-{i}") for i in range(3)]
+
+        _settle_wake(agent, envs, 3)
+
+        assert sorted(f.name for f in inbox_dir("A").glob("*.json")) == sorted(
+            e.name for e in envs
+        )
+        assert read_wake_retry("A")["unit"] == sorted(e.name for e in envs)
+        assert "requeued 3" in _read_log("A")
+
+    def test_success_after_a_failure_clears_the_backoff(self, agent):
+        env = _in_trash("A", "eventually fine")
+        _settle_wake(agent, [env], 3)
+        env = inbox_dir("A") / env.name
+        env.rename(trash_dir("A") / env.name)
+
+        _settle_wake(agent, [trash_dir("A") / env.name], 0)
+
+        assert read_wake_retry("A") is None
+        assert not list(inbox_dir("A").glob("*.json"))
+
+
+class TestWakeRetryReady:
+    def test_no_record_is_ready(self, agent):
+        assert _wake_retry_ready("A")
+
+    def test_future_next_at_is_not_ready(self, agent):
+        write_wake_retry(
+            "A", ["x.json"], 1, datetime.now(timezone.utc) + timedelta(seconds=30)
+        )
+        assert not _wake_retry_ready("A")
+
+    def test_elapsed_next_at_is_ready(self, agent):
+        write_wake_retry(
+            "A", ["x.json"], 1, datetime.now(timezone.utc) - timedelta(seconds=1)
+        )
+        assert _wake_retry_ready("A")
+
+    def test_corrupt_record_is_ready(self, agent):
+        wake_retry_path("A").parent.mkdir(parents=True, exist_ok=True)
+        wake_retry_path("A").write_text("{not json")
+        assert _wake_retry_ready("A")
+
+    def test_unparseable_timestamp_is_ready(self, agent):
+        wake_retry_path("A").parent.mkdir(parents=True, exist_ok=True)
+        wake_retry_path("A").write_text(json.dumps({"attempts": 1, "next_at": "soon"}))
+        assert _wake_retry_ready("A")
+
+
+# ---------- failure modes end-to-end through attached_loop ----------
+
+def _register(tmp_path: Path, definition: dict) -> Participant:
+    root = tmp_path / "a"
+    root.mkdir(exist_ok=True)
+    defp = tmp_path / "def.json"
+    defp.write_text(json.dumps(definition))
+    save_registry({"A": {"root": str(root), "definition": str(defp)}})
+    p = Participant("A", root)
+    ensure_mailboxes(p)
+    return p
+
+
+def _flaky_def(fixtures_dir: Path, **extra) -> dict:
+    return {
+        "invoke": [str(fixtures_dir / "mock-flaky-cli"), "MSG:$MESSAGE"],
+        **extra,
+    }
+
+
+class TestFailureModesKeepMailDeliverable:
+    def test_nonzero_exit_requeues_the_message(self, fake_home, tmp_path, fixtures_dir):
+        _register(tmp_path, _flaky_def(fixtures_dir))
+        _queue_inbox("A", "survive the crash")
+
+        attached_loop(["A"], 0.05, single_pass=True)
+
+        bodies = [
+            json.loads(f.read_text())["content"]
+            for f in inbox_dir("A").glob("*.json")
+        ]
+        assert bodies == ["survive the crash"]
+        log = _read_log("A")
+        assert "wake failed (exit 3)" in log
+        assert read_wake_retry("A")["attempts"] == 1
+
+    def test_missing_binary_requeues_the_message(self, fake_home, tmp_path):
+        _register(tmp_path, {"invoke": [str(tmp_path / "no-such-cli"), "$MESSAGE"]})
+        _queue_inbox("A", "bad definition")
+
+        attached_loop(["A"], 0.05, single_pass=True)
+
+        assert len(list(inbox_dir("A").glob("*.json"))) == 1
+        log = _read_log("A")
+        assert "command not found" in log
+        assert "wake failed (spawn failed)" in log
+
+    def test_undefined_var_requeues_the_message(self, fake_home, tmp_path, fixtures_dir):
+        _register(
+            tmp_path,
+            {"invoke": [str(fixtures_dir / "mock-cli"), "MODEL:$MODEL|$MESSAGE"]},
+        )
+        _queue_inbox("A", "unexpanded")
+
+        attached_loop(["A"], 0.05, single_pass=True)
+
+        assert len(list(inbox_dir("A").glob("*.json"))) == 1
+        assert "wake failed (undefined a8s var: $MODEL)" in _read_log("A")
+
+    def test_timeout_kill_requeues_the_message(
+        self, fake_home, tmp_path, fixtures_dir, monkeypatch
+    ):
+        import daemon as daemon_mod
+
+        monkeypatch.setenv("MOCK_SLEEP", "5")
+        _register(
+            tmp_path,
+            {
+                "invoke": [str(fixtures_dir / "mock-slow-cli"), "MSG:$MESSAGE"],
+                "max_wake_seconds": 0.25,
+            },
+        )
+        _queue_inbox("A", "hangs forever")
+
+        waits = 0
+
+        def stop_once_requeued(self, timeout=None):
+            nonlocal waits
+            waits += 1
+            if "wake failed" in _read_log("A") or waits >= 60:
+                if daemon_mod._STOP_EVENT is not None:
+                    daemon_mod._STOP_EVENT.set()
+            return True
+
+        monkeypatch.setattr(threading.Event, "wait", stop_once_requeued)
+        attached_loop(["A"], 0.05, single_pass=False)
+
+        log = _read_log("A")
+        assert "max wake time" in log
+        assert "wake failed" in log
+        bodies = [
+            json.loads(f.read_text())["content"]
+            for f in inbox_dir("A").glob("*.json")
+        ]
+        assert bodies == ["hangs forever"]
+
+    def test_batch_failure_requeues_the_whole_batch(
+        self, fake_home, tmp_path, fixtures_dir
+    ):
+        _register(
+            tmp_path,
+            {
+                "invoke": [str(fixtures_dir / "mock-flaky-cli"), "SINGLE"],
+                "batch": {
+                    "invoke": [str(fixtures_dir / "mock-flaky-cli"), "BATCH"],
+                    "limit": 5,
+                },
+            },
+        )
+        for i in range(3):
+            _queue_inbox("A", f"batch-{i}")
+
+        attached_loop(["A"], 0.05, single_pass=True)
+
+        assert len(list(inbox_dir("A").glob("*.json"))) == 3
+        assert "batch exec:" in _read_log("A")
+        assert read_wake_retry("A")["attempts"] == 1
+
+
+class TestBackoffPreventsHotSpin:
+    def test_a_broken_cli_wakes_once_across_many_passes(
+        self, fake_home, tmp_path, fixtures_dir
+    ):
+        _register(tmp_path, _flaky_def(fixtures_dir))
+        _queue_inbox("A", "poison for now")
+
+        for _ in range(5):
+            attached_loop(["A"], 0.01, single_pass=True)
+
+        log = _read_log("A")
+        assert log.count("] exec: ") == 1, "backoff must gate the retry, not spin"
+        assert len(list(inbox_dir("A").glob("*.json"))) == 1
+        assert read_wake_retry("A")["attempts"] == 1
+
+    def test_backoff_gates_the_inner_drain_loop(
+        self, fake_home, tmp_path, fixtures_dir
+    ):
+        # A single sync pass with several queued messages drains the inbox in an
+        # inner while-loop. Without the retry gate the first failure requeues the
+        # message and the loop immediately sees it again — a tight spin inside
+        # one iteration.
+        _register(tmp_path, _flaky_def(fixtures_dir))
+        for i in range(3):
+            _queue_inbox("A", f"msg-{i}")
+
+        attached_loop(["A"], 0.01, single_pass=True)
+
+        log = _read_log("A")
+        assert log.count("] exec: ") == 1
+        assert len(list(inbox_dir("A").glob("*.json"))) == 3
+
+    def test_the_record_survives_a_handler_restart(
+        self, fake_home, tmp_path, fixtures_dir
+    ):
+        _register(tmp_path, _flaky_def(fixtures_dir))
+        _queue_inbox("A", "still backing off")
+
+        attached_loop(["A"], 0.01, single_pass=True)
+        armed = read_wake_retry("A")
+        attached_loop(["A"], 0.01, single_pass=True)
+
+        assert read_wake_retry("A") == armed
+        assert _read_log("A").count("] exec: ") == 1
+
+
+class TestRecovery:
+    def test_delivery_succeeds_once_the_cli_recovers(
+        self, fake_home, tmp_path, fixtures_dir, monkeypatch
+    ):
+        ok_file = tmp_path / "cli-fixed"
+        monkeypatch.setenv("MOCK_OK_FILE", str(ok_file))
+        _register(tmp_path, _flaky_def(fixtures_dir))
+        _queue_inbox("A", "delivered on retry")
+
+        attached_loop(["A"], 0.01, single_pass=True)
+        assert len(list(inbox_dir("A").glob("*.json"))) == 1
+
+        # Fix the CLI and let the backoff elapse.
+        ok_file.write_text("ok")
+        record = read_wake_retry("A")
+        write_wake_retry(
+            "A",
+            record["unit"],
+            record["attempts"],
+            datetime.now(timezone.utc) - timedelta(seconds=1),
+        )
+
+        attached_loop(["A"], 0.01, single_pass=True)
+
+        assert not list(inbox_dir("A").glob("*.json")), "acked — no requeue"
+        assert read_wake_retry("A") is None
+        assert len(list(trash_dir("A").glob("*.json"))) == 1
+        assert _read_log("A").count("] exec: ") == 2
+        assert "MOCK-CLI: MSG:delivered on retry" in _read_log("A")
+
+    def test_exhaustion_dead_letters_after_the_full_schedule(
+        self, fake_home, tmp_path, fixtures_dir
+    ):
+        _register(tmp_path, _flaky_def(fixtures_dir))
+        _queue_inbox("A", "never deliverable")
+
+        for _ in range(MAX_WAKE_ATTEMPTS):
+            record = read_wake_retry("A")
+            if record is not None:
+                write_wake_retry(
+                    "A",
+                    record["unit"],
+                    record["attempts"],
+                    datetime.now(timezone.utc) - timedelta(seconds=1),
+                )
+            attached_loop(["A"], 0.01, single_pass=True)
+
+        log = _read_log("A")
+        assert log.count("] exec: ") == MAX_WAKE_ATTEMPTS
+        assert f"dead letter after {MAX_WAKE_ATTEMPTS} failed wakes" in log
+        assert not list(inbox_dir("A").glob("*.json"))
+        assert len(list(trash_dir("A").glob("*.json"))) == 1
+        assert read_wake_retry("A") is None

--- a/apps/r4t/dispatch.py
+++ b/apps/r4t/dispatch.py
@@ -28,10 +28,13 @@ structured fields, per-turn send quota, then either the node's real outbox
 recipient member's queue (intra-team, no header, no round-trip). A reply is
 attributed to the thread of the message it answers.
 
-Requeueing note: a8s trashes the inbox message BEFORE spawning the wake
-subprocess and only logs its exit code (daemon.wake_once), so exiting nonzero
-does NOT redeliver. That is fine — the message is already durably queued
-before any turn runs.
+Requeueing note: a8s treats exit 0 as the only delivery ack and redelivers the
+envelope (with backoff) when a wake exits nonzero. `handle_message` therefore
+acks early — it enqueues durably, then returns 0 whatever the turn does — so a
+failed turn is retried by r4t's own quota-aware machinery rather than by a8s
+handing the same message to the queue again. Redelivery only happens when
+dispatch itself dies, and `state.enqueue`'s duplicate collapse absorbs it as
+long as the queue hasn't drained yet.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
Closes #152.

## What was lost before

`wake_once` trashed the inbox envelope before spawning and then dropped the exit code, so every failure mode lost the message:

| Failure | Where | Before |
|---|---|---|
| Nonzero exit | `daemon.py` — sync `run_with_prefix` returned `rc` to a caller that ignored it; async `_finish_wake_if_done` only logged `(exit N)` | envelope already in trash, gone |
| `max_wake_seconds` timeout | `_check_wake_timeout` killed the process group | same as nonzero |
| Spawn failure (missing binary) | `_start_wake_subprocess` returned False → 127 | envelope trashed by a wake that never ran |
| `UndefinedVarsError` | wake aborted after the trash rename | envelope gone, nothing ever ran |

Delivery was at-most-once and gave no way to distinguish delivered from lost.

## Semantics

**Exit 0 is the only ack.** Any other outcome moves the envelopes back into the inbox and arms a per-agent `wake-retry` record (30s → 2m → 10m); after 4 failed attempts they stay in trash as dead letters with an agent-log line and a `DROPPED` transaction record.

- The record lives next to the other per-agent handler state (`~/.a8s/agents/<NAME>/wake-retry`) and survives restarts, so a broken CLI can't reset its own backoff.
- `_wake_retry_ready` gates both `_dispatch_agent` and `attached_loop`'s inner drain — without the second gate a sync pass requeues and immediately re-reads the same message, burning the whole cap in one iteration.
- No new daemon and no thread: the handler already visits every agent each pass.
- The schedule is shorter and shallower than the remote-publish `BACKOFF_SCHEDULE` because a redelivered envelope costs an LLM turn, and the cap is what bounds head-of-line blocking from a poison message.

## r4t

Delivery is now at-least-once, which puts idempotency on the wake command. r4t needed no code change: `handle_message` enqueues durably and returns 0 whatever the turn does, so a8s retries *delivery* while r4t's quota-aware breaker owns re-running *turns*. Its stale module docstring (which asserted a8s never redelivers) is corrected here.

## Tests

24 new tests in `apps/a8s/tests/test_wake_retry.py` — schedule walk, dead-letter cap with the txlog record, unit-key reset, corrupt-record tolerance, plus real-subprocess coverage of nonzero exit, timeout kill, missing binary, unexpanded vars, batch requeue, hot-spin gating (inner loop and across restarts), and recovery once the CLI starts succeeding. New `tests/fixtures/mock-flaky-cli` fails on demand and flips to success via a sentinel file.

Full a8s suite: **826 passed** (802 before). r4t suite: **755 passed**. The known-flaky remote e2e test passed on both runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
