### PR TITLE
test(k7e): lock down usage-weighted ranking behavior (#104)

### DIFF
--- a/apps/k7e/docs/architecture.md
+++ b/apps/k7e/docs/architecture.md
@@ -69,8 +69,8 @@ ssh -L 8080:target:80 bastion — forwards local:8080 to target:80 via bastion
 The `nodes` table in `.index.db` mirrors the frontmatter plus two
 **index-only** ranking columns that are *not* written back to markdown:
 
-- `last_used_at` — last time the entry was returned by `recall()` or read by
-  `get()`.
+- `last_used_at` — last time the entry was consumed: synthesized by `recall`
+  or read by `k7e get`. A `search` listing does not count.
 - `use_count` — how many times it has been used.
 
 These reset on `reindex` by design: ranking is *re-earned from usage*, not

--- a/apps/k7e/docs/retrieval.md
+++ b/apps/k7e/docs/retrieval.md
@@ -49,8 +49,10 @@ Each fused score is multiplied by:
 - **Use-count boost** — `1 + log10(1 + use_count) × use_count_weight`
   (~1.2× at 10 uses, ~1.4× at 100). Facts you keep retrieving stay near the top.
 
-Entries earn freshness when returned by `recall()` or read by `get()`. Because
-`last_used_at`/`use_count` are index-only, this signal resets on `reindex`.
+Entries earn freshness when consumed: synthesized by `recall` or read by
+`k7e get`. Appearing in a `search` listing does not count — the caller may
+never open the entry. Because `last_used_at`/`use_count` are index-only, this
+signal resets on `reindex`.
 
 ### 4. LLM reranker (optional)
 

--- a/apps/k7e/tests/test_usage_ranking.py
+++ b/apps/k7e/tests/test_usage_ranking.py
@@ -1,0 +1,173 @@
+"""Usage-weighted ranking — what counts as a use, and how it moves scores."""
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import engine
+
+K7E_PY = str(Path(__file__).resolve().parent.parent / "k7e.py")
+
+
+def use_count(node_id):
+    conn = engine._connect()
+    row = conn.execute("SELECT use_count FROM nodes WHERE id = ?", (node_id,)).fetchone()
+    conn.close()
+    return row[0]
+
+
+def last_used_at(node_id):
+    conn = engine._connect()
+    row = conn.execute("SELECT last_used_at FROM nodes WHERE id = ?", (node_id,)).fetchone()
+    conn.close()
+    return row[0]
+
+
+class TestWhatCountsAsUse:
+    """Consumption counts; a search listing does not. Appearing in a result list
+    is a weak signal (the caller may never look at the entry), so only reading
+    full content counts: `get(track_usage=True)` and recall synthesis."""
+
+    def test_fresh_entry_starts_at_zero(self, store):
+        nid = engine.store_entry("Redis Port", "Redis listens on 6379", tags=["redis"])
+        assert use_count(nid) == 0
+        assert last_used_at(nid) is None
+
+    def test_search_listing_does_not_count(self, store):
+        nid = engine.store_entry("Redis Port", "Redis listens on 6379", tags=["redis"])
+        for _ in range(3):
+            results = engine.search("redis port")
+            assert any(r["id"] == nid for r in results)
+        assert use_count(nid) == 0
+
+    def test_untracked_get_does_not_count(self, store):
+        nid = engine.store_entry("Redis Port", "Redis listens on 6379", tags=["redis"])
+        engine.get(nid)
+        assert use_count(nid) == 0
+
+    def test_tracked_get_counts_every_read(self, store):
+        nid = engine.store_entry("Redis Port", "Redis listens on 6379", tags=["redis"])
+        for expected in (1, 2, 3):
+            engine.get(nid, track_usage=True)
+            assert use_count(nid) == expected
+
+    def test_tracked_get_stamps_last_used_at(self, store):
+        nid = engine.store_entry("Redis Port", "Redis listens on 6379", tags=["redis"])
+        engine.get(nid, track_usage=True)
+        assert last_used_at(nid) is not None
+
+    def test_cli_get_counts(self, store, tmp_path):
+        nid = engine.store_entry("Redis Port", "Redis listens on 6379", tags=["redis"])
+        env = os.environ.copy()
+        env["K7E_HOME"] = str(tmp_path)
+        r = subprocess.run(
+            [sys.executable, K7E_PY, "get", nid],
+            env=env, capture_output=True, text=True,
+        )
+        assert r.returncode == 0
+        assert use_count(nid) == 1
+
+    def test_recall_counts_returned_sources(self, store):
+        nid = engine.store_entry("Redis Eviction", "Redis evicts with allkeys-lru", tags=["redis"])
+        _, sources = engine.recall("redis eviction")
+        assert [s["id"] for s in sources] == [nid]
+        assert use_count(nid) == 1
+
+    def test_recall_leaves_unmatched_entries_alone(self, store):
+        hit = engine.store_entry("Redis Eviction", "Redis evicts with allkeys-lru", tags=["redis"])
+        miss = engine.store_entry("Vim Macros", "Record with qa, replay with @a", tags=["vim"])
+        _, sources = engine.recall("redis eviction")
+        assert [s["id"] for s in sources] == [hit]
+        assert use_count(hit) == 1
+        assert use_count(miss) == 0
+
+
+class TestUseBoost:
+    def test_zero_count_is_identity(self):
+        assert engine._use_boost(0, 0.2) == 1.0
+        assert engine._use_boost(None, 0.2) == 1.0
+
+    def test_boost_is_log10_scaled(self):
+        assert engine._use_boost(9, 0.2) == 1.2
+        assert engine._use_boost(99, 0.2) == 1.4
+
+    def test_boost_is_monotonic(self):
+        boosts = [engine._use_boost(n, 0.2) for n in range(0, 50)]
+        assert boosts == sorted(boosts)
+        assert boosts[0] < boosts[-1]
+
+    def test_zero_weight_disables(self):
+        assert engine._use_boost(1000, 0.0) == 1.0
+
+
+class TestRankingWithUsage:
+    def test_zero_counts_rank_exactly_as_boost_disabled(self, store, monkeypatch):
+        """A fresh index ranks identically to an index with the boost turned
+        off — the feature degrades to the pre-usage behavior."""
+        for title, content, tags in (
+            ("Nginx Reverse Proxy", "Use nginx proxy_pass for upstreams", ["nginx"]),
+            ("Nginx TLS", "Terminate TLS at nginx with ssl_certificate", ["nginx", "tls"]),
+            ("Nginx Rate Limit", "limit_req_zone throttles nginx requests", ["nginx"]),
+        ):
+            engine.store_entry(title, content, tags=tags)
+
+        with_boost = [(r["id"], r["score"]) for r in engine.search("nginx", limit=5)]
+        monkeypatch.setenv("K7E_USE_WEIGHT", "0")
+        without_boost = [(r["id"], r["score"]) for r in engine.search("nginx", limit=5)]
+        assert with_boost == without_boost
+
+    def test_score_rises_with_use(self, store):
+        nid = engine.store_entry("Redis Eviction", "Redis evicts with allkeys-lru", tags=["redis"])
+        before = engine.search("redis eviction")[0]["score"]
+        for _ in range(10):
+            engine.get(nid, track_usage=True)
+        after = engine.search("redis eviction")[0]["score"]
+        assert after > before
+
+    def test_used_entry_overtakes_tied_peer(self, store):
+        a = engine.store_entry("Redis Cache Eviction", "Redis evicts keys with allkeys-lru policy", tags=["redis"])
+        b = engine.store_entry("Redis Eviction Tuning", "Tune redis eviction with maxmemory-policy", tags=["redis"])
+        baseline = engine.search("redis eviction policy", limit=5)
+        assert {r["id"] for r in baseline} == {a, b}
+        assert baseline[0]["score"] == baseline[1]["score"]
+
+        runner_up = baseline[1]["id"]
+        engine.get(runner_up, track_usage=True)
+        assert engine.search("redis eviction policy", limit=5)[0]["id"] == runner_up
+
+    def test_usage_does_not_overturn_a_large_relevance_gap(self, store):
+        """The boost is log-scaled and weighted, so relevance stays dominant."""
+        strong = engine.store_entry(
+            "Redis Eviction Policy", "Redis eviction policy is allkeys-lru by default",
+            tags=["redis", "eviction"],
+        )
+        weak = engine.store_entry("Redis Eviction Trivia", "Redis eviction was added long ago", tags=["redis"])
+        baseline = engine.search("redis eviction policy allkeys", limit=5)
+        assert [r["id"] for r in baseline] == [strong, weak]
+        assert baseline[0]["score"] > 2 * baseline[1]["score"]
+
+        for _ in range(200):
+            engine.get(weak, track_usage=True)
+        after = engine.search("redis eviction policy allkeys", limit=5)
+        assert [r["id"] for r in after] == [strong, weak]
+        assert after[1]["score"] > baseline[1]["score"]
+
+    def test_usage_does_not_surface_a_non_matching_entry(self, store):
+        engine.store_entry("Redis Eviction Policy", "Redis eviction policy is allkeys-lru", tags=["redis"])
+        unrelated = engine.store_entry("Vim Macros", "Record with qa, replay with @a", tags=["vim"])
+        for _ in range(100):
+            engine.get(unrelated, track_usage=True)
+        results = engine.search("redis eviction policy", limit=5)
+        assert unrelated not in [r["id"] for r in results]
+
+
+class TestReindexResetsUsage:
+    def test_counts_reset_on_reindex(self, store):
+        nid = engine.store_entry("Redis Port", "Redis listens on 6379", tags=["redis"])
+        for _ in range(5):
+            engine.get(nid, track_usage=True)
+        assert use_count(nid) == 5
+
+        engine.reindex()
+        assert use_count(nid) == 0
+        assert last_used_at(nid) is None


### PR DESCRIPTION
Closes #104.

## What was already there

The feature #104 asks for is on `main` — shipped by #146. Verified against
`apps/k7e/engine.py`: `use_count`/`last_used_at` columns on `nodes`,
`_bump_usage()`, `_use_boost()` folded into the fused score, and `reindex()`
clearing counts. What was missing was any test coverage, so the two decisions
that make the feature safe were undefended. This PR adds them (18 tests) and
tightens two doc sentences.

## Signal chosen: consumption, not listing

`use_count` bumps when an entry is **read**, not when it is listed:

| surface | counts | why |
| --- | --- | --- |
| `k7e get <id>` → `get(id, track_usage=True)` | yes | caller read the content |
| `recall(...)` synthesis | yes | content entered the answer |
| `search(...)` | **no** | a title in a list is a weak signal |
| internal `get()` (e.g. supersede validation) | no | not a user read |

Counting search hits would inflate every entry that merely co-occurs with a
query, and would make every read a write — the overhead the issue flagged in
its tradeoff section. `recall` calls `search` internally and bumps once per
synthesized entry, so a recall does not double-count.

## Ranking formula

Stated in `docs/retrieval.md`. The fused RRF score is multiplied by three
factors; the usage one is:

```
use_boost = 1 + log10(1 + use_count) × use_count_weight     # weight default 0.2
```

~1.2x at 10 uses, ~1.4x at 100. This is a multiplier on the RRF score rather
than the additive `+ 0.001 * log(...)` the issue sketched, which keeps the
boost proportional instead of swamping small scores.

**Zero-count parity**: `_use_boost(0, w) == 1.0` exactly, so a fresh or freshly
reindexed index ranks identically to one with the boost off. Asserted directly
against `K7E_USE_WEIGHT=0` — same scores, same order.

## Tests

`apps/k7e/tests/test_usage_ranking.py`, 18 tests in 4 classes:

- **What counts as a use** (8) — fresh entry at zero; three searches leave it at
  zero; untracked `get` does not count; tracked `get` counts every read and
  stamps `last_used_at`; the `k7e get` CLI path counts (subprocess); `recall`
  counts its returned sources and leaves unmatched entries at zero.
- **`_use_boost`** (4) — identity at 0 and `None`; exact log10 values
  (`1.2` at 9, `1.4` at 99); monotonic; `weight=0` disables.
- **Ranking with usage** (5) — zero counts rank exactly as boost-disabled;
  score rises after 10 uses; a used entry overtakes a score-tied peer; 200 uses
  do **not** overturn a >2x relevance gap; usage never pulls a non-matching
  entry into the pool.
- **Reindex** (1) — counts and `last_used_at` reset.

Suite: **126 passed** (108 before, +18). No new deps; stdlib only.

Mutation-checked — each of these makes the file fail: dropping `track_usage=True`
from `cli.py`, replacing `_bump_usage` in `recall` with `pass`, and making
`_use_boost` return a constant `1.0`. The parity test correctly survives the
`_use_boost` mutation, which is the point of it.

## Docs

`retrieval.md` and `architecture.md` said entries earn freshness when "read by
`get()`", which reads as though any read counts, internal callers included. They
now name the counting surfaces and state that a search listing does not count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
