### PR TITLE
feat(r4t): rig-level env maps for harness knobs, used frugally

### DIFF
--- a/apps/r4t/dispatch.py
+++ b/apps/r4t/dispatch.py
@@ -622,6 +622,9 @@ def run_harness(
     that fails closed returns a nonzero exit like any other failed turn — the
     batch stays queued and the breaker counts it.
 
+    The rig's `env` map rides the turn environment on top of r4t's own controls,
+    and is named to the isolation wrapper so it survives the boundary.
+
     `R4T_CONTINUE` in the env (set for a member with `Continue: on`) appends the
     rig's continue tokens so the CLI resumes the conversation it already has in
     `cwd`. It rides the env for the same reason isolation does: the run_fn
@@ -643,6 +646,13 @@ def run_harness(
             return 127, f"agy --model {rig.model!r} did not resolve: {e}", 0.0, False
         argv = [resolved if a == "{model}" else a for a in argv]
 
+    # The rig's `env` map (docs/rigs.md): static harness knobs on every turn.
+    # It goes on before r4t's own per-turn injections below (the mcp idiom's
+    # variables, the PWD pin) so those still win, and a name the turn owns fails
+    # the rig closed at parse time, so this cannot shadow one.
+    if env is not None:
+        env.update(rig.env)
+
     staging = (env or {}).get("TELL_OUTBOX_DIR", "")
     isolation = isolate.isolation_from_env(env)
 
@@ -655,6 +665,11 @@ def run_harness(
     if rig.mcp_on and env is not None:
         mcp = apply_mcp(rig, argv, env, cwd, isolation)
         argv = mcp.argv
+
+    # An `env_reset`/container keeps only what the wrapper is told to carry, so
+    # the rig map has to be named to it the same way the mcp idiom's env is.
+    # The idiom wins a collision — it is r4t's own per-turn injection.
+    boundary_env = {**rig.env, **mcp.env_pass}
 
     kill_container_name: str | None = None
     if isolation.run_as:
@@ -670,7 +685,7 @@ def run_harness(
         if staging:
             isolate.assert_writable_shared_dir(staging, isolate.agent_gid(isolation.run_as))
         argv = isolate.wrap_run_as(
-            argv, isolation.run_as, staging, cwd, env_pass=mcp.env_pass
+            argv, isolation.run_as, staging, cwd, env_pass=boundary_env
         )
     elif isolation.container:
         kill_container_name = isolate.container_name(
@@ -684,7 +699,7 @@ def run_harness(
             workplace=cwd,
             tell_outbox=staging,
             container_args=isolation.container_args,
-            extra_env=mcp.env_pass,
+            extra_env=boundary_env,
             extra_ro_dirs=mcp.mount_dirs,
         )
 

--- a/apps/r4t/docs/rigs.md
+++ b/apps/r4t/docs/rigs.md
@@ -150,7 +150,8 @@ other r4t preset, agy is trusted with normal filesystem permissions.
 Rig settings never need hand-edited JSON. The configurable keys are
 `concurrency`, `rig_budget_max`, `rig_budget_earn_per_hour`, the context knobs
 `history_max_bytes` / `history_body_max` / `prompt_body_max`, `model`, `mcp`,
-and the echo keys `echo` / `echo_max_chars`
+the echo keys `echo` / `echo_max_chars`, and `env.<NAME>` for a
+[harness env knob](#harness-env-knobs-env)
 (each detailed in the [knob table](#governance-knobs) below).
 
 ```bash
@@ -170,7 +171,8 @@ becomes an explicit value. Piped stdin works (one answer per line, EOF keeps
 the rest), so an agent can drive it non-interactively.
 
 `get` annotates each value's source: `explicit`, `from preset <name>` (a
-context knob inheriting the preset's text tier), or `built-in default`. With a
+context knob inheriting the preset's text tier), `built-in default`, or
+`not set` (an `env.<NAME>` the rig does not carry). With a
 key it prints the bare value on stdout and the source on stderr, so
 `conc=$(r4t rig get specialist concurrency)` captures cleanly.
 
@@ -223,6 +225,41 @@ appears. Under an org boundary (`run_as` / `container`) r4t carries each
 harness's idiom across and fails the turn closed when it cannot — see
 [isolation](isolation.md#the-a8s_tell-tool-behind-the-boundary).
 
+## Harness env knobs (`env`)
+
+A rig may carry static `NAME=value` pairs handed to its harness on every turn.
+**Use it frugally.** Every entry earns its place with a documented reason: this
+is the one rig key whose effect r4t cannot see, so a dumping ground here is a
+team whose behaviour nobody can explain from the config.
+
+```bash
+r4t rig set brain env.ENABLE_PROMPT_CACHING_1H 1  # the 1-hour prompt-cache tier
+r4t rig get brain env.ENABLE_PROMPT_CACHING_1H    # bare value, source on stderr
+r4t rig unset brain env.ENABLE_PROMPT_CACHING_1H
+```
+
+The proven case is Claude Code's prompt-cache TTL. On API-key auth the CLI
+writes the 5-minute cache tier, so a member woken ten minutes after its last
+turn re-reads its whole context at full price; `ENABLE_PROMPT_CACHING_1H=1`
+opts into the 1-hour tier, which is the highest-leverage cost knob there is for
+scheduled wakes minutes to tens of minutes apart. On subscription auth the
+1-hour tier already applies and the variable is a no-op, so it is safe on any
+claude rig.
+
+Values are literal strings — no `{prompt}`-style substitution, nothing
+expanded, no shell. Names are validated where they are written: r4t's own turn
+variables (`TELL_OUTBOX_DIR`, `PWD`, and the `R4T_*` family, which carry the
+member's staging outbox, its pinned workdir, and node / member / isolation /
+continue state) are refused by `rig set` and fail a hand-edited rig closed at
+`rig get` / `roster check` / the first turn. The turn owns those, and a rig that
+could quietly redirect them would steer dispatch from a config file. r4t's
+per-turn `mcp` injection likewise wins any variable it sets (`OPENCODE_CONFIG`).
+
+Under an org boundary the map is named to the wrapper the same way the `mcp`
+idiom's env is — re-exported past sudoers `env_reset`, passed as `docker run -e`
+— so an isolated org's rig env still arrives (see
+[isolation](isolation.md)).
+
 ## The economics: budgets, not cuts
 
 A member runs while its own spend bucket, the shared cell bucket, and (if the
@@ -262,6 +299,7 @@ invoke lines is a fully governed team. Rationale and prior art per layer:
 | `history_max_bytes` / `history_body_max` / `prompt_body_max` (rig) | by preset tier — big (agy/codex/claude) 50k/12k/24k · moderate (cursor/opencode/copilot) 25k/6k/12k · small (ollama variants, or no preset) 8192/2000/4000 | Context sizing on the rig: rolling-history budget, per-entry history clip, and per-message prompt clip. `rig add`/`swap` record the preset; explicit values override the tier | A weak rig drowning in context, or a strong one starved of it |
 | `echo` / `echo_max_chars` (rig) | false / 1500 | Stdout-only members (see [Echo rigs](#echo-rigs)): no messaging scaffolding in the prompt, cleaned stdout staged as the one reply, bodies past the cap truncated with the full text attached | A model that misuses `tell`, looping "I did it" messages instead of answering |
 | `mcp` (rig) | by preset — **on** for claude/codex/copilot/opencode and their `ollama launch` variants; **off** for cursor (its idiom writes `.cursor/mcp.json` into your repo) and for agy / bare ollama (no per-turn idiom) | Members send with the `a8s_tell` tool instead of the `tell` shell command (see [The `a8s_tell` tool](#the-a8s_tell-tool-mcp)): `a8s mcp serve` is injected per turn through the harness's own idiom and the prompt names the tool. `mcp off` is the escape hatch anywhere; `mcp on` errors on agy and bare ollama | Shell quoting mangling a body, and a member that describes a message instead of sending one |
+| `env` (rig) | empty | Static `NAME=value` pairs handed to the harness every turn — harness knobs r4t has no flag for (see [Harness env knobs](#harness-env-knobs-env)); set one at a time with `r4t rig set <rig> env.<NAME> <value>`. Frugal by doctrine; r4t's own turn variables are refused | Money burned on a harness default you cannot reach any other way — the first case is `ENABLE_PROMPT_CACHING_1H=1` on claude, the 1-hour prompt-cache tier for wakes minutes apart |
 | `timeout_seconds` (rig) | 900 | Harness wall clock; the process group is killed | Hung harnesses |
 | `concurrency` (rig) | 1 | Live turns within one rig | Rig-wide pile-ups |
 | `cell_budget_max` / `cell_budget_earn_per_hour` | 16 / 8 | Shared cell spend bucket; a turn also costs 1 cell unit. When empty, everyone rests | Whole-cell money burn |

--- a/apps/r4t/r4t.py
+++ b/apps/r4t/r4t.py
@@ -46,6 +46,7 @@ from rig import (
     rig_setting,
     rig_settings,
     set_rig_value,
+    setting_label,
     swap_preset_rig,
     unset_rig_value,
 )
@@ -1411,13 +1412,11 @@ def cmd_rig_unset(args: argparse.Namespace) -> int:
             print(str(e), file=sys.stderr)
             rc = 1
             continue
+        label = setting_label(key)
         if removed:
-            print(f"unset {rig_key} {key.strip().lower()} in {config_path}")
+            print(f"unset {rig_key} {label} in {config_path}")
         else:
-            print(
-                f"{rig_key} {key.strip().lower()} was not explicitly set; "
-                f"nothing to unset"
-            )
+            print(f"{rig_key} {label} was not explicitly set; nothing to unset")
     return rc
 
 

--- a/apps/r4t/rig.py
+++ b/apps/r4t/rig.py
@@ -430,6 +430,7 @@ class Rig:
     echo: bool = False
     echo_max_chars: int = DEFAULT_ECHO_MAX_CHARS
     mcp: bool | None = None
+    env: dict[str, str] = field(default_factory=dict)
     error: str | None = None
 
     @property
@@ -1171,6 +1172,44 @@ def remove_rig(path: Path, rig_name: str) -> str:
     return rig_key
 
 
+# --- the `env` map: harness knobs that ride the turn environment -------------
+#
+# A rig may carry static NAME=value pairs handed to its harness on every turn —
+# the harness CLIs expose real knobs there (the first case is claude's
+# ENABLE_PROMPT_CACHING_1H). Doctrine is FRUGAL: an entry earns its place with a
+# documented reason, because this is the one rig key whose effect r4t cannot see.
+#
+# The turn environment is r4t's own channel: TELL_OUTBOX_DIR points at the
+# member's staging outbox, PWD is pinned to the member's workdir, and the R4T_*
+# family carries node, member, isolation and continue state. A rig naming one of
+# those would steer dispatch from a config file, so the name is refused where it
+# is written rather than silently losing to the turn.
+TURN_OWNED_ENV = ("TELL_OUTBOX_DIR", "PWD")
+TURN_OWNED_ENV_PREFIX = "R4T_"
+ENV_SETTING_PREFIX = "env."
+_ENV_NAME_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
+
+
+def _env_name_problem(name: str) -> str | None:
+    """Why `name` cannot be a rig env entry, or None if it can."""
+    if not _ENV_NAME_RE.match(name):
+        return f"{name!r} is not a usable environment variable name"
+    if name in TURN_OWNED_ENV or name.startswith(TURN_OWNED_ENV_PREFIX):
+        return (
+            f"{name} belongs to the turn, not the rig — r4t sets it per member "
+            f"and a rig may not override it"
+        )
+    return None
+
+
+def _split_env_key(key: str) -> str | None:
+    """The variable name in an `env.<NAME>` setting key, else None. Only the
+    prefix case-folds; environment variable names are case-sensitive."""
+    if key[: len(ENV_SETTING_PREFIX)].lower() != ENV_SETTING_PREFIX:
+        return None
+    return key[len(ENV_SETTING_PREFIX):].strip()
+
+
 CONFIGURABLE_INT_KEYS = (
     "concurrency",
     "history_max_bytes",
@@ -1222,11 +1261,42 @@ def resolve_config_path(raw: str | None) -> Path:
 
 
 def _unknown_setting_error(key: str) -> RigError:
-    valid = ", ".join(CONFIGURABLE_RIG_KEYS)
+    valid = ", ".join(CONFIGURABLE_RIG_KEYS) + ", env.<NAME>"
     return RigError(
         f"unknown rig setting {key!r} "
         f"(try: r4t rig set <rig> <key> <value> with one of: {valid})"
     )
+
+
+def _normalize_setting_key(key: str) -> tuple[str, str | None]:
+    """(canonical setting key, env variable name or None). Raises for a key no
+    rig has."""
+    key = key.strip()
+    name = _split_env_key(key)
+    if name is not None:
+        problem = _env_name_problem(name)
+        if problem:
+            raise RigError(
+                f"{problem} "
+                f"(try: r4t rig set <rig> env.ENABLE_PROMPT_CACHING_1H 1)"
+            )
+        return f"{ENV_SETTING_PREFIX}{name}", name
+    key = key.lower()
+    if key not in CONFIGURABLE_RIG_KEYS:
+        raise _unknown_setting_error(key)
+    return key, None
+
+
+def setting_label(key: str) -> str:
+    """The canonical spelling of a setting key, for CLI messages. Scalar keys
+    case-fold; an `env.<NAME>` key keeps NAME as written."""
+    return _normalize_setting_key(key)[0]
+
+
+def _entry_env(entry: dict) -> dict:
+    """The rig entry's live env map, or an empty stand-in when it has none."""
+    raw = entry.get("env")
+    return raw if isinstance(raw, dict) else {}
 
 
 def _rig_entry(path: Path, rig_name: str) -> tuple[str, dict, dict]:
@@ -1289,16 +1359,26 @@ def _resolve_setting(entry: dict, key: str) -> RigSetting:
 
 
 def rig_settings(path: Path, rig_name: str) -> list[RigSetting]:
-    """Every configurable setting for a rig, effective value + source."""
+    """Every configurable setting for a rig, effective value + source. The
+    `env` map has no defaults to inherit, so only the pairs the rig carries
+    show up."""
     _, entry, _ = _rig_entry(path, rig_name)
-    return [_resolve_setting(entry, key) for key in CONFIGURABLE_RIG_KEYS]
+    rows = [_resolve_setting(entry, key) for key in CONFIGURABLE_RIG_KEYS]
+    rows += [
+        RigSetting(f"{ENV_SETTING_PREFIX}{name}", str(value), "explicit", True)
+        for name, value in sorted(_entry_env(entry).items())
+    ]
+    return rows
 
 
 def rig_setting(path: Path, rig_name: str, key: str) -> RigSetting:
-    key = key.strip().lower()
-    if key not in CONFIGURABLE_RIG_KEYS:
-        raise _unknown_setting_error(key)
+    key, env_name = _normalize_setting_key(key)
     _, entry, _ = _rig_entry(path, rig_name)
+    if env_name is not None:
+        env_map = _entry_env(entry)
+        if env_name in env_map:
+            return RigSetting(key, str(env_map[env_name]), "explicit", True)
+        return RigSetting(key, None, "not set", False)
     return _resolve_setting(entry, key)
 
 
@@ -1355,10 +1435,15 @@ def set_rig_model(path: Path, rig_name: str, model: str) -> None:
 
 def set_rig_value(path: Path, rig_name: str, key: str, value: object) -> RigSetting:
     """Write one explicit rig setting. Numeric keys validate as numbers; `model`
-    re-resolves the invoke through the preset. Returns the resulting setting."""
-    key = key.strip().lower()
-    if key not in CONFIGURABLE_RIG_KEYS:
-        raise _unknown_setting_error(key)
+    re-resolves the invoke through the preset; `env.<NAME>` writes one static
+    harness variable. Returns the resulting setting."""
+    key, env_name = _normalize_setting_key(key)
+    if env_name is not None:
+        text = str(value)
+        _, entry, payload = _rig_entry(path, rig_name)
+        entry["env"] = {**_entry_env(entry), env_name: text}
+        atomic_write_json(path, payload)
+        return RigSetting(key, text, "explicit", True)
     rig_key = _validate_rig_name(rig_name)
     if key == "model":
         model = str(value).strip()
@@ -1390,10 +1475,19 @@ def unset_rig_value(path: Path, rig_name: str, key: str) -> bool:
     default. Returns True if something was removed, False if it was not
     explicitly set (a friendly no-op). `model` re-resolves the invoke to the
     preset's base."""
-    key = key.strip().lower()
-    if key not in CONFIGURABLE_RIG_KEYS:
-        raise _unknown_setting_error(key)
+    key, env_name = _normalize_setting_key(key)
     rig_key, entry, payload = _rig_entry(path, rig_name)
+    if env_name is not None:
+        env_map = _entry_env(entry)
+        if env_name not in env_map:
+            return False
+        del env_map[env_name]
+        # An empty map is no map: nothing is inherited, so the key would only
+        # sit in rigs.json saying nothing.
+        if not env_map:
+            del entry["env"]
+        atomic_write_json(path, payload)
+        return True
     if key == "model":
         preset = _entry_preset(entry)
         if preset is None:
@@ -1523,6 +1617,23 @@ def _parse_rig(name: str, raw: object) -> Rig:
             )
         else:
             rig.mcp = raw_mcp
+
+    # A rig env entry the turn owns, or a value that is not a plain string,
+    # fails the rig closed here — the operator hears about it at `rig get` /
+    # `roster check` / the first turn rather than losing the entry silently.
+    raw_env = raw.get("env")
+    if raw_env is not None:
+        if not isinstance(raw_env, dict):
+            problems.append('env: expected an object of "NAME": "value" pairs')
+        else:
+            for name, value in raw_env.items():
+                problem = _env_name_problem(str(name))
+                if problem:
+                    problems.append(f"env: {problem}")
+                elif not isinstance(value, str):
+                    problems.append(f"env.{name}: expected a string, got {value!r}")
+                else:
+                    rig.env[str(name)] = value
 
     # The rig spend bucket is opt-in: absent leaves both None and the rig gate
     # off. If present, both knobs are required — a real subscription always

--- a/apps/r4t/tests/test_isolate.py
+++ b/apps/r4t/tests/test_isolate.py
@@ -699,6 +699,120 @@ class TestMcpWithoutIsolation:
         assert not plan.env_pass and not plan.mount_dirs and not plan.read_paths
 
 
+# ---------- the rig's `env` map has to cross the boundary too (#284) ----------
+
+
+def _env_rig(env_map: dict[str, str], invoke: list[str] | None = None) -> Rig:
+    return Rig(name="worker", invoke=invoke or ["claude", "-p", "{prompt}"], env=env_map)
+
+
+class TestRigEnvReachesTheHarness:
+    """A rig env entry is worthless if it stops at the isolation wrapper, so the
+    same three shapes the `mcp` idioms are asserted through carry it too."""
+
+    def test_plain_turn_hands_it_to_the_harness_process(self, tmp_path):
+        script = tmp_path / "show-env.py"
+        script.write_text(
+            "import os\nprint(os.environ.get('ENABLE_PROMPT_CACHING_1H', 'unset'))\n",
+            encoding="utf-8",
+        )
+        rig = _env_rig(
+            {"ENABLE_PROMPT_CACHING_1H": "1"},
+            invoke=[sys.executable, str(script), "{prompt}"],
+        )
+        env, workplace, _staging = _mcp_turn_env(tmp_path, Isolation())
+
+        code, out, _dur, timed = run_harness(rig, "P", workplace, env=env)
+
+        assert (code, timed) == (0, False)
+        assert out.strip() == "1"
+
+    def test_the_workdir_pin_still_wins(self, tmp_path):
+        script = tmp_path / "show-pwd.py"
+        script.write_text("import os\nprint(os.environ['PWD'])\n", encoding="utf-8")
+        # A rig carrying PWD fails closed at parse time (test_rig), so the only
+        # way here is in-memory — and the pin holds whatever a Rig object says.
+        rig = _env_rig(
+            {"PWD": "/nowhere"}, invoke=[sys.executable, str(script), "{prompt}"]
+        )
+        env, workplace, _staging = _mcp_turn_env(tmp_path, Isolation())
+
+        _code, out, _dur, _timed = run_harness(rig, "P", workplace, env=env)
+
+        assert out.strip() == str(workplace)
+
+    def test_run_as_re_exports_it_past_env_reset(self, tmp_path, fakebin):
+        record = tmp_path / "sudo.txt"
+        _recording_sudo(fakebin, record)
+        rig = _env_rig({"ENABLE_PROMPT_CACHING_1H": "1", "NOTE": "a b"})
+        env, workplace, staging = _mcp_turn_env(tmp_path, Isolation(run_as="agent-x"))
+
+        run_harness(rig, "P", workplace, env=env)
+
+        argv = _wrapped_argv(record)
+        assert argv[6:12] == [
+            "_", str(staging), str(workplace), "2",
+            "ENABLE_PROMPT_CACHING_1H=1", "NOTE=a b",
+        ]
+        assert argv[12:] == ["claude", "-p", "P"]
+
+    def test_container_gets_it_as_a_dash_e_before_the_image(self, tmp_path, fakebin):
+        record = tmp_path / "docker.txt"
+        _recording_docker(fakebin, record)
+        rig = _env_rig({"ENABLE_PROMPT_CACHING_1H": "1"})
+        env, workplace, _staging = _mcp_turn_env(tmp_path, Isolation(container="img"))
+
+        run_harness(rig, "P", workplace, env=env)
+
+        argv = _wrapped_argv(record)
+        at = argv.index("ENABLE_PROMPT_CACHING_1H=1")
+        assert argv[at - 1] == "-e"
+        assert at < argv.index("img")
+
+    def test_it_rides_alongside_the_mcp_idiom_env(self, tmp_path, fakebin):
+        record = tmp_path / "sudo-both.txt"
+        _recording_sudo(fakebin, record)
+        rig = _mcp_rig(tmp_path, "opencode")
+        rig.env = {"ENABLE_PROMPT_CACHING_1H": "1"}
+        env, workplace, staging = _mcp_turn_env(tmp_path, Isolation(run_as="agent-x"))
+
+        run_harness(rig, "P", workplace, env=env)
+
+        config = staging.parent / "mcp" / "mcp-opencode.json"
+        argv = _wrapped_argv(record)
+        assert argv[9] == "2"
+        assert set(argv[10:12]) == {
+            "ENABLE_PROMPT_CACHING_1H=1", f"OPENCODE_CONFIG={config}"
+        }
+
+    def test_the_mcp_idiom_wins_its_own_variable(self, tmp_path, fakebin):
+        record = tmp_path / "sudo-clash.txt"
+        _recording_sudo(fakebin, record)
+        rig = _mcp_rig(tmp_path, "opencode")
+        rig.env = {"OPENCODE_CONFIG": "/theirs"}
+        env, workplace, staging = _mcp_turn_env(tmp_path, Isolation(run_as="agent-x"))
+
+        run_harness(rig, "P", workplace, env=env)
+
+        config = staging.parent / "mcp" / "mcp-opencode.json"
+        argv = _wrapped_argv(record)
+        # r4t's own per-turn injection is not something a rig knob can unseat.
+        assert argv[9] == "1"
+        assert argv[10] == f"OPENCODE_CONFIG={config}"
+        assert env["OPENCODE_CONFIG"] == str(config)
+
+    def test_a_bare_rig_asks_the_wrapper_for_nothing(self, tmp_path, fakebin):
+        record = tmp_path / "sudo-bare.txt"
+        _recording_sudo(fakebin, record)
+        env, workplace, staging = _mcp_turn_env(tmp_path, Isolation(run_as="agent-x"))
+
+        run_harness(_env_rig({}), "P", workplace, env=env)
+
+        assert _wrapped_argv(record)[6:] == [
+            "_", str(staging), str(workplace), "0", "claude", "-p", "P",
+        ]
+
+
 class TestStatusRowRendering:
     def test_isolation_tag(self):
         from r4t import _isolation_tag

--- a/apps/r4t/tests/test_rig.py
+++ b/apps/r4t/tests/test_rig.py
@@ -1620,3 +1620,171 @@ class TestMcpInjection:
         apply_mcp(rig, rig.argv("PROMPT"), env, cwd)
         config = json.loads(Path(env["OPENCODE_CONFIG"]).read_text(encoding="utf-8"))
         assert config["mcp"]["a8s"]["environment"]["A8S_MCP_LOG"] == env["A8S_MCP_LOG"]
+
+
+class TestRigEnvMap:
+    """The `env` map: static harness knobs on the rig (issue #284). Frugal by
+    doctrine, and never a way to reach r4t's own turn variables."""
+
+    def test_absent_by_default_and_keyless_in_the_file(self, tmp_path):
+        path = tmp_path / "rigs.json"
+        add_preset_rig(path, "worker", "claude")
+        assert load_rig_config(path).rigs["worker"].env == {}
+        assert "env" not in json.loads(path.read_text(encoding="utf-8"))["worker"]
+
+    def test_set_get_unset_round_trip(self, tmp_path):
+        path = tmp_path / "rigs.json"
+        add_preset_rig(path, "worker", "claude")
+        s = set_rig_value(path, "worker", "env.ENABLE_PROMPT_CACHING_1H", "1")
+        assert (s.key, s.value, s.explicit, s.display()) == (
+            "env.ENABLE_PROMPT_CACHING_1H", "1", True, "1"
+        )
+        raw = json.loads(path.read_text(encoding="utf-8"))["worker"]
+        assert raw["env"] == {"ENABLE_PROMPT_CACHING_1H": "1"}
+        assert load_rig_config(path).rigs["worker"].env == {
+            "ENABLE_PROMPT_CACHING_1H": "1"
+        }
+        got = rig_setting(path, "worker", "env.ENABLE_PROMPT_CACHING_1H")
+        assert (got.value, got.source) == ("1", "explicit")
+        assert unset_rig_value(path, "worker", "env.ENABLE_PROMPT_CACHING_1H") is True
+        # An empty map is no map — nothing is inherited for it to shadow.
+        assert "env" not in json.loads(path.read_text(encoding="utf-8"))["worker"]
+
+    def test_unset_of_an_unset_name_is_a_noop(self, tmp_path):
+        path = tmp_path / "rigs.json"
+        add_preset_rig(path, "worker", "claude")
+        assert unset_rig_value(path, "worker", "env.NOPE") is False
+        set_rig_value(path, "worker", "env.KEEP", "1")
+        assert unset_rig_value(path, "worker", "env.NOPE") is False
+        assert json.loads(path.read_text(encoding="utf-8"))["worker"]["env"] == {
+            "KEEP": "1"
+        }
+
+    def test_second_entry_joins_rather_than_replaces(self, tmp_path):
+        path = tmp_path / "rigs.json"
+        add_preset_rig(path, "worker", "claude")
+        set_rig_value(path, "worker", "env.ENABLE_PROMPT_CACHING_1H", "1")
+        set_rig_value(path, "worker", "env.MAX_THINKING_TOKENS", "8000")
+        assert load_rig_config(path).rigs["worker"].env == {
+            "ENABLE_PROMPT_CACHING_1H": "1",
+            "MAX_THINKING_TOKENS": "8000",
+        }
+
+    def test_names_keep_their_case_the_prefix_does_not(self, tmp_path):
+        path = tmp_path / "rigs.json"
+        add_preset_rig(path, "worker", "claude")
+        set_rig_value(path, "worker", "ENV.MixedCase_1", "v")
+        assert load_rig_config(path).rigs["worker"].env == {"MixedCase_1": "v"}
+        assert rig_setting(path, "worker", "env.MixedCase_1").value == "v"
+        assert rig_setting(path, "worker", "env.MIXEDCASE_1").value is None
+
+    def test_unset_name_reports_not_set(self, tmp_path):
+        path = tmp_path / "rigs.json"
+        add_preset_rig(path, "worker", "claude")
+        s = rig_setting(path, "worker", "env.ENABLE_PROMPT_CACHING_1H")
+        assert (s.value, s.explicit, s.source, s.display()) == (
+            None, False, "not set", "unset"
+        )
+
+    @pytest.mark.parametrize(
+        "name", ["TELL_OUTBOX_DIR", "PWD", "R4T_CONTINUE", "R4T_NODE", "R4T_ANYTHING"]
+    )
+    def test_turn_owned_names_are_refused_not_silently_overridden(self, tmp_path, name):
+        path = tmp_path / "rigs.json"
+        add_preset_rig(path, "worker", "claude")
+        with pytest.raises(RigError) as excinfo:
+            set_rig_value(path, "worker", f"env.{name}", "x")
+        message = str(excinfo.value)
+        assert message.startswith(f"{name} belongs to the turn")
+        assert "(try: r4t rig set <rig> env." in message
+        assert "env" not in json.loads(path.read_text(encoding="utf-8"))["worker"]
+
+    def test_hand_edited_turn_owned_name_fails_the_rig_closed(self, tmp_path):
+        path = write_config(tmp_path, {
+            "worker": {
+                "invoke": ["x", "{prompt}"],
+                "env": {"TELL_OUTBOX_DIR": "/nowhere/theirs"},
+            },
+        })
+        rig = load_rig_config(path).rigs["worker"]
+        assert rig.error and "TELL_OUTBOX_DIR belongs to the turn" in rig.error
+        assert rig.env == {}
+        assert load_rig_config(path).rig_for(member(rig="worker"))[0] is None
+
+    @pytest.mark.parametrize("name", ["", "1BAD", "HAS SPACE", "HAS-DASH", "a=b"])
+    def test_unusable_variable_names_are_refused(self, tmp_path, name):
+        path = tmp_path / "rigs.json"
+        add_preset_rig(path, "worker", "claude")
+        with pytest.raises(RigError, match="not a usable environment variable name"):
+            set_rig_value(path, "worker", f"env.{name}", "x")
+
+    def test_parse_rejects_a_non_string_value(self, tmp_path):
+        path = write_config(tmp_path, {
+            "worker": {"invoke": ["x", "{prompt}"], "env": {"CACHE": 1}},
+        })
+        rig = load_rig_config(path).rigs["worker"]
+        assert "env.CACHE: expected a string, got 1" in rig.error
+
+    def test_parse_rejects_a_non_object_map(self, tmp_path):
+        path = write_config(tmp_path, {
+            "worker": {"invoke": ["x", "{prompt}"], "env": ["CACHE=1"]},
+        })
+        assert "env: expected an object" in load_rig_config(path).rigs["worker"].error
+
+    def test_a_set_value_is_always_a_string(self, tmp_path):
+        path = tmp_path / "rigs.json"
+        add_preset_rig(path, "worker", "claude")
+        set_rig_value(path, "worker", "env.CACHE", 1)
+        assert json.loads(path.read_text(encoding="utf-8"))["worker"]["env"] == {
+            "CACHE": "1"
+        }
+
+    def test_get_lists_only_the_entries_the_rig_carries(self, tmp_path):
+        path = tmp_path / "rigs.json"
+        add_preset_rig(path, "worker", "claude")
+        assert [s.key for s in rig_settings(path, "worker")] == list(
+            CONFIGURABLE_RIG_KEYS
+        )
+        set_rig_value(path, "worker", "env.ZED", "2")
+        set_rig_value(path, "worker", "env.ABLE", "1")
+        rows = rig_settings(path, "worker")
+        assert [s.key for s in rows[len(CONFIGURABLE_RIG_KEYS):]] == [
+            "env.ABLE", "env.ZED"
+        ]
+
+    def test_unknown_setting_error_advertises_the_env_shape(self, tmp_path):
+        path = tmp_path / "rigs.json"
+        add_preset_rig(path, "worker", "claude")
+        with pytest.raises(RigError, match=r"env\.<NAME>"):
+            set_rig_value(path, "worker", "env", "1")
+
+    def test_cli_set_get_unset(self, tmp_path, capsys):
+        path = tmp_path / "rigs.json"
+        add_preset_rig(path, "worker", "claude")
+        args = ["--rig-config", str(path)]
+        assert r4t_main(
+            ["rig", "set", "worker", "env.ENABLE_PROMPT_CACHING_1H", "1", *args]
+        ) == 0
+        assert "set worker env.ENABLE_PROMPT_CACHING_1H = 1" in capsys.readouterr().out
+        assert r4t_main(
+            ["rig", "get", "worker", "env.ENABLE_PROMPT_CACHING_1H", *args]
+        ) == 0
+        captured = capsys.readouterr()
+        assert captured.out.strip() == "1"
+        assert captured.err.strip() == "(explicit)"
+        assert r4t_main(["rig", "get", "worker", *args]) == 0
+        assert "env.ENABLE_PROMPT_CACHING_1H  1  (explicit)" in capsys.readouterr().out
+        assert r4t_main(
+            ["rig", "unset", "worker", "env.ENABLE_PROMPT_CACHING_1H", *args]
+        ) == 0
+        assert "unset worker env.ENABLE_PROMPT_CACHING_1H" in capsys.readouterr().out
+        assert "env" not in json.loads(path.read_text(encoding="utf-8"))["worker"]
+
+    def test_cli_refuses_a_turn_owned_name_action_first(self, tmp_path, capsys):
+        path = tmp_path / "rigs.json"
+        add_preset_rig(path, "worker", "claude")
+        assert r4t_main(
+            ["rig", "set", "worker", "env.R4T_NODE", "x", "--rig-config", str(path)]
+        ) == 1
+        err = capsys.readouterr().err
+        assert err.startswith("R4T_NODE belongs to the turn") and "(try:" in err


### PR DESCRIPTION
Closes #284.

Rigs were argv-only, so a harness knob that lives in the environment had no home in r4t. The proven case is Claude Code's prompt-cache TTL: on API-key auth the CLI writes the 5-minute tier, so a member woken ten minutes after its last turn re-reads its whole context at full price, and `ENABLE_PROMPT_CACHING_1H=1` opts into the 1-hour tier — the highest-leverage cost knob for scheduled wakes minutes to tens of minutes apart. A setting, not a code path, so it rides the rig.

## What this adds

- **`env` map on a rig** — static `NAME=value` pairs merged into the turn environment at dispatch. Values are literal strings; no substitution, no shell.
- **Crosses the isolation boundary** — named to the wrapper the same way the `mcp` idiom's env is: re-exported past sudoers `env_reset`, passed as `docker run -e`. An isolated org's rig env actually arrives.
- **r4t's own injections still win** — the map goes on *before* the `mcp` idiom's variables and the workdir `PWD` pin, so neither can be unseated by a rig knob.
- **Turn variables are refused, not overridden** — `TELL_OUTBOX_DIR`, `PWD` and the `R4T_*` family carry the member's staging outbox, pinned workdir, and node / member / isolation / continue state. `rig set` rejects the name with an action-first error; a hand-edited `rigs.json` fails the rig closed, surfaced at `rig get` / `roster check` / the first turn rather than lost silently.
- **Existing settings grammar** — `r4t rig set <rig> env.<NAME> <value>` / `get` / `unset`, no new argparse. `rig get <rig>` lists the pairs the rig carries (there are no defaults to inherit, so nothing is materialized); unsetting the last pair drops the key entirely.

```bash
r4t rig set brain env.ENABLE_PROMPT_CACHING_1H 1
r4t rig get brain env.ENABLE_PROMPT_CACHING_1H    # 1  (explicit)
r4t rig unset brain env.ENABLE_PROMPT_CACHING_1H
```

## Doctrine

FRUGAL, and the docs say so. This is the one rig key whose effect r4t cannot see, so an entry earns its place with a documented reason — not a dumping ground.

## Scope note

Preset-level default env maps (the issue's first bullet) are **not** in this PR. The operator sets the knob on the rig that wants it; nothing changes for rigs that do not.

## Tests

30 new tests (`TestRigEnvMap` in `test_rig.py`, `TestRigEnvReachesTheHarness` in `test_isolate.py`): env reaching a real harness process, the run_as bootstrap positionals, the container `-e` argv, riding alongside the mcp idiom's env, the idiom winning its own variable, the workdir pin holding, turn-variable refusal through both the CLI and a hand-edited config, and keyless serialization when unset.

Full r4t suite: **808 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
