### PR TITLE
feat: message class crosses nodes as envelope metadata (#167)

### DIFF
--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -341,11 +341,12 @@ Argv elements run through built-in substitutions plus any per-node **a8s vars**:
 - `$MESSAGE` → the message body (`content`, with any `ATTACHED FILE: <path>` lines appended for inbound attachments).
 - `$TIMESTAMP` → ISO 8601 UTC timestamp the message was queued (e.g. `2026-04-28T14:30:00.123456Z`). Useful when you want a stable machine-readable time.
 - `$AGE` → human-readable age relative to now (e.g. `5 minutes ago`). Computed at wake time, so a long backlog gets accurate values per message. Pick this OR `$TIMESTAMP` per definition based on which the LLM will read more naturally.
+- `$META` → the envelope's `meta` object as compact JSON (`{"class":"auto"}`), empty when the message carries none. Protocol metadata one node stamps for another; a8s carries and hands it over without reading a key, so the vocabulary belongs to the nodes at the edges (r4t's message class is the first user).
 - `$A8S_DIR` → `apps/a8s/` itself, so definitions can point at bundled scripts (`default.json` uses this for `dummy-cli`).
 - `$DEFINITION_PATH` → resolved path of this agent's definition file.
 - `$KEY` → any key from `a8s vars <name> set KEY value` (registry `vars` map). **Not** OS environment — no correlation with process env. If the definition references `$KEY` and that var is unset, wake fails closed.
 
-`$TIMESTAMP` and `$AGE` are empty for any message without a `date` field (defensive — every `_write_outbox` stamps one).
+`$TIMESTAMP` and `$AGE` are empty for any message without a `date` field (defensive — every `_write_outbox` stamps one). `$META` is empty unless the sending node stamped a `meta` object.
 
 ```bash
 a8s add bob ./ ollama-opencode --model=qwen3.6

--- a/apps/a8s/definitions.py
+++ b/apps/a8s/definitions.py
@@ -2,11 +2,17 @@
 
 Each agent has a definition JSON (built-in or custom) that encodes one argv
 under the `invoke` key. `build_command` substitutes `$SENDER` / `$RECIPIENT`
-/ `$MESSAGE` / `$TIMESTAMP` / `$AGE` / `$A8S_DIR` / `$DEFINITION_PATH` into it,
-plus any per-node a8s vars (`a8s vars <name> set KEY value`) as `$KEY`.
+/ `$MESSAGE` / `$TIMESTAMP` / `$AGE` / `$META` / `$A8S_DIR` /
+`$DEFINITION_PATH` into it, plus any per-node a8s vars
+(`a8s vars <name> set KEY value`) as `$KEY`.
 `$DEFINITION_PATH` is the resolved path of the agent's own definition file, so
 a self-contained node (e.g. r4t) can read its own definition for settings the
 wire does not carry.
+
+`$META` is the envelope's `meta` object as verbatim JSON — protocol metadata
+one node stamps for another (r4t's message class, #167). a8s carries it and
+hands it to the wake; it never reads inside, so the vocabulary belongs to the
+nodes at the edges and a8s learns nothing about any node's protocol.
 
 A8s vars are NOT process environment variables — they live on the agent in
 the registry and expand only through this interpolator. A `$NAME` that is
@@ -46,6 +52,7 @@ BUILTIN_PLACEHOLDERS = frozenset({
     "MESSAGE",
     "TIMESTAMP",
     "AGE",
+    "META",
     "A8S_DIR",
     "DEFINITION_PATH",
 })
@@ -339,6 +346,18 @@ def _format_age(date_str: str, *, now: datetime | None = None) -> str:
     return f"{n} {unit}{plural} ago"
 
 
+def envelope_meta(msg: dict) -> str:
+    """The envelope's `meta` object as compact JSON — the `$META` value.
+
+    Opaque protocol metadata between nodes: a8s copies it along the wire and
+    hands it to the wake verbatim, never reading a key. A missing or non-object
+    `meta` expands empty, exactly as `$SENDER` does on a senderless wake."""
+    meta = msg.get("meta")
+    if not isinstance(meta, dict) or not meta:
+        return ""
+    return json.dumps(meta, sort_keys=True, separators=(",", ":"))
+
+
 def _expand_argv(
     argv: list[str],
     sender: str,
@@ -348,6 +367,7 @@ def _expand_argv(
     age: str = "",
     definition_path: str = "",
     vars: dict[str, str] | None = None,
+    meta: str = "",
 ) -> list[str]:
     """Expand placeholders in argv.
 
@@ -357,6 +377,7 @@ def _expand_argv(
       - `$MESSAGE`    content + any ATTACHED FILE: lines
       - `$TIMESTAMP`  ISO 8601 UTC time the message was queued
       - `$AGE`        human-readable age relative to now
+      - `$META`       the envelope's `meta` object as JSON (empty when absent)
       - `$A8S_DIR`    the apps/a8s/ directory
       - `$DEFINITION_PATH`  this agent's definition file path
 
@@ -379,6 +400,7 @@ def _expand_argv(
         "MESSAGE": message,
         "TIMESTAMP": timestamp,
         "AGE": age,
+        "META": meta,
         "A8S_DIR": str(SCRIPT_DIR),
         "DEFINITION_PATH": definition_path,
     }
@@ -421,6 +443,7 @@ def build_command(
         age,
         definition_path,
         vars=vars,
+        meta=envelope_meta(msg),
     )
 
 

--- a/apps/a8s/definitions/r4t.json
+++ b/apps/a8s/definitions/r4t.json
@@ -13,7 +13,9 @@
     "--to",
     "$RECIPIENT",
     "--message",
-    "$MESSAGE"
+    "$MESSAGE",
+    "--meta",
+    "$META"
   ],
   "max_wake_seconds": 2700,
   "idle": {

--- a/apps/a8s/docs/tell.md
+++ b/apps/a8s/docs/tell.md
@@ -43,6 +43,12 @@ Envelope shape:
 }
 ```
 
+A node that speaks a protocol with its peers may add a `meta` object
+(`"meta": {"class": "auto"}`). a8s carries it across every hop — local routing,
+alias fan-out, remote publish and receive — and expands it into the wake as
+`$META` without reading a key; the vocabulary belongs to the nodes at the edges.
+`tell` writes no `meta` itself.
+
 On disk alongside the JSON:
 
 ```

--- a/apps/a8s/tests/test_definitions.py
+++ b/apps/a8s/tests/test_definitions.py
@@ -2,6 +2,7 @@
 and auto-discovery."""
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -158,6 +159,44 @@ class TestBuildCommand:
         defn = {"invoke": ["r4t", "$DEFINITION_PATH", "$MESSAGE"]}
         argv = build_command(defn, {"from": "A", "to": "B", "content": "hi"}, agent_root)
         assert argv == ["r4t", "", "hi"]
+
+    def test_meta_expands_to_compact_json(self, agent_root):
+        # #167: protocol metadata between nodes. a8s carries the object and
+        # hands it over verbatim — the vocabulary is the nodes' business.
+        defn = {"invoke": ["r4t", "--meta", "$META", "-p", "$MESSAGE"]}
+        msg = {"from": "A", "to": "B", "content": "hi", "meta": {"class": "auto"}}
+        argv = build_command(defn, msg, agent_root)
+        assert argv == ["r4t", "--meta", '{"class":"auto"}', "-p", "hi"]
+
+    def test_meta_absent_expands_empty(self, agent_root):
+        defn = {"invoke": ["r4t", "--meta", "$META"]}
+        argv = build_command(defn, {"from": "A", "to": "B", "content": "hi"}, agent_root)
+        assert argv == ["r4t", "--meta", ""]
+
+    def test_meta_non_object_expands_empty(self, agent_root):
+        # A remote cluster wrote the envelope; a scalar `meta` is that
+        # boundary's problem, not a crash in the wake.
+        defn = {"invoke": ["r4t", "--meta", "$META"]}
+        msg = {"from": "A", "to": "B", "content": "hi", "meta": "auto"}
+        argv = build_command(defn, msg, agent_root)
+        assert argv == ["r4t", "--meta", ""]
+
+    def test_meta_value_is_not_reinterpolated(self, agent_root):
+        defn = {"invoke": ["r4t", "--meta", "$META"]}
+        msg = {"from": "A", "to": "B", "content": "hi", "meta": {"note": "$SENDER \\ x"}}
+        argv = build_command(defn, msg, agent_root)
+        assert argv[2] == '{"note":"$SENDER \\\\ x"}'
+
+    def test_bundled_r4t_node_receives_the_class_on_its_argv(self, agent_root):
+        # The seam itself: the shipped r4t definition forwards `$META`, so a
+        # peer cluster's class reaches `r4t dispatch` without a8s reading it.
+        defn = json.loads(default_definition_path("r4t").read_text(encoding="utf-8"))
+        msg = {
+            "from": "beta", "to": "acme", "content": "roster sync",
+            "meta": {"class": "auto"},
+        }
+        argv = build_command(defn, msg, agent_root)
+        assert argv[argv.index("--meta") + 1] == '{"class":"auto"}'
 
     def test_does_not_mutate_original_argv(self, agent_root):
         defn = {"invoke": ["claude", "-p", "$MESSAGE"]}

--- a/apps/a8s/tests/test_mailbox.py
+++ b/apps/a8s/tests/test_mailbox.py
@@ -562,6 +562,71 @@ class TestNamespaceEgressIdentity:
         assert delivered["from"] == "B"
 
 
+class TestEnvelopeMeta:
+    """Issue #167 — the envelope carries an opaque `meta` object so one node can
+    hand another its protocol metadata (r4t's message class). a8s is the
+    courier: it copies the object across every hop it owns and never reads a
+    key of it."""
+
+    def _stage(self, sender: Participant, name: str, to: str, meta: dict) -> None:
+        f = outbox_dir(sender.root) / "20260101T000000_A.json"
+        f.write_text(json.dumps({
+            "from": name, "to": to, "content": "status green",
+            "files": [], "meta": meta,
+        }))
+
+    def test_local_routing_carries_meta(self, two_agents):
+        a, b = two_agents
+        self._stage(a, "A", "B", {"class": "auto"})
+        route_outboxes([a, b], all_agents=[a, b])
+        delivered = json.loads(next(inbox_dir("B").iterdir()).read_text())
+        assert delivered["meta"] == {"class": "auto"}
+
+    def test_alias_fanout_carries_meta_to_every_recipient(self, three_agents):
+        a, b, c = three_agents
+        save_aliases({"devs": ["B", "C"]})
+        self._stage(a, "A", "devs", {"class": "auto"})
+        route_outboxes([a, b, c], all_agents=[a, b, c])
+        for n in ("B", "C"):
+            m = json.loads(next(inbox_dir(n).iterdir()).read_text())
+            assert m["meta"] == {"class": "auto"}
+
+    def test_remote_publish_carries_meta(self, two_agents):
+        a, b = two_agents
+        published: list[dict] = []
+
+        def publish(msg, sender_name, succeeded_so_far, attempt_count):
+            published.append(msg)
+            return ["hub"]
+
+        self._stage(a, "A", "B", {"class": "auto"})
+        route_outboxes(
+            [a, b], all_agents=[a, b],
+            publish_remotes=publish, configured_remote_ids=["hub"],
+        )
+        assert [m["meta"] for m in published] == [{"class": "auto"}]
+
+    def test_namespace_egress_stamping_leaves_meta_alone(self, fake_home, tmp_path):
+        # The stamp rewrites how the sender presents (#315). Metadata rides
+        # through untouched — the two decisions are independent.
+        node_root = tmp_path / "node"; node_root.mkdir()
+        outsider_root = tmp_path / "outsider"; outsider_root.mkdir()
+        save_registry({
+            "acme-node": {"root": str(node_root)},
+            "B": {"root": str(outsider_root)},
+        })
+        save_namespaces({"acme": "acme-node"})
+        node = Participant("acme-node", node_root)
+        outsider = Participant("B", outsider_root)
+        ensure_mailboxes(node)
+        ensure_mailboxes(outsider)
+        self._stage(node, "acme:lead", "B", {"class": "auto"})
+        route_outboxes([node, outsider], all_agents=[node, outsider])
+        delivered = json.loads(next(inbox_dir("B").iterdir()).read_text())
+        assert delivered["from"] == "acme"
+        assert delivered["meta"] == {"class": "auto"}
+
+
 class TestAtomicFanout:
     """Issue #67 — `route_outboxes` stages routed copies under each recipient's
     `inbox.tmp/<source-name>` and only renames them into `inbox/` after every

--- a/apps/a8s/tests/test_network.py
+++ b/apps/a8s/tests/test_network.py
@@ -260,6 +260,18 @@ class TestReceiveEnvelope:
         assert body["from"] == "REMOTE_X"
         assert body["content"] == "hello via remote"
 
+    def test_meta_survives_the_wire(self, two_local_agents):
+        # #167: the receiving cluster writes the sender's `meta` into the inbox
+        # untouched, so the wake can hand it to the node that speaks it.
+        msg_id = new_ulid()
+        envelope = json.dumps({
+            "id": msg_id, "from": "acme", "to": "B",
+            "content": "status green", "files": [], "meta": {"class": "auto"},
+        }).encode()
+        receive_envelope(envelope, two_local_agents)
+        body = json.loads((inbox_dir("B") / f"{msg_id}.json").read_text())
+        assert body["meta"] == {"class": "auto"}
+
     def test_unknown_recipient_records_rate_limited_diagnostic(
         self, two_local_agents, monkeypatch,
     ):

--- a/apps/r4t/dispatch.py
+++ b/apps/r4t/dispatch.py
@@ -771,6 +771,24 @@ def _throttle_block(ctx: DispatchContext, config: RigConfig) -> str | None:
 
 # ---------- ingress (enqueue only; never runs a turn) ----------
 
+def class_from_meta(raw: str) -> str:
+    """The class an external peer stamped on the a8s envelope's `meta` (#167).
+
+    Wire metadata is advisory for governance and never for identity: a peer may
+    downgrade its OWN traffic to machine relay (`auto`), and anything else —
+    absent, unparseable, a word this version does not know — is deliberate
+    attention. Thread and hop stay garden-internal whatever the wire says."""
+    if not raw.strip():
+        return "human"
+    try:
+        meta = json.loads(raw)
+    except ValueError:
+        return "human"
+    if not isinstance(meta, dict):
+        return "human"
+    return "auto" if str(meta.get("class", "")).strip().lower() == "auto" else "human"
+
+
 def _ingest(
     ctx: DispatchContext,
     sender: str,
@@ -885,7 +903,9 @@ def _ingest(
     if thread is None:
         thread = tasks.new_thread_id()
         hop = 0
-    tasks.ensure_task(ctx.node, thread, sender)
+    tasks.ensure_task(
+        ctx.node, thread, sender, relay=not internal and klass == "auto"
+    )
 
     state.enqueue(
         ctx.node,
@@ -960,7 +980,7 @@ def _release_one(
     # must not need to know whether a name is one agent, a human, a device, or
     # a whole roster — class marking survives as envelope metadata only.
     envelope["content"] = body
-    envelope["x_r4t_class"] = "auto"
+    envelope["meta"] = {"class": "auto"}
     envelope["from"] = sender_addr
     outbox.mkdir(parents=True, exist_ok=True)
     msg_id = str(envelope.get("id", "")) or tasks.new_thread_id()
@@ -1748,12 +1768,13 @@ def handle_message(
     to: str,
     message: str,
     *,
+    klass: str = "human",
     run_fn=run_harness,
     drain_after: bool = True,
 ) -> int:
     _ingest(
         ctx, sender, to, (message or "").strip(),
-        klass="human", internal=_is_internal(ctx.node, sender),
+        klass=klass, internal=_is_internal(ctx.node, sender),
     )
     if drain_after:
         drain_until_quiet(ctx, run_fn=run_fn)
@@ -1864,7 +1885,12 @@ def _quiet_task_sweep(
     member's turn succeeds while staging no reply, or a chain stalls. When an
     open thread with an unanswered originator sees no ledger activity for
     `quiet_task_seconds`, wake the leader with a nudge to report current state
-    (NOT to force-finish the work). Returns the threads nudged."""
+    (NOT to force-finish the work). Returns the threads nudged.
+
+    A relay thread is skipped: its originator is another cluster's machinery
+    (#167), so a status report to it is not attention owed — it is one more
+    inbound that peer must class and answer, which is how two rosters keep each
+    other awake forever. The nudge exists for whoever is actually waiting."""
     if config.quiet_task_seconds <= 0:
         return []
     if state.live_locks(ctx.node):
@@ -1876,6 +1902,8 @@ def _quiet_task_sweep(
     nudged: list[str] = []
     for task in tasks.list_tasks(ctx.node):
         if task.get("status") != tasks.STATUS_OPEN or task.get("answered"):
+            continue
+        if task.get("relay"):
             continue
         if tasks.last_activity(task) > cutoff:
             continue

--- a/apps/r4t/docs/governance.md
+++ b/apps/r4t/docs/governance.md
@@ -136,6 +136,13 @@ an open thread whose originator is unanswered sees no activity for
 state — NOT to force-finish the work. The human, or the leader, decides what
 "done" means; r4t only makes sure the originator is not left in silence.
 
+A thread opened by relayed mail — an inbound the sending cluster marked
+`meta.class: auto` (see [message-flow.md](message-flow.md#class-across-the-wall))
+— is skipped. Its originator is another cluster's machinery, so a status report
+to it is not attention owed; it is one more inbound that peer must answer, which
+is how two rosters keep each other awake forever. The nudge exists for whoever
+is actually waiting.
+
 Prior art: Erlang/OTP supervision — a bounded, rate-limited recovery action
 rather than an unbounded retry loop.
 

--- a/apps/r4t/docs/message-flow.md
+++ b/apps/r4t/docs/message-flow.md
@@ -34,7 +34,7 @@ member's queue and back out. For governance rationale see
    applies, outbound messages land in the sender's history, and the message goes
    straight onto the recipient member's queue (intra-team, no header, no
    round-trip) or is converted to an a8s envelope at the wall (external — the
-   only place a wire header exists, carrying `class` as `x_r4t_class`).
+   only place a wire header exists, carrying `class` in the envelope's `meta`).
    Inside the team, agents address each other by bare first name
    (`tell gerry`) — the namespace prefix is the *outside* address of the
    walled garden, and roster agents never see it. Release canonicalizes
@@ -78,11 +78,26 @@ r4t-message whose fields (`thread` label, telemetry `hop` that never cuts a
 message, and a `class` of `human`/`auto`/`error`) travel end to end, stamped by
 dispatch and never written or parsed as prose. The only wire header is at
 egress, where an external release is converted to an a8s envelope carrying the
-bare body and `class` as `x_r4t_class` metadata — other a8s nodes must not need
-to know whether a name is one agent, a human, a device, or a whole roster.
+bare body and `class` in the envelope's `meta` object — other a8s nodes must not
+need to know whether a name is one agent, a human, a device, or a whole roster.
 Symmetrically, external ingress is untrusted: a sub-address can't pick a member
 and nothing is parsed out of the body — everything from outside enters at the
 top lead on a fresh thread. One ingress point means one thing to reason about.
+
+## Class across the wall
+
+`meta.class` is the one protocol field that crosses the wall in both
+directions. Releases carry `auto`, because everything a member sends is machine
+traffic; inbound mail is deliberate attention unless the sender marked it
+`auto`, so a human, a phone, or a peer that says nothing is heard as a person.
+
+Metadata is advisory for governance and never for identity. A peer can only
+downgrade its own traffic, an unknown word means deliberate, and thread and hop
+stay garden-internal — nothing on the wire can claim a thread. What a relayed
+inbound changes is what the garden owes it: the thread it opens is a label, not
+a report someone is waiting on, so the quiet-thread sweep leaves it alone. That
+is what keeps two federated rosters from reading each other's polite
+status updates as fresh human attention and nudging each other awake forever.
 
 The sender the outside sees is the bare namespace. Dispatch releases with
 `from: <node>:<member>`, and the a8s router — which owns `from`, because the

--- a/apps/r4t/r4t.py
+++ b/apps/r4t/r4t.py
@@ -23,6 +23,7 @@ import tasks
 import verdict
 from dispatch import (
     DispatchContext,
+    class_from_meta,
     handle_message,
     run_clear,
     run_flush,
@@ -514,6 +515,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     state.stamp_root(ctx.node, ctx.root)
     return handle_message(
         ctx, args.from_agent, args.to, args.message,
+        klass=class_from_meta(args.meta),
         drain_after=not args.no_drain,
     )
 
@@ -789,7 +791,8 @@ def _activity_rows(node: str) -> list[tuple[bool | None, str, str, str | None]]:
             None, "thread",
             f"{task['id']}  creator={task.get('creator', '?')}  "
             f"status={task.get('status', '?')}"
-            + ("  answered" if task.get("answered") else ""),
+            + ("  answered" if task.get("answered") else "")
+            + ("  relay" if task.get("relay") else ""),
             None,
         ))
     if not open_tasks:
@@ -1947,6 +1950,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="Full recipient as delivered ($RECIPIENT): <node> or <node>:<member>.",
     )
     dispatch_p.add_argument("--message", required=True)
+    dispatch_p.add_argument(
+        "--meta",
+        default="",
+        help="Envelope metadata as JSON ($META): the sending cluster's "
+        "protocol fields, of which r4t reads `class`.",
+    )
     dispatch_p.add_argument(
         "--no-drain",
         action="store_true",

--- a/apps/r4t/tasks.py
+++ b/apps/r4t/tasks.py
@@ -6,6 +6,11 @@ be attributed to the exchange it answers, so the originator can be tracked
 its originator hearing back can wake the leader. It never gates delivery:
 every inbound message enqueues regardless of a thread's status.
 
+A `relay` thread was opened by machine-classed external mail (`meta.class`
+`auto` on the wire, #167) — an originator that is another cluster's relay, not
+someone waiting on an answer. It carries a label like any other thread; what it
+does not carry is owed attention, so the quiet sweep leaves it alone.
+
 The thread id + hop travel as structured fields on the r4t-message
 (`dispatch.py`), never as a text header — there is no serialize/parse step
 inside the walls. Hop counts are stamped for telemetry (and the tree) but
@@ -54,7 +59,7 @@ def save_task(node: str, task: dict) -> None:
     atomic_write_json(task_path(node, task["id"]), task)
 
 
-def new_task(task_id: str, creator: str) -> dict:
+def new_task(task_id: str, creator: str, *, relay: bool = False) -> dict:
     now = utc_now()
     return {
         "id": task_id,
@@ -63,13 +68,14 @@ def new_task(task_id: str, creator: str) -> dict:
         "updated_at": now,
         "status": STATUS_OPEN,
         "answered": False,
+        "relay": relay,
     }
 
 
-def ensure_task(node: str, task_id: str, creator: str) -> dict:
+def ensure_task(node: str, task_id: str, creator: str, *, relay: bool = False) -> dict:
     task = load_task(node, task_id)
     if task is None:
-        task = new_task(task_id, creator)
+        task = new_task(task_id, creator, relay=relay)
         save_task(node, task)
     return task
 

--- a/apps/r4t/tests/test_dispatch.py
+++ b/apps/r4t/tests/test_dispatch.py
@@ -329,7 +329,7 @@ class TestStagingRelease:
         assert len(envelopes) == 1
         envelope = envelopes[0]
         assert envelope["to"] == "outsider"
-        assert envelope["x_r4t_class"] == "auto"
+        assert envelope["meta"] == {"class": "auto"}
         assert envelope["content"] == "the fix is deployed"
         assert not envelope["content"].startswith("[r4t")
         assert not state.staging_dir(NODE, "gerry").exists()
@@ -1192,7 +1192,7 @@ class TestStdoutFallback:
         envelopes = outbox_envelopes(repo)
         assert [e["to"] for e in envelopes] == ["boss"]
         assert envelopes[0]["content"] == ANSWER.strip()
-        assert envelopes[0]["x_r4t_class"] == "auto"
+        assert envelopes[0]["meta"] == {"class": "auto"}
         assert "[r4t" not in envelopes[0]["content"]
         assert "r4t: STDOUT-REPLY gerry" in read_log()
 
@@ -1727,6 +1727,81 @@ class TestAttachmentRelease:
         assert bundle.is_dir()
         assert (outbox / "message-4" / "report.txt").is_file()
         assert (outbox / "message-4.json").is_file()
+
+
+class TestExternalClassIngress:
+    """Issue #167 — a peer cluster stamps `meta.class` on the a8s envelope and
+    the wake hands it over as `$META`. Machine-classed inbound is relay, not
+    attention: it delivers like any other message and opens a thread, but the
+    thread owes nobody a status report, which is what keeps two federated
+    rosters from nudging each other awake forever."""
+
+    def test_unmarked_external_mail_is_deliberate(self):
+        assert dispatch.class_from_meta("") == "human"
+
+    def test_auto_marking_is_honored(self):
+        assert dispatch.class_from_meta('{"class":"auto"}') == "auto"
+
+    @pytest.mark.parametrize("raw", [
+        '{"class":"human"}',
+        '{"class":"whatever-2027-invents"}',
+        '{"other":"auto"}',
+        "not json at all",
+        '"auto"',
+        "[]",
+    ])
+    def test_anything_else_stays_deliberate(self, raw):
+        # A peer may only downgrade its own traffic; an unknown word must never
+        # silently acquire meaning.
+        assert dispatch.class_from_meta(raw) == "human"
+
+    def test_relay_mail_queues_as_auto_and_opens_a_relay_thread(self, ctx, r4t_home):
+        handle_message(ctx, "beta", "acme", "roster sync", klass="auto", drain_after=False)
+        queued = state.read_queue(NODE, "gerry")
+        assert [e["class"] for e in queued] == ["auto"]
+        assert tasks.list_tasks(NODE)[0]["relay"] is True
+
+    def test_deliberate_mail_opens_a_thread_that_owes_a_report(self, ctx, r4t_home):
+        handle_message(ctx, "boss", "acme", "ship it", drain_after=False)
+        assert [e["class"] for e in state.read_queue(NODE, "gerry")] == ["human"]
+        assert tasks.list_tasks(NODE)[0]["relay"] is False
+
+    def test_relay_thread_is_never_nudged(self, ctx, fake_harness):
+        handle_message(ctx, "beta", "acme", "roster sync", klass="auto", drain_after=False)
+        task = tasks.list_tasks(NODE)[0]
+        task["updated_at"] = "2020-01-01T00:00:00Z"
+        state.atomic_write_json(tasks.task_path(NODE, task["id"]), task)
+        assert run_idle(ctx)["quiet_nudged"] == []
+
+    def test_a_thread_the_human_opened_still_gets_nudged(self, ctx, fake_harness):
+        handle_message(ctx, "boss", "acme", "ship it", drain_after=False)
+        task = tasks.list_tasks(NODE)[0]
+        task["updated_at"] = "2020-01-01T00:00:00Z"
+        state.atomic_write_json(tasks.task_path(NODE, task["id"]), task)
+        assert run_idle(ctx)["quiet_nudged"] == [task["id"]]
+
+    def test_status_marks_the_relay_thread(self, ctx, repo, rig_config, r4t_home, capsys):
+        # Why a thread is never nudged has to be visible to whoever is reading
+        # the surface at 2am.
+        handle_message(ctx, "beta", "acme", "roster sync", klass="auto", drain_after=False)
+        r4t_main([
+            "status", "--root", str(repo), "--node", NODE,
+            "--rig-config", str(rig_config), "--no-notify",
+        ])
+        out = capsys.readouterr().out
+        assert "creator=beta" in out and "relay" in out
+
+    def test_internal_relay_keeps_the_originating_thread_owed(self, ctx, r4t_home):
+        # The class means the same thing inside the walls (member mail is relay
+        # too), but an intra-team message rides an existing thread — the
+        # human's — and must not turn it into a relay thread.
+        handle_message(ctx, "boss", "acme", "ship it", drain_after=False)
+        thread_id = tasks.list_tasks(NODE)[0]["id"]
+        dispatch._ingest(
+            ctx, f"{NODE}:gerry", f"{NODE}:phil", "your turn",
+            klass="auto", internal=True, thread=thread_id, hop=1,
+        )
+        assert tasks.load_task(NODE, thread_id)["relay"] is False
 
 
 class TestQuietSweep:
@@ -2327,6 +2402,29 @@ class TestCli:
         )
         assert rc == 0
         assert len(harness_calls(fake_harness)) == 1
+
+    def test_dispatch_carries_the_envelope_class(self, r4t_home, repo, rig_config, fake_harness):
+        # The whole ingress half of #167: a8s expands `$META` into this flag and
+        # the thread it opens is relay, owed no report.
+        rc = self.run(
+            "dispatch", "--root", str(repo), "--from", "beta",
+            "--to", "acme", "--message", "roster sync",
+            "--meta", '{"class":"auto"}',
+            "--rig-config", str(rig_config), "--no-notify", "--no-drain",
+        )
+        assert rc == 0
+        assert [e["class"] for e in state.read_queue(NODE, "gerry")] == ["auto"]
+        assert tasks.list_tasks(NODE)[0]["relay"] is True
+
+    def test_dispatch_without_meta_is_deliberate(self, r4t_home, repo, rig_config, fake_harness):
+        rc = self.run(
+            "dispatch", "--root", str(repo), "--from", "boss",
+            "--to", "acme", "--message", "ship it",
+            "--rig-config", str(rig_config), "--no-notify", "--no-drain",
+        )
+        assert rc == 0
+        assert [e["class"] for e in state.read_queue(NODE, "gerry")] == ["human"]
+        assert tasks.list_tasks(NODE)[0]["relay"] is False
 
     def test_dispatch_batches_queued_with_live(self, r4t_home, repo, rig_config, fake_harness):
         state.enqueue(


### PR DESCRIPTION
Closes #167.

Egress strips the r4t header, so a receiving r4t node heard every external
inbound as deliberate human attention. Fine for a human or a phone; between two
r4t rosters each side reads the other's polite status update as someone waiting,
and the quiet-thread sweep — the one place r4t generates unbidden outbound mail —
nudges the leader to report back. Two gardens keep each other awake on courtesy.

### a8s carries, r4t means

| Layer | Change |
|---|---|
| Envelope | `meta` — one opaque object (was the flat `x_r4t_class`) |
| Router | unchanged: extras already rode local routing, alias fan-out, remote publish/receive, and the #319 namespace `from` stamping |
| Wake | new `$META` builtin: the object as compact JSON, empty when absent |
| r4t node | definition forwards `--meta $META`; `r4t dispatch --meta` classes the inbound |

a8s never reads a key of `meta`, so the vocabulary lives at the edges and a8s
learns nothing about any node's protocol. A non-object `meta` off the wire
expands empty rather than failing a wake.

### The consumer

A thread opened by relayed mail is marked `relay` in the ledger and the
quiet-thread sweep skips it: its originator is another cluster's machinery, so a
status report to it is not attention owed — it is one more inbound that peer must
class and answer. Everything else holds — the message still enqueues
unconditionally, opens a thread, closes on answer-the-originator, and expires
with the rest — and `r4t status` marks the thread so the reason it is never
nudged is visible.

Wire metadata is advisory for governance, never for identity: a peer may only
downgrade its OWN traffic (absent, unparseable, or an unknown word all mean
deliberate), and thread/hop stay garden-internal, so nothing on the wire can
claim a thread.

### Tests

`apps/a8s/tests/` 820 passed · `apps/r4t/tests/` 793 passed (separate runs).
New: `$META` expansion incl. non-object and no-reinterpolation cases, the
bundled r4t definition's argv seam, `meta` round-trip across local routing /
alias fan-out / remote publish / remote receive / namespace egress stamping,
`class_from_meta` trust cases, relay-vs-deliberate ingress, the sweep skip, and
`r4t dispatch --meta` end to end.

### Deploy note

Pre-v1, so the envelope field is renamed outright. A per-node copy of
`r4t.json` needs the two new argv entries (`"--meta", "$META"`) to gain ingress
classing; without them dispatch behaves exactly as today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)