### PR TITLE
test(r4t): sandbox failure scenarios — timeout member, silent member, mute member

### DIFF
--- a/apps/r4t/docs/development.md
+++ b/apps/r4t/docs/development.md
@@ -24,6 +24,55 @@ python3 -m pytest apps/r4t/tests/     # from anywhere in ~/bin — the repo
                                       # venv wrapper supplies pytest
 ```
 
+### Failure scenarios
+
+`r4t sandbox --fake --break MEMBER[:SHAPE]` breaks one member on purpose and
+grades the recovery path. Each shape is a way real harnesses fail, and each
+lands somewhere different in dispatch:
+
+| SHAPE | The member | r4t must |
+|---|---|---|
+| `exit` (default) | exits nonzero every turn | requeue the batch, trip the breaker, hold the queue |
+| `hang` | sleeps past its rig timeout | kill the process group at the timeout, requeue, trip the breaker |
+| `silent` | does the work, then answers on stdout without ever calling `tell` | stage the cleaned stdout as one reply to the sender, breaker closed, deliverable intact |
+| `mute` | prints tool chrome, stages nothing, exits 0 | let the quiet sweep nudge the leader so the originator still hears back |
+
+Every shape also checks the turn was charged to the member's budget: a member
+that keeps failing pays for its attempts. Each has a pytest in
+`tests/test_sandbox.py`, and the checks are written so a governance regression
+reads as FAIL rather than a quieter run.
+
+### What the sandbox fakes
+
+Every line here is a place a green sandbox run says nothing about a real
+roster:
+
+- **Roles are scripted.** `fake-agent.py` picks its action from a regex over
+  the prompt, so the pipeline completes however well or badly the prompt
+  teaches. Nothing here tests whether a model would follow it.
+- **Sends bypass `tell`.** Fake and live sandbox agents both write staged
+  envelopes into `$TELL_OUTBOX_DIR` from Python. Staging release, routing and
+  header stamping are the real thing; the member's own `tell` invocation —
+  shell quoting, outbox discovery — is not.
+- **No `a8s_tell` tool.** Sandbox rigs carry no preset, so the `mcp` knob is
+  off in both modes and the per-turn MCP injection never runs.
+- **Live mode still scripts two turns.** `live-agent.py` skips the LLM
+  entirely for the Tester role and for the Lead's post-VERIFIED turn.
+- **Live mode covers for the model.** After every turn it stages the tell the
+  model should have sent, and seeds `battleship.py` when Dev leaves none. A
+  green live report proves the pipeline ran, not that the harness followed
+  protocol.
+- **VERIFIED is a regex.** Both modes read `VERIFIED:` out of the incoming
+  text; a model that phrases its verdict any other way reads as unverified.
+- **Fake turns are instant.** Fake mode drops the cadence gate and every turn
+  returns in milliseconds, so throttling, concurrency and budget resting under
+  real latency go untested.
+- **Broken members break cleanly.** The `--break` shapes are a nonzero exit, a
+  `sleep`, a `print` and chrome-only output. Real harnesses fail messier:
+  partial output, tool loops, a CLI that blocks on stdin.
+- **Nobody continues.** The sandbox roster sets no `Continue:`, so refounds,
+  dump turns and the cold-start retry never run.
+
 ## Layout
 
 `r4t.py` (CLI) · `dispatch.py` (enqueue, batch turns, staging

--- a/apps/r4t/r4t.py
+++ b/apps/r4t/r4t.py
@@ -2019,9 +2019,10 @@ def build_parser() -> argparse.ArgumentParser:
     sandbox_p.add_argument(
         "--break",
         dest="break_member",
-        metavar="MEMBER",
-        help="Pin MEMBER (e.g. dev) to an always-failing rig to exercise "
-        "the failure breaker; checks expect the trip and a synthesized answer.",
+        metavar="MEMBER[:SHAPE]",
+        help="Break one member on purpose and check the recovery path. SHAPE is "
+        "exit (default, always fails), hang (times out), silent (answers on "
+        "stdout, never tells) or mute (one turn stages nothing).",
     )
     sandbox_p.add_argument("--timeout", type=float, default=1800, metavar="SECS")
     sandbox_p.set_defaults(func=cmd_sandbox)

--- a/apps/r4t/sandbox.py
+++ b/apps/r4t/sandbox.py
@@ -16,6 +16,15 @@ delegation, and the final leader answer with zero LLM calls. Live mode uses
 `--preset` (any `r4t rig presets` entry; default `opencode`) and
 optional `--model` for presets like `opencode-ollama`. The chosen argv is
 passed to live-agent.py via R4T_SANDBOX_INVOKE.
+
+`--break MEMBER[:SHAPE]` pins one member to a deliberately broken rig. Each
+shape is a different way real harnesses fail, and each lands on a different
+recovery path (see FAILURE_SHAPES); the mechanical checks assert the path,
+so a governance regression turns the run red.
+
+What fake mode deliberately fakes vs live mode is listed in
+apps/r4t/docs/development.md — every divergence is a place `--fake` can pass
+while a real roster misbehaves.
 """
 from __future__ import annotations
 
@@ -43,6 +52,17 @@ TEAM = "crew"
 NODE = "crew-node"
 ALIAS = "sandboxcrew"
 MAX_TURNS = 15
+
+
+FAILURE_SHAPES = {
+    "exit": "rig always exits nonzero — breaker trips, queue holds",
+    "hang": "rig sleeps past its timeout — turn killed, batch requeued",
+    "silent": "member works but answers on stdout, never tells — stdout fallback",
+    "mute": "member's first turn stages nothing — quiet sweep nudges the leader",
+}
+FAILURE_RIG_NAMES = {"exit": "broken", "hang": "hung", "silent": "silent", "mute": "mute"}
+FAILURE_BUDGET_MAX = 10
+QUIET_TASK_SECONDS = 10
 
 
 class SandboxError(Exception):
@@ -103,7 +123,47 @@ def _write_definition(path: Path) -> None:
     )
 
 
-def _write_rig_config(path: Path, fake: bool, break_member: str | None = None) -> None:
+def parse_break(spec: str) -> tuple[str, str]:
+    member, _, shape = spec.strip().partition(":")
+    shape = (shape or "exit").lower()
+    if not member:
+        raise SandboxError("--break needs a member name, e.g. --break dev:hang")
+    if shape not in FAILURE_SHAPES:
+        raise SandboxError(
+            f"unknown break shape {shape!r} — pick one of "
+            f"{', '.join(sorted(FAILURE_SHAPES))}"
+        )
+    return member.lower(), shape
+
+
+def _failure_rig(shape: str) -> dict:
+    if shape == "exit":
+        invoke = [sys.executable, "-c", "import sys; sys.exit(1)", "{prompt}"]
+        timeout = 30.0
+    elif shape == "hang":
+        # Sleeps far past its own timeout so the turn can only end one way:
+        # killed by r4t. A sleep near the timeout would race the check.
+        invoke = [sys.executable, "-c", "import time; time.sleep(300)", "{prompt}"]
+        timeout = 3.0
+    else:
+        invoke = [
+            sys.executable,
+            str(SANDBOX_DIR / "fake-agent.py"),
+            "{prompt}",
+            f"--{shape}",
+        ]
+        timeout = 60.0
+    return {
+        "invoke": invoke,
+        "timeout_seconds": timeout,
+        "budget_max": FAILURE_BUDGET_MAX,
+        "budget_earn_per_hour": FAILURE_BUDGET_MAX,
+    }
+
+
+def _write_rig_config(
+    path: Path, fake: bool, failure: tuple[str, str] | None = None
+) -> None:
     config = json.loads((SANDBOX_DIR / "rigs.json").read_text(encoding="utf-8"))
     if fake:
         for value in config.values():
@@ -123,13 +183,17 @@ def _write_rig_config(path: Path, fake: bool, break_member: str | None = None) -
                     str(SANDBOX_DIR / "live-agent.py"),
                     "{prompt}",
                 ]
-    if break_member:
-        config["broken"] = {
-            "invoke": [sys.executable, "-c", "import sys; sys.exit(1)", "{prompt}"],
-            "timeout_seconds": 30,
-        }
-        config["pins"] = {break_member.lower(): "broken"}
+    if failure:
+        member, shape = failure
+        rig_name = FAILURE_RIG_NAMES[shape]
+        config[rig_name] = _failure_rig(shape)
+        config["pins"] = {member: rig_name}
+        # Kept low for every shape, not just the failing ones: a shape that
+        # exits 0 must reach its recovery path with the breaker still closed,
+        # and a cap of 2 makes any stray trip visible.
         config["breaker_cap"] = 2
+        if shape == "mute":
+            config["quiet_task_seconds"] = QUIET_TASK_SECONDS
     state.atomic_write_json(path, config)
 
 
@@ -182,10 +246,14 @@ def _final_answer(a8s_home: Path) -> dict | None:
     return None
 
 
-def _busy(a8s_home: Path, repo: Path) -> bool:
+def _busy(a8s_home: Path, repo: Path, *, parked: str = "") -> bool:
     if state.live_locks(TEAM):
         return True
-    if any(state.queue_depth(TEAM, m) for m in state.members_with_queue(TEAM)):
+    if any(
+        state.queue_depth(TEAM, m)
+        for m in state.members_with_queue(TEAM)
+        if m != parked
+    ):
         return True
     for d in (
         a8s_home / "agents" / NODE / "inbox",
@@ -373,6 +441,140 @@ def _emit_progress(
     return seen_velocity, seen_gov, seen_locks
 
 
+def _parked_member(failure: tuple[str, str] | None) -> str:
+    """The member whose queue is meant to sit still. Once its breaker has
+    tripped, the held message IS the scenario's end state — counting it as work
+    in flight would keep the run waiting for a turn that can never come."""
+    if not failure or failure[1] not in ("exit", "hang"):
+        return ""
+    member = failure[0]
+    if any(f"BREAKER {member} tripped" in line for line in _governance_lines()):
+        return member
+    return ""
+
+
+def _scenario_pending(failure: tuple[str, str] | None) -> bool:
+    """A failure scenario is over when the recovery path it targets has fired,
+    not when the team first goes quiet — the leader's early ack to the human
+    would otherwise end the run before the failure had any consequence."""
+    if not failure:
+        return False
+    member, shape = failure
+    gov = _governance_lines()
+    if shape in ("exit", "hang"):
+        return not (
+            any("BREAKER" in line and "tripped" in line for line in gov)
+            and any("BREAKER" in line and "breaker open" in line for line in gov)
+        )
+    if shape == "silent":
+        return not any(f"STDOUT-REPLY {member}" in line for line in gov)
+    return not any("QUIET thread=" in line for line in gov)
+
+
+def _gov_detail(lines: list[str]) -> str:
+    return lines[0].split("r4t: ", 1)[-1]
+
+
+def _failure_checks(
+    failure: tuple[str, str], turns: int
+) -> list[tuple[str, object, str]]:
+    """Mechanical assertions for one failure shape: each names the recovery
+    path r4t is supposed to take, so a governance regression reads as FAIL."""
+    member, shape = failure
+    gov = _governance_lines()
+    tripped = [line for line in gov if "BREAKER" in line and "tripped" in line]
+    held = [line for line in gov if "BREAKER" in line and "breaker open" in line]
+    level = state.budget_level(TEAM, member, FAILURE_BUDGET_MAX, FAILURE_BUDGET_MAX)
+    checks: list[tuple[str, object, str]] = []
+
+    if shape == "exit":
+        checks += [
+            (
+                "Breaker tripped",
+                bool(tripped),
+                f"{member} pinned to an always-failing rig (breaker_cap 2)",
+            ),
+            (
+                "Breaker held queued message(s)",
+                bool(held),
+                "messages hold in the queue while the breaker is open — none dropped",
+            ),
+        ]
+    elif shape == "hang":
+        killed = [
+            line
+            for line in gov
+            if line.startswith(f"r4t: RETRY {member}") and "killed at timeout" in line
+        ]
+        requeued = [line for line in killed if "returned to the queue" in line]
+        checks += [
+            (
+                "Turn killed at its timeout",
+                bool(killed),
+                _gov_detail(killed) if killed else f"{member} never recorded a timed-out turn",
+            ),
+            (
+                "Timed-out batch requeued",
+                bool(requeued),
+                "a killed turn returns its whole batch to the queue — nothing lost",
+            ),
+            (
+                "Breaker tripped on timeouts",
+                bool(tripped),
+                "repeated timeouts count as failures until the breaker trips",
+            ),
+            (
+                "Breaker held queued message(s)",
+                bool(held),
+                "messages hold in the queue while the breaker is open — none dropped",
+            ),
+        ]
+    elif shape == "silent":
+        relayed = [line for line in gov if f"STDOUT-REPLY {member}" in line]
+        checks += [
+            (
+                "Stdout answer relayed as a reply",
+                bool(relayed),
+                _gov_detail(relayed) if relayed else f"{member}'s stdout reached nobody",
+            ),
+            (
+                "Breaker stayed closed",
+                not tripped,
+                "answering on stdout is not a failed turn — exit 0 must not trip it",
+            ),
+        ]
+    else:
+        silent = [line for line in gov if f"SILENT {member}" in line]
+        nudged = [line for line in gov if "QUIET thread=" in line]
+        checks += [
+            (
+                "Silent turn logged",
+                bool(silent),
+                _gov_detail(silent) if silent else f"{member} staged nothing and r4t said nothing",
+            ),
+            (
+                "Quiet sweep nudged the leader",
+                bool(nudged),
+                _gov_detail(nudged) if nudged else "no thread was swept as quiet",
+            ),
+            (
+                "Breaker stayed closed",
+                not tripped,
+                "a turn that exits 0 without staging is not a failure",
+            ),
+        ]
+
+    checks.append(
+        (
+            f"Budget charged for {member}'s turn(s)",
+            turns > 0 and level < FAILURE_BUDGET_MAX,
+            f"member budget {state.fmt_budget(level)} of {FAILURE_BUDGET_MAX} — "
+            "a turn is charged at admission, however it ends",
+        )
+    )
+    return checks
+
+
 def _build_report(
     *,
     mode: str,
@@ -448,6 +650,13 @@ def run_sandbox(
     break_member: str | None = None,
 ) -> int:
     start = time.time()
+    failure: tuple[str, str] | None = None
+    if break_member:
+        try:
+            failure = parse_break(break_member)
+        except SandboxError as e:
+            _log(str(e))
+            return 1
     tmp = Path(tempfile.mkdtemp(prefix="r4t-sandbox-"))
     saved_env = {k: os.environ.get(k) for k in ("A8S_HOME", "R4T_HOME", "R4T_SANDBOX_INVOKE", "R4T_SANDBOX")}
     a8s_home = tmp / "a8s-home"
@@ -455,8 +664,9 @@ def run_sandbox(
     os.environ["R4T_HOME"] = str(tmp / "r4t-home")
     os.environ["R4T_SANDBOX"] = "1"
     mode = "fake" if fake else "live"
-    if break_member:
-        mode += f"+break:{break_member.lower()}"
+    if failure:
+        mode += f"+break:{failure[0]}:{failure[1]}"
+        _log(f"break {failure[0]}: {FAILURE_SHAPES[failure[1]]}")
     harness_line = ""
     seen_velocity = 0
     seen_gov: set[str] = set()
@@ -493,9 +703,7 @@ def run_sandbox(
         )
         goal = (repo / "GOAL.md").read_text(encoding="utf-8")
 
-        _write_rig_config(
-            tmp / "r4t-home" / "rigs.json", fake, break_member=break_member
-        )
+        _write_rig_config(tmp / "r4t-home" / "rigs.json", fake, failure=failure)
         definition = tmp / "r4t-def.json"
         _write_definition(definition)
         human_root = tmp / "human"
@@ -517,8 +725,9 @@ def run_sandbox(
         final = None
         while True:
             now = time.time()
+            parked = _parked_member(failure)
             if now >= deadline:
-                if _busy(a8s_home, repo):
+                if _busy(a8s_home, repo, parked=parked):
                     _log("timeout with work in flight — killing harness processes")
                     killed = _kill_sandbox_processes(tmp)
                     if killed:
@@ -532,7 +741,7 @@ def run_sandbox(
                             seen_locks=seen_locks,
                         )
                         final = _final_answer(a8s_home) or final
-                        if not _busy(a8s_home, repo):
+                        if not _busy(a8s_home, repo, parked=parked):
                             _log("drained after timeout kill")
                             break
                 else:
@@ -548,24 +757,11 @@ def run_sandbox(
             final = _final_answer(a8s_home)
             if final is not None:
                 _log("leader answered the human")
-            if _busy(a8s_home, repo):
+            if _busy(a8s_home, repo, parked=parked):
                 quiet_polls = 0
                 continue
             quiet_polls += 1
-            # In break mode the scenario isn't over until the breaker has
-            # tripped AND blocked a message — the leader's early ack to the
-            # human must not end the run before either.
-            breaker_pending = break_member and (
-                not any(
-                    "BREAKER" in line and "tripped" in line
-                    for line in _governance_lines()
-                )
-                or not any(
-                    "BREAKER" in line and "breaker open" in line
-                    for line in _governance_lines()
-                )
-            )
-            if final is not None and quiet_polls >= 2 and not breaker_pending:
+            if final is not None and quiet_polls >= 2 and not _scenario_pending(failure):
                 _log("quiescent with final answer")
                 break
             if quiet_polls >= 20:
@@ -589,23 +785,12 @@ def run_sandbox(
         dead = _dead_letter_counts()
 
         checks: list[tuple[str, object, str]] = []
-        if break_member:
-            gov = _governance_lines()
-            tripped = any("BREAKER" in line and "tripped" in line for line in gov)
-            held = any("BREAKER" in line and "breaker open" in line for line in gov)
-            checks += [
-                (
-                    "Breaker tripped",
-                    tripped,
-                    f"{break_member} pinned to an always-failing rig (breaker_cap 2)",
-                ),
-                (
-                    "Breaker held queued message(s)",
-                    held,
-                    "messages hold in the queue while the breaker is open — none dropped",
-                ),
-            ]
-        else:
+        if failure:
+            checks += _failure_checks(failure, turns)
+        # A shape that only garbles how the answer travels still owes the
+        # program: the member did its work, so the deliverable must survive the
+        # detour. Shapes whose rig never runs the role at all cannot.
+        if failure is None or failure[1] == "silent":
             checks += [
                 (
                     "Program file(s) created",

--- a/apps/r4t/sandbox/fake-agent.py
+++ b/apps/r4t/sandbox/fake-agent.py
@@ -5,6 +5,15 @@ Parses the r4t prompt it is invoked with, plays its roster role (Lead
 delegates and answers, Dev writes battleship.py, Tester runs it), and sends
 messages by writing tell-shaped envelopes into $TELL_OUTBOX_DIR — the same
 staging contract a real `tell` uses, with zero LLM calls.
+
+`r4t sandbox --break MEMBER:SHAPE` pins one member to a rig that adds one of
+these argv flags, replaying a failure shape real harnesses produce:
+
+- `--silent` — do the role's work, then answer on stdout instead of calling
+  `tell`. The measured weak-harness shape: the reply exists but never leaves.
+- `--mute` — first turn only: emit harness chrome and nothing else, stage
+  nothing, exit 0. The turn looks fine and says nothing. Later turns behave
+  normally, the way a member that swallowed one answer keeps working.
 """
 from __future__ import annotations
 
@@ -53,8 +62,35 @@ VERIFIED_RE = re.compile(r"VERIFIED:", re.I)
 
 TEAM = {"lead", "dev", "tester", "owner"}
 
+FLAGS = set(sys.argv[2:])
+SILENT = "--silent" in FLAGS
+MUTE = "--mute" in FLAGS
+
+# Tool-trace glyph lines: real chrome that r4t's transcript cleaner strips, so
+# a turn printing only these said nothing at all.
+CHROME = (
+    "● Read(GOAL.md)\n"
+    "● Read(ROSTER.md)\n"
+    "● Bash(python3 -c 'import sys; print(sys.version)')\n"
+    "● TodoWrite(3 items)\n"
+    "● Read(WORKSPACE.md)\n"
+)
+
+
+def _first_mute_turn(name: str) -> bool:
+    """A member goes quiet for one turn, then recovers — the marker in the
+    workdir is what makes the second turn a normal one."""
+    marker = Path(f".fake-mute-{name}")
+    if marker.exists():
+        return False
+    marker.write_text("", encoding="utf-8")
+    return True
+
 
 def send(to: str, content: str) -> None:
+    if SILENT:
+        print(f"To {to}: {content}")
+        return
     outbox = Path(os.environ["TELL_OUTBOX_DIR"])
     outbox.mkdir(parents=True, exist_ok=True)
     msg_id = f"{time.time_ns():026d}"
@@ -75,6 +111,9 @@ def first_external_sender(prompt: str) -> str:
 def main() -> int:
     prompt = sys.argv[1]
     name = re.search(r"You are (\w+),", prompt).group(1).lower()
+    if MUTE and _first_mute_turn(name):
+        sys.stdout.write(CHROME)
+        return 0
     incoming = prompt.split("## Messages since your last turn", 1)[-1].split(
         "## How to work", 1
     )[0]
@@ -83,7 +122,7 @@ def main() -> int:
     print(f"fake-agent: {name} woken by {sender}")
 
     if name == "lead":
-        if (VERIFIED_RE.search(incoming) and "tester" in incoming.lower()) or "gone quiet" in incoming:
+        if VERIFIED_RE.search(incoming) and "tester" in incoming.lower():
             originator = first_external_sender(prompt)
             send(
                 originator,
@@ -91,8 +130,24 @@ def main() -> int:
                 "5x5 game with 3 ships and Tester confirmed a winning "
                 "playthrough exits 0. Play it with: python3 battleship.py",
             )
+        elif "gone quiet" in incoming:
+            # What the nudge asks for: report current state, not a claim the
+            # work finished.
+            send(
+                first_external_sender(prompt),
+                "Status: nothing is verified yet — the thread went quiet before "
+                "Dev reported back. Next step is to re-delegate the build.",
+            )
         elif "FAILED" in incoming:
             send("dev", "Tester reports the game FAILED — please fix battleship.py.")
+        elif sender.lower().split(":")[-1] == "dev":
+            # ROSTER turn 2. Dev normally hands off to Tester itself; the Lead
+            # hears from Dev when r4t relays what a silent Dev said on stdout.
+            send(
+                "tester",
+                "Dev reports battleship.py is written — run it and report "
+                "VERIFIED or FAILED to me.",
+            )
         else:
             # Ack the human AND delegate in the same turn — the real leader
             # pattern that must not close the task and kill the delegation.

--- a/apps/r4t/tests/test_sandbox.py
+++ b/apps/r4t/tests/test_sandbox.py
@@ -1,4 +1,10 @@
-"""End-to-end fake-sandbox run. Live mode is never run from pytest."""
+"""End-to-end fake-sandbox runs. Live mode is never run from pytest.
+
+The `--break MEMBER:SHAPE` cases are the governance tests: each shape is a
+different way a real harness fails, and each asserts the recovery path r4t is
+supposed to take. A shape whose path stops working turns its check FAIL, so the
+run's exit code carries the regression.
+"""
 from __future__ import annotations
 
 import re
@@ -6,28 +12,43 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
+from sandbox import SandboxError, parse_break
+
 R4T_PY = Path(__file__).resolve().parent.parent / "r4t.py"
 
 
-def test_fake_sandbox_end_to_end():
+def _run_sandbox(*extra: str) -> tuple[str, str]:
     result = subprocess.run(
-        [
-            sys.executable,
-            str(R4T_PY),
-            "sandbox",
-            "--fake",
-            "--timeout",
-            "240",
-        ],
+        [sys.executable, str(R4T_PY), "sandbox", "--fake", "--timeout", "240", *extra],
         capture_output=True,
         text=True,
         timeout=300,
     )
     assert result.returncode == 0, result.stdout + result.stderr
-    report = result.stdout
-    assert "sandbox:" in result.stderr
+    return result.stdout, result.stderr
 
-    mechanical = report.split("## Mechanical checks", 1)[1].split("## Run", 1)[0]
+
+def _mechanical(report: str) -> str:
+    return report.split("## Mechanical checks", 1)[1].split("## Run", 1)[0]
+
+
+def test_break_spec_parses_member_and_shape():
+    assert parse_break("Dev") == ("dev", "exit")
+    assert parse_break("dev:hang") == ("dev", "hang")
+    assert parse_break("LEAD:MUTE") == ("lead", "mute")
+    with pytest.raises(SandboxError):
+        parse_break("dev:explode")
+    with pytest.raises(SandboxError):
+        parse_break(":hang")
+
+
+def test_fake_sandbox_end_to_end():
+    report, stderr = _run_sandbox()
+    assert "sandbox:" in stderr
+
+    mechanical = _mechanical(report)
     for check in (
         "Program file(s) created",
         "Program runs and exits 0",
@@ -48,25 +69,9 @@ def test_fake_sandbox_end_to_end():
 
 
 def test_fake_sandbox_breaker_trips_and_task_still_closes():
-    result = subprocess.run(
-        [
-            sys.executable,
-            str(R4T_PY),
-            "sandbox",
-            "--fake",
-            "--break",
-            "dev",
-            "--timeout",
-            "240",
-        ],
-        capture_output=True,
-        text=True,
-        timeout=300,
-    )
-    assert result.returncode == 0, result.stdout + result.stderr
-    report = result.stdout
+    report, _ = _run_sandbox("--break", "dev")
 
-    mechanical = report.split("## Mechanical checks", 1)[1].split("## Run", 1)[0]
+    mechanical = _mechanical(report)
     for check in (
         "Breaker tripped",
         "Breaker held queued message(s)",
@@ -77,3 +82,63 @@ def test_fake_sandbox_breaker_trips_and_task_still_closes():
     assert "| FAIL |" not in mechanical
     assert "BREAKER dev tripped" in report  # governance events section
     assert "breaker open" in report  # queue held while the breaker is open
+
+
+def test_fake_sandbox_timeout_member_is_killed_and_requeued():
+    report, _ = _run_sandbox("--break", "dev:hang")
+
+    mechanical = _mechanical(report)
+    for check in (
+        "Turn killed at its timeout",
+        "Timed-out batch requeued",
+        "Breaker tripped on timeouts",
+        "Budget charged for dev's turn(s)",
+    ):
+        assert check in mechanical
+    assert "| FAIL |" not in mechanical
+    # A killed turn, not one that finished on its own: the sleeper is SIGKILLed
+    # at the rig's timeout and its whole batch goes back to the queue.
+    assert "killed at timeout" in report
+    assert re.search(r"\| dev \| hung \|[^|]*\|[^|]*\|[^|]*\| -9 \|", report)
+    assert "message(s) returned to the queue" in report
+    assert "Dead letters | 0" in mechanical
+
+
+def test_fake_sandbox_silent_member_answers_on_stdout():
+    report, _ = _run_sandbox("--break", "dev:silent")
+
+    mechanical = _mechanical(report)
+    for check in (
+        "Stdout answer relayed as a reply",
+        "Breaker stayed closed",
+        "Program runs and exits 0",
+    ):
+        assert check in mechanical
+    assert "| FAIL |" not in mechanical
+    # Dev never called tell; r4t staged its cleaned stdout as one reply to the
+    # sender, the lead routed it on, and the deliverable still shipped.
+    assert "STDOUT-REPLY dev" in report
+    assert "crew:dev -> crew:lead" in report
+    assert "crew:lead -> crew:tester" in report
+    assert "BREAKER" not in report
+
+
+def test_fake_sandbox_mute_member_is_swept_as_quiet():
+    report, _ = _run_sandbox("--break", "lead:mute")
+
+    mechanical = _mechanical(report)
+    for check in (
+        "Silent turn logged",
+        "Quiet sweep nudged the leader",
+        "Breaker stayed closed",
+        "Leader answered the originator",
+    ):
+        assert check in mechanical
+    assert "| FAIL |" not in mechanical
+    # Nothing staged, nothing worth relaying, no failed turn — the quiet sweep
+    # is the only thing that gets the originator an answer.
+    assert "SILENT lead" in report
+    assert "QUIET thread=" in report
+    assert "nudged leader lead" in report
+    assert "BREAKER" not in report
+    assert "ANSWERED thread=" in report


### PR DESCRIPTION
Closes #158.

`r4t sandbox --break MEMBER` exercised one failure shape — a rig that always exits nonzero. Real harnesses fail in messier ways, and those ways land on different recovery paths in dispatch. `--break MEMBER[:SHAPE]` now names the shape, and each scenario grades the path r4t is supposed to take.

## Shapes

| SHAPE | The member | The run asserts |
|---|---|---|
| `exit` (default) | exits nonzero every turn | breaker trips, queue holds (unchanged) |
| `hang` | sleeps 300s against a 3s rig timeout | the turn is killed at the timeout (velocity `exit -9`, `killed at timeout` in the RETRY line), the whole batch is requeued, repeated timeouts trip the breaker |
| `silent` | writes `battleship.py`, then answers on stdout without ever calling `tell` | `STDOUT-REPLY` stages the cleaned stdout as one reply to the sender, the breaker stays **closed**, and the deliverable still ships — the lead re-routes to Tester and the human gets a verified answer |
| `mute` | first turn prints tool chrome, stages nothing, exits 0 | `SILENT` logged, no breaker trip, and the quiet sweep (`QUIET thread=`) is the only thing that gets the originator an answer |

Every shape also asserts the member's budget was charged: a turn is paid for at admission, however it ends.

The two new fake-agent behaviours are argv flags (`--silent`, `--mute`) on the scripted agent, so the member keeps doing its real role work and only the *way it answers* is broken — messy-LLM behaviour, not idealized protocol. `--mute` recovers after one turn, the way a member that swallowed one answer keeps working.

## The checks fail when governance regresses

Measured, not asserted by hope:

- `quiet_task_seconds` pushed out of the run window → `Quiet sweep nudged the leader` FAIL and `Leader answered the originator` FAIL.
- `STDOUT_REPLY_MIN_CHARS` raised so the fallback cannot fire → `Stdout answer relayed as a reply` FAIL.

## Faster, too

A queue held behind an open breaker is the scenario's end state, not work in flight. The runner treats that member's queue as parked once the breaker has tripped, so a break run no longer waits out its whole `--timeout`: the `exit` shape goes 227s → 7s.

## Divergence doc

`docs/development.md` gains the shape table plus **What the sandbox fakes**: scripted roles, sends that bypass `tell`, no `a8s_tell` idiom (sandbox rigs are presetless, so the `mcp` knob is off in both modes), live mode's two scripted turns and its protocol fallback, VERIFIED-as-regex, instant turns, clean failures, no continuing conversations. Every line is a place a green sandbox run says nothing about a real roster.

## Verification

- `r4t sandbox --fake` green; each new shape green on its own.
- Full suite: `769 passed in 65.5s` (`apps/r4t/tests/`), up 4 tests and down from the old ~235s sandbox portion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
