### PR TITLE
fix(h4l): truncated notifies recover via /view <room> <id>

### DIFF
--- a/apps/h4l/README.md
+++ b/apps/h4l/README.md
@@ -81,21 +81,24 @@ history with cursor hints; open/trusted membership (no channel modes or bans).
 | `/invite` | `/invite war BOB CAROL` |
 | `/remove` | `/remove war BOB` (`/kick` alias) |
 | `/list` | `/list` |
-| `/view` | `/view war [start limit] [--start N] [--limit N]` |
+| `/view` | `/view war [id \| start limit] [--id ID] [--start N] [--limit N]` |
 | `/members` | `/members war` (`/names` alias) |
 | `/help` | `/help` |
 
 `/view` returns a convo-style markdown transcript (latest 10 messages by default).
 A footer reports the viewed message range and total count, with `tell` commands to
 page older/newer (`--start`), latest (bare `/view`), or an arbitrary window
-(`/view war <start> <limit>`).
+(`/view war <start> <limit>`). Pass a message id (`/view war <id>` or
+`/view war --id <id>`) to expand one stored post in full — truncated notifies
+include that command.
 
 Room slugs: `[a-z0-9_-]+`, case-insensitive, stored lowercase.
 
 - Posting auto-creates the room and auto-joins the poster.
 - Malformed input → `tell` error back to sender.
 - Successful post → stdout ACK + `tell` ACK to sender; other members get truncated notify
-  (1000 chars) with a `[truncated]` footer pointing at `tell <node> "/view <room>"`.
+  (1000 chars) with a `[truncated]` footer pointing at
+  `tell <node> "/view <room> <msg_id>"`.
 - Attachments: a8s wake appends `ATTACHED FILE:` lines; hall re-`tell --attach`s them to
   other room members (one inbound attach, N outbound copies via a8s).
 

--- a/apps/h4l/README.md
+++ b/apps/h4l/README.md
@@ -94,7 +94,8 @@ Room slugs: `[a-z0-9_-]+`, case-insensitive, stored lowercase.
 
 - Posting auto-creates the room and auto-joins the poster.
 - Malformed input → `tell` error back to sender.
-- Successful post → stdout ACK + `tell` ACK to sender; other members get truncated notify.
+- Successful post → stdout ACK + `tell` ACK to sender; other members get truncated notify
+  (1000 chars) with a `[truncated]` footer pointing at `tell <node> "/view <room>"`.
 - Attachments: a8s wake appends `ATTACHED FILE:` lines; hall re-`tell --attach`s them to
   other room members (one inbound attach, N outbound copies via a8s).
 

--- a/apps/h4l/dispatch.py
+++ b/apps/h4l/dispatch.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from attachments import split_attached_files
-from format import format_room_view, parse_view_args
+from format import format_message_view, format_room_view, parse_view_args
 from notify import TellFn, ack, error, notify_agent, notify_members, usage_help
 from rooms import RoomStore, normalize_agent, normalize_slug
 
@@ -254,7 +254,7 @@ def _do_post(
     store.save_meta(slug, meta)
 
     paths = list(attachments or [])
-    store.append_message(
+    posted = store.append_message(
         slug,
         sender=sender,
         content=content,
@@ -274,6 +274,7 @@ def _do_post(
         body=content,
         skip={sender},
         attachments=paths,
+        msg_id=posted.get("id"),
     )
     return 0
 
@@ -488,34 +489,54 @@ def _cmd_view(
     tell_fn: TellFn,
 ) -> int:
     try:
-        slug, limit, start_n = parse_view_args(args)
+        view = parse_view_args(args)
     except ValueError as exc:
         error(
             tell_fn,
             sender,
             node,
             str(exc),
-            hint="/view <room> [[start] limit] [--start N] [--limit N]",
+            hint='/view <room> [<id> | [start] limit] [--id ID] [--start N] [--limit N]',
         )
         return 1
     try:
-        store.load_meta(slug)
+        store.load_meta(view.slug)
     except KeyError:
         error(
             tell_fn,
             sender,
             node,
-            f"room not found: {slug}",
+            f"room not found: {view.slug}",
             hint="/list",
         )
         return 1
-    messages = store.list_messages(slug)
+    if view.msg_id is not None:
+        try:
+            entry = store.get_message(view.slug, view.msg_id)
+        except KeyError:
+            error(
+                tell_fn,
+                sender,
+                node,
+                f"message not found: {view.msg_id}",
+                hint=f'/view {view.slug}',
+            )
+            return 1
+        text = format_message_view(
+            view.slug,
+            entry,
+            sender,
+            node=node,
+        )
+        ack(tell_fn, sender, text)
+        return 0
+    messages = store.list_messages(view.slug)
     text = format_room_view(
-        slug,
+        view.slug,
         messages,
         sender,
-        limit=limit,
-        start_n=start_n,
+        limit=view.limit,
+        start_n=view.start_n,
         node=node,
     )
     ack(tell_fn, sender, text)

--- a/apps/h4l/format.py
+++ b/apps/h4l/format.py
@@ -1,9 +1,26 @@
 from __future__ import annotations
 
+import re
+from typing import NamedTuple
+
 DEFAULT_VIEW_LIMIT = 10
 
 HEADING_OUT = "## from {from} to {to} at {timestamp}"
 HEADING_IN = "### from {from} to {to} at {timestamp}"
+
+# Crockford base32 ULID (26 chars); h4l message ids are ULIDs.
+_MSG_ID_RE = re.compile(r"^[0-9A-HJKMNP-TV-Z]{26}$", re.IGNORECASE)
+
+
+class ViewArgs(NamedTuple):
+    slug: str
+    limit: int = DEFAULT_VIEW_LIMIT
+    start_n: int | None = None
+    msg_id: str | None = None
+
+
+def is_message_id(token: str) -> bool:
+    return bool(_MSG_ID_RE.match(token.strip()))
 
 
 def _attachment_lines(entry: dict) -> list[str]:
@@ -30,6 +47,24 @@ def _format_heading(template: str, entry: dict, room: str) -> str:
             "date": ts,
         }
     )
+
+
+def _format_entry(entry: dict, room: str, viewer_key: str) -> str:
+    sent = (entry.get("from") or "").strip().lower() == viewer_key
+    heading = _format_heading(
+        HEADING_OUT if sent else HEADING_IN,
+        entry,
+        room,
+    )
+    content = entry.get("content", "")
+    file_lines = _attachment_lines(entry)
+    body_parts: list[str] = []
+    if content:
+        body_parts.append(content)
+    body_parts.extend(file_lines)
+    if body_parts:
+        return f"{heading}\n\n" + "\n".join(body_parts)
+    return heading
 
 
 def select_messages(
@@ -86,6 +121,22 @@ def _format_view_footer(
     return "\n".join(lines)
 
 
+def format_message_view(
+    room: str,
+    entry: dict,
+    viewer: str,
+    *,
+    node: str | None = None,
+) -> str:
+    """Full single-message transcript (no notify truncation)."""
+    viewer_key = (viewer or "").strip().lower()
+    block = _format_entry(entry, room, viewer_key)
+    if node:
+        msg_id = (entry.get("id") or "").strip()
+        block += f"\n\n---\n#{room}: message {msg_id}"
+    return block
+
+
 def format_room_view(
     room: str,
     messages: list[dict],
@@ -108,25 +159,7 @@ def format_room_view(
         return header
 
     viewer_key = (viewer or "").strip().lower()
-    parts: list[str] = []
-
-    for entry in window:
-        sent = (entry.get("from") or "").strip().lower() == viewer_key
-        heading = _format_heading(
-            HEADING_OUT if sent else HEADING_IN,
-            entry,
-            room,
-        )
-        content = entry.get("content", "")
-        file_lines = _attachment_lines(entry)
-        block = heading
-        body_parts: list[str] = []
-        if content:
-            body_parts.append(content)
-        body_parts.extend(file_lines)
-        if body_parts:
-            block = f"{heading}\n\n" + "\n".join(body_parts)
-        parts.append(block)
+    parts: list[str] = [_format_entry(entry, room, viewer_key) for entry in window]
 
     if node:
         if window:
@@ -149,8 +182,8 @@ def format_room_view(
     return "\n\n".join(parts)
 
 
-def parse_view_args(args: list[str]) -> tuple[str, int, int | None]:
-    """Parse `/view <room> [[start] limit] [--start N] [--limit N]`."""
+def parse_view_args(args: list[str]) -> ViewArgs:
+    """Parse `/view <room> [<id> | [start] limit] [--id ID] [--start N] [--limit N]`."""
     if not args:
         raise ValueError("/view requires <room>")
     from rooms import normalize_slug
@@ -158,15 +191,23 @@ def parse_view_args(args: list[str]) -> tuple[str, int, int | None]:
     slug = normalize_slug(args[0])
     limit = DEFAULT_VIEW_LIMIT
     start_n: int | None = None
+    msg_id: str | None = None
     i = 1
-    if i < len(args) and args[i].isdigit():
-        if i + 1 < len(args) and args[i + 1].isdigit():
-            start_n = int(args[i])
-            limit = int(args[i + 1])
-            i += 2
-        else:
-            limit = int(args[i])
+    if i < len(args) and not args[i].startswith("-"):
+        token = args[i]
+        if token.isdigit():
+            if i + 1 < len(args) and args[i + 1].isdigit():
+                start_n = int(token)
+                limit = int(args[i + 1])
+                i += 2
+            else:
+                limit = int(token)
+                i += 1
+        elif is_message_id(token):
+            msg_id = token.strip().upper()
             i += 1
+        else:
+            raise ValueError(f"unknown /view argument: {token}")
     while i < len(args):
         token = args[i]
         if token == "--limit":
@@ -191,7 +232,18 @@ def parse_view_args(args: list[str]) -> tuple[str, int, int | None]:
                 raise ValueError("--start must be at least 1")
             i += 2
             continue
+        if token == "--id":
+            if i + 1 >= len(args):
+                raise ValueError("--id requires a message id")
+            raw = args[i + 1].strip()
+            if not is_message_id(raw):
+                raise ValueError(f"invalid message id: {raw}")
+            msg_id = raw.upper()
+            i += 2
+            continue
         raise ValueError(f"unknown /view argument: {token}")
     if limit < 1:
         raise ValueError("--limit must be at least 1")
-    return slug, limit, start_n
+    if msg_id is not None and start_n is not None:
+        raise ValueError("/view <id> cannot be combined with --start / window args")
+    return ViewArgs(slug=slug, limit=limit, start_n=start_n, msg_id=msg_id)

--- a/apps/h4l/notify.py
+++ b/apps/h4l/notify.py
@@ -22,6 +22,14 @@ MAX_NOTIFY_CHARS = 1000
 SIMULATE_ENV = "H4L_SIMULATE_TELL"
 
 
+def truncation_footer(node: str, room: str, *, limit: int = MAX_NOTIFY_CHARS) -> str:
+    return (
+        "\n\n---\n"
+        f"[truncated] Notify cut at {limit} characters. "
+        f'Full message: tell {node} "/view {room}"'
+    )
+
+
 def default_tell(
     agent: str,
     body: str,
@@ -69,10 +77,10 @@ def simulate_enabled(flag: bool) -> bool:
     return raw in ("1", "true", "yes", "on")
 
 
-def truncate(text: str, limit: int = MAX_NOTIFY_CHARS) -> str:
+def truncate(text: str, limit: int = MAX_NOTIFY_CHARS) -> tuple[str, bool]:
     if len(text) <= limit:
-        return text
-    return text[: limit - 3] + "..."
+        return text, False
+    return text[: limit - 3] + "...", True
 
 
 def usage_help(node: str) -> str:
@@ -130,7 +138,7 @@ def notify_members(
     attachments: list[Path] | None = None,
 ) -> None:
     omitted = {m.lower() for m in (skip or set())}
-    text = truncate(body)
+    text, truncated = truncate(body)
     paths = list(attachments or [])
     meta = store.load_meta(slug)
     dirty = False
@@ -140,6 +148,8 @@ def notify_members(
         suffix, meta, changed = _onboard_suffix(store, meta, member, node, room)
         dirty = dirty or changed
         message = f"{headline}\n\n{text}{suffix}"
+        if truncated:
+            message += truncation_footer(node, room)
         tell_fn(member, message, paths if paths else None)
     if dirty:
         store.save_meta(slug, meta)

--- a/apps/h4l/notify.py
+++ b/apps/h4l/notify.py
@@ -22,11 +22,21 @@ MAX_NOTIFY_CHARS = 1000
 SIMULATE_ENV = "H4L_SIMULATE_TELL"
 
 
-def truncation_footer(node: str, room: str, *, limit: int = MAX_NOTIFY_CHARS) -> str:
+def truncation_footer(
+    node: str,
+    room: str,
+    *,
+    msg_id: str | None = None,
+    limit: int = MAX_NOTIFY_CHARS,
+) -> str:
+    if msg_id:
+        recover = f'tell {node} "/view {room} {msg_id}"'
+    else:
+        recover = f'tell {node} "/view {room}"'
     return (
         "\n\n---\n"
         f"[truncated] Notify cut at {limit} characters. "
-        f'Full message: tell {node} "/view {room}"'
+        f"Full message: {recover}"
     )
 
 
@@ -95,7 +105,7 @@ def usage_help(node: str) -> str:
         f'tell {node} "/remove <room> <agent> [<agent>...]"  (/kick)',
         f'tell {node} "/list"',
         f'tell {node} "/names <room>"  (/members)',
-        f'tell {node} "/view <room> [[start] limit] [--start N] [--limit N]"',
+        f'tell {node} "/view <room> [<id> | [start] limit] [--id ID] [--start N] [--limit N]"',
         f'tell {node} "/help"',
         "",
         "Also: /post, /leave, /members, /kick; # prefix optional on room names.",
@@ -136,6 +146,7 @@ def notify_members(
     body: str,
     skip: set[str] | None = None,
     attachments: list[Path] | None = None,
+    msg_id: str | None = None,
 ) -> None:
     omitted = {m.lower() for m in (skip or set())}
     text, truncated = truncate(body)
@@ -149,7 +160,7 @@ def notify_members(
         dirty = dirty or changed
         message = f"{headline}\n\n{text}{suffix}"
         if truncated:
-            message += truncation_footer(node, room)
+            message += truncation_footer(node, room, msg_id=msg_id)
         tell_fn(member, message, paths if paths else None)
     if dirty:
         store.save_meta(slug, meta)

--- a/apps/h4l/rooms.py
+++ b/apps/h4l/rooms.py
@@ -152,6 +152,24 @@ class RoomStore:
         self._atomic_write(path, payload)
         return payload
 
+    def get_message(self, slug: str, msg_id: str) -> dict:
+        slug = normalize_slug(slug)
+        key = (msg_id or "").strip()
+        if not key:
+            raise KeyError(msg_id)
+        msg_dir = self.messages_dir(slug)
+        for candidate in (key, key.upper(), key.lower()):
+            path = msg_dir / f"{candidate}.json"
+            if not path.is_file():
+                continue
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if isinstance(data, dict):
+                return data
+        raise KeyError(msg_id)
+
     def list_messages(self, slug: str) -> list[dict]:
         slug = normalize_slug(slug)
         msg_dir = self.messages_dir(slug)

--- a/apps/h4l/tests/test_format.py
+++ b/apps/h4l/tests/test_format.py
@@ -4,6 +4,8 @@ import pytest
 
 from format import (
     DEFAULT_VIEW_LIMIT,
+    ViewArgs,
+    format_message_view,
     format_room_view,
     parse_view_args,
     select_messages,
@@ -106,23 +108,50 @@ class TestFormatRoomView:
         text = format_room_view("war", [], "ALICE", node="HALL")
         assert text == '#war: no messages\n\ntell HALL "#war <message>"'
 
+    def test_single_message_view(self):
+        entry = {
+            "id": "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            "date": "2026-01-01T12:00:00.000000Z",
+            "from": "BOB",
+            "content": "entire body",
+        }
+        text = format_message_view("war", entry, "ALICE", node="HALL")
+        assert "entire body" in text
+        assert "### from BOB to #war at" in text
+        assert "#war: message 01ARZ3NDEKTSV4RRFFQ69G5FAV" in text
+
 
 class TestParseViewArgs:
     def test_room_only(self):
-        assert parse_view_args(["war"]) == ("war", DEFAULT_VIEW_LIMIT, None)
+        assert parse_view_args(["war"]) == ViewArgs("war", DEFAULT_VIEW_LIMIT, None, None)
 
     def test_positional_limit(self):
-        assert parse_view_args(["war", "5"]) == ("war", 5, None)
+        assert parse_view_args(["war", "5"]) == ViewArgs("war", 5, None, None)
 
     def test_positional_start_and_limit(self):
-        assert parse_view_args(["war", "5", "10"]) == ("war", 10, 5)
+        assert parse_view_args(["war", "5", "10"]) == ViewArgs("war", 10, 5, None)
 
     def test_named_flags(self):
-        assert parse_view_args(["war", "--start", "5", "--limit", "3"]) == (
-            "war",
-            3,
-            5,
+        assert parse_view_args(["war", "--start", "5", "--limit", "3"]) == ViewArgs(
+            "war", 3, 5, None
         )
+
+    def test_positional_message_id(self):
+        mid = "01ARZ3NDEKTSV4RRFFQ69G5FAV"
+        assert parse_view_args(["war", mid.lower()]) == ViewArgs(
+            "war", DEFAULT_VIEW_LIMIT, None, mid
+        )
+
+    def test_id_flag(self):
+        mid = "01ARZ3NDEKTSV4RRFFQ69G5FAV"
+        assert parse_view_args(["war", "--id", mid]) == ViewArgs(
+            "war", DEFAULT_VIEW_LIMIT, None, mid
+        )
+
+    def test_id_rejects_start(self):
+        mid = "01ARZ3NDEKTSV4RRFFQ69G5FAV"
+        with pytest.raises(ValueError, match="cannot be combined"):
+            parse_view_args(["war", mid, "--start", "1"])
 
     def test_requires_room(self):
         with pytest.raises(ValueError, match="requires <room>"):

--- a/apps/h4l/tests/test_h4l.py
+++ b/apps/h4l/tests/test_h4l.py
@@ -161,8 +161,10 @@ class TestPost:
         bob = [b for a, b, _ in sent if a == "BOB"][0]
         assert "[truncated]" in bob
         assert f"Notify cut at {MAX_NOTIFY_CHARS} characters" in bob
-        assert 'tell CHATROOM "/view demopony"' in bob
-        assert bob.rstrip().endswith('tell CHATROOM "/view demopony"')
+        msg_id = store.list_messages("demopony")[0]["id"]
+        recover = f'tell CHATROOM "/view demopony {msg_id}"'
+        assert recover in bob
+        assert bob.rstrip().endswith(recover)
         stored = store.list_messages("demopony")[0]["content"]
         assert stored == body
         assert "[truncated]" not in stored
@@ -369,7 +371,63 @@ class TestView:
         assert "hi back" in ack
         assert "viewed messages 1–2 of 2" in ack
 
+    def test_view_specific_message_by_id(self, store, tells):
+        from notify import MAX_NOTIFY_CHARS
 
+        sent, tell_fn = tells
+        store.ensure_room("war")
+        long_body = "full-" + ("y" * (MAX_NOTIFY_CHARS + 20))
+        first = store.append_message("war", sender="ALICE", content="old")
+        target = store.append_message("war", sender="BOB", content=long_body)
+        store.append_message("war", sender="CAROL", content="newer")
+        assert first["id"] != target["id"]
+
+        dispatch_slash(
+            store,
+            sender="ALICE",
+            node="HALL",
+            message=f"/view war {target['id']}",
+            tell_fn=tell_fn,
+        )
+        ack = [b for a, b, _ in sent if a == "ALICE"][-1]
+        assert long_body in ack
+        assert "old" not in ack
+        assert "newer" not in ack
+        assert f"#war: message {target['id']}" in ack
+        assert "viewed messages" not in ack
+
+    def test_view_specific_message_via_id_flag(self, store, tells):
+        sent, tell_fn = tells
+        store.ensure_room("war")
+        msg = store.append_message("war", sender="BOB", content="only me")
+        dispatch_slash(
+            store,
+            sender="ALICE",
+            node="HALL",
+            message=f"/view war --id {msg['id'].lower()}",
+            tell_fn=tell_fn,
+        )
+        ack = [b for a, b, _ in sent if a == "ALICE"][-1]
+        assert "only me" in ack
+        assert f"#war: message {msg['id']}" in ack
+
+    def test_view_missing_message_id_errors(self, store, tells):
+        sent, tell_fn = tells
+        store.ensure_room("war")
+        fake = "01ARZ3NDEKTSV4RRFFQ69G5FAV"
+        rc = dispatch_slash(
+            store,
+            sender="ALICE",
+            node="HALL",
+            message=f"/view war {fake}",
+            tell_fn=tell_fn,
+        )
+        assert rc == 1
+        err = [b for a, b, _ in sent if a == "ALICE"][-1]
+        assert "message not found" in err
+
+
+class TestList:
     def test_lists_all_rooms_and_members(self, store, tells):
         sent, tell_fn = tells
         m1 = store.ensure_room("war")

--- a/apps/h4l/tests/test_h4l.py
+++ b/apps/h4l/tests/test_h4l.py
@@ -143,6 +143,47 @@ class TestPost:
         assert "More commands: tell HALL /help" in bob_msgs[0]
         assert "tell HALL /view" not in bob_msgs[0]
 
+    def test_long_post_notify_includes_truncation_footer(self, store, tells):
+        from notify import MAX_NOTIFY_CHARS
+
+        sent, tell_fn = tells
+        meta = store.ensure_room("demopony")
+        meta["members"] = ["ALICE", "BOB"]
+        store.save_meta("demopony", meta)
+        body = "x" * (MAX_NOTIFY_CHARS + 50)
+        dispatch_slash(
+            store,
+            sender="ALICE",
+            node="CHATROOM",
+            message=f"#demopony {body}",
+            tell_fn=tell_fn,
+        )
+        bob = [b for a, b, _ in sent if a == "BOB"][0]
+        assert "[truncated]" in bob
+        assert f"Notify cut at {MAX_NOTIFY_CHARS} characters" in bob
+        assert 'tell CHATROOM "/view demopony"' in bob
+        assert bob.rstrip().endswith('tell CHATROOM "/view demopony"')
+        stored = store.list_messages("demopony")[0]["content"]
+        assert stored == body
+        assert "[truncated]" not in stored
+
+    def test_short_post_notify_has_no_truncation_footer(self, store, tells):
+        sent, tell_fn = tells
+        meta = store.ensure_room("war")
+        meta["members"] = ["ALICE", "BOB"]
+        meta["help_seen"] = ["BOB"]
+        store.save_meta("war", meta)
+        dispatch_slash(
+            store,
+            sender="ALICE",
+            node="HALL",
+            message="#war short",
+            tell_fn=tell_fn,
+        )
+        bob = [b for a, b, _ in sent if a == "BOB"][0]
+        assert "[truncated]" not in bob
+        assert "/view war" not in bob
+
     def test_onboard_footer_only_once(self, store, tells):
         sent, tell_fn = tells
         meta = store.ensure_room("war")


### PR DESCRIPTION
## Summary
- Truncated room notifies end with an explicit `[truncated]` footer
- Footer includes `tell <node> "/view <room> <msg_id>"` to expand that exact stored post
- `/view <room> <id>` and `/view <room> --id <id>` return the full single message (no scrollback window)
- Room windowing (`/view <room>`, `--start` / `--limit`) unchanged

## Test plan
- [x] `venv/bin/python3 -m pytest apps/h4l/tests/` (63 passed)
- [ ] Post a >1000-char message; confirm truncate footer cites `/view <room> <id>`
- [ ] Run that command; confirm full body returns and neighboring posts do not
- [ ] Confirm short posts have no truncation footer