### PR TITLE
feat(r4t): `task trace` reconstructs one task's delegation tree

### DIFF
--- a/apps/r4t/README.md
+++ b/apps/r4t/README.md
@@ -91,7 +91,7 @@ in production too. Full flow: [docs/message-flow.md](docs/message-flow.md).
 - [Message flow](docs/message-flow.md) — threads, queues, the stdout fallback
 - [Operations](docs/operations.md) — `status`, `logs`, `chat`, the human seat
 - [Org design](docs/org.md) — cells and leads, `MISSION.md`, portable orgs
-- [Verification](docs/verification.md) — `r4t check`, checklists, doorbell gate, the post-hoc judge
+- [Verification](docs/verification.md) — `r4t check`, checklists, doorbell gate, the post-hoc judge, `r4t task trace`
 - [Governance](docs/governance.md) — why each layer exists, with prior art
 - [Security model](docs/security.md) — what a repo edit can never change
 - [Isolation](docs/isolation.md) — run an org behind a Unix user or a container

--- a/apps/r4t/docs/operations.md
+++ b/apps/r4t/docs/operations.md
@@ -18,6 +18,10 @@ registered team.
 - `r4t chat` — the human, interactively (below).
 - `r4t seat` — an orchestrating agent, programmatically (below).
 
+These four watch a team as it works. For one task after the fact — who told
+whom, and what each hop cost — see
+[`r4t task trace`](verification.md#tracing-one-task).
+
 The first dispatch stamps the repo root into team state, so `--node` works
 from any directory — and from inside a team repo the `--node` flag itself
 is optional. (`a8s logs <node> -f` still shows the cross-wall view.)

--- a/apps/r4t/docs/verification.md
+++ b/apps/r4t/docs/verification.md
@@ -52,3 +52,33 @@ an agent that could read its own grade would learn to game it. Reports land
 under the team dir's `judge/` — a surface no roster agent ever reads — never
 inside the workplace repo. Pass `--json` instead of the sectioned panel to
 derive an experiment-ledger column.
+
+## Tracing one task
+
+The judge grades a run; `r4t task trace <id>` reconstructs a single task. It
+answers "what actually happened here?" in one screen: the delegation tree, hop
+by hop — who received the task, who they passed it to, what came back — plus
+every turn the thread cost with its exit code and duration, dead letters
+inline, and whatever is still in flight.
+
+```
+Delegation
+  boss -> gerry        hop 0  "ship the parser by friday"
+    gerry -> phil      hop 1  "take the tokenizer and land it behind the flag"
+      phil -> neil     hop 2
+      phil -> gerry    hop 2  "tokenizer landed, PR is up"
+        gerry -> boss  hop 3  (out of the walls)  (closes the thread)
+```
+
+Nothing new is written for it, and no new transport is involved: the whole
+trace is read back out of state the team already keeps. The day log is the
+spine — append-only, never pruned, and every delivery and turn boundary lands
+in it carrying the thread id — while the thread ledger, the dead-letter dir,
+the members' queues and any in-flight turn supply the originator, what never
+got delivered, and what is still moving. A thread whose ledger has already
+expired still traces: the panel says so, and reads the originator and the
+closure back out of the log.
+
+`--json` gives the same reconstruction as a structure, so an acceptance check
+can assert on trace shape (`delegation`, `turns`, `dead_letters`) instead of
+grepping logs.

--- a/apps/r4t/r4t.py
+++ b/apps/r4t/r4t.py
@@ -138,6 +138,12 @@ COMMAND_HELP = [
                 "Sweep a team's work for the patterns you forbid",
                 "check",
             ),
+            Command(
+                "task trace <id>",
+                "Who told whom on one task, hop by hop",
+                None,
+                "r4t task list",
+            ),
         ],
     ),
 ]
@@ -1438,8 +1444,12 @@ def cmd_task(args: argparse.Namespace) -> int:
             )
         return 0
     if not args.id:
-        print("task show: <id> is required", file=sys.stderr)
+        print(f"task {args.action}: <id> is required", file=sys.stderr)
         return 2
+    if args.action == "trace":
+        import tasktrace
+
+        return tasktrace.run(node, args.id.strip().upper(), json_mode=args.json)
     task = tasks.load_task(node, args.id.strip().upper())
     if task is None:
         print(f"task not found: {args.id}", file=sys.stderr)
@@ -1914,10 +1924,19 @@ def build_parser() -> argparse.ArgumentParser:
     _add_tell_flags(flush_p)
     flush_p.set_defaults(func=cmd_flush)
 
-    task_p = sub.add_parser("task", help=_cmd_help("task"))
-    task_p.add_argument("action", choices=["list", "show"])
+    task_p = sub.add_parser(
+        "task",
+        help=_cmd_help("task"),
+        description="Conversation threads: list them, show one ledger, or trace "
+        "one task's delegation tree from recorded state.",
+    )
+    task_p.add_argument("action", choices=["list", "show", "trace"])
     task_p.add_argument("id", nargs="?", help="Task ULID.")
     task_p.add_argument("--node", help="Team node name (default: sole ~/.config/r4t team).")
+    task_p.add_argument(
+        "--json", action="store_true",
+        help="With trace: the reconstruction as JSON instead of the panel.",
+    )
     task_p.set_defaults(func=cmd_task)
 
     check_p = sub.add_parser(

--- a/apps/r4t/tasktrace.py
+++ b/apps/r4t/tasktrace.py
@@ -1,0 +1,488 @@
+"""Task trace — reconstruct one thread's delegation tree from state on disk.
+
+Read-only, and writes nothing of its own: every fact here is already recorded,
+just spread across four files. The day log (`log/<date>.md`) is the spine —
+append-only, never pruned, and every delivery, turn boundary and closure lands
+in it carrying the thread id. The ledger (`tasks/<id>.json`) adds the
+originator and the closure stamp while it is live; `expire_tasks` deletes it
+once a thread goes idle, so an old thread's trace reconstructs both from the
+log instead. The dead-letter dir, the members' queues and any in-flight
+`.turn.json` fill in what never got delivered and what is still moving.
+
+velocity.csv is deliberately not read: a row records only a turn's NEWEST
+thread, so it cannot answer whether a turn touched this one. The log's dispatch
+header lists every thread in the batch, which is the question a trace asks.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+
+import state
+import tasks
+
+MARKS = {True: "✓", False: "✗"}
+
+QUEUED_RE = re.compile(
+    r'^r4t: QUEUED (?P<sender>\S+) -> (?P<to>\S+) thread=(?P<thread>\S+) '
+    r'hop=(?P<hop>\d+) "(?P<preview>.*)" \(depth \d+\)$'
+)
+RELEASED_RE = re.compile(
+    r"^r4t: RELEASED(?P<internal>-internal)? (?P<sender>\S+) -> (?P<to>\S+) "
+    r"thread=(?P<thread>\S+) hop=(?P<hop>\d+)$"
+)
+ANSWERED_RE = re.compile(
+    r"^r4t: ANSWERED thread=(?P<thread>\S+) (?P<sender>\S+) -> (?P<to>\S+) "
+)
+DISPATCH_RE = re.compile(
+    r"^## (?P<at>\S+) dispatch (?P<messages>\d+) message\(s\) -> (?P<member>\S+) "
+    r"\(threads (?P<threads>.*?), rig (?P<rig>[^\s)]+)"
+)
+OUTPUT_RE = re.compile(
+    r"^### Output \((?P<member>[^,]+), exit (?P<exit>-?\d+) in "
+    r"(?P<duration>[\d.]+)s(?P<killed> \(killed at timeout [^)]*\))?\)$"
+)
+EVENT_RE = re.compile(r"^r4t: (?P<kind>[A-Z][A-Z0-9-]*)\b")
+
+
+@dataclass
+class Edge:
+    """One delivery attributed to this thread: who sent, who received, at
+    which hop."""
+
+    seq: int
+    sender: str
+    to: str
+    hop: int
+    preview: str
+    external: bool
+    closes: bool = False
+
+
+@dataclass
+class Turn:
+    at: str
+    member: str
+    rig: str
+    messages: int
+    exit_code: int | None = None
+    duration: float | None = None
+    killed: bool = False
+
+
+@dataclass
+class Trace:
+    node: str
+    thread: str
+    ledger: dict | None
+    edges: list[Edge] = field(default_factory=list)
+    turns: list[Turn] = field(default_factory=list)
+    events: list[str] = field(default_factory=list)
+    dead_letters: list[dict] = field(default_factory=list)
+    queued: list[dict] = field(default_factory=list)
+    running: list[dict] = field(default_factory=list)
+    answered_by: str | None = None
+
+    @property
+    def empty(self) -> bool:
+        return not (
+            self.ledger
+            or self.edges
+            or self.turns
+            or self.events
+            or self.dead_letters
+            or self.queued
+            or self.running
+        )
+
+    @property
+    def closed(self) -> bool:
+        if self.ledger is not None:
+            return self.ledger.get("status") == tasks.STATUS_CLOSED
+        return self.answered_by is not None
+
+
+def _norm(node: str, addr: str) -> str:
+    """An address as the trace names it: intra-team `acme:phil` reads `phil`,
+    everything else (outside agents, the `r4t:<node>` dispatcher voice) stays
+    verbatim."""
+    a = (addr or "").strip().lower()
+    prefix = node.lower() + ":"
+    return a[len(prefix):] if a.startswith(prefix) else a
+
+
+def _scan_log(node: str, thread: str) -> tuple[list[Edge], list[Turn], list[str], str | None]:
+    edges: list[Edge] = []
+    turns: list[Turn] = []
+    events: list[str] = []
+    answered_by: str | None = None
+    # An intra-team send logs BOTH the recipient's QUEUED and the sender's
+    # RELEASED-internal; a send to a human seat logs only the latter, and an
+    # external one only RELEASED. Counting QUEUEDs per sender+recipient+hop lets
+    # each RELEASED spend one — so every delivery becomes exactly one edge.
+    delivered: dict[tuple[str, str, int], int] = {}
+    turn: Turn | None = None
+
+    log_dir = state.team_dir(node) / "log"
+    for path in sorted(log_dir.glob("*.md")) if log_dir.is_dir() else []:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for line in text.splitlines():
+            head = DISPATCH_RE.match(line)
+            if head:
+                batch = [t.strip() for t in head["threads"].split(",")]
+                turn = None
+                if thread in batch:
+                    turn = Turn(
+                        at=head["at"],
+                        member=head["member"].strip().lower(),
+                        rig=head["rig"],
+                        messages=int(head["messages"]),
+                    )
+                    turns.append(turn)
+                continue
+            done = OUTPUT_RE.match(line)
+            if done is not None and turn is not None:
+                if done["member"].strip().lower() == turn.member:
+                    turn.exit_code = int(done["exit"])
+                    turn.duration = float(done["duration"])
+                    turn.killed = bool(done["killed"])
+                    turn = None
+                continue
+
+            queued = QUEUED_RE.match(line)
+            if queued is not None:
+                if queued["thread"] == thread:
+                    key = (
+                        _norm(node, queued["sender"]),
+                        _norm(node, queued["to"]),
+                        int(queued["hop"]),
+                    )
+                    delivered[key] = delivered.get(key, 0) + 1
+                    edges.append(
+                        Edge(
+                            seq=len(edges),
+                            sender=key[0],
+                            to=key[1],
+                            hop=key[2],
+                            preview=queued["preview"],
+                            external=False,
+                        )
+                    )
+                continue
+            released = RELEASED_RE.match(line)
+            if released is not None:
+                if released["thread"] == thread:
+                    key = (
+                        _norm(node, released["sender"]),
+                        _norm(node, released["to"]),
+                        int(released["hop"]),
+                    )
+                    if delivered.get(key):
+                        delivered[key] -= 1
+                    else:
+                        edges.append(
+                            Edge(
+                                seq=len(edges),
+                                sender=key[0],
+                                to=key[1],
+                                hop=key[2],
+                                preview="",
+                                external=not released["internal"],
+                            )
+                        )
+                continue
+            answered = ANSWERED_RE.match(line)
+            if answered is not None:
+                if answered["thread"] == thread:
+                    sender = _norm(node, answered["sender"])
+                    to = _norm(node, answered["to"])
+                    answered_by = f"{sender} -> {to}"
+                    for edge in reversed(edges):
+                        if edge.sender == sender and edge.to == to:
+                            edge.closes = True
+                            break
+                continue
+            event = EVENT_RE.match(line)
+            if event is not None and f"thread={thread}" in line:
+                events.append(line[len("r4t: "):])
+    return edges, turns, events, answered_by
+
+
+def _member_names(node: str) -> list[str]:
+    root = state.team_dir(node) / "agents"
+    if not root.is_dir():
+        return []
+    return sorted(entry.name for entry in root.iterdir() if entry.is_dir())
+
+
+def _in_flight(node: str, thread: str) -> tuple[list[dict], list[dict]]:
+    queued: list[dict] = []
+    running: list[dict] = []
+    locked = {str(lock.get("agent", "")) for lock in state.live_locks(node, prune=False)}
+    for member in _member_names(node):
+        for envelope in state.read_queue(node, member):
+            if str(envelope.get("thread", "")) != thread:
+                continue
+            queued.append(
+                {
+                    "member": member,
+                    "from": _norm(node, str(envelope.get("from", "?"))),
+                    "hop": int(envelope.get("hop", 0) or 0),
+                    "preview": " ".join(str(envelope.get("body", "")).split())[:80],
+                }
+            )
+        turn = state.read_turn(node, member)
+        if turn is not None and thread in [str(t) for t in turn.get("threads", [])]:
+            running.append(
+                {
+                    "member": member,
+                    "started": str(turn.get("started", "?")),
+                    "rig": str(turn.get("rig", "?")),
+                    "live": member in locked,
+                }
+            )
+    return queued, running
+
+
+def build(node: str, thread: str) -> Trace:
+    edges, turns, events, answered_by = _scan_log(node, thread)
+    queued, running = _in_flight(node, thread)
+    return Trace(
+        node=node,
+        thread=thread,
+        ledger=tasks.load_task(node, thread),
+        edges=edges,
+        turns=turns,
+        events=events,
+        dead_letters=[
+            d for d in state.list_dead_letters(node)
+            if str(d.get("thread", "")) == thread
+        ],
+        queued=queued,
+        running=running,
+        answered_by=answered_by,
+    )
+
+
+def delegation(edges: list[Edge]) -> list[tuple[int, Edge]]:
+    """(depth, edge) pairs in delegation order. An edge's parent is the most
+    recent earlier delivery INTO its sender — which is what makes a flat
+    ordered edge list a tree: the message a member is answering, or the task it
+    is passing on. A parent index is always lower than its child's, so the walk
+    can never cycle."""
+    children: dict[int | None, list[int]] = {}
+    latest_into: dict[str, int] = {}
+    for i, edge in enumerate(edges):
+        children.setdefault(latest_into.get(edge.sender), []).append(i)
+        latest_into[edge.to] = i
+    ordered: list[tuple[int, Edge]] = []
+    stack = [(index, 0) for index in reversed(children.get(None, []))]
+    while stack:
+        index, depth = stack.pop()
+        ordered.append((depth, edges[index]))
+        stack.extend(
+            (child, depth + 1) for child in reversed(children.get(index, []))
+        )
+    return ordered
+
+
+def _rows(rows: list[tuple[bool | None, str, str, str | None]]) -> list[str]:
+    if not rows:
+        return ["  (none)"]
+    width = max(len(name) for _m, name, _t, _h in rows)
+    out = []
+    for mark, name, text, hint in rows:
+        line = f"  {MARKS.get(mark, ' ')} {name:<{width}}  {text}"
+        if hint:
+            line += f"   (try: {hint})"
+        out.append(line.rstrip())
+    return out
+
+
+def _originator(t: Trace) -> str:
+    if t.ledger is not None:
+        return _norm(t.node, str(t.ledger.get("creator", "?")))
+    return t.edges[0].sender if t.edges else "(unknown)"
+
+
+def _thread_rows(t: Trace) -> list[tuple[bool | None, str, str, str | None]]:
+    rows: list[tuple[bool | None, str, str, str | None]] = []
+    if t.closed:
+        answered = f" (answered by {t.answered_by})" if t.answered_by else ""
+        rows.append((True, "status", f"closed{answered}", None))
+    else:
+        rows.append((None, "status", "open — the originator has not heard back", None))
+    rows.append((None, "originator", _originator(t), None))
+    if t.ledger is not None:
+        rows.append((
+            None, "ledger",
+            f"opened {t.ledger.get('created_at', '?')}, "
+            f"last write {t.ledger.get('updated_at', '?')}",
+            None,
+        ))
+    else:
+        rows.append((
+            None, "ledger",
+            "expired — this trace is reconstructed from the day log",
+            None,
+        ))
+    rows.append((
+        None, "volume",
+        f"{len(t.turns)} turn(s), {len(t.edges)} delivery(s), "
+        f"{len(t.dead_letters)} dead letter(s)",
+        None,
+    ))
+    return rows
+
+
+def _delegation_lines(t: Trace) -> list[str]:
+    ordered = delegation(t.edges)
+    if not ordered:
+        return ["  (nothing delivered — see In flight or Dead letters below)"]
+    labels = [
+        f"{'  ' * depth}{edge.sender} -> {edge.to}" for depth, edge in ordered
+    ]
+    width = max(len(label) for label in labels)
+    out = []
+    for label, (_depth, edge) in zip(labels, ordered):
+        line = f"  {label:<{width}}  hop {edge.hop}"
+        if edge.external:
+            line += "  (out of the walls)"
+        if edge.closes:
+            line += "  (closes the thread)"
+        if edge.preview:
+            line += f'  "{edge.preview}"'
+        out.append(line)
+    return out
+
+
+def _turn_rows(t: Trace) -> list[tuple[bool | None, str, str, str | None]]:
+    rows: list[tuple[bool | None, str, str, str | None]] = []
+    width = max((len(turn.rig) for turn in t.turns), default=0)
+    for turn in t.turns:
+        if turn.exit_code is None:
+            rows.append((None, turn.member, f"rig {turn.rig}  no outcome recorded", None))
+            continue
+        detail = (
+            f"rig {turn.rig:<{width}}  exit {turn.exit_code}  "
+            f"{turn.duration:>6.1f}s  {turn.messages} msg  {turn.at}"
+        )
+        if turn.killed:
+            detail += "  (killed at the rig timeout)"
+        ok = turn.exit_code == 0 and not turn.killed
+        hint = None if ok else f"r4t logs --node {t.node} --agent {turn.member} --full"
+        rows.append((ok, turn.member, detail, hint))
+    return rows
+
+
+def render(t: Trace) -> list[str]:
+    out = [
+        f"task: {t.thread}",
+        f"team: {t.node}  (state: {state.team_dir(t.node)})",
+        "",
+        "Thread",
+        *_rows(_thread_rows(t)),
+        "",
+        "Delegation",
+        *_delegation_lines(t),
+        "",
+        "Turns",
+        *_rows(_turn_rows(t)),
+    ]
+    if t.dead_letters:
+        out += ["", "Dead letters", *_rows([
+            (
+                False,
+                str(d.get("reason", "?")),
+                f"{_norm(t.node, str(d.get('from', '?')))} -> "
+                f"{_norm(t.node, str(d.get('to', '?')))}  {d.get('time', '?')}",
+                None,
+            )
+            for d in t.dead_letters
+        ])]
+    if t.events:
+        out += ["", "Events", *[f"    {line}" for line in t.events]]
+    if t.running or t.queued:
+        rows: list[tuple[bool | None, str, str, str | None]] = [
+            (
+                run["live"],
+                run["member"],
+                f"turn running since {run['started']} (rig {run['rig']})"
+                + ("" if run["live"] else " — no live lock, so the turn crashed"),
+                None,
+            )
+            for run in t.running
+        ] + [
+            (
+                None,
+                q["member"],
+                f"queued from {q['from']} at hop {q['hop']}"
+                + (f'  "{q["preview"]}"' if q["preview"] else ""),
+                None,
+            )
+            for q in t.queued
+        ]
+        out += ["", "In flight", *_rows(rows)]
+    return out
+
+
+def payload(t: Trace) -> dict:
+    return {
+        "node": t.node,
+        "thread": t.thread,
+        "closed": t.closed,
+        "answered_by": t.answered_by,
+        "originator": _originator(t),
+        "ledger": t.ledger,
+        "delegation": [
+            {
+                "depth": depth,
+                "seq": edge.seq,
+                "from": edge.sender,
+                "to": edge.to,
+                "hop": edge.hop,
+                "external": edge.external,
+                "closes": edge.closes,
+                "preview": edge.preview,
+            }
+            for depth, edge in delegation(t.edges)
+        ],
+        "turns": [
+            {
+                "at": turn.at,
+                "member": turn.member,
+                "rig": turn.rig,
+                "messages": turn.messages,
+                "exit": turn.exit_code,
+                "duration_seconds": turn.duration,
+                "timed_out": turn.killed,
+            }
+            for turn in t.turns
+        ],
+        "events": t.events,
+        "dead_letters": t.dead_letters,
+        "queued": t.queued,
+        "running": t.running,
+    }
+
+
+def run(node: str, thread_id: str, *, json_mode: bool = False) -> int:
+    t = build(node, thread_id)
+    if t.empty:
+        print(
+            f"task trace: nothing recorded for thread {thread_id!r} on team {node}\n"
+            f"   (try: r4t task list --node {node})",
+            file=sys.stderr,
+        )
+        return 1
+    if json_mode:
+        print(json.dumps(payload(t), indent=2))
+        return 0
+    for line in render(t):
+        print(line)
+    return 0

--- a/apps/r4t/tests/test_tasktrace.py
+++ b/apps/r4t/tests/test_tasktrace.py
@@ -1,0 +1,237 @@
+"""`r4t task trace` — the delegation tree reconstructed from recorded state.
+
+Every fixture here is real dispatch output: the trace is only worth anything if
+it reads the files dispatch actually writes, so no test hand-writes a log line.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import dispatch
+import state
+import tasks
+import tasktrace
+from dispatch import drain_until_quiet, handle_message
+from r4t import main as r4t_main
+from rig import load_rig_config
+from roster import load_roster
+from ulid import new as new_ulid
+
+from test_dispatch import dead_reasons, run_one
+
+NODE = "acme"
+
+
+def only_thread() -> str:
+    listing = tasks.list_tasks(NODE)
+    assert len(listing) == 1, [t["id"] for t in listing]
+    return str(listing[0]["id"])
+
+
+def shape(trace) -> list[tuple[int, str, str, int]]:
+    return [
+        (depth, edge.sender, edge.to, edge.hop)
+        for depth, edge in tasktrace.delegation(trace.edges)
+    ]
+
+
+@pytest.fixture
+def two_hop(chatty_ctx, chatty_harness, monkeypatch):
+    """boss asks the team; Gerry delegates to Phil; Phil answers the human
+    seat. Three deliveries, two turns, one thread."""
+    monkeypatch.setenv("CHATTY_TO", "acme:phil")
+    monkeypatch.setenv("CHATTY_BODY", "take the tokenizer")
+    assert run_one(chatty_ctx, "boss", "acme", "ship the parser") == 1
+    monkeypatch.setenv("CHATTY_TO", "neil")
+    monkeypatch.setenv("CHATTY_BODY", "tokenizer landed")
+    assert drain_until_quiet(chatty_ctx) == 1
+    return chatty_ctx
+
+
+class TestDelegationTree:
+    def test_reconstructs_sender_recipient_hops(self, two_hop):
+        trace = tasktrace.build(NODE, only_thread())
+        assert shape(trace) == [
+            (0, "boss", "gerry", 0),
+            (1, "gerry", "phil", 1),
+            (2, "phil", "neil", 2),
+        ]
+
+    def test_carries_the_queued_preview(self, two_hop):
+        trace = tasktrace.build(NODE, only_thread())
+        previews = {edge.to: edge.preview for edge in trace.edges}
+        assert previews["gerry"] == "ship the parser"
+        assert previews["phil"] == "take the tokenizer"
+
+    def test_records_every_turn_with_outcome(self, two_hop):
+        trace = tasktrace.build(NODE, only_thread())
+        assert [(t.member, t.rig, t.exit_code) for t in trace.turns] == [
+            ("gerry", "leader", 0),
+            ("phil", "junior-dev", 0),
+        ]
+        assert all(t.duration is not None and not t.killed for t in trace.turns)
+
+    def test_seat_delivery_has_no_duplicate_edge(self, two_hop):
+        # A human recipient parks in the seat: only the sender's
+        # RELEASED-internal is logged, never a QUEUED. One edge either way.
+        trace = tasktrace.build(NODE, only_thread())
+        assert [e for e in trace.edges if e.to == "neil"][0].preview == ""
+        assert len(trace.edges) == 3
+
+    def test_two_seat_sends_at_one_hop_stay_two_edges(
+        self, chatty_ctx, chatty_harness, monkeypatch
+    ):
+        monkeypatch.setenv("CHATTY_TO", "neil")
+        monkeypatch.setenv("CHATTY_SENDS", "2")
+        assert run_one(chatty_ctx, "acme:gerry", "acme:phil", "ship it") == 1
+        trace = tasktrace.build(NODE, only_thread())
+        assert shape(trace) == [
+            (0, "gerry", "phil", 0),
+            (1, "phil", "neil", 1),
+            (1, "phil", "neil", 1),
+        ]
+
+    def test_open_thread_reads_open(self, two_hop):
+        trace = tasktrace.build(NODE, only_thread())
+        assert not trace.closed
+        assert trace.answered_by is None
+        assert trace.ledger["creator"] == "boss"
+
+
+class TestClosure:
+    def test_answer_to_the_originator_marks_the_edge(
+        self, chatty_ctx, chatty_harness, monkeypatch
+    ):
+        monkeypatch.setenv("CHATTY_TO", "boss-agent")
+        monkeypatch.setenv("CHATTY_BODY", "done: shipped and verified")
+        assert run_one(chatty_ctx, "boss-agent", "acme:phil", "ship it") == 1
+        trace = tasktrace.build(NODE, only_thread())
+        assert trace.closed
+        # External mail always enters at the top, so Gerry answers it.
+        assert trace.answered_by == "gerry -> boss-agent"
+        egress = [e for e in trace.edges if e.to == "boss-agent"]
+        assert len(egress) == 1
+        assert egress[0].external and egress[0].closes
+        assert "out of the walls" in "\n".join(tasktrace.render(trace))
+
+
+class TestMissingLedger:
+    def test_expired_ledger_still_traces_from_the_log(self, two_hop):
+        thread = only_thread()
+        assert tasks.expire_tasks(NODE, older_than_seconds=0) == [thread]
+        trace = tasktrace.build(NODE, thread)
+        assert trace.ledger is None
+        assert not trace.empty
+        assert shape(trace)[0] == (0, "boss", "gerry", 0)
+        text = "\n".join(tasktrace.render(trace))
+        assert "expired" in text
+        assert "originator  boss" in text
+
+    def test_expired_and_closed_reads_closed_from_the_log(
+        self, chatty_ctx, chatty_harness, monkeypatch
+    ):
+        monkeypatch.setenv("CHATTY_TO", "boss-agent")
+        monkeypatch.setenv("CHATTY_BODY", "done: shipped and verified")
+        run_one(chatty_ctx, "boss-agent", "acme:phil", "ship it")
+        thread = only_thread()
+        tasks.expire_tasks(NODE, older_than_seconds=0)
+        trace = tasktrace.build(NODE, thread)
+        assert trace.ledger is None and trace.closed
+
+
+class TestMidFlight:
+    def test_queued_but_not_yet_run(self, ctx, fake_harness):
+        handle_message(ctx, "boss", "acme", "ship the parser", drain_after=False)
+        trace = tasktrace.build(NODE, only_thread())
+        assert trace.turns == []
+        assert shape(trace) == [(0, "boss", "gerry", 0)]
+        assert [(q["member"], q["hop"]) for q in trace.queued] == [("gerry", 0)]
+        assert "In flight" in "\n".join(tasktrace.render(trace))
+
+    def test_running_turn_without_a_live_lock_reads_crashed(self, ctx):
+        handle_message(ctx, "boss", "acme", "ship the parser", drain_after=False)
+        thread = only_thread()
+        state.write_turn(
+            NODE, "gerry",
+            {"threads": [thread], "started": "2026-07-29T00:00:00Z", "rig": "leader"},
+        )
+        trace = tasktrace.build(NODE, thread)
+        assert [(r["member"], r["live"]) for r in trace.running] == [("gerry", False)]
+        assert "crashed" in "\n".join(tasktrace.render(trace))
+
+
+class TestTrouble:
+    def test_dead_letters_land_in_the_trace(
+        self, chatty_ctx, chatty_harness, monkeypatch
+    ):
+        monkeypatch.setenv("CHATTY_TO", "gerry")
+        monkeypatch.setenv("CHATTY_SENDS", "4")  # max_sends_per_turn is 2
+        run_one(chatty_ctx, "acme:gerry", "acme:phil", "fan out")
+        assert dead_reasons() == ["quota", "quota"]
+        trace = tasktrace.build(NODE, only_thread())
+        assert [d["reason"] for d in trace.dead_letters] == ["quota", "quota"]
+        assert "Dead letters" in "\n".join(tasktrace.render(trace))
+
+    def test_thread_tagged_events_land_in_the_trace(self, ctx):
+        task = tasks.new_task(new_ulid(), "acme:neil")
+        task["updated_at"] = "2020-01-01T00:00:00Z"
+        state.atomic_write_json(tasks.task_path(NODE, task["id"]), task)
+        roster = load_roster(ctx.roster_path)
+        config = load_rig_config(ctx.config_path)
+        assert dispatch._quiet_task_sweep(ctx, config, roster) == [task["id"]]
+        trace = tasktrace.build(NODE, task["id"])
+        assert [e.split()[0] for e in trace.events] == ["QUIET"]
+        assert "Events" in "\n".join(tasktrace.render(trace))
+
+    def test_a_failed_turn_points_at_the_captured_output(
+        self, ctx, repo, rig_config, monkeypatch
+    ):
+        script = repo / "boom.py"
+        script.write_text("import sys\nsys.exit(3)\n", encoding="utf-8")
+        config = json.loads(rig_config.read_text(encoding="utf-8"))
+        config["leader"]["invoke"] = ["python3", str(script), "{prompt}"]
+        rig_config.write_text(json.dumps(config), encoding="utf-8")
+        run_one(ctx, "boss", "acme", "ship the parser")
+        trace = tasktrace.build(NODE, only_thread())
+        assert [t.exit_code for t in trace.turns] == [3]
+        text = "\n".join(tasktrace.render(trace))
+        assert "r4t logs --node acme --agent gerry --full" in text
+
+
+class TestCli:
+    def test_trace_prints_the_panel(self, two_hop, capsys):
+        assert r4t_main(["task", "trace", only_thread(), "--node", NODE]) == 0
+        out = capsys.readouterr().out
+        for section in ("Thread", "Delegation", "Turns"):
+            assert section in out
+        assert "boss -> gerry" in out
+        assert "gerry -> phil" in out
+
+    def test_trace_json_is_machine_readable(self, two_hop, capsys):
+        thread = only_thread()
+        assert r4t_main(["task", "trace", thread, "--node", NODE, "--json"]) == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["thread"] == thread
+        assert data["originator"] == "boss"
+        assert [(e["from"], e["to"], e["hop"]) for e in data["delegation"]] == [
+            ("boss", "gerry", 0),
+            ("gerry", "phil", 1),
+            ("phil", "neil", 2),
+        ]
+        assert [t["member"] for t in data["turns"]] == ["gerry", "phil"]
+
+    def test_trace_lowercase_id_resolves(self, two_hop, capsys):
+        assert r4t_main(["task", "trace", only_thread().lower(), "--node", NODE]) == 0
+        assert "Delegation" in capsys.readouterr().out
+
+    def test_unknown_thread_says_nothing_recorded(self, two_hop, capsys):
+        assert r4t_main(["task", "trace", new_ulid(), "--node", NODE]) == 1
+        err = capsys.readouterr().err
+        assert "nothing recorded" in err
+        assert "(try: r4t task list --node acme)" in err
+
+    def test_trace_without_an_id_is_a_usage_error(self, two_hop, capsys):
+        assert r4t_main(["task", "trace", "--node", NODE]) == 2
+        assert "task trace: <id> is required" in capsys.readouterr().err


### PR DESCRIPTION
Closes #155.

`r4t task trace <id>` answers "what actually happened on this task?" in one
screen, instead of grepping the ledger, the dead-letter dir, velocity.csv and
the day log separately.

```
task: 01KYRQQ69Y3RKBSCAYZH1C2DP6
team: acme  (state: ~/.config/r4t/teams/acme)

Thread
  ✓ status      closed (answered by gerry -> boss)
    originator  boss
    ledger      opened 2026-07-30T05:24:55.230446Z, last write 2026-07-30T05:24:55.316442Z
    volume      3 turn(s), 5 delivery(s), 0 dead letter(s)

Delegation
  boss -> gerry        hop 0  "ship the parser by friday"
    gerry -> phil      hop 1  "take the tokenizer and land it behind the flag"
      phil -> neil     hop 2
      phil -> gerry    hop 2  "tokenizer landed, PR is up"
        gerry -> boss  hop 3  (out of the walls)  (closes the thread)

Turns
  ✓ gerry  rig leader      exit 0     0.0s  1 msg  2026-07-30T05:24:55.233130Z
  ✓ phil   rig junior-dev  exit 0     0.0s  1 msg  2026-07-30T05:24:55.261492Z
  ✓ gerry  rig leader      exit 0     0.0s  1 msg  2026-07-30T05:24:55.290947Z
```

`Dead letters`, `Events` (thread-tagged governance decisions, e.g. a quiet-thread
nudge) and `In flight` (queued deliveries, a running or crashed turn) print only
when they have something to say. A failed turn carries a
`(try: r4t logs --node … --agent … --full)` hint. `--json` gives the same
reconstruction as a structure so an acceptance check can assert on trace shape.

## Nothing new is written for it

No breadcrumb had to be added to dispatch — the day log is already the complete
spine. It is append-only, never pruned, and every delivery and turn boundary
lands in it carrying the thread id. Two design notes:

- **velocity.csv is deliberately not read.** A row records only a turn's NEWEST
  thread, so it cannot answer whether a turn touched this one. The log's
  dispatch header lists every thread in the batch, which is the question a
  trace asks.
- **`expire_tasks` can keep deleting idle ledgers** — the issue's `tasks/done/`
  wrinkle turns out not to be needed. The ledger only supplied the originator
  and the closure stamp, and the log carries both, so a trace of an expired
  thread says `ledger expired — this trace is reconstructed from the day log`
  and reads them back out.

## The tree

A flat ordered edge list becomes a tree by one rule: an edge's parent is the
most recent earlier delivery INTO its sender — exactly "the message this member
is answering, or the task it is passing on". Parent indices are always lower
than their children's, so the walk can never cycle.

Edge extraction has one wrinkle: an intra-team send logs both the recipient's
`QUEUED` and the sender's `RELEASED-internal`, a send to a human seat logs only
the latter, and an external send only `RELEASED`. So QUEUEDs are counted per
sender+recipient+hop and each RELEASED spends one — every delivery becomes
exactly one edge, with no double counting and no dropped seat hop.

## Surface and naming

Placed in the **Verification** section of the command panel: it is an operator's
instrument, and the issue's own note about mechanical acceptance checks asserting
on trace shape puts it there too. Documented in `docs/verification.md`
("Tracing one task"), with a pointer from `docs/operations.md`.

The module is `tasktrace.py`, not `trace.py`: r4t imports flat off its own
directory, so `trace.py` would shadow the stdlib `trace` module for the whole
process.

## Tests

19 new tests in `apps/r4t/tests/test_tasktrace.py`, every fixture driven through
real dispatch so no test hand-writes a log line — the delegation tree and hop
numbers, previews, per-turn outcomes, the seat hop, closure marking the
answering edge, an expired ledger (open and closed), mid-flight queued messages
and a running turn with no live lock, quota dead letters, a thread-tagged quiet
nudge, a failed turn's hint, and the CLI (panel, `--json`, lowercase id, unknown
thread, missing id).

Full r4t suite: 785 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
