### PR TITLE
ci probe: r4t suite on unmodified main

### DIFF
--- a/apps/r4t/docs/development.md
+++ b/apps/r4t/docs/development.md
@@ -86,3 +86,4 @@ line UI) · `chat_tui.py` (Textual front end) · `notify.py` (doorbell) ·
 `sandbox.py` + `sandbox/` (the end-to-end harness).
 Observability rides on a8s: traffic in the a8s txlog/convo, r4t decision
 lines in the node log via dispatch stdout, r4t-only state via `r4t status`.
+


### PR DESCRIPTION
Counterfactual for the PR #335 r4t-job failure: identical suite, no r4t code changes. If this fails too, the sandbox e2e is CI-environment-hostile on main and #335 is innocent. Will be closed either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)