### PR TITLE
ci: run the full r4t suite on r4t-touching PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,6 +81,18 @@ jobs:
       - run: pip install pytest
       - run: python -m pytest apps/ark/tests/ -x -q
 
+  r4t:
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.r4t == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install pytest
+      - run: python -m pytest apps/r4t/tests/ -x -q
+
   r4t-isolation:
     runs-on: ubuntu-latest
     needs: changes


### PR DESCRIPTION
Found during #155: the workflow has jobs for a8s, k7e, ark, l9m — but the main r4t suite never ran on PRs; only the Docker isolation test did. Every r4t merge tonight relied on builders running the suite locally.

Adds an `r4t` job mirroring the k7e shape, gated on the existing `changes.outputs.r4t` path filter so unrelated PRs don't pay the ~5 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)