### PR TITLE
feat(a8s): namespace opacity is opt-in — attribution outward by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,9 +115,10 @@ apply on top.
 
 The router (`mailbox.py:_process_pending`) force-overwrites `from` based on
 which agent owns the enclosing root — the filesystem is the unforgeable
-identity. A namespace bound to that agent changes only how the identity
-presents: mail leaving the namespace goes out as the bare prefix, mail inside
-it keeps `<prefix>:<sub-sender>`.
+identity. A namespace bound with `--opaque` conceals how that identity
+presents — mail leaving the prefix goes out as the bare prefix — while a
+default binding keeps member attribution outward; mail inside a prefix keeps
+`<prefix>:<sub-sender>` either way.
 
 a8s plants no skill files in an agent's repo: `tell` reads `TELL_OUTBOX_DIR`
 from the environment a8s injects on wake. Top-level doc skills for the user's

--- a/apps/a8s/README.md
+++ b/apps/a8s/README.md
@@ -173,18 +173,20 @@ tell acme:phil "lunch at noon?"      # delivered to acme-node with to = "acme:ph
 tell acme:team:ops "deploy done"     # same node; sub-address opaque to a8s
 ```
 
-A bound prefix is also the node's outward identity. Mail leaving the namespace
-presents `from` as the bare prefix — `acme`, not the `acme-node` registration
-name and not the `acme:phil` sub-sender that wrote it — so a namespace is one
-opaque address on the network whether it fronts one agent, a human, or a whole
-roster, and a reply to that name routes back in through the binding. Mail
-addressed *inside* the prefix keeps sub-sender attribution: an envelope to
-`acme:jane` claiming `from: acme:phil` keeps that `from`, since only the bound
-node writes that outbox and a claim under its own prefix carries its own
-authority. Ownership is still settled by the filesystem, not the JSON: a claim
-the sender's own namespaces don't back is discarded. A node with several
-prefixes bound has no unambiguous outward name, so its agent name stands for
-anything but a claim under one of them.
+By default a binding changes nothing about how the node presents: a sub-sender
+claim under the node's own prefix stands to any recipient (`acme:phil` arrives
+as `acme:phil`), since only the bound node writes that outbox and a claim under
+its own prefix carries its own authority. Bind with `--opaque` to conceal
+instead: mail leaving that prefix presents `from` as the bare prefix — `acme`,
+not the `acme-node` registration name and not the sub-sender that wrote it —
+so an opaque namespace is one address on the network whether it fronts one
+agent, a human, or a whole roster, and a reply to that name routes back in
+through the binding. Mail addressed *inside* the prefix keeps sub-sender
+attribution either way. Ownership is always settled by the filesystem, not the
+JSON: a claim the sender's own namespaces don't back is discarded. An opaque
+node with several opaque prefixes has no unambiguous outward name, so its
+agent name stands for anything but a claim under one of them. Rebinding
+without the flag clears opacity; `a8s namespaces` marks opaque bindings.
 
 Prefixes share the agent/alias name grammar (lowercase canonical form,
 case-insensitive match). A prefix may match the name of the agent it binds to
@@ -450,7 +452,7 @@ The state root resolves as follows when `A8S_HOME` is unset: use `~/.config/a8s`
 
 The outbox lives in the agent's own dir because some sandboxes (codex `--full-auto`) only let the agent write inside its workspace. Inbox/trash/pending live under `~/.a8s/` where the agent can't see them — and per the agent-directory invariant, a8s never sidecars or rewrites in `.outbox/`. New outbox files are atomically renamed to `pending/` on every routing pass; everything from there (sidecars, retries, trash, remote publishes) happens in `~/.a8s/`.
 
-`from` is force-overwritten at routing time. An agent that hand-writes a JSON with `from: "VICTIM"` doesn't get to spoof — the file's outbox location is the unforgeable identity. A namespace bound to that agent changes what the identity *presents as*, never whose it is: see [Namespaces](#namespaces).
+`from` is force-overwritten at routing time. An agent that hand-writes a JSON with `from: "VICTIM"` doesn't get to spoof — the file's outbox location is the unforgeable identity. A namespace binding can change what the identity *presents as* (`--opaque`), never whose it is: see [Namespaces](#namespaces).
 
 ## Connectors
 

--- a/apps/a8s/cli.py
+++ b/apps/a8s/cli.py
@@ -58,7 +58,7 @@ COMMANDS: list[tuple[str, str, str]] = [
     ("alias",    "[<name> [<member>]]",       "Group agents under an alias name; show one with `<name>`."),
     ("unalias",  "<alias> [<member>]",        "Remove a member from an alias, or the whole alias."),
     ("aliases",  "",                          "List aliases and their members."),
-    ("namespace", "[<prefix> [<agent>]]",     "Bind an address prefix to one agent (`tell <prefix>:<sub> ...`); show one with `<prefix>`."),
+    ("namespace", "[<prefix> [<agent>] [--opaque]]", "Bind an address prefix to one agent (`tell <prefix>:<sub> ...`); `--opaque` conceals member attribution outward."),
     ("unnamespace", "<prefix>",               "Remove a namespace binding."),
     ("namespaces", "",                        "List namespace prefixes and their bound agents."),
     ("start",    "<name>",                    "Run an agent in the background."),

--- a/apps/a8s/commands.py
+++ b/apps/a8s/commands.py
@@ -77,6 +77,8 @@ from registry import (
     save_aliases,
     save_namespaces,
     save_registry,
+    load_namespace_options,
+    save_namespace_options,
 )
 from txlog import read_events
 from ulid import is_ulid
@@ -997,14 +999,16 @@ def cmd_namespace(args: list[str]) -> int:
     canonical form). A prefix may match the name of the agent it binds to (a
     node owning its own namespace, #175) but must not collide with an alias or
     with any other agent."""
-    if len(args) == 0:
+    opaque = "--opaque" in args
+    args = [a for a in args if a != "--opaque"]
+    if len(args) == 0 and not opaque:
         return cmd_namespaces()
-    if len(args) == 1:
+    if len(args) == 1 and not opaque:
         return _cmd_namespace_show(args[0])
     if len(args) != 2:
-        print("usage: a8s namespace <prefix> <agent>   # bind or rebind", file=sys.stderr)
-        print("       a8s namespace <prefix>           # show one", file=sys.stderr)
-        print("       a8s namespace                    # list", file=sys.stderr)
+        print("usage: a8s namespace <prefix> <agent> [--opaque]   # bind or rebind", file=sys.stderr)
+        print("       a8s namespace <prefix>                      # show one", file=sys.stderr)
+        print("       a8s namespace                               # list", file=sys.stderr)
         return 2
     raw_prefix, raw_target = args
     try:
@@ -1046,10 +1050,19 @@ def cmd_namespace(args: list[str]) -> int:
     previous = namespaces.get(prefix)
     namespaces[prefix] = target_resolved
     save_namespaces(namespaces)
-    if previous is not None and str(previous).lower() != target_resolved.lower():
-        print(f"rebound {prefix}: -> {target_resolved} (was {previous})")
+    # Rebinding is how opacity flips: the flag's absence clears it, so the
+    # stored option always mirrors the latest bind.
+    options = load_namespace_options()
+    if opaque:
+        options[prefix] = {"opaque": True}
     else:
-        print(f"bound {prefix}: -> {target_resolved}")
+        options.pop(prefix, None)
+    save_namespace_options(options)
+    tail = " (opaque)" if opaque else ""
+    if previous is not None and str(previous).lower() != target_resolved.lower():
+        print(f"rebound {prefix}: -> {target_resolved}{tail} (was {previous})")
+    else:
+        print(f"bound {prefix}: -> {target_resolved}{tail}")
     return 0
 
 
@@ -1068,6 +1081,9 @@ def cmd_unnamespace(args: list[str]) -> int:
         return 1
     del namespaces[canonical]
     save_namespaces(namespaces)
+    options = load_namespace_options()
+    if options.pop(canonical, None) is not None:
+        save_namespace_options(options)
     print(f"removed namespace {canonical}")
     return 0
 
@@ -1090,7 +1106,13 @@ def _cmd_namespace_show(name: str) -> int:
         print(f"no namespace named {name!r}", file=sys.stderr)
         return 1
     bound = namespaces[canonical]
-    print(f"{canonical}: -> {bound}{_namespace_binding_tail(bound)}")
+    options = load_namespace_options()
+    is_opaque = any(
+        k.lower() == canonical.lower() and (o or {}).get("opaque")
+        for k, o in options.items()
+    )
+    mark = "  [opaque]" if is_opaque else ""
+    print(f"{canonical}: -> {bound}{mark}{_namespace_binding_tail(bound)}")
     return 0
 
 
@@ -1101,9 +1123,12 @@ def cmd_namespaces() -> int:
         print("(no namespaces — use `a8s namespace <prefix> <agent>` to bind one)")
         return 0
     width = max(len(p) for p in namespaces)
+    options = load_namespace_options()
+    opaque = {k.lower() for k, o in options.items() if (o or {}).get("opaque")}
     for prefix in sorted(namespaces, key=str.lower):
         bound = namespaces[prefix]
-        print(f"  {prefix.ljust(width)}  -> {bound}{_namespace_binding_tail(bound)}")
+        mark = "  [opaque]" if prefix.lower() in opaque else ""
+        print(f"  {prefix.ljust(width)}  -> {bound}{mark}{_namespace_binding_tail(bound)}")
     return 0
 
 

--- a/apps/a8s/mailbox.py
+++ b/apps/a8s/mailbox.py
@@ -65,7 +65,7 @@ from core import (
     unique_path,
 )
 from network import seen_id_append
-from registry import load_namespaces, resolve_name
+from registry import load_namespaces, resolve_name, opaque_prefixes
 from services import StorageError, StorageService
 import txlog
 from ulid import new as new_ulid
@@ -495,28 +495,28 @@ def _stamp_from(
     claimed: str,
     recipient: str,
     owned_prefixes: dict[str, str],
+    opaque: set[str],
 ) -> str:
-    """The `from` a routed message carries, keyed by the namespace prefixes bound
-    to the sender (lowercase key -> registry spelling).
+    """The `from` a routed message carries, keyed by the namespace prefixes
+    bound to the sender (lowercase key -> registry spelling) and their opacity.
 
-    The outbox is agent-writable, so its JSON can lie about `from`. Ownership is
-    settled by the filesystem — a claim the sender's own namespaces don't back is
-    discarded — and a namespace decides only how that owner *presents*: the
-    prefix is one address on the network and the agent behind it is registration
-    plumbing (`acme-node`), so a node with one bound prefix speaks as the prefix.
-    Whatever it fronts (one agent, a human, a whole roster) is one opaque name
-    outside, and a reply to that name routes back in through the binding.
+    Ownership is settled by the filesystem — a claim the sender's own
+    namespaces don't back is discarded. By default a namespace changes nothing
+    about presentation: a sub-sender claim under the node's own prefix stands
+    to any recipient (`crew:gerry` arrives as `crew:gerry`), because
+    attribution is the default and only the bound node writes this outbox.
 
-    Inside the prefix, a sub-sender claim stands (`acme:phil` to `acme:jane`):
-    only the bound node writes this outbox, so a claim under its own prefix
-    carries the node's own authority. Several bound prefixes leave the outward
-    name ambiguous for anything but a claim under one of them, so the agent name
-    stands."""
+    A binding made with `--opaque` conceals instead: mail leaving that prefix
+    presents as the bare prefix — one address outside, whatever it fronts —
+    while mail addressed inside the prefix keeps the sub-sender. A node-name
+    or unbacked claim presents as the node's single opaque prefix when it has
+    exactly one; anything else falls back to the agent name."""
     prefix = owned_prefixes.get(claimed.partition(":")[0].strip().lower())
+    if prefix is not None and prefix.lower() not in opaque:
+        return claimed if ":" in claimed else sender_name
     if prefix is None:
-        if len(owned_prefixes) != 1:
-            return sender_name
-        return next(iter(owned_prefixes.values()))
+        concealed = [p for p in owned_prefixes.values() if p.lower() in opaque]
+        return concealed[0] if len(concealed) == 1 else sender_name
     if recipient.partition(":")[0].strip().lower() == prefix.lower():
         return claimed if ":" in claimed else prefix
     return prefix
@@ -543,6 +543,7 @@ def _process_pending(
         p.lower(): p for p, a in load_namespaces().items()
         if a.lower() == sender.name.lower()
     }
+    opaque = opaque_prefixes()
     now = datetime.now(timezone.utc)
     files = sorted(
         f for f in pending.iterdir()
@@ -569,7 +570,7 @@ def _process_pending(
         recipient_name = (msg.get("to") or "").strip()
         msg["from"] = _stamp_from(
             sender.name, str(msg.get("from") or "").strip(),
-            recipient_name, owned_prefixes,
+            recipient_name, owned_prefixes, opaque,
         )
         preview = _preview(msg.get("content", ""))
         msg_files = [e.get("filename", "") for e in (msg.get("files") or []) if e.get("filename")]

--- a/apps/a8s/registry.py
+++ b/apps/a8s/registry.py
@@ -36,7 +36,7 @@ from core import (
 
 # ---------- registry I/O ----------
 
-_REGISTRY_SECTIONS = ("agents", "aliases", "namespaces")
+_REGISTRY_SECTIONS = ("agents", "aliases", "namespaces", "namespace_options")
 
 
 def _empty_registry() -> dict:
@@ -95,6 +95,27 @@ def save_namespaces(namespaces: dict) -> None:
     raw = _load_raw_registry()
     raw["namespaces"] = namespaces
     _save_raw_registry(raw)
+
+
+def load_namespace_options() -> dict:
+    return _load_raw_registry()["namespace_options"]
+
+
+def save_namespace_options(options: dict) -> None:
+    raw = _load_raw_registry()
+    raw["namespace_options"] = options
+    _save_raw_registry(raw)
+
+
+def opaque_prefixes() -> set[str]:
+    """Lowercased prefixes bound with `--opaque` — presentation policy, kept
+    beside the routing map rather than inside it so every consumer of
+    `namespaces` keeps reading `{prefix: agent}`."""
+    return {
+        p.lower()
+        for p, opts in load_namespace_options().items()
+        if isinstance(opts, dict) and opts.get("opaque")
+    }
 
 
 # ---------- lookups ----------

--- a/apps/a8s/tests/test_mailbox.py
+++ b/apps/a8s/tests/test_mailbox.py
@@ -29,7 +29,7 @@ from mailbox import (
     next_inbox_message,
     route_outboxes,
 )
-from registry import participants_from_registry, save_aliases, save_namespaces, save_registry
+from registry import participants_from_registry, save_aliases, save_namespaces, save_registry, save_namespace_options
 
 
 class TestPendingAttachmentStatus:
@@ -462,11 +462,11 @@ class TestNamespaceRouting:
 
 
 class TestNamespaceEgressIdentity:
-    """Issue #315 — a bound prefix is the node's name on the network. Mail
-    leaving the namespace presents `from` as the bare prefix, so whatever the
-    prefix fronts is one opaque address outside it; mail addressed inside the
-    prefix keeps sub-sender attribution. Presentation is all a namespace
-    changes — the enclosing outbox still settles whose message it is."""
+    """A namespace binding presents member attribution outward by default —
+    a sub-sender claim under the node's own prefix stands to any recipient.
+    Binding with `--opaque` conceals instead: mail leaving the prefix presents
+    as the bare prefix, one address outside whatever it fronts. Either way the
+    enclosing outbox settles whose message it is."""
 
     @pytest.fixture
     def node_and_outsider(self, fake_home, tmp_path):
@@ -483,6 +483,9 @@ class TestNamespaceEgressIdentity:
         ensure_mailboxes(outsider)
         return node, outsider
 
+    def _conceal(self, *prefixes: str) -> None:
+        save_namespace_options({p: {"opaque": True} for p in prefixes})
+
     def _stage(self, node: Participant, claimed: str, to: str) -> None:
         f = outbox_dir(node.root) / "20260101T000000_NODE.json"
         f.write_text(json.dumps({
@@ -493,47 +496,80 @@ class TestNamespaceEgressIdentity:
         route_outboxes([node, outsider], all_agents=[node, outsider])
         return json.loads(next(inbox_dir("B").iterdir()).read_text())["from"]
 
+    # --- default: attribution outward ---
+
+    def test_member_claim_stands_to_an_outsider_by_default(self, node_and_outsider):
+        node, outsider = node_and_outsider
+        self._stage(node, "acme:lead", "B")
+        assert self._delivered_from(node, outsider) == "acme:lead"
+
+    def test_node_name_egresses_as_itself_by_default(self, node_and_outsider):
+        node, outsider = node_and_outsider
+        self._stage(node, "acme-node", "B")
+        assert self._delivered_from(node, outsider) == "acme-node"
+
+    def test_spoofed_claim_is_discarded_by_default(self, node_and_outsider):
+        node, outsider = node_and_outsider
+        self._stage(node, "VICTIM", "B")
+        assert self._delivered_from(node, outsider) == "acme-node"
+
+    # --- opaque: the binding conceals ---
+
     def test_member_egress_presents_the_bare_namespace(self, node_and_outsider):
         node, outsider = node_and_outsider
+        self._conceal("acme")
         self._stage(node, "acme:lead", "B")
         assert self._delivered_from(node, outsider) == "acme"
 
-    def test_node_name_egresses_as_its_sole_namespace(self, node_and_outsider):
-        # A plain `tell` from the node root: `acme-node` is the registration
-        # name a prefix can't share, not the node's identity on the network.
+    def test_node_name_egresses_as_its_sole_opaque_namespace(self, node_and_outsider):
         node, outsider = node_and_outsider
+        self._conceal("acme")
         self._stage(node, "acme-node", "B")
         assert self._delivered_from(node, outsider) == "acme"
 
     def test_presented_prefix_uses_the_registry_spelling(self, node_and_outsider):
         node, outsider = node_and_outsider
         save_namespaces({"Acme": "acme-node"})
+        self._conceal("Acme")
         self._stage(node, "ACME:lead", "B")
         assert self._delivered_from(node, outsider) == "Acme"
 
-    def test_spoofed_claim_is_discarded_not_carried_out(self, node_and_outsider):
+    def test_spoofed_claim_presents_as_the_opaque_prefix(self, node_and_outsider):
         # The claim buys nothing — the node presents as its own namespace, and
         # `VICTIM` is gone.
         node, outsider = node_and_outsider
+        self._conceal("acme")
         self._stage(node, "VICTIM", "B")
         assert self._delivered_from(node, outsider) == "acme"
 
-    def test_several_prefixes_leave_the_agent_name_standing(self, node_and_outsider):
+    def test_several_opaque_prefixes_leave_the_agent_name_standing(self, node_and_outsider):
         node, outsider = node_and_outsider
         save_namespaces({"acme": "acme-node", "ops": "acme-node"})
+        self._conceal("acme", "ops")
         self._stage(node, "acme-node", "B")
         assert self._delivered_from(node, outsider) == "acme-node"
 
-    def test_several_prefixes_still_honor_a_claim_under_one(self, node_and_outsider):
+    def test_several_opaque_prefixes_still_honor_a_claim_under_one(self, node_and_outsider):
         node, outsider = node_and_outsider
         save_namespaces({"acme": "acme-node", "ops": "acme-node"})
+        self._conceal("acme", "ops")
         self._stage(node, "ops:lead", "B")
         assert self._delivered_from(node, outsider) == "ops"
 
-    def test_traffic_inside_the_prefix_keeps_the_sub_sender(self, node_and_outsider):
+    def test_opacity_is_per_prefix(self, node_and_outsider):
+        # A claim under the node's non-opaque prefix keeps attribution even
+        # though a sibling prefix conceals.
+        node, outsider = node_and_outsider
+        save_namespaces({"acme": "acme-node", "ops": "acme-node"})
+        self._conceal("acme")
+        self._stage(node, "ops:lead", "B")
+        assert self._delivered_from(node, outsider) == "ops:lead"
+
+    def test_traffic_inside_the_opaque_prefix_keeps_the_sub_sender(self, node_and_outsider):
         # The recipient is the node itself, so there is no local delivery to
         # read — the remote publish carries the envelope that would go out.
         node, outsider = node_and_outsider
+        self._conceal("acme")
         published: list[dict] = []
 
         def publish(msg, sender_name, succeeded_so_far, attempt_count):
@@ -550,16 +586,33 @@ class TestNamespaceEgressIdentity:
     def test_reply_to_the_bare_namespace_routes_in_through_the_binding(
         self, node_and_outsider
     ):
-        # The round trip the presentation depends on: the outsider answers the
-        # name it saw, and the message enters at the bound node with `to` intact
-        # for the node to self-route.
+        # The round trip opacity depends on: the outsider answers the name it
+        # saw, and the message enters at the bound node with `to` intact for
+        # the node to self-route. Routing is opacity-independent.
         node, outsider = node_and_outsider
+        self._conceal("acme")
         _write_outbox("B", outsider.root, "acme", "thanks", [])
         n = route_outboxes([node, outsider], all_agents=[node, outsider])
         assert n == 1
         delivered = json.loads(next(inbox_dir("acme-node").iterdir()).read_text())
         assert delivered["to"] == "acme"
         assert delivered["from"] == "B"
+
+    def test_unnamespace_clears_the_opacity_option(self, node_and_outsider, capsys):
+        from commands import cmd_namespace, cmd_unnamespace
+        assert cmd_namespace(["acme", "acme-node", "--opaque"]) == 0
+        assert "opaque" in capsys.readouterr().out
+        assert cmd_unnamespace(["acme"]) == 0
+        from registry import load_namespace_options
+        assert load_namespace_options() == {}
+
+    def test_rebind_without_the_flag_clears_opacity(self, node_and_outsider, capsys):
+        from commands import cmd_namespace
+        from registry import opaque_prefixes
+        assert cmd_namespace(["acme", "acme-node", "--opaque"]) == 0
+        assert opaque_prefixes() == {"acme"}
+        assert cmd_namespace(["acme", "acme-node"]) == 0
+        assert opaque_prefixes() == set()
 
 
 class TestEnvelopeMeta:
@@ -616,6 +669,7 @@ class TestEnvelopeMeta:
             "B": {"root": str(outsider_root)},
         })
         save_namespaces({"acme": "acme-node"})
+        save_namespace_options({"acme": {"opaque": True}})
         node = Participant("acme-node", node_root)
         outsider = Participant("B", outsider_root)
         ensure_mailboxes(node)

--- a/apps/a8s/tests/test_network.py
+++ b/apps/a8s/tests/test_network.py
@@ -31,7 +31,7 @@ from network import (
     start_remotes,
     stop_remotes,
 )
-from registry import save_aliases, save_namespaces, save_registry
+from registry import save_aliases, save_namespaces, save_registry, save_namespace_options
 from transports import Transport, TransportError
 from ulid import new as new_ulid
 from delivery_receipt import build_delivery_receipt, parse_delivery_receipt
@@ -400,6 +400,7 @@ class TestReceiveEnvelope:
         events = []
         monkeypatch.setattr(network.txlog, "log", lambda event, **fields: events.append((event, fields)))
         save_namespaces({"crew": "A"})
+        save_namespace_options({"crew": {"opaque": True}})
         envelope = build_delivery_receipt({"id": new_ulid(), "from": "crew"}, ["B"])
         receive_envelope(json.dumps(envelope).encode(), two_local_agents)
         receipts = [fields for event, fields in events if event == "DELIVERY_RECEIPT"]

--- a/apps/a8s/tests/test_registry.py
+++ b/apps/a8s/tests/test_registry.py
@@ -77,7 +77,7 @@ class TestCanonicalName:
 class TestRegistryIO:
     def test_empty_registry_returns_zero_sections(self, fake_home):
         raw = _load_raw_registry()
-        assert raw == {"agents": {}, "aliases": {}, "namespaces": {}}
+        assert raw == {"agents": {}, "aliases": {}, "namespaces": {}, "namespace_options": {}}
 
     def test_save_and_load_agents(self, fake_home):
         save_registry({"CLAUDE": {"root": "/tmp/x", "definition": "/tmp/d.json"}})
@@ -113,11 +113,11 @@ class TestRegistryIO:
 
     def test_corrupt_file_returns_empty(self, fake_home):
         registry_path().write_text("not json")
-        assert _load_raw_registry() == {"agents": {}, "aliases": {}, "namespaces": {}}
+        assert _load_raw_registry() == {"agents": {}, "aliases": {}, "namespaces": {}, "namespace_options": {}}
 
     def test_non_dict_top_level_returns_empty(self, fake_home):
         registry_path().write_text("[1, 2, 3]")
-        assert _load_raw_registry() == {"agents": {}, "aliases": {}, "namespaces": {}}
+        assert _load_raw_registry() == {"agents": {}, "aliases": {}, "namespaces": {}, "namespace_options": {}}
 
     def test_missing_sections_default_empty(self, fake_home):
         # No migration code (pre-v1): a registry written before namespaces

--- a/apps/r4t/docs/message-flow.md
+++ b/apps/r4t/docs/message-flow.md
@@ -99,11 +99,12 @@ a report someone is waiting on, so the quiet-thread sweep leaves it alone. That
 is what keeps two federated rosters from reading each other's polite
 status updates as fresh human attention and nudging each other awake forever.
 
-The sender the outside sees is the bare namespace. Dispatch releases with
-`from: <node>:<member>`, and the a8s router — which owns `from`, because the
-outbox is agent-writable — presents that as the bound prefix on the way out:
-mail from the org arrives as `acme`, never `acme:lead` or `acme-node`. So the
-org speaks with one mouth (only the topmost leader originates external mail)
-under one name, and a reply to `acme` re-enters at the top lead. Inside the
-walls attribution stays member-level; the collapse is presentation at the wall,
-not a loss of who said what.
+What the outside sees is the org owner's choice. Dispatch releases with
+`from: <node>:<member>`, and by default that attribution stands — external
+mail arrives as `acme:lead`. Bind the namespace with `a8s namespace acme
+<node> --opaque` and the a8s router — which owns `from`, because the outbox is
+agent-writable — presents egress as the bound prefix instead: mail from the
+org arrives as `acme`, never `acme:lead` or `acme-node`, so the org speaks
+with one mouth under one name and a reply to `acme` re-enters at the top lead.
+Inside the walls attribution stays member-level either way; opacity is
+presentation at the wall, not a loss of who said what.

--- a/apps/r4t/docs/org.md
+++ b/apps/r4t/docs/org.md
@@ -116,7 +116,7 @@ config without a `repo` key is an in-repo org that just wants settings.
 |---|---|---|
 | `comms` | `open` | `open` delivers a tell to any valid member (learned addresses); `closed` reroutes non-adjacent tells through the sender's lead |
 | `leader_sees_lateral` | `false` | when `true`, a lateral (peer) delivery lands a read-only copy in the lead's history — no turn burned |
-| `egress` | `true` | only the topmost leader may message outside the garden; a non-top member's external tell redirects up to it. `false` keeps the org silent outward. What leaves is stamped with the bare namespace prefix, so the org is one name outside its walls (see [message-flow.md](message-flow.md)) |
+| `egress` | `true` | only the topmost leader may message outside the garden; a non-top member's external tell redirects up to it. `false` keeps the org silent outward. Bind the org's namespace `--opaque` and what leaves is stamped with the bare prefix — one name outside the walls; the default binding keeps member attribution (see [message-flow.md](message-flow.md)) |
 | `doorbell_check` | *absent* | a shell command that gates every ring of an absent human's doorbell (see [verification.md](verification.md)); absent or empty means no gate |
 | `run_as` | *absent* | OS-level isolation: wrap every member turn in `sudo -u <username>`. One user serves the whole roster (see [isolation.md](isolation.md)) |
 | `container` | *absent* | OS-level isolation: run every member turn under `docker run --rm <image>`; mutually exclusive with `run_as` (see [isolation.md](isolation.md)) |


### PR DESCRIPTION
Closes #339. The owner's ruling on #315/#319: user opts in to conceal.

Both modes, from the reworked `TestNamespaceEgressIdentity`:

| envelope `from` | binding | delivered `from` (external) |
|---|---|---|
| `acme:lead` | default | `acme:lead` |
| `acme-node` | default | `acme-node` |
| `VICTIM` | default | `acme-node` (claim discarded) |
| `acme:lead` | `--opaque` | `acme` |
| `acme-node` | sole `--opaque` prefix | `acme` |
| `ops:lead` | `acme` opaque, `ops` not | `ops:lead` (opacity is per-prefix) |
| `acme:phil` → `acme:jane` | either | `acme:phil` (inside keeps attribution) |

Store: `namespace_options` registry section beside the routing map — `namespaces` consumers keep reading `{prefix: agent}`. CLI: `a8s namespace <prefix> <agent> [--opaque]`; rebind without the flag clears; `a8s namespaces` shows `[opaque]`; unnamespace cleans up. Docs updated at every surface that stated the unconditional behavior (a8s README, CLAUDE.md, r4t message-flow.md, org.md).

Suites: a8s **850 passed**, r4t **862 passed** (separate invocations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)