### PR TITLE
fix(r4t): dispatch resolves tell from its own repo, not the operator's PATH

### DIFF
--- a/apps/r4t/notify.py
+++ b/apps/r4t/notify.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 import sys
 from collections.abc import Callable
+from pathlib import Path
 from typing import TypeAlias
 
 TellFn: TypeAlias = Callable[[str, str], None]
@@ -11,8 +12,14 @@ TellFn: TypeAlias = Callable[[str, str], None]
 SIMULATE_ENV = "R4T_SIMULATE_TELL"
 
 
+# The `tell` on PATH is an operator convenience installed by install.sh; a
+# dispatch host (CI runner, container, fresh Linux box) has no such PATH entry,
+# so r4t resolves its sibling a8s entry point absolutely.
+A8S_PY = Path(__file__).resolve().parent.parent / "a8s" / "a8s.py"
+
+
 def default_tell(agent: str, body: str) -> None:
-    subprocess.run(["tell", agent, body], check=False)
+    subprocess.run([sys.executable, str(A8S_PY), "tell", agent, body], check=False)
 
 
 def simulate_tell(agent: str, body: str) -> None:

--- a/apps/r4t/tests/test_notify.py
+++ b/apps/r4t/tests/test_notify.py
@@ -1,0 +1,26 @@
+"""Issue #337 — dispatch's tell must not depend on the operator's PATH.
+
+`default_tell` once spawned the bare `tell` command, which exists only where
+install.sh has edited the shell PATH. On a CI runner or container the spawn
+raised FileNotFoundError mid-release, killing dispatch after QUEUED and turning
+every wake into a retry loop."""
+import subprocess
+import sys
+
+import notify
+
+
+class TestDefaultTell:
+    def test_resolves_the_sibling_a8s_entry_point(self):
+        assert notify.A8S_PY.is_file()
+        assert notify.A8S_PY.name == "a8s.py"
+
+    def test_spawns_path_independent_argv(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            subprocess, "run", lambda argv, **kw: calls.append(argv)
+        )
+        notify.default_tell("bob", "status green")
+        assert calls == [
+            [sys.executable, str(notify.A8S_PY), "tell", "bob", "status green"]
+        ]


### PR DESCRIPTION
Closes #337.

The fake sandbox e2e failed on every Linux run (and always would have — the new r4t CI job from #334 just made it visible): `notify.default_tell` spawned the bare `tell` via PATH, and only machines where install.sh edited the shell profile have that entry. The spawn's FileNotFoundError propagated through `_park_seat` → `_ingest` → `_release_one`, killing dispatch after QUEUED; #328's wake-retry then redelivered the kickoff and each redelivery minted a fresh thread — the exact CI symptom.

Fix: resolve the sibling `apps/a8s/a8s.py` absolutely (`[sys.executable, A8S_PY, "tell", ...]`), the same pattern rig.py uses for `a8s mcp serve`. Beyond CI this is a deployment fix: a Linux dispatch host has no reason to have `~/bin` on PATH.

Verified: container (python:3.12) — direct `r4t sandbox --fake` all checks PASS, `test_sandbox.py` 6/6; macOS full suite 846 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)