### PR TITLE
feat(n0b): ai research --fanout for parallel breadth

### DIFF
--- a/apps/n0b/cli.py
+++ b/apps/n0b/cli.py
@@ -166,9 +166,10 @@ def build_parser() -> argparse.ArgumentParser:
         description=(
             "OpenAI deep research (gpt-5.6-sol + web_search_preview). "
             "Default (--fanout absent or 1) is a single background job. "
-            "--fanout [N] plans complementary angles (brief + MMR), runs N "
-            "background jobs (default N=4, clamped 1-8), and writes a merged "
-            "brief under .files/research/fanout-<hash>/."
+            "--fanout [N] plans complementary angles (brief + MMR + reserved "
+            "adversarial), runs N background jobs (bare --fanout uses Stage 0 "
+            "recommended_fanout; clamped 1-8), and writes a merged brief under "
+            ".files/research/fanout-<hash>/."
         ),
         epilog=(
             "examples:\n"
@@ -179,22 +180,22 @@ def build_parser() -> argparse.ArgumentParser:
             "  n0b ai research --fanout 4 --plan-only what is X\n"
             "\n"
             "Put flags before the prompt (prompt is argparse REMAINDER). "
-            "--fanout with no value defaults to 4. --plan-only prints the "
-            "brief and selected sub-questions without submitting research "
-            "jobs. Fanout costs roughly N times a single run — see "
-            "apps/n0b/docs/research.md."
+            "Bare --fanout asks Stage 0 for recommended_fanout (may be 1). "
+            "Explicit --fanout N always wins. --plan-only prints the brief "
+            "and selected sub-questions without submitting research jobs. "
+            "See apps/n0b/docs/research.md."
         ),
     )
     ai_research.add_argument(
         "--fanout",
         nargs="?",
-        const=4,
+        const=0,
         default=None,
         type=int,
         metavar="N",
         help=(
-            "Fan out into N research jobs (default 4 if flag present without "
-            "value; 1 or omitted = single-shot; clamped 1-8)"
+            "Fan out into N research jobs (bare flag = Stage 0 "
+            "recommended_fanout; 1 or omitted = single-shot; clamped 1-8)"
         ),
     )
     ai_research.add_argument(
@@ -492,7 +493,10 @@ def dispatch(args: argparse.Namespace) -> int:
 
 
 def _inject_bare_fanout_default(argv: list[str]) -> list[str]:
-    """Turn bare ``--fanout`` into ``--fanout 4`` so the prompt is not eaten."""
+    """Turn bare ``--fanout`` into ``--fanout 0`` (auto) so the prompt is not eaten.
+
+    ``0`` means Stage 0 picks ``recommended_fanout``; an explicit N always wins.
+    """
     out: list[str] = []
     i = 0
     while i < len(argv):
@@ -504,12 +508,12 @@ def _inject_bare_fanout_default(argv: list[str]) -> list[str]:
                 try:
                     int(nxt)
                 except ValueError:
-                    out.append("4")
+                    out.append("0")
                 else:
                     out.append(nxt)
                     i += 1
             else:
-                out.append("4")
+                out.append("0")
         else:
             out.append(a)
         i += 1

--- a/apps/n0b/cli.py
+++ b/apps/n0b/cli.py
@@ -165,24 +165,42 @@ def build_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description=(
             "OpenAI deep research (gpt-5.6-sol + web_search_preview). "
-            "Default is a single background job. --fanout N decomposes the "
-            "prompt into N complementary sub-questions, runs them in parallel, "
-            "and writes a merged brief under .files/research/fanout-<hash>/."
+            "Default (--fanout absent or 1) is a single background job. "
+            "--fanout [N] plans complementary angles (brief + MMR), runs N "
+            "background jobs (default N=4, clamped 1-8), and writes a merged "
+            "brief under .files/research/fanout-<hash>/."
         ),
         epilog=(
             "examples:\n"
             "  n0b ai research what is X\n"
-            "  n0b ai research --fanout 3 what is X\n"
+            "  n0b ai research --fanout 1 what is X\n"
+            "  n0b ai research --fanout what is X\n"
+            "  n0b ai research --fanout 4 what is X\n"
+            "  n0b ai research --fanout 4 --plan-only what is X\n"
             "\n"
-            "Put --fanout before the prompt (prompt is argparse REMAINDER). "
-            "Fanout costs roughly N times a single run — see apps/n0b/docs/research.md."
+            "Put flags before the prompt (prompt is argparse REMAINDER). "
+            "--fanout with no value defaults to 4. --plan-only prints the "
+            "brief and selected sub-questions without submitting research "
+            "jobs. Fanout costs roughly N times a single run — see "
+            "apps/n0b/docs/research.md."
         ),
     )
     ai_research.add_argument(
         "--fanout",
+        nargs="?",
+        const=4,
+        default=None,
         type=int,
         metavar="N",
-        help="Decompose into N complementary research jobs and merge (prototype)",
+        help=(
+            "Fan out into N research jobs (default 4 if flag present without "
+            "value; 1 or omitted = single-shot; clamped 1-8)"
+        ),
+    )
+    ai_research.add_argument(
+        "--plan-only",
+        action="store_true",
+        help="Plan brief + MMR selection and exit without submitting research jobs",
     )
     ai_research.add_argument("prompt", nargs=argparse.REMAINDER)
     ai_speak = ai_sub.add_parser(
@@ -413,7 +431,9 @@ def dispatch(args: argparse.Namespace) -> int:
             return cmd_sub(rest)
     if group == "ai":
         if args.ai_kind == "research":
-            return cmd_research(args.prompt, fanout=args.fanout)
+            return cmd_research(
+                args.prompt, fanout=args.fanout, plan_only=args.plan_only
+            )
         if args.ai_kind == "speak":
             return cmd_speak(
                 args.text,
@@ -471,6 +491,31 @@ def dispatch(args: argparse.Namespace) -> int:
     return 2
 
 
+def _inject_bare_fanout_default(argv: list[str]) -> list[str]:
+    """Turn bare ``--fanout`` into ``--fanout 4`` so the prompt is not eaten."""
+    out: list[str] = []
+    i = 0
+    while i < len(argv):
+        a = argv[i]
+        if a == "--fanout":
+            out.append(a)
+            nxt = argv[i + 1] if i + 1 < len(argv) else None
+            if nxt is not None and not nxt.startswith("-"):
+                try:
+                    int(nxt)
+                except ValueError:
+                    out.append("4")
+                else:
+                    out.append(nxt)
+                    i += 1
+            else:
+                out.append("4")
+        else:
+            out.append(a)
+        i += 1
+    return out
+
+
 def main(argv: list[str] | None = None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
     if len(argv) >= 2 and argv[0] == "ai" and "-h" not in argv and "--help" not in argv:
@@ -498,6 +543,8 @@ def main(argv: list[str] | None = None) -> int:
             if a.out:
                 rest.extend(["-o", a.out])
             return cmd_audio(a.model, rest)
+    if len(argv) >= 2 and argv[0] == "ai" and argv[1] == "research":
+        argv = _inject_bare_fanout_default(argv)
     parser = build_parser()
     args = parser.parse_args(argv)
     return dispatch(args)

--- a/apps/n0b/cli.py
+++ b/apps/n0b/cli.py
@@ -159,7 +159,31 @@ def build_parser() -> argparse.ArgumentParser:
 
     ai_p = sub.add_parser("ai", help="AI generation and research")
     ai_sub = ai_p.add_subparsers(dest="ai_kind", required=True)
-    ai_research = ai_sub.add_parser("research", help="Deep research via gpt-5.6-sol")
+    ai_research = ai_sub.add_parser(
+        "research",
+        help="Deep research via gpt-5.6-sol",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=(
+            "OpenAI deep research (gpt-5.6-sol + web_search_preview). "
+            "Default is a single background job. --fanout N decomposes the "
+            "prompt into N complementary sub-questions, runs them in parallel, "
+            "and writes a merged brief under .files/research/fanout-<hash>/."
+        ),
+        epilog=(
+            "examples:\n"
+            "  n0b ai research what is X\n"
+            "  n0b ai research --fanout 3 what is X\n"
+            "\n"
+            "Put --fanout before the prompt (prompt is argparse REMAINDER). "
+            "Fanout costs roughly N times a single run — see apps/n0b/docs/research.md."
+        ),
+    )
+    ai_research.add_argument(
+        "--fanout",
+        type=int,
+        metavar="N",
+        help="Decompose into N complementary research jobs and merge (prototype)",
+    )
     ai_research.add_argument("prompt", nargs=argparse.REMAINDER)
     ai_speak = ai_sub.add_parser(
         "speak",
@@ -389,7 +413,7 @@ def dispatch(args: argparse.Namespace) -> int:
             return cmd_sub(rest)
     if group == "ai":
         if args.ai_kind == "research":
-            return cmd_research(args.prompt)
+            return cmd_research(args.prompt, fanout=args.fanout)
         if args.ai_kind == "speak":
             return cmd_speak(
                 args.text,

--- a/apps/n0b/commands/ai_research_cmd.py
+++ b/apps/n0b/commands/ai_research_cmd.py
@@ -18,10 +18,14 @@ def cmd_research(
             file=sys.stderr,
         )
         return 2
-    # --fanout absent or 1 → single-shot path unchanged.
+    # --fanout absent or explicit 1 → single-shot path unchanged.
     if fanout is None or fanout == 1:
         if plan_only:
-            print('{"error": "--plan-only requires --fanout N with N>=2"}')
+            print(
+                '{"error": "--plan-only requires --fanout '
+                '(bare or N>=2)"}'
+            )
             return 1
         return run_research(args)
+    # fanout == FANOUT_AUTO (bare --fanout) → Stage 0 picks N.
     return run_research_fanout(args, fanout, plan_only=plan_only)

--- a/apps/n0b/commands/ai_research_cmd.py
+++ b/apps/n0b/commands/ai_research_cmd.py
@@ -6,13 +6,22 @@ import sys
 from research import run_research, run_research_fanout
 
 
-def cmd_research(args: list[str], fanout: int | None = None) -> int:
+def cmd_research(
+    args: list[str],
+    fanout: int | None = None,
+    *,
+    plan_only: bool = False,
+) -> int:
     if not args:
         print(
-            "Usage: n0b ai research [--fanout N] <prompt...>",
+            "Usage: n0b ai research [--fanout [N]] [--plan-only] <prompt...>",
             file=sys.stderr,
         )
         return 2
-    if fanout is not None:
-        return run_research_fanout(args, fanout)
-    return run_research(args)
+    # --fanout absent or 1 → single-shot path unchanged.
+    if fanout is None or fanout == 1:
+        if plan_only:
+            print('{"error": "--plan-only requires --fanout N with N>=2"}')
+            return 1
+        return run_research(args)
+    return run_research_fanout(args, fanout, plan_only=plan_only)

--- a/apps/n0b/commands/ai_research_cmd.py
+++ b/apps/n0b/commands/ai_research_cmd.py
@@ -3,11 +3,16 @@ from __future__ import annotations
 
 import sys
 
-from research import run_research
+from research import run_research, run_research_fanout
 
 
-def cmd_research(args: list[str]) -> int:
+def cmd_research(args: list[str], fanout: int | None = None) -> int:
     if not args:
-        print("Usage: n0b ai research <prompt...>", file=sys.stderr)
+        print(
+            "Usage: n0b ai research [--fanout N] <prompt...>",
+            file=sys.stderr,
+        )
         return 2
+    if fanout is not None:
+        return run_research_fanout(args, fanout)
     return run_research(args)

--- a/apps/n0b/docs/research.md
+++ b/apps/n0b/docs/research.md
@@ -15,11 +15,14 @@ CLI for OpenAI deep research via the Responses API (`gpt-5.6-sol`, with
 
 ```bash
 n0b ai research "Your research prompt here"
-n0b ai research --fanout 3 "Your research prompt here"
+n0b ai research --fanout 1 "Your research prompt here"   # same as single-shot
+n0b ai research --fanout "Your research prompt here"     # N=4
+n0b ai research --fanout 4 "Your research prompt here"
+n0b ai research --fanout 4 --plan-only "Your research prompt here"
 ```
 
 All arguments after `research` (and after any flags) are concatenated into a
-single prompt. Put `--fanout` before the prompt — the prompt is an argparse
+single prompt. Put flags before the prompt — the prompt is an argparse
 `REMAINDER`, so flags after the first word of the prompt are swallowed.
 
 ## How it works
@@ -31,33 +34,74 @@ single prompt. Put `--fanout` before the prompt — the prompt is an argparse
 5. Polls every 30 seconds until `completed` or `failed`.
 6. Final JSON on stdout (pipe to `jq`).
 
-## Fanout (prototype)
+## Fanout
 
-`--fanout N` buys breadth: one deep-research job answers one angle; N parallel
+`--fanout` buys breadth: one deep-research job answers one angle; N background
 jobs cover complementary dimensions and cross-check each other. Cost is roughly
-**N times a single run**, plus two cheap (`gpt-4.1-mini`) calls to decompose and
-merge. stderr prints job counts and a running cost estimate.
+**N times a single run**, plus cheap (`gpt-4.1-mini`) calls to plan, merge, and
+citation-check. stderr prints job counts and a running cost estimate.
 
-1. A cheap model call decomposes the prompt into exactly N complementary
-   sub-questions (distinct dimensions — mechanism, evidence, counter-evidence,
-   adoption, risks, alternatives — not paraphrases). Malformed JSON fails
-   cleanly instead of fanning out garbage.
-2. N background research jobs submit in parallel. Each job caches its submit
-   envelope under the run directory, so an interrupted run rejoins the same
-   in-flight ids on re-run.
-3. Jobs poll concurrently; per-job status goes to stderr as they resolve.
-4. Output lands in `.files/research/fanout-<hash>/`:
-   - `meta.json` — original prompt, N, sub-questions
-   - `job-1.json` … `job-N.json` — submit envelopes (rejoin cache)
-   - `report-01.md` … `report-NN.md` — one sub-report per sub-question
-   - `merged.md` — union of findings with per-claim `[report-NN.md | URL]`
-     attribution and an explicit **Conflicts** section
-5. The run directory path is printed on stdout.
+**Defaults and clamp:** `--fanout` absent or `--fanout 1` leaves the single-shot
+path unchanged. `--fanout` with no value defaults to **N=4**. N is clamped to
+**1–8** (stderr notes when clamping). Prefer `--plan-only` before spending.
 
-Single-shot (`n0b ai research <prompt>` with no `--fanout`) is unchanged.
+### Plan (avoid anchor collapse)
+
+Naively asking a model for N sub-questions collapses them onto the same anchor.
+Instead:
+
+1. One cheap call emits a **brief (≤200 words)** plus **12–16 candidate angles**
+   (each with `angle` + `seed_query`).
+2. Locally select N candidates by **MMR** (maximal marginal relevance) over
+   token-level Jaccard similarity on seed queries, **λ=0** (pure diversity).
+   Pure stdlib — no embeddings.
+3. Each selected sub-prompt carries: objective, output format, source guidance,
+   explicit boundaries (sibling angles this job does **not** cover), and a
+   restatement of the top-level goal.
+
+`--plan-only` stops after step 2: prints the brief and the N selected
+sub-questions (with seed queries) and **submits zero research jobs**.
+
+### Dispatch and resume
+
+Background mode returns a job id immediately, so dispatch is **N sequential
+POSTs**, then one poll loop over a **set** of jobs (no threads).
+`max_tool_calls` scales down as N rises so width does not multiply tool spend
+linearly on top of job count.
+
+Run state lives under `.files/research/fanout-<hash>/`:
+
+- `manifest.json` — brief, selected sub-questions, model, N, job ids, per-job state
+- `job-<i>.json` — submit envelope (keyed conceptually on
+  `sha256(question + fanout + model)`)
+- `job-<i>-result.json` — **persisted the moment a job completes** (OpenAI
+  retains background results ~10 minutes; a polled-but-unwritten result is
+  money burned)
+- `report-01.md` … — one sub-report per completed job
+- `merged.md` — merged brief
+
+An interrupted run **resumes** from `manifest.json`: rejoins live job ids and
+skips jobs already finished.
+
+### Partial merge and timeout
+
+Stuck background jobs are a documented failure mode. Each job has a ~**20 minute**
+timeout. Merge proceeds once **≥ ceil(N/2)** jobs are complete. The merged
+output states which sub-questions are missing and why (timed out / failed) so a
+partial brief is never mistaken for a complete one.
+
+### Merge
+
+One **serialized** cheap-model call over the completed sub-reports (not a fan-in
+of many). Citations are a **URL-normalized union with corroboration counts**.
+Claims are clustered across sub-reports. **Contradictions get their own section
+and are surfaced, never silently resolved** — both sides appear with attribution;
+the merge model is instructed not to pick a winner. A separate cheap
+**citation-check** pass verifies merged claims against sources in the
+sub-reports.
 
 ## Implementation
 
-- **CLI:** `n0b ai research` / `n0b ai research --fanout N`
+- **CLI:** `n0b ai research` / `n0b ai research --fanout [N]` / `--plan-only`
 - **Code:** `apps/n0b/research.py` (stdlib only)
-- **Model:** `gpt-5.6-sol` (research); `gpt-4.1-mini` (decompose / merge)
+- **Model:** `gpt-5.6-sol` (research); `gpt-4.1-mini` (plan / merge / citation-check)

--- a/apps/n0b/docs/research.md
+++ b/apps/n0b/docs/research.md
@@ -15,9 +15,12 @@ CLI for OpenAI deep research via the Responses API (`gpt-5.6-sol`, with
 
 ```bash
 n0b ai research "Your research prompt here"
+n0b ai research --fanout 3 "Your research prompt here"
 ```
 
-All arguments after `research` are concatenated into a single prompt.
+All arguments after `research` (and after any flags) are concatenated into a
+single prompt. Put `--fanout` before the prompt — the prompt is an argparse
+`REMAINDER`, so flags after the first word of the prompt are swallowed.
 
 ## How it works
 
@@ -28,8 +31,33 @@ All arguments after `research` are concatenated into a single prompt.
 5. Polls every 30 seconds until `completed` or `failed`.
 6. Final JSON on stdout (pipe to `jq`).
 
+## Fanout (prototype)
+
+`--fanout N` buys breadth: one deep-research job answers one angle; N parallel
+jobs cover complementary dimensions and cross-check each other. Cost is roughly
+**N times a single run**, plus two cheap (`gpt-4.1-mini`) calls to decompose and
+merge. stderr prints job counts and a running cost estimate.
+
+1. A cheap model call decomposes the prompt into exactly N complementary
+   sub-questions (distinct dimensions — mechanism, evidence, counter-evidence,
+   adoption, risks, alternatives — not paraphrases). Malformed JSON fails
+   cleanly instead of fanning out garbage.
+2. N background research jobs submit in parallel. Each job caches its submit
+   envelope under the run directory, so an interrupted run rejoins the same
+   in-flight ids on re-run.
+3. Jobs poll concurrently; per-job status goes to stderr as they resolve.
+4. Output lands in `.files/research/fanout-<hash>/`:
+   - `meta.json` — original prompt, N, sub-questions
+   - `job-1.json` … `job-N.json` — submit envelopes (rejoin cache)
+   - `report-01.md` … `report-NN.md` — one sub-report per sub-question
+   - `merged.md` — union of findings with per-claim `[report-NN.md | URL]`
+     attribution and an explicit **Conflicts** section
+5. The run directory path is printed on stdout.
+
+Single-shot (`n0b ai research <prompt>` with no `--fanout`) is unchanged.
+
 ## Implementation
 
-- **CLI:** `n0b ai research`
+- **CLI:** `n0b ai research` / `n0b ai research --fanout N`
 - **Code:** `apps/n0b/research.py` (stdlib only)
-- **Model:** `gpt-5.6-sol`
+- **Model:** `gpt-5.6-sol` (research); `gpt-4.1-mini` (decompose / merge)

--- a/apps/n0b/docs/research.md
+++ b/apps/n0b/docs/research.md
@@ -16,7 +16,7 @@ CLI for OpenAI deep research via the Responses API (`gpt-5.6-sol`, with
 ```bash
 n0b ai research "Your research prompt here"
 n0b ai research --fanout 1 "Your research prompt here"   # same as single-shot
-n0b ai research --fanout "Your research prompt here"     # N=4
+n0b ai research --fanout "Your research prompt here"     # Stage 0 picks N
 n0b ai research --fanout 4 "Your research prompt here"
 n0b ai research --fanout 4 --plan-only "Your research prompt here"
 ```
@@ -38,29 +38,52 @@ single prompt. Put flags before the prompt — the prompt is an argparse
 
 `--fanout` buys breadth: one deep-research job answers one angle; N background
 jobs cover complementary dimensions and cross-check each other. Cost is roughly
-**N times a single run**, plus cheap (`gpt-4.1-mini`) calls to plan, merge, and
-citation-check. stderr prints job counts and a running cost estimate.
+**N times a single run**, plus planner (`gpt-5.6-luna`) and merge (`gpt-5.6-sol`)
+calls. stderr prints which N was used (recommendation vs flag), job counts, an
+unverified research-job cost estimate, and a metrics block.
 
 **Defaults and clamp:** `--fanout` absent or `--fanout 1` leaves the single-shot
-path unchanged. `--fanout` with no value defaults to **N=4**. N is clamped to
-**1–8** (stderr notes when clamping). Prefer `--plan-only` before spending.
+path unchanged. Bare `--fanout` (no value) asks Stage 0 for
+`recommended_fanout` — a simple question can come back with `1` and submit
+**zero** fanout jobs. Explicit `--fanout N` always wins over the recommendation.
+N is clamped to **1–8** (stderr notes when clamping). Prefer `--plan-only`
+before spending.
+
+There is **no `--depth` flag and no recursion knob**. Fanout is one level, by
+design.
+
+### Models and cost
+
+| Role | Model | Pricing note |
+|------|-------|--------------|
+| Stage 0 decomposer, citation-check | `gpt-5.6-luna` | $1 / $6 per 1M input / output tokens |
+| Research jobs, compose, citation attach | `gpt-5.6-sol` | Per-job figure is an **unverified estimate** (not seeded from deprecated o3 / o4-mini deep-research tables) |
 
 ### Plan (avoid anchor collapse)
 
 Naively asking a model for N sub-questions collapses them onto the same anchor.
 Instead:
 
-1. One cheap call emits a **brief (≤200 words)** plus **12–16 candidate angles**
-   (each with `angle` + `seed_query`).
-2. Locally select N candidates by **MMR** (maximal marginal relevance) over
-   token-level Jaccard similarity on seed queries, **λ=0** (pure diversity).
-   Pure stdlib — no embeddings.
-3. Each selected sub-prompt carries: objective, output format, source guidance,
-   explicit boundaries (sibling angles this job does **not** cover), and a
-   restatement of the top-level goal.
+1. One planner call emits a **brief (≤200 words)**, **`recommended_fanout`**,
+   a **floor of 12 candidate angles** (each with `angle` + `seed_query`), and a
+   dedicated **`adversarial`** angle (contradiction-seeking).
+2. Locally select **N-1** candidates by **MMR** (maximal marginal relevance)
+   over token-level Jaccard on seed queries, **λ=0** (pure diversity). The
+   remaining slot is **reserved for the adversarial angle** and appended after
+   MMR — never competed. MMR cannot surface it: a skeptic's query is lexically
+   close to the topical query it attacks, so diversity selection rejects it.
+3. Each selected sub-prompt carries: a restatement of the **global objective**,
+   objective / output format / source guidance / boundaries, and **sibling
+   assignments** with an explicit instruction not to enter a sibling's scope
+   except to surface a contradiction with it.
 
-`--plan-only` stops after step 2: prints the brief and the N selected
-sub-questions (with seed queries) and **submits zero research jobs**.
+HyDE-style query expansion is permitted for retrieval inside a research job,
+but any generated pseudo-answer must be discarded and must never flow into
+results or the merge input.
+
+`--plan-only` stops after selection: prints the brief and the N selected
+sub-questions (with seed queries; adversarial tagged) and **submits zero
+research jobs**.
 
 ### Dispatch and resume
 
@@ -71,7 +94,8 @@ linearly on top of job count.
 
 Run state lives under `.files/research/fanout-<hash>/`:
 
-- `manifest.json` — brief, selected sub-questions, model, N, job ids, per-job state
+- `manifest.json` — brief, selected sub-questions, models, N, job ids, per-job
+  state, metrics
 - `job-<i>.json` — submit envelope (keyed conceptually on
   `sha256(question + fanout + model)`)
 - `job-<i>-result.json` — **persisted the moment a job completes** (OpenAI
@@ -86,22 +110,44 @@ skips jobs already finished.
 ### Partial merge and timeout
 
 Stuck background jobs are a documented failure mode. Each job has a ~**20 minute**
-timeout. Merge proceeds once **≥ ceil(N/2)** jobs are complete. The merged
-output states which sub-questions are missing and why (timed out / failed) so a
-partial brief is never mistaken for a complete one.
+timeout. Merge proceeds once **≥ ceil(0.67 × N)** jobs are complete (e.g. N=4
+needs 3). The merged output states which sub-questions are missing and why
+(timed out / failed) so a partial brief is never mistaken for a complete one.
 
 ### Merge
 
-One **serialized** cheap-model call over the completed sub-reports (not a fan-in
-of many). Citations are a **URL-normalized union with corroboration counts**.
-Claims are clustered across sub-reports. **Contradictions get their own section
-and are surfaced, never silently resolved** — both sides appear with attribution;
-the merge model is instructed not to pick a winner. A separate cheap
-**citation-check** pass verifies merged claims against sources in the
-sub-reports.
+**Composition and citation re-attachment are separate passes** (both on
+`gpt-5.6-sol`), not one call:
+
+1. **Compose** — cluster claims into prose; surface contradictions; name
+   missing sub-questions. No citation markers yet.
+2. **Attach citations** — claim-level citation unions over normalized URLs.
+   Normalization is conservative: do **not** collapse different document
+   revisions, separate filings, a primary source and a summary of it, or
+   similar-titled papers. When in doubt, keep them separate.
+3. **Citation-check** (`gpt-5.6-luna`) — per claim: URL present/resolves,
+   correct document, actually supports the claim, numerics/dates match, no
+   citations inherited from a neighbour, conflicts still preserved.
+
+**Contradictions** get their own section. Each side is phrased with an
+observation date — "A reports X as of \<date\>" — so a disagreement that is
+really a staleness gap is visible as one. Both sides are surfaced; the merge
+never picks a winner.
+
+### Metrics
+
+At the end of a fanout run, stderr prints (and the manifest stores):
+
+- **mean QPD** (queries per document) — warn when it drops below **0.4**
+- **citation overlap ratio** across sub-reports
+- **count of unique authoritative domains**
+- **contradiction count**
+- **total cost** — actual where the API reported usage, unverified estimate
+  where it did not (labelled)
 
 ## Implementation
 
 - **CLI:** `n0b ai research` / `n0b ai research --fanout [N]` / `--plan-only`
 - **Code:** `apps/n0b/research.py` (stdlib only)
-- **Model:** `gpt-5.6-sol` (research); `gpt-4.1-mini` (plan / merge / citation-check)
+- **Models:** `gpt-5.6-sol` (research / compose / attach); `gpt-5.6-luna`
+  (Stage 0 / citation-check)

--- a/apps/n0b/research.py
+++ b/apps/n0b/research.py
@@ -1,7 +1,7 @@
 """OpenAI deep research via the Responses API (stdlib only).
 
-Uses ``gpt-5.6-sol`` (OpenAI's replacement after ``o4-mini-deep-research``
-shut down 2026-07-23).
+Uses ``gpt-5.6-sol`` for research jobs and merge; ``gpt-5.6-luna`` for
+Stage 0 planning and the citation-check pass.
 """
 from __future__ import annotations
 
@@ -20,21 +20,21 @@ from commands.secrets_cmd import resolve
 from paths import BIN_ROOT
 
 RESEARCH_MODEL = "gpt-5.6-sol"
-CHEAP_MODEL = "gpt-4.1-mini"
+PLANNER_MODEL = "gpt-5.6-luna"
 POLL_INTERVAL_S = 30
 JOB_TIMEOUT_S = 20 * 60
 FANOUT_MIN = 1
 FANOUT_MAX = 8
-FANOUT_DEFAULT_N = 4
-CANDIDATE_MIN = 12
-CANDIDATE_MAX = 16
-# Rough per-job estimate until a completed response carries usage.
-EST_RESEARCH_JOB_USD = 0.50
-# Rough gpt-4.1-mini $/1M tokens (estimate; labeled as such in stderr).
-EST_CHEAP_INPUT_PER_M = 0.40
-EST_CHEAP_OUTPUT_PER_M = 1.60
-# Base tool budget for a single research job; scaled down as N rises.
+FANOUT_AUTO = 0
+CANDIDATE_FLOOR = 12
+# gpt-5.6-luna $/1M tokens.
+EST_PLANNER_INPUT_PER_M = 1.0
+EST_PLANNER_OUTPUT_PER_M = 6.0
+# Unverified: no published per-job figure for gpt-5.6-sol deep research.
+# Do not seed from deprecated o3 / o4-mini deep-research price tables.
+UNVERIFIED_EST_RESEARCH_JOB_USD = 0.50
 BASE_MAX_TOOL_CALLS = 50
+QPD_WARN_THRESHOLD = 0.4
 
 
 def _get_hash(prompt: str) -> str:
@@ -62,6 +62,10 @@ def _max_tool_calls(n: int) -> int:
 def _clamp_fanout(n: int) -> tuple[int, bool]:
     clamped = max(FANOUT_MIN, min(FANOUT_MAX, n))
     return clamped, clamped != n
+
+
+def _merge_quorum(n: int) -> int:
+    return math.ceil(0.67 * n)
 
 
 def _call_openai(
@@ -105,14 +109,14 @@ def _check_status(api_key: str, response_id: str) -> dict:
         return {"error": str(e)}
 
 
-def _call_cheap(api_key: str, prompt: str) -> dict:
+def _call_model(api_key: str, model: str, prompt: str) -> dict:
     url = "https://api.openai.com/v1/responses"
     headers = {
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",
     }
     data = {
-        "model": CHEAP_MODEL,
+        "model": model,
         "input": prompt,
     }
     req = urllib.request.Request(
@@ -126,6 +130,14 @@ def _call_cheap(api_key: str, prompt: str) -> dict:
         return {"error": f"HTTP Error {e.code}: {body}"}
     except OSError as e:
         return {"error": str(e)}
+
+
+def _call_planner(api_key: str, prompt: str) -> dict:
+    return _call_model(api_key, PLANNER_MODEL, prompt)
+
+
+def _call_sol_text(api_key: str, prompt: str) -> dict:
+    return _call_model(api_key, RESEARCH_MODEL, prompt)
 
 
 def _output_text(response_data: dict) -> str:
@@ -160,10 +172,10 @@ def _usage_tokens(response_data: dict) -> tuple[int, int]:
     return inp, out
 
 
-def _est_cheap_usd(input_tokens: int, output_tokens: int) -> float:
+def _est_planner_usd(input_tokens: int, output_tokens: int) -> float:
     return (
-        input_tokens * EST_CHEAP_INPUT_PER_M / 1_000_000
-        + output_tokens * EST_CHEAP_OUTPUT_PER_M / 1_000_000
+        input_tokens * EST_PLANNER_INPUT_PER_M / 1_000_000
+        + output_tokens * EST_PLANNER_OUTPUT_PER_M / 1_000_000
     )
 
 
@@ -180,6 +192,13 @@ def _extract_urls(text: str) -> list[str]:
 
 
 def _normalize_url(url: str) -> str:
+    """Conservative URL key for citation unions.
+
+    Lowercases scheme/host and drops trailing slashes / empty fragments only.
+    Keeps path, query (incl. rev/version), and distinct paths so revisions,
+    filings, and primary-vs-summary URLs stay separate. Over-merging citations
+    hides independent corroboration.
+    """
     try:
         p = urllib.parse.urlparse(url.strip())
     except ValueError:
@@ -191,6 +210,7 @@ def _normalize_url(url: str) -> str:
     path = p.path or ""
     if path != "/" and path.endswith("/"):
         path = path.rstrip("/")
+    # Keep all query params (sorted for stable keys); never drop rev/version.
     query = urllib.parse.urlencode(
         sorted(urllib.parse.parse_qsl(p.query, keep_blank_values=True))
     )
@@ -264,7 +284,6 @@ def mmr_select(
     selected: list[int] = []
     remaining = list(range(len(candidates)))
 
-    # Seed with the first candidate (stable order) then diversify.
     selected.append(remaining.pop(0))
 
     while len(selected) < n and remaining:
@@ -272,7 +291,6 @@ def mmr_select(
         best_score = float("-inf")
         for i in remaining:
             toks = tokenized[i]
-            # Relevance term unused at λ=0; keep the shape for clarity.
             relevance = 1.0
             max_sim = max(_jaccard(toks, tokenized[j]) for j in selected)
             score = lambda_ * relevance - (1.0 - lambda_) * max_sim
@@ -285,81 +303,152 @@ def mmr_select(
     return [candidates[i] for i in selected]
 
 
+def select_with_adversarial(
+    candidates: list[dict], adversarial: dict, n: int
+) -> list[dict]:
+    """Select N-1 topical angles by MMR; always append the adversarial slot.
+
+    MMR rejects a skeptic's query because it is lexically close to the topical
+    query it attacks — so the adversarial angle is reserved, never competed.
+    """
+    if n <= 0:
+        return []
+    if n == 1:
+        return [adversarial]
+    topical_n = n - 1
+    # Drop candidates that are the same angle label as the adversarial slot.
+    adv_angle = str(adversarial.get("angle") or "").strip().lower()
+    pool = [
+        c
+        for c in candidates
+        if str(c.get("angle") or "").strip().lower() != adv_angle
+    ]
+    topical = mmr_select(pool if pool else candidates, topical_n, lambda_=0.0)
+    return topical + [adversarial]
+
+
 def _build_sub_prompt(
     goal: str, brief: str, selected: dict, all_selected: list[dict]
 ) -> str:
     angle = str(selected.get("angle") or "").strip()
     seed = str(selected.get("seed_query") or angle).strip()
-    others = [
+    siblings = [
         str(o.get("angle") or "").strip()
         for o in all_selected
         if o is not selected and str(o.get("angle") or "").strip()
     ]
-    boundaries = (
-        "Do NOT cover these sibling angles (other sub-jobs own them):\n"
-        + "\n".join(f"- {o}" for o in others)
-        if others
-        else "Stay tightly scoped to this angle only."
-    )
+    if siblings:
+        sibling_block = (
+            "Sibling assignments (other sub-jobs own these scopes):\n"
+            + "\n".join(f"- {o}" for o in siblings)
+            + "\nDo not enter a sibling's scope except to surface a "
+            "contradiction with it."
+        )
+    else:
+        sibling_block = "Stay tightly scoped to this angle only."
     return (
-        f"## Top-level research goal\n{goal}\n\n"
+        f"## Global objective\n{goal}\n\n"
         f"## Shared brief\n{brief}\n\n"
         f"## Your objective\n"
         f"Research this angle only: {angle}\n"
         f"Seed query / search focus: {seed}\n\n"
         f"## Output format\n"
         "Markdown brief with: short summary, numbered findings with inline "
-        "source URLs, and a Sources list. Every claim needs a URL.\n\n"
+        "source URLs (include observation dates when the source states them), "
+        "and a Sources list. Every claim needs a URL.\n\n"
         f"## Source guidance\n"
         "Prefer primary sources, peer-reviewed work, official docs, and "
         "high-signal reporting. Note date and provenance when relevant.\n\n"
-        f"## Boundaries (what this sub-question does NOT cover)\n"
-        f"{boundaries}\n"
+        f"## Boundaries\n"
+        f"{sibling_block}\n"
     )
+
+
+def _clean_angle(c: dict) -> dict | None:
+    if not isinstance(c, dict):
+        return None
+    angle = c.get("angle")
+    seed = c.get("seed_query") or angle
+    if isinstance(angle, str) and angle.strip() and isinstance(seed, str) and seed.strip():
+        return {"angle": angle.strip(), "seed_query": seed.strip()}
+    return None
 
 
 def _brief_and_candidates(
     api_key: str, prompt: str
-) -> tuple[str | None, list[dict] | None, str, dict]:
+) -> tuple[str | None, list[dict] | None, dict | None, int | None, str, dict]:
+    """Stage 0: brief, >=12 candidates, adversarial slot, recommended_fanout."""
     decompose_prompt = (
         "You are planning a multi-angle deep-research run.\n"
         "Given the research question below, return ONLY a JSON object with:\n"
         '  "brief": a planning brief of at most 200 words,\n'
-        f'  "candidates": an array of {CANDIDATE_MIN}-{CANDIDATE_MAX} objects, '
+        '  "recommended_fanout": an integer in [1, 8] for how many parallel '
+        "angles this question warrants (use 1 for simple factual questions "
+        "that need no fanout),\n"
+        f'  "candidates": an array of at least {CANDIDATE_FLOOR} objects, '
         'each with "angle" (short label) and "seed_query" (search-oriented '
         "phrase). Candidates must cover DISTINCT dimensions — not paraphrases "
-        "of the same anchor.\n\n"
+        "of the same anchor,\n"
+        '  "adversarial": one object with "angle" and "seed_query" that '
+        "actively seeks contradictions, counter-evidence, or reasons the "
+        "main thesis may be wrong. This is reserved separately from "
+        "candidates and must not be omitted.\n\n"
         f"Question:\n{prompt}"
     )
-    resp = _call_cheap(api_key, decompose_prompt)
+    resp = _call_planner(api_key, decompose_prompt)
     if resp.get("error"):
-        return None, None, f"decompose failed: {resp['error']}", resp
+        return None, None, None, None, f"decompose failed: {resp['error']}", resp
     text = _output_text(resp)
     parsed = _parse_json_obj(text)
     if not isinstance(parsed, dict):
-        return None, None, f"decompose did not return a JSON object (got: {text[:200]!r})", resp
-    brief = parsed.get("brief")
-    candidates = parsed.get("candidates")
-    if not isinstance(brief, str) or not brief.strip():
-        return None, None, "decompose brief must be a non-empty string", resp
-    if not isinstance(candidates, list):
-        return None, None, "decompose candidates must be a list", resp
-    cleaned: list[dict] = []
-    for c in candidates:
-        if not isinstance(c, dict):
-            continue
-        angle = c.get("angle")
-        seed = c.get("seed_query") or angle
-        if isinstance(angle, str) and angle.strip() and isinstance(seed, str) and seed.strip():
-            cleaned.append({"angle": angle.strip(), "seed_query": seed.strip()})
-    if len(cleaned) < CANDIDATE_MIN:
         return (
             None,
             None,
-            f"decompose returned {len(cleaned)} usable candidates, need >= {CANDIDATE_MIN}",
+            None,
+            None,
+            f"decompose did not return a JSON object (got: {text[:200]!r})",
             resp,
         )
-    return brief.strip(), cleaned[:CANDIDATE_MAX], "", resp
+    brief = parsed.get("brief")
+    candidates = parsed.get("candidates")
+    adv_raw = parsed.get("adversarial")
+    rec = parsed.get("recommended_fanout")
+    if not isinstance(brief, str) or not brief.strip():
+        return None, None, None, None, "decompose brief must be a non-empty string", resp
+    if not isinstance(candidates, list):
+        return None, None, None, None, "decompose candidates must be a list", resp
+    adversarial = _clean_angle(adv_raw) if isinstance(adv_raw, dict) else None
+    if adversarial is None:
+        return None, None, None, None, "decompose adversarial must be an angle object", resp
+    cleaned: list[dict] = []
+    for c in candidates:
+        item = _clean_angle(c)
+        if item is not None:
+            cleaned.append(item)
+    if len(cleaned) < CANDIDATE_FLOOR:
+        return (
+            None,
+            None,
+            None,
+            None,
+            f"decompose returned {len(cleaned)} usable candidates, "
+            f"need >= {CANDIDATE_FLOOR}",
+            resp,
+        )
+    if not isinstance(rec, int) or isinstance(rec, bool):
+        try:
+            rec = int(rec)
+        except (TypeError, ValueError):
+            return (
+                None,
+                None,
+                None,
+                None,
+                "decompose recommended_fanout must be an integer",
+                resp,
+            )
+    rec, _ = _clamp_fanout(rec)
+    return brief.strip(), cleaned, adversarial, rec, "", resp
 
 
 def _citation_union(reports: list[tuple[str, str, list[str]]]) -> list[dict]:
@@ -367,20 +456,23 @@ def _citation_union(reports: list[tuple[str, str, list[str]]]) -> list[dict]:
     for i, (_q, _body, urls) in enumerate(reports, start=1):
         for u in urls:
             norm = _normalize_url(u)
-            entry = counts.setdefault(norm, {"url": norm, "count": 0, "reports": []})
+            entry = counts.setdefault(
+                norm, {"url": u.strip(), "norm": norm, "count": 0, "reports": []}
+            )
             entry["count"] += 1
             label = f"report-{i:02d}.md"
             if label not in entry["reports"]:
                 entry["reports"].append(label)
-    return sorted(counts.values(), key=lambda e: (-e["count"], e["url"]))
+    return sorted(counts.values(), key=lambda e: (-e["count"], e["norm"]))
 
 
-def _merge_reports(
+def _compose_reports(
     api_key: str,
     prompt: str,
     reports: list[tuple[int, str, str, list[str]]],
     missing: list[dict],
 ) -> tuple[str | None, str, dict]:
+    """Pass 1: compose prose only — no citation re-attachment yet."""
     blocks: list[str] = []
     for i, question, body, urls in reports:
         url_lines = "\n".join(f"- {u}" for u in urls) or "- (none extracted)"
@@ -405,38 +497,80 @@ def _merge_reports(
             + "\n".join(lines)
             + "\n"
         )
-    citation_rows = _citation_union([(q, b, u) for _, q, b, u in reports])
-    cite_lines = "\n".join(
-        f"- {c['url']} (corroboration={c['count']}; {', '.join(c['reports'])})"
-        for c in citation_rows
-    ) or "- (none)"
-
-    merge_prompt = (
-        "Merge the completed sub-reports below into ONE markdown research brief.\n"
+    compose_prompt = (
+        "Compose ONE markdown research brief from the completed sub-reports.\n"
+        "This is the COMPOSITION pass only — do NOT attach citation markers "
+        "yet; a later pass will re-attach them.\n"
         "Requirements:\n"
-        "1. Cluster related claims across sub-reports. Every claim must have "
-        "per-claim source attribution of the form [report-NN.md | URL].\n"
-        "2. Include ## Citations with the URL-normalized union below, preserving "
-        "corroboration counts (how many sub-reports independently cite each URL).\n"
-        "3. Include ## Contradictions listing every point where sub-reports "
+        "1. Cluster related claims across sub-reports into coherent prose.\n"
+        "2. Include ## Contradictions listing every point where sub-reports "
         "disagree. SURFACING is mandatory — do NOT pick a winner, reconcile, "
-        "or silently drop either side. Attribute both sides "
-        "[report-NN.md | URL].\n"
-        "4. If any sub-questions are missing, include ## Missing sub-questions "
+        "or silently drop either side. Phrase each side with its observation "
+        "date: 'A reports X as of <date>' / 'B reports Y as of <date>' so a "
+        "staleness gap is visible as one. If a side gives no date, write "
+        "'as of (undated)'.\n"
+        "3. If any sub-questions are missing, include ## Missing sub-questions "
         "naming each and the reason (timed out / failed).\n"
-        "5. Start with # Merged research and a short ## Summary.\n"
-        "6. Output markdown only. One merge pass — do not invent sources.\n\n"
-        f"Original question:\n{prompt}\n\n"
-        f"Citation union (normalized):\n{cite_lines}\n"
+        "4. Start with # Merged research and a short ## Summary.\n"
+        "5. Output markdown only. Do not invent sources or resolve conflicts.\n\n"
+        f"Original question:\n{prompt}\n"
         f"{missing_block}\n"
         + "\n".join(blocks)
     )
-    resp = _call_cheap(api_key, merge_prompt)
+    resp = _call_sol_text(api_key, compose_prompt)
     if resp.get("error"):
-        return None, f"merge failed: {resp['error']}", resp
+        return None, f"compose failed: {resp['error']}", resp
     text = _output_text(resp).strip()
     if not text:
-        return None, "merge returned empty text", resp
+        return None, "compose returned empty text", resp
+    return text, "", resp
+
+
+def _attach_citations(
+    api_key: str,
+    composed: str,
+    reports: list[tuple[int, str, str, list[str]]],
+) -> tuple[str | None, str, dict]:
+    """Pass 2: re-attach per-claim citations; separate from composition."""
+    citation_rows = _citation_union([(q, b, u) for _, q, b, u in reports])
+    cite_lines = "\n".join(
+        f"- {c['url']} (norm={c['norm']}; corroboration={c['count']}; "
+        f"{', '.join(c['reports'])})"
+        for c in citation_rows
+    ) or "- (none)"
+    report_blobs = []
+    for i, question, body, urls in reports:
+        report_blobs.append(
+            f"report-{i:02d}.md | {question}\n"
+            f"URLs: {', '.join(urls) if urls else '(none)'}\n"
+            f"Excerpt:\n{body[:2000]}\n"
+        )
+    attach_prompt = (
+        "Citation re-attachment pass. The composed brief below has NO "
+        "citation markers yet. Attach per-claim source attribution of the "
+        "form [report-NN.md | URL], using the citation union and sub-reports.\n"
+        "Rules:\n"
+        "1. Claim-level citation unions over normalized URLs — but do NOT "
+        "collapse distinct sources: different document revisions, separate "
+        "filings, a primary source and a summary of it, or similar-titled "
+        "papers must stay separate. When in doubt, keep them separate.\n"
+        "2. Include ## Citations with the URL union below, preserving "
+        "corroboration counts.\n"
+        "3. Preserve ## Contradictions exactly (including per-side "
+        "'as of <date>' phrasing); only add citation markers, never smooth "
+        "disagreement away.\n"
+        "4. Output the full markdown brief with citations attached. "
+        "Do not invent sources.\n\n"
+        f"Composed brief:\n{composed}\n\n"
+        f"Citation union:\n{cite_lines}\n\n"
+        "Sub-reports:\n" + "\n".join(report_blobs)
+    )
+    resp = _call_sol_text(api_key, attach_prompt)
+    if resp.get("error"):
+        return None, f"citation attach failed: {resp['error']}", resp
+    text = _output_text(resp).strip()
+    if not text:
+        return None, "citation attach returned empty text", resp
     return text, "", resp
 
 
@@ -451,16 +585,21 @@ def _citation_check(
             f"Excerpt:\n{body[:1500]}\n"
         )
     check_prompt = (
-        "Citation check pass. Given the merged brief and the sub-reports, "
-        "verify each claim in the merged brief actually traces to a cited "
-        "source present in the sub-reports. Return markdown:\n"
+        "Citation check pass. For each claim in the merged brief, verify:\n"
+        "1. The cited URL resolves (or is present in the sub-report sources).\n"
+        "2. It is the correct document for that claim (not a neighbour's).\n"
+        "3. The document actually supports the adjacent claim.\n"
+        "4. Numerics and dates in the claim match the source.\n"
+        "5. No citations were inherited from a neighbouring claim.\n"
+        "6. Conflicts / contradictions are still preserved, not smoothed away.\n"
+        "Return markdown:\n"
         "## Citation check\n"
         "- OK / WEAK / MISSING lines per claim (brief).\n"
         "Do not rewrite the brief. Do not resolve contradictions.\n\n"
         f"Merged brief:\n{merged}\n\n"
         "Sub-reports:\n" + "\n".join(report_blobs)
     )
-    resp = _call_cheap(api_key, check_prompt)
+    resp = _call_planner(api_key, check_prompt)
     if resp.get("error"):
         return None, f"citation check failed: {resp['error']}", resp
     text = _output_text(resp).strip()
@@ -500,6 +639,107 @@ def _save_manifest(path: Path, manifest: dict) -> None:
 
 def _save_job(path: Path, payload: dict) -> None:
     path.write_text(json.dumps(payload, indent=2) + "\n")
+
+
+def _count_web_queries(data: dict) -> int:
+    n = 0
+    for item in data.get("output") or []:
+        if not isinstance(item, dict):
+            continue
+        t = str(item.get("type") or "")
+        if "web_search" in t:
+            n += 1
+            continue
+        if t == "message":
+            for block in item.get("content") or []:
+                if isinstance(block, dict) and "web_search" in str(
+                    block.get("type") or ""
+                ):
+                    n += 1
+    return n
+
+
+def _domain_of(url: str) -> str:
+    try:
+        netloc = urllib.parse.urlparse(url).netloc.lower()
+    except ValueError:
+        return ""
+    if netloc.startswith("www."):
+        netloc = netloc[4:]
+    return netloc
+
+
+def _mean_qpd(
+    completed_data: list[dict], url_lists: list[list[str]]
+) -> float:
+    total_q = 0
+    total_d = 0
+    for data, urls in zip(completed_data, url_lists):
+        total_q += _count_web_queries(data)
+        total_d += len({_normalize_url(u) for u in urls})
+    if total_d == 0:
+        return 0.0
+    return total_q / total_d
+
+
+def _citation_overlap_ratio(url_lists: list[list[str]]) -> float:
+    sets = [{_normalize_url(u) for u in urls} for urls in url_lists]
+    if len(sets) < 2:
+        return 0.0
+    total = 0.0
+    pairs = 0
+    for i in range(len(sets)):
+        for j in range(i + 1, len(sets)):
+            total += _jaccard(sets[i], sets[j])
+            pairs += 1
+    return total / pairs if pairs else 0.0
+
+
+def _unique_domains(url_lists: list[list[str]]) -> int:
+    domains: set[str] = set()
+    for urls in url_lists:
+        for u in urls:
+            d = _domain_of(u)
+            if d:
+                domains.add(d)
+    return len(domains)
+
+
+def _count_contradictions(merged: str) -> int:
+    if "## Contradictions" not in merged:
+        return 0
+    section = merged.split("## Contradictions", 1)[1]
+    next_h = re.search(r"\n##\s+", section)
+    if next_h:
+        section = section[: next_h.start()]
+    count = 0
+    for line in section.splitlines():
+        s = line.strip()
+        if not s.startswith("-"):
+            continue
+        body = s.lstrip("-").strip().lower()
+        if not body or body.startswith("none"):
+            continue
+        count += 1
+    return count
+
+
+def _format_metrics(metrics: dict) -> str:
+    lines = [
+        "--- fanout metrics ---",
+        f"mean QPD: {metrics['mean_qpd']:.3f}",
+        f"citation overlap ratio: {metrics['citation_overlap_ratio']:.3f}",
+        f"unique authoritative domains: {metrics['unique_domains']}",
+        f"contradiction count: {metrics['contradiction_count']}",
+        f"total cost: {metrics['total_cost_label']}",
+    ]
+    if metrics.get("qpd_warning"):
+        lines.append(
+            f"WARNING: mean QPD {metrics['mean_qpd']:.3f} "
+            f"< {QPD_WARN_THRESHOLD} (retrieval-efficiency gate)"
+        )
+    lines.append("---")
+    return "\n".join(lines) + "\n"
 
 
 def run_research(prompt_parts: list[str]) -> int:
@@ -543,29 +783,9 @@ def run_research(prompt_parts: list[str]) -> int:
         time.sleep(30)
 
 
-def _plan_fanout(
-    api_key: str, prompt: str, n: int
-) -> tuple[str | None, list[dict] | None, list[str] | None, float, str]:
-    """Decompose + MMR select. Returns brief, selected, sub_prompts, cheap_cost, err."""
-    brief, candidates, err, decomp_resp = _brief_and_candidates(api_key, prompt)
-    if brief is None or candidates is None:
-        return None, None, None, 0.0, err
-    inp, out = _usage_tokens(decomp_resp)
-    cheap_cost = _est_cheap_usd(inp, out)
-    selected = mmr_select(candidates, n, lambda_=0.0)
-    if len(selected) < n:
-        return (
-            None,
-            None,
-            None,
-            cheap_cost,
-            f"MMR selected {len(selected)} candidates, need {n}",
-        )
-    sub_prompts = [_build_sub_prompt(prompt, brief, s, selected) for s in selected]
-    return brief, selected, sub_prompts, cheap_cost, ""
-
-
-def run_research_plan_only(prompt_parts: list[str], n: int) -> int:
+def run_research_plan_only(
+    prompt_parts: list[str], n: int, *, n_source: str = "flag"
+) -> int:
     api_key = resolve("OPENAI_API_KEY")
     if not api_key:
         print(json.dumps({"error": "OPENAI_API_KEY not found (try: n0b secrets set OPENAI_API_KEY)"}))
@@ -574,27 +794,67 @@ def run_research_plan_only(prompt_parts: list[str], n: int) -> int:
         print(json.dumps({"error": "No prompt provided"}))
         return 1
 
-    n, was_clamped = _clamp_fanout(n)
-    if was_clamped:
-        sys.stderr.write(f"Clamped --fanout to {n} (allowed {FANOUT_MIN}-{FANOUT_MAX})\n")
-
     prompt = " ".join(prompt_parts)
-    brief, selected, _sub_prompts, cheap_cost, err = _plan_fanout(api_key, prompt, n)
-    if brief is None or selected is None:
+    auto = n == FANOUT_AUTO
+    if not auto:
+        n, was_clamped = _clamp_fanout(n)
+        if was_clamped:
+            sys.stderr.write(
+                f"Clamped --fanout to {n} (allowed {FANOUT_MIN}-{FANOUT_MAX})\n"
+            )
+
+    brief, candidates, adversarial, recommended, err, decomp_resp = (
+        _brief_and_candidates(api_key, prompt)
+    )
+    if brief is None or candidates is None or adversarial is None or recommended is None:
         print(json.dumps({"error": err}))
         return 1
+    inp, out = _usage_tokens(decomp_resp)
+    planner_cost = _est_planner_usd(inp, out)
 
+    if auto:
+        n = recommended
+        n_source = "recommendation"
+        sys.stderr.write(
+            f"Using fanout N={n} (from Stage 0 recommendation)\n"
+        )
+    else:
+        sys.stderr.write(
+            f"Using fanout N={n} (from --fanout flag"
+            f"; Stage 0 recommended {recommended})\n"
+        )
+
+    if n <= 1:
+        sys.stderr.write(
+            "recommended/selected N=1 — no fanout jobs; plan-only exits "
+            "without submitting research.\n"
+        )
+        print(f"# Research plan (N=1, single-shot)\n")
+        print("## Brief\n")
+        print(brief)
+        print()
+        print("## Selected sub-questions\n")
+        print("(none — N=1 uses the single-shot path)\n")
+        print("## Adversarial (reserved, unused at N=1)\n")
+        print(f"- {adversarial['angle']}")
+        print(f"  seed_query: {adversarial['seed_query']}")
+        return 0
+
+    selected = select_with_adversarial(candidates, adversarial, n)
     sys.stderr.write(
-        f"Plan-only: {n} sub-questions selected from {CANDIDATE_MIN}+ candidates "
-        f"(cheap-call estimate ${cheap_cost:.4f}); no research jobs submitted.\n"
+        f"Plan-only: {n} sub-questions "
+        f"({n - 1} MMR + 1 reserved adversarial) from "
+        f">={CANDIDATE_FLOOR} candidates "
+        f"(planner estimate ${planner_cost:.4f}); no research jobs submitted.\n"
     )
-    print(f"# Research plan (N={n})\n")
+    print(f"# Research plan (N={n}, source={n_source})\n")
     print("## Brief\n")
     print(brief)
     print()
     print("## Selected sub-questions\n")
     for i, s in enumerate(selected, start=1):
-        print(f"{i}. {s['angle']}")
+        tag = " [adversarial]" if s is selected[-1] else ""
+        print(f"{i}. {s['angle']}{tag}")
         print(f"   seed_query: {s['seed_query']}")
     return 0
 
@@ -607,23 +867,23 @@ def _poll_set(
     manifest_path: Path,
     *,
     timeout_s: float | None = None,
+    quorum: int | None = None,
 ) -> tuple[dict[int, dict], dict[int, str]]:
     """Poll a set of background jobs until quorum or all settle.
 
-    ``jobs`` maps index -> job record with at least ``id``. Mutates manifest
-    job entries and persists each completion immediately (OpenAI retains
-    background results ~10 minutes).
+    Persists each completion immediately (OpenAI retains background results
+    ~10 minutes — deferred writes are a data-loss bug).
     """
     if timeout_s is None:
         timeout_s = float(JOB_TIMEOUT_S)
     n = len(jobs)
-    quorum = math.ceil(n / 2)
+    if quorum is None:
+        quorum = _merge_quorum(n)
     completed: dict[int, dict] = {}
     terminal: dict[int, str] = {}
     started_at = {i: time.monotonic() for i in jobs}
     pending = set(jobs)
 
-    # Already-finished jobs from a prior run (result on disk).
     for i in list(pending):
         job_meta = next(
             (j for j in manifest["jobs"] if j["index"] == i), None
@@ -702,7 +962,6 @@ def _poll_set(
         if not pending:
             break
 
-        # Once quorum is met, stop waiting on stragglers past their budget.
         if len(completed) >= quorum and all(
             (time.monotonic() - started_at[i]) >= timeout_s for i in pending
         ):
@@ -718,7 +977,6 @@ def _poll_set(
             _save_manifest(manifest_path, manifest)
             break
 
-        # If quorum already met, sleep only until the soonest job timeout.
         if len(completed) >= quorum:
             waits = [
                 max(0.0, timeout_s - (time.monotonic() - started_at[i]))
@@ -734,10 +992,17 @@ def _poll_set(
 
 
 def run_research_fanout(
-    prompt_parts: list[str], n: int, *, plan_only: bool = False
+    prompt_parts: list[str],
+    n: int,
+    *,
+    plan_only: bool = False,
+    n_source: str | None = None,
 ) -> int:
+    if n_source is None:
+        n_source = "recommendation" if n == FANOUT_AUTO else "flag"
+
     if plan_only:
-        return run_research_plan_only(prompt_parts, n)
+        return run_research_plan_only(prompt_parts, n, n_source=n_source)
 
     api_key = resolve("OPENAI_API_KEY")
     if not api_key:
@@ -747,21 +1012,24 @@ def run_research_fanout(
         print(json.dumps({"error": "No prompt provided"}))
         return 1
 
-    n, was_clamped = _clamp_fanout(n)
-    if was_clamped:
-        sys.stderr.write(f"Clamped --fanout to {n} (allowed {FANOUT_MIN}-{FANOUT_MAX})\n")
-    if n == 1:
-        return run_research(prompt_parts)
+    auto = n == FANOUT_AUTO
+    if not auto:
+        n, was_clamped = _clamp_fanout(n)
+        if was_clamped:
+            sys.stderr.write(
+                f"Clamped --fanout to {n} (allowed {FANOUT_MIN}-{FANOUT_MAX})\n"
+            )
+        if n == 1:
+            return run_research(prompt_parts)
 
     prompt = " ".join(prompt_parts)
     prompt_hash = _get_hash(prompt)
     run_dir = _research_cache_dir() / f"fanout-{prompt_hash}"
-    run_dir.mkdir(parents=True, exist_ok=True)
     manifest_path = run_dir / "manifest.json"
-    tool_budget = _max_tool_calls(n)
-    cheap_cost = 0.0
+    planner_cost = 0.0
 
-    if manifest_path.is_file():
+    if manifest_path.is_file() and not auto:
+        run_dir.mkdir(parents=True, exist_ok=True)
         manifest = json.loads(manifest_path.read_text())
         if int(manifest.get("n", 0)) != n:
             print(
@@ -782,37 +1050,89 @@ def run_research_fanout(
             f"Resuming fanout run at {run_dir} "
             f"({n} sub-questions from manifest)\n"
         )
+        sys.stderr.write(f"Using fanout N={n} (from --fanout flag)\n")
     else:
         sys.stderr.write(
-            f"Planning fanout: brief + {CANDIDATE_MIN}-{CANDIDATE_MAX} "
-            f"candidate angles, MMR-select {n}…\n"
+            f"Planning fanout: brief + >={CANDIDATE_FLOOR} candidate angles, "
+            f"MMR-select N-1 + reserved adversarial…\n"
         )
-        brief, selected, sub_prompts, cheap_cost, err = _plan_fanout(
-            api_key, prompt, n
+        brief, candidates, adversarial, recommended, err, decomp_resp = (
+            _brief_and_candidates(api_key, prompt)
         )
-        if brief is None or selected is None or sub_prompts is None:
+        if (
+            brief is None
+            or candidates is None
+            or adversarial is None
+            or recommended is None
+        ):
             print(json.dumps({"error": err}))
             return 1
+        inp, out = _usage_tokens(decomp_resp)
+        planner_cost += _est_planner_usd(inp, out)
+
+        if auto:
+            n = recommended
+            n_source = "recommendation"
+            sys.stderr.write(
+                f"Using fanout N={n} (from Stage 0 recommendation)\n"
+            )
+            if n <= 1:
+                sys.stderr.write(
+                    "Stage 0 recommended N=1 — falling through to single-shot "
+                    "(zero fanout jobs).\n"
+                )
+                return run_research(prompt_parts)
+        else:
+            sys.stderr.write(
+                f"Using fanout N={n} (from --fanout flag"
+                f"; Stage 0 recommended {recommended})\n"
+            )
+
+        tool_budget = _max_tool_calls(n)
+        selected = select_with_adversarial(candidates, adversarial, n)
+        if len(selected) < n:
+            print(
+                json.dumps(
+                    {
+                        "error": (
+                            f"selected {len(selected)} angles, need {n}"
+                        )
+                    }
+                )
+            )
+            return 1
+        sub_prompts = [
+            _build_sub_prompt(prompt, brief, s, selected) for s in selected
+        ]
         sys.stderr.write(
-            f"Plan ready (cheap-call estimate ${cheap_cost:.4f}); "
-            f"max_tool_calls={tool_budget} per job\n"
+            f"Plan ready (planner estimate ${planner_cost:.4f}); "
+            f"max_tool_calls={tool_budget} per job; "
+            f"{n - 1} MMR + 1 adversarial\n"
         )
         for i, s in enumerate(selected, start=1):
-            sys.stderr.write(f"  {i}. {s['angle']}  [{s['seed_query']}]\n")
+            tag = " [adversarial]" if i == n else ""
+            sys.stderr.write(
+                f"  {i}. {s['angle']}{tag}  [{s['seed_query']}]\n"
+            )
+        run_dir.mkdir(parents=True, exist_ok=True)
         manifest = {
             "prompt": prompt,
             "n": n,
+            "n_source": n_source,
+            "recommended_fanout": recommended,
             "model": RESEARCH_MODEL,
+            "planner_model": PLANNER_MODEL,
             "brief": brief,
             "selected": selected,
+            "adversarial": adversarial,
             "sub_prompts": sub_prompts,
             "max_tool_calls": tool_budget,
             "jobs": [],
         }
         _save_manifest(manifest_path, manifest)
 
-    # Sequential submit (background POSTs return immediately). Resume skips
-    # jobs that already have an id / completed result on disk.
+    tool_budget = int(manifest.get("max_tool_calls") or _max_tool_calls(n))
+
     job_records: dict[int, dict] = {}
     existing_jobs = {j["index"]: j for j in manifest.get("jobs") or []}
 
@@ -873,11 +1193,12 @@ def run_research_fanout(
         }
         sys.stderr.write(f"[job-{i}] submitted id={rid}\n")
 
-    manifest["jobs"] = [existing_jobs[i] for i in range(1, n + 1) if i in existing_jobs]
+    manifest["jobs"] = [
+        existing_jobs[i] for i in range(1, n + 1) if i in existing_jobs
+    ]
     _save_manifest(manifest_path, manifest)
 
     live = {i: rec for i, rec in job_records.items() if rec.get("id")}
-    # Include already-completed so poll_set can load them; exclude submit failures.
     for i, j in existing_jobs.items():
         if j.get("state") == "completed" and i not in live:
             live[i] = {"id": j.get("id") or "cached", "key": j.get("key", "")}
@@ -887,21 +1208,27 @@ def run_research_fanout(
         for j in manifest["jobs"]
         if j.get("state") in ("submitted", "completed") and j.get("id")
     )
+    unverified = UNVERIFIED_EST_RESEARCH_JOB_USD
     sys.stderr.write(
         f"Jobs submitted/rejoined: {submitted}/{n} "
-        f"(estimate {submitted} x ${EST_RESEARCH_JOB_USD:.2f} = "
-        f"${submitted * EST_RESEARCH_JOB_USD:.2f} research + "
-        f"${cheap_cost:.4f} cheap-calls; max_tool_calls={tool_budget})\n"
+        f"(unverified estimate {submitted} x ${unverified:.2f} = "
+        f"${submitted * unverified:.2f} research + "
+        f"${planner_cost:.4f} planner; max_tool_calls={tool_budget})\n"
     )
     if not live:
         print(json.dumps({"error": "all fanout submits failed"}))
         return 1
 
+    quorum = _merge_quorum(n)
     completed, terminal = _poll_set(
-        api_key, live, run_dir, manifest, manifest_path
+        api_key,
+        live,
+        run_dir,
+        manifest,
+        manifest_path,
+        quorum=quorum,
     )
 
-    quorum = math.ceil(n / 2)
     if len(completed) < quorum:
         print(
             json.dumps(
@@ -917,6 +1244,8 @@ def run_research_fanout(
         return 1
 
     reports: list[tuple[int, str, str, list[str]]] = []
+    completed_data: list[dict] = []
+    url_lists: list[list[str]] = []
     missing: list[dict] = []
     for i in range(1, n + 1):
         question = selected[i - 1]["angle"]
@@ -930,24 +1259,35 @@ def run_research_fanout(
         report_path = run_dir / f"report-{i:02d}.md"
         _write_sub_report(report_path, i, question, body, urls)
         reports.append((i, question, body, urls))
+        completed_data.append(data)
+        url_lists.append(urls)
 
     sys.stderr.write(
-        f"Merging {len(reports)}/{n} completed sub-reports "
+        f"Composing {len(reports)}/{n} completed sub-reports "
         f"({len(missing)} missing)…\n"
     )
-    merged, err, merge_resp = _merge_reports(api_key, prompt, reports, missing)
+    composed, err, compose_resp = _compose_reports(
+        api_key, prompt, reports, missing
+    )
+    if composed is None:
+        print(json.dumps({"error": err, "run_dir": str(run_dir)}))
+        return 1
+    compose_usage = _usage_tokens(compose_resp)
+
+    sys.stderr.write("Attaching citations (separate pass)…\n")
+    merged, err, attach_resp = _attach_citations(api_key, composed, reports)
     if merged is None:
         print(json.dumps({"error": err, "run_dir": str(run_dir)}))
         return 1
-    inp, out = _usage_tokens(merge_resp)
-    cheap_cost += _est_cheap_usd(inp, out)
+    attach_usage = _usage_tokens(attach_resp)
 
     check_text, check_err, check_resp = _citation_check(api_key, merged, reports)
+    check_usage = (0, 0)
     if check_text is None:
         sys.stderr.write(f"Citation check skipped: {check_err}\n")
     else:
-        inp, out = _usage_tokens(check_resp)
-        cheap_cost += _est_cheap_usd(inp, out)
+        check_usage = _usage_tokens(check_resp)
+        planner_cost += _est_planner_usd(*check_usage)
         if not merged.endswith("\n"):
             merged += "\n"
         merged = merged + "\n" + check_text
@@ -955,7 +1295,6 @@ def run_research_fanout(
             merged += "\n"
 
     if missing:
-        # Guarantee the partial-merge disclosure even if the model omitted it.
         missing_section = "\n## Missing sub-questions\n\n"
         for m in missing:
             missing_section += (
@@ -967,19 +1306,48 @@ def run_research_fanout(
     (run_dir / "merged.md").write_text(
         merged if merged.endswith("\n") else merged + "\n"
     )
+
+    mean_qpd = _mean_qpd(completed_data, url_lists)
+    overlap = _citation_overlap_ratio(url_lists)
+    domains = _unique_domains(url_lists)
+    contra = _count_contradictions(merged)
+    research_est = submitted * UNVERIFIED_EST_RESEARCH_JOB_USD
+    planner_actual = planner_cost
+    # Sol compose/attach: usage reported but no verified $/M — label estimated.
+    sol_tokens = compose_usage[0] + compose_usage[1] + attach_usage[0] + attach_usage[1]
+    total_est = research_est + planner_actual
+    cost_label = (
+        f"${total_est:.4f} "
+        f"(research ${research_est:.2f} unverified estimate; "
+        f"planner ${planner_actual:.4f} from reported usage @ "
+        f"${EST_PLANNER_INPUT_PER_M:.0f}/${EST_PLANNER_OUTPUT_PER_M:.0f} per 1M; "
+        f"sol compose+attach {sol_tokens} tokens reported, $/M unverified)"
+    )
+    metrics = {
+        "mean_qpd": mean_qpd,
+        "citation_overlap_ratio": overlap,
+        "unique_domains": domains,
+        "contradiction_count": contra,
+        "total_cost_usd": total_est,
+        "total_cost_label": cost_label,
+        "qpd_warning": mean_qpd < QPD_WARN_THRESHOLD,
+        "research_cost_unverified_usd": research_est,
+        "planner_cost_usd": planner_actual,
+        "sol_compose_attach_tokens": sol_tokens,
+    }
+    metrics_text = _format_metrics(metrics)
+    sys.stderr.write(metrics_text)
+
     manifest["state"] = "merged"
     manifest["completed"] = sorted(completed)
     manifest["missing"] = missing
+    manifest["metrics"] = metrics
     _save_manifest(manifest_path, manifest)
 
     failed_or_missing = n - len(completed)
-    est_total = submitted * EST_RESEARCH_JOB_USD + cheap_cost
     sys.stderr.write(
         f"Fanout complete: {len(completed)}/{n} jobs ok, "
         f"{failed_or_missing} missing/failed\n"
-        f"Cost estimate: {submitted} research jobs x ${EST_RESEARCH_JOB_USD:.2f} "
-        f"= ${submitted * EST_RESEARCH_JOB_USD:.2f} (estimate) + "
-        f"cheap calls ${cheap_cost:.4f} (estimate) ≈ ${est_total:.2f}\n"
         f"Run directory: {run_dir}\n"
     )
     print(str(run_dir))

--- a/apps/n0b/research.py
+++ b/apps/n0b/research.py
@@ -7,20 +7,36 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 import sys
 import time
 import urllib.error
 import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
 
 from commands.secrets_cmd import resolve
 from paths import BIN_ROOT
 
 RESEARCH_MODEL = "gpt-5.6-sol"
+CHEAP_MODEL = "gpt-4.1-mini"
+POLL_INTERVAL_S = 30
+# Rough per-job estimate until a completed response carries usage.
+EST_RESEARCH_JOB_USD = 0.50
+# Rough gpt-4.1-mini $/1M tokens (estimate; labeled as such in stderr).
+EST_CHEAP_INPUT_PER_M = 0.40
+EST_CHEAP_OUTPUT_PER_M = 1.60
 
 
 def _get_hash(prompt: str) -> str:
     clean = "".join(prompt.split())
     return hashlib.sha256(clean.encode("utf-8")).hexdigest()
+
+
+def _research_cache_dir() -> Path:
+    d = BIN_ROOT / ".files" / "research"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
 
 
 def _call_openai(api_key: str, prompt: str) -> dict:
@@ -60,6 +76,220 @@ def _check_status(api_key: str, response_id: str) -> dict:
         return {"error": str(e)}
 
 
+def _load_or_submit(api_key: str, prompt: str, cache_file: Path) -> dict:
+    if cache_file.is_file():
+        return json.loads(cache_file.read_text())
+    response_data = _call_openai(api_key, prompt)
+    if response_data.get("error"):
+        return response_data
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    cache_file.write_text(json.dumps(response_data))
+    return response_data
+
+
+def _call_cheap(api_key: str, prompt: str) -> dict:
+    url = "https://api.openai.com/v1/responses"
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    data = {
+        "model": CHEAP_MODEL,
+        "input": prompt,
+    }
+    req = urllib.request.Request(
+        url, data=json.dumps(data).encode("utf-8"), headers=headers
+    )
+    try:
+        with urllib.request.urlopen(req) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8")
+        return {"error": f"HTTP Error {e.code}: {body}"}
+    except OSError as e:
+        return {"error": str(e)}
+
+
+def _output_text(response_data: dict) -> str:
+    parts: list[str] = []
+    for item in response_data.get("output") or []:
+        if not isinstance(item, dict):
+            continue
+        if item.get("type") == "message":
+            for block in item.get("content") or []:
+                if isinstance(block, dict) and block.get("type") in (
+                    "output_text",
+                    "text",
+                ):
+                    text = block.get("text")
+                    if text:
+                        parts.append(text)
+        elif item.get("type") == "output_text" and item.get("text"):
+            parts.append(item["text"])
+    if parts:
+        return "\n".join(parts)
+    # Fallbacks some Responses shapes use.
+    for key in ("output_text", "text"):
+        val = response_data.get(key)
+        if isinstance(val, str) and val.strip():
+            return val
+    return ""
+
+
+def _usage_tokens(response_data: dict) -> tuple[int, int]:
+    usage = response_data.get("usage") or {}
+    inp = int(usage.get("input_tokens") or usage.get("prompt_tokens") or 0)
+    out = int(usage.get("output_tokens") or usage.get("completion_tokens") or 0)
+    return inp, out
+
+
+def _est_cheap_usd(input_tokens: int, output_tokens: int) -> float:
+    return (
+        input_tokens * EST_CHEAP_INPUT_PER_M / 1_000_000
+        + output_tokens * EST_CHEAP_OUTPUT_PER_M / 1_000_000
+    )
+
+
+def _extract_urls(text: str) -> list[str]:
+    found = re.findall(r"https?://[^\s\]\)>'\"<>]+", text)
+    seen: set[str] = set()
+    out: list[str] = []
+    for u in found:
+        u = u.rstrip(".,;:)")
+        if u not in seen:
+            seen.add(u)
+            out.append(u)
+    return out
+
+
+def _parse_json_list(text: str) -> object | None:
+    text = text.strip()
+    if not text:
+        return None
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+    fence = re.search(r"```(?:json)?\s*(\[.*?\])\s*```", text, re.DOTALL)
+    if fence:
+        try:
+            return json.loads(fence.group(1))
+        except json.JSONDecodeError:
+            pass
+    bracket = re.search(r"\[.*\]", text, re.DOTALL)
+    if bracket:
+        try:
+            return json.loads(bracket.group(0))
+        except json.JSONDecodeError:
+            pass
+    return None
+
+
+def _decompose(api_key: str, prompt: str, n: int) -> tuple[list[str] | None, str, dict]:
+    decompose_prompt = (
+        f"Decompose the research question below into exactly {n} complementary "
+        "sub-questions. Each sub-question must cover a DISTINCT dimension "
+        "(examples: mechanism, evidence, counter-evidence, adoption/practice, "
+        "risks, alternatives). Do NOT paraphrase the original; avoid overlap.\n\n"
+        f"Return ONLY a JSON array of exactly {n} strings. No other text.\n\n"
+        f"Question:\n{prompt}"
+    )
+    resp = _call_cheap(api_key, decompose_prompt)
+    if resp.get("error"):
+        return None, f"decompose failed: {resp['error']}", resp
+    text = _output_text(resp)
+    parsed = _parse_json_list(text)
+    if not isinstance(parsed, list):
+        return None, f"decompose did not return a JSON list (got: {text[:200]!r})", resp
+    if len(parsed) != n:
+        return None, f"decompose returned {len(parsed)} items, expected {n}", resp
+    if not all(isinstance(x, str) and x.strip() for x in parsed):
+        return None, "decompose list must contain only non-empty strings", resp
+    return [x.strip() for x in parsed], "", resp
+
+
+def _merge_reports(
+    api_key: str, prompt: str, reports: list[tuple[str, str, list[str]]]
+) -> tuple[str | None, str, dict]:
+    blocks: list[str] = []
+    for i, (question, body, urls) in enumerate(reports, start=1):
+        url_lines = "\n".join(f"- {u}" for u in urls) or "- (none extracted)"
+        blocks.append(
+            f"### Sub-report {i}\n"
+            f"File: report-{i:02d}.md\n"
+            f"Question: {question}\n\n"
+            f"{body}\n\n"
+            f"Cited URLs:\n{url_lines}\n"
+        )
+    merge_prompt = (
+        "Merge the sub-reports below into a single markdown research brief.\n"
+        "Requirements:\n"
+        "1. Union the findings. Every claim must have per-claim source "
+        "attribution of the form [report-NN.md | URL] (use the sub-report "
+        "filename and the cited URL that supports the claim; if no URL, "
+        "use [report-NN.md | no-url]).\n"
+        "2. Include an explicit ## Conflicts section listing points where "
+        "sub-reports disagree, with both sides attributed the same way.\n"
+        "3. Start with # Merged research and a short ## Summary.\n"
+        "4. Output markdown only.\n\n"
+        f"Original question:\n{prompt}\n\n"
+        + "\n".join(blocks)
+    )
+    resp = _call_cheap(api_key, merge_prompt)
+    if resp.get("error"):
+        return None, f"merge failed: {resp['error']}", resp
+    text = _output_text(resp).strip()
+    if not text:
+        return None, "merge returned empty text", resp
+    return text, "", resp
+
+
+def _write_sub_report(
+    path: Path, index: int, question: str, body: str, urls: list[str]
+) -> None:
+    lines = [
+        f"# Sub-report {index}",
+        "",
+        "## Question",
+        "",
+        question,
+        "",
+        "## Findings",
+        "",
+        body.strip() or "(no text extracted from response)",
+        "",
+        "## Sources",
+        "",
+    ]
+    if urls:
+        lines.extend(f"- {u}" for u in urls)
+    else:
+        lines.append("- (none extracted)")
+    lines.append("")
+    path.write_text("\n".join(lines))
+
+
+def _poll_one(
+    api_key: str, response_id: str, label: str
+) -> tuple[str, dict]:
+    while True:
+        status_data = _check_status(api_key, response_id)
+        status = status_data.get("status", "unknown")
+        if status == "completed":
+            sys.stderr.write(f"[{label}] completed\n")
+            return "completed", status_data
+        if status == "failed":
+            sys.stderr.write(f"[{label}] failed\n")
+            return "failed", status_data
+        if status_data.get("error") and "status" not in status_data:
+            sys.stderr.write(f"[{label}] error: {status_data.get('error')}\n")
+            return "error", status_data
+        sys.stderr.write(
+            f"[{label}] status={status} — polling again in {POLL_INTERVAL_S}s\n"
+        )
+        time.sleep(POLL_INTERVAL_S)
+
+
 def run_research(prompt_parts: list[str]) -> int:
     api_key = resolve("OPENAI_API_KEY")
     if not api_key:
@@ -71,8 +301,7 @@ def run_research(prompt_parts: list[str]) -> int:
 
     prompt = " ".join(prompt_parts)
     prompt_hash = _get_hash(prompt)
-    cache_dir = BIN_ROOT / ".files" / "research"
-    cache_dir.mkdir(parents=True, exist_ok=True)
+    cache_dir = _research_cache_dir()
     cache_file = cache_dir / f"{prompt_hash}.json"
 
     if cache_file.is_file():
@@ -100,3 +329,180 @@ def run_research(prompt_parts: list[str]) -> int:
             f"Status: {status_data.get('status', 'unknown')} — polling again in 30s\n"
         )
         time.sleep(30)
+
+
+def run_research_fanout(prompt_parts: list[str], n: int) -> int:
+    api_key = resolve("OPENAI_API_KEY")
+    if not api_key:
+        print(json.dumps({"error": "OPENAI_API_KEY not found (try: n0b secrets set OPENAI_API_KEY)"}))
+        return 1
+    if not prompt_parts:
+        print(json.dumps({"error": "No prompt provided"}))
+        return 1
+    if n < 2:
+        print(json.dumps({"error": "--fanout N requires N >= 2"}))
+        return 1
+
+    prompt = " ".join(prompt_parts)
+    prompt_hash = _get_hash(prompt)
+    run_dir = _research_cache_dir() / f"fanout-{prompt_hash}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    meta_file = run_dir / "meta.json"
+
+    cheap_cost = 0.0
+    sub_questions: list[str]
+
+    if meta_file.is_file():
+        meta = json.loads(meta_file.read_text())
+        sub_questions = list(meta["sub_questions"])
+        if len(sub_questions) != n:
+            print(
+                json.dumps(
+                    {
+                        "error": (
+                            f"cached fanout has {len(sub_questions)} sub-questions, "
+                            f"but --fanout {n} was requested"
+                        )
+                    }
+                )
+            )
+            return 1
+        sys.stderr.write(
+            f"Rejoining fanout run at {run_dir} ({n} sub-questions from cache)\n"
+        )
+    else:
+        sys.stderr.write(f"Decomposing into {n} complementary sub-questions…\n")
+        sub_questions, err, decomp_resp = _decompose(api_key, prompt, n)
+        if sub_questions is None:
+            print(json.dumps({"error": err}))
+            return 1
+        inp, out = _usage_tokens(decomp_resp)
+        cheap_cost += _est_cheap_usd(inp, out)
+        sys.stderr.write(
+            f"Decompose done ({inp} in / {out} out tokens; "
+            f"cheap-call estimate ${cheap_cost:.4f})\n"
+        )
+        for i, q in enumerate(sub_questions, start=1):
+            sys.stderr.write(f"  {i}. {q}\n")
+        meta_file.write_text(
+            json.dumps(
+                {"prompt": prompt, "n": n, "sub_questions": sub_questions},
+                indent=2,
+            )
+            + "\n"
+        )
+
+    # Submit (or rejoin) all jobs — parallel submits, shared cache files.
+    job_ids: list[str] = []
+
+    def _submit_one(i: int, question: str) -> tuple[int, dict, bool]:
+        cache_file = run_dir / f"job-{i}.json"
+        rejoined = cache_file.is_file()
+        return i, _load_or_submit(api_key, question, cache_file), rejoined
+
+    with ThreadPoolExecutor(max_workers=min(n, 8)) as pool:
+        futures = [
+            pool.submit(_submit_one, i, q) for i, q in enumerate(sub_questions, start=1)
+        ]
+        results: dict[int, tuple[dict, bool]] = {}
+        for fut in as_completed(futures):
+            i, data, rejoined = fut.result()
+            results[i] = (data, rejoined)
+
+    for i in range(1, n + 1):
+        data, rejoined = results[i]
+        if data.get("error"):
+            job_ids.append("")
+            sys.stderr.write(f"[job-{i}] submit error: {data.get('error')}\n")
+            continue
+        rid = data.get("id") or ""
+        job_ids.append(rid)
+        sys.stderr.write(
+            f"[job-{i}] {'rejoined' if rejoined else 'submitted'} id={rid}\n"
+        )
+
+    submitted = sum(1 for j in job_ids if j)
+    sys.stderr.write(
+        f"Jobs submitted/rejoined: {submitted}/{n} "
+        f"(estimate {submitted} x ${EST_RESEARCH_JOB_USD:.2f} = "
+        f"${submitted * EST_RESEARCH_JOB_USD:.2f} research + "
+        f"${cheap_cost:.4f} cheap-calls)\n"
+    )
+    if submitted == 0:
+        print(json.dumps({"error": "all fanout submits failed"}))
+        return 1
+
+    # Poll all jobs concurrently (each thread polls its own job).
+    completed: dict[int, dict] = {}
+    failed = 0
+    pending = {i: job_ids[i - 1] for i in range(1, n + 1) if job_ids[i - 1]}
+
+    with ThreadPoolExecutor(max_workers=min(n, 8)) as pool:
+        future_map = {
+            pool.submit(_poll_one, api_key, rid, f"job-{i}"): i
+            for i, rid in pending.items()
+        }
+        done_count = 0
+        total = len(future_map)
+        for fut in as_completed(future_map):
+            i = future_map[fut]
+            status, data = fut.result()
+            done_count += 1
+            running = total - done_count
+            if status == "completed":
+                completed[i] = data
+                sys.stderr.write(
+                    f"Progress: {done_count} done, {running} running "
+                    f"(research estimate ${submitted * EST_RESEARCH_JOB_USD:.2f} + "
+                    f"cheap ${cheap_cost:.4f})\n"
+                )
+            else:
+                failed += 1
+                sys.stderr.write(
+                    f"Progress: {done_count} done ({failed} failed), {running} running\n"
+                )
+
+    reports: list[tuple[str, str, list[str]]] = []
+    for i, question in enumerate(sub_questions, start=1):
+        data = completed.get(i)
+        if data is None:
+            body = "(job did not complete)"
+            urls: list[str] = []
+        else:
+            body = _output_text(data)
+            urls = _extract_urls(body)
+            # Also pull URL annotations if present.
+            for item in data.get("output") or []:
+                if not isinstance(item, dict):
+                    continue
+                for block in item.get("content") or []:
+                    if not isinstance(block, dict):
+                        continue
+                    for ann in block.get("annotations") or []:
+                        if isinstance(ann, dict) and ann.get("url"):
+                            u = ann["url"]
+                            if u not in urls:
+                                urls.append(u)
+        report_path = run_dir / f"report-{i:02d}.md"
+        _write_sub_report(report_path, i, question, body, urls)
+        reports.append((question, body, urls))
+
+    sys.stderr.write("Merging sub-reports…\n")
+    merged, err, merge_resp = _merge_reports(api_key, prompt, reports)
+    if merged is None:
+        print(json.dumps({"error": err, "run_dir": str(run_dir)}))
+        return 1
+    inp, out = _usage_tokens(merge_resp)
+    cheap_cost += _est_cheap_usd(inp, out)
+    (run_dir / "merged.md").write_text(merged if merged.endswith("\n") else merged + "\n")
+
+    est_total = submitted * EST_RESEARCH_JOB_USD + cheap_cost
+    sys.stderr.write(
+        f"Fanout complete: {len(completed)}/{n} jobs ok, {failed} failed\n"
+        f"Cost estimate: {submitted} research jobs x ${EST_RESEARCH_JOB_USD:.2f} "
+        f"= ${submitted * EST_RESEARCH_JOB_USD:.2f} (estimate) + "
+        f"cheap calls ${cheap_cost:.4f} (estimate) ≈ ${est_total:.2f}\n"
+        f"Run directory: {run_dir}\n"
+    )
+    print(str(run_dir))
+    return 0 if failed == 0 and len(completed) == n else 1

--- a/apps/n0b/research.py
+++ b/apps/n0b/research.py
@@ -7,12 +7,13 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import re
 import sys
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 from commands.secrets_cmd import resolve
@@ -21,16 +22,29 @@ from paths import BIN_ROOT
 RESEARCH_MODEL = "gpt-5.6-sol"
 CHEAP_MODEL = "gpt-4.1-mini"
 POLL_INTERVAL_S = 30
+JOB_TIMEOUT_S = 20 * 60
+FANOUT_MIN = 1
+FANOUT_MAX = 8
+FANOUT_DEFAULT_N = 4
+CANDIDATE_MIN = 12
+CANDIDATE_MAX = 16
 # Rough per-job estimate until a completed response carries usage.
 EST_RESEARCH_JOB_USD = 0.50
 # Rough gpt-4.1-mini $/1M tokens (estimate; labeled as such in stderr).
 EST_CHEAP_INPUT_PER_M = 0.40
 EST_CHEAP_OUTPUT_PER_M = 1.60
+# Base tool budget for a single research job; scaled down as N rises.
+BASE_MAX_TOOL_CALLS = 50
 
 
 def _get_hash(prompt: str) -> str:
     clean = "".join(prompt.split())
     return hashlib.sha256(clean.encode("utf-8")).hexdigest()
+
+
+def _job_key(question: str, fanout: int, model: str) -> str:
+    raw = f"{question}\0{fanout}\0{model}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
 
 
 def _research_cache_dir() -> Path:
@@ -39,18 +53,33 @@ def _research_cache_dir() -> Path:
     return d
 
 
-def _call_openai(api_key: str, prompt: str) -> dict:
+def _max_tool_calls(n: int) -> int:
+    if n <= 1:
+        return BASE_MAX_TOOL_CALLS
+    return max(10, BASE_MAX_TOOL_CALLS // n)
+
+
+def _clamp_fanout(n: int) -> tuple[int, bool]:
+    clamped = max(FANOUT_MIN, min(FANOUT_MAX, n))
+    return clamped, clamped != n
+
+
+def _call_openai(
+    api_key: str, prompt: str, *, max_tool_calls: int | None = None
+) -> dict:
     url = "https://api.openai.com/v1/responses"
     headers = {
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",
     }
-    data = {
+    data: dict = {
         "model": RESEARCH_MODEL,
         "input": prompt,
         "tools": [{"type": "web_search_preview"}],
         "background": True,
     }
+    if max_tool_calls is not None:
+        data["max_tool_calls"] = max_tool_calls
     req = urllib.request.Request(
         url, data=json.dumps(data).encode("utf-8"), headers=headers
     )
@@ -74,17 +103,6 @@ def _check_status(api_key: str, response_id: str) -> dict:
             return json.loads(response.read().decode("utf-8"))
     except OSError as e:
         return {"error": str(e)}
-
-
-def _load_or_submit(api_key: str, prompt: str, cache_file: Path) -> dict:
-    if cache_file.is_file():
-        return json.loads(cache_file.read_text())
-    response_data = _call_openai(api_key, prompt)
-    if response_data.get("error"):
-        return response_data
-    cache_file.parent.mkdir(parents=True, exist_ok=True)
-    cache_file.write_text(json.dumps(response_data))
-    return response_data
 
 
 def _call_cheap(api_key: str, prompt: str) -> dict:
@@ -128,7 +146,6 @@ def _output_text(response_data: dict) -> str:
             parts.append(item["text"])
     if parts:
         return "\n".join(parts)
-    # Fallbacks some Responses shapes use.
     for key in ("output_text", "text"):
         val = response_data.get(key)
         if isinstance(val, str) and val.strip():
@@ -162,7 +179,41 @@ def _extract_urls(text: str) -> list[str]:
     return out
 
 
-def _parse_json_list(text: str) -> object | None:
+def _normalize_url(url: str) -> str:
+    try:
+        p = urllib.parse.urlparse(url.strip())
+    except ValueError:
+        return url.strip().lower()
+    scheme = (p.scheme or "https").lower()
+    netloc = (p.netloc or "").lower()
+    if netloc.startswith("www."):
+        netloc = netloc[4:]
+    path = p.path or ""
+    if path != "/" and path.endswith("/"):
+        path = path.rstrip("/")
+    query = urllib.parse.urlencode(
+        sorted(urllib.parse.parse_qsl(p.query, keep_blank_values=True))
+    )
+    return urllib.parse.urlunparse((scheme, netloc, path, "", query, ""))
+
+
+def _urls_from_response(data: dict, body: str) -> list[str]:
+    urls = _extract_urls(body)
+    for item in data.get("output") or []:
+        if not isinstance(item, dict):
+            continue
+        for block in item.get("content") or []:
+            if not isinstance(block, dict):
+                continue
+            for ann in block.get("annotations") or []:
+                if isinstance(ann, dict) and ann.get("url"):
+                    u = ann["url"]
+                    if u not in urls:
+                        urls.append(u)
+    return urls
+
+
+def _parse_json_obj(text: str) -> object | None:
     text = text.strip()
     if not text:
         return None
@@ -170,49 +221,168 @@ def _parse_json_list(text: str) -> object | None:
         return json.loads(text)
     except json.JSONDecodeError:
         pass
-    fence = re.search(r"```(?:json)?\s*(\[.*?\])\s*```", text, re.DOTALL)
+    fence = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
     if fence:
         try:
             return json.loads(fence.group(1))
         except json.JSONDecodeError:
             pass
-    bracket = re.search(r"\[.*\]", text, re.DOTALL)
-    if bracket:
+    brace = re.search(r"\{.*\}", text, re.DOTALL)
+    if brace:
         try:
-            return json.loads(bracket.group(0))
+            return json.loads(brace.group(0))
         except json.JSONDecodeError:
             pass
     return None
 
 
-def _decompose(api_key: str, prompt: str, n: int) -> tuple[list[str] | None, str, dict]:
+def _tokenize(text: str) -> set[str]:
+    return {t for t in re.findall(r"[a-z0-9]+", text.lower()) if t}
+
+
+def _jaccard(a: set[str], b: set[str]) -> float:
+    if not a and not b:
+        return 1.0
+    if not a or not b:
+        return 0.0
+    inter = len(a & b)
+    union = len(a | b)
+    return inter / union if union else 0.0
+
+
+def mmr_select(
+    candidates: list[dict], n: int, *, lambda_: float = 0.0
+) -> list[dict]:
+    """Select ``n`` candidates by MMR on token Jaccard of seed_query.
+
+    ``lambda_=0`` is pure diversity (minimize similarity to the selected set).
+    """
+    if n <= 0 or not candidates:
+        return []
+    n = min(n, len(candidates))
+    tokenized = [_tokenize(str(c.get("seed_query") or c.get("angle") or "")) for c in candidates]
+    selected: list[int] = []
+    remaining = list(range(len(candidates)))
+
+    # Seed with the first candidate (stable order) then diversify.
+    selected.append(remaining.pop(0))
+
+    while len(selected) < n and remaining:
+        best_i = remaining[0]
+        best_score = float("-inf")
+        for i in remaining:
+            toks = tokenized[i]
+            # Relevance term unused at λ=0; keep the shape for clarity.
+            relevance = 1.0
+            max_sim = max(_jaccard(toks, tokenized[j]) for j in selected)
+            score = lambda_ * relevance - (1.0 - lambda_) * max_sim
+            if score > best_score:
+                best_score = score
+                best_i = i
+        remaining.remove(best_i)
+        selected.append(best_i)
+
+    return [candidates[i] for i in selected]
+
+
+def _build_sub_prompt(
+    goal: str, brief: str, selected: dict, all_selected: list[dict]
+) -> str:
+    angle = str(selected.get("angle") or "").strip()
+    seed = str(selected.get("seed_query") or angle).strip()
+    others = [
+        str(o.get("angle") or "").strip()
+        for o in all_selected
+        if o is not selected and str(o.get("angle") or "").strip()
+    ]
+    boundaries = (
+        "Do NOT cover these sibling angles (other sub-jobs own them):\n"
+        + "\n".join(f"- {o}" for o in others)
+        if others
+        else "Stay tightly scoped to this angle only."
+    )
+    return (
+        f"## Top-level research goal\n{goal}\n\n"
+        f"## Shared brief\n{brief}\n\n"
+        f"## Your objective\n"
+        f"Research this angle only: {angle}\n"
+        f"Seed query / search focus: {seed}\n\n"
+        f"## Output format\n"
+        "Markdown brief with: short summary, numbered findings with inline "
+        "source URLs, and a Sources list. Every claim needs a URL.\n\n"
+        f"## Source guidance\n"
+        "Prefer primary sources, peer-reviewed work, official docs, and "
+        "high-signal reporting. Note date and provenance when relevant.\n\n"
+        f"## Boundaries (what this sub-question does NOT cover)\n"
+        f"{boundaries}\n"
+    )
+
+
+def _brief_and_candidates(
+    api_key: str, prompt: str
+) -> tuple[str | None, list[dict] | None, str, dict]:
     decompose_prompt = (
-        f"Decompose the research question below into exactly {n} complementary "
-        "sub-questions. Each sub-question must cover a DISTINCT dimension "
-        "(examples: mechanism, evidence, counter-evidence, adoption/practice, "
-        "risks, alternatives). Do NOT paraphrase the original; avoid overlap.\n\n"
-        f"Return ONLY a JSON array of exactly {n} strings. No other text.\n\n"
+        "You are planning a multi-angle deep-research run.\n"
+        "Given the research question below, return ONLY a JSON object with:\n"
+        '  "brief": a planning brief of at most 200 words,\n'
+        f'  "candidates": an array of {CANDIDATE_MIN}-{CANDIDATE_MAX} objects, '
+        'each with "angle" (short label) and "seed_query" (search-oriented '
+        "phrase). Candidates must cover DISTINCT dimensions — not paraphrases "
+        "of the same anchor.\n\n"
         f"Question:\n{prompt}"
     )
     resp = _call_cheap(api_key, decompose_prompt)
     if resp.get("error"):
-        return None, f"decompose failed: {resp['error']}", resp
+        return None, None, f"decompose failed: {resp['error']}", resp
     text = _output_text(resp)
-    parsed = _parse_json_list(text)
-    if not isinstance(parsed, list):
-        return None, f"decompose did not return a JSON list (got: {text[:200]!r})", resp
-    if len(parsed) != n:
-        return None, f"decompose returned {len(parsed)} items, expected {n}", resp
-    if not all(isinstance(x, str) and x.strip() for x in parsed):
-        return None, "decompose list must contain only non-empty strings", resp
-    return [x.strip() for x in parsed], "", resp
+    parsed = _parse_json_obj(text)
+    if not isinstance(parsed, dict):
+        return None, None, f"decompose did not return a JSON object (got: {text[:200]!r})", resp
+    brief = parsed.get("brief")
+    candidates = parsed.get("candidates")
+    if not isinstance(brief, str) or not brief.strip():
+        return None, None, "decompose brief must be a non-empty string", resp
+    if not isinstance(candidates, list):
+        return None, None, "decompose candidates must be a list", resp
+    cleaned: list[dict] = []
+    for c in candidates:
+        if not isinstance(c, dict):
+            continue
+        angle = c.get("angle")
+        seed = c.get("seed_query") or angle
+        if isinstance(angle, str) and angle.strip() and isinstance(seed, str) and seed.strip():
+            cleaned.append({"angle": angle.strip(), "seed_query": seed.strip()})
+    if len(cleaned) < CANDIDATE_MIN:
+        return (
+            None,
+            None,
+            f"decompose returned {len(cleaned)} usable candidates, need >= {CANDIDATE_MIN}",
+            resp,
+        )
+    return brief.strip(), cleaned[:CANDIDATE_MAX], "", resp
+
+
+def _citation_union(reports: list[tuple[str, str, list[str]]]) -> list[dict]:
+    counts: dict[str, dict] = {}
+    for i, (_q, _body, urls) in enumerate(reports, start=1):
+        for u in urls:
+            norm = _normalize_url(u)
+            entry = counts.setdefault(norm, {"url": norm, "count": 0, "reports": []})
+            entry["count"] += 1
+            label = f"report-{i:02d}.md"
+            if label not in entry["reports"]:
+                entry["reports"].append(label)
+    return sorted(counts.values(), key=lambda e: (-e["count"], e["url"]))
 
 
 def _merge_reports(
-    api_key: str, prompt: str, reports: list[tuple[str, str, list[str]]]
+    api_key: str,
+    prompt: str,
+    reports: list[tuple[int, str, str, list[str]]],
+    missing: list[dict],
 ) -> tuple[str | None, str, dict]:
     blocks: list[str] = []
-    for i, (question, body, urls) in enumerate(reports, start=1):
+    for i, question, body, urls in reports:
         url_lines = "\n".join(f"- {u}" for u in urls) or "- (none extracted)"
         blocks.append(
             f"### Sub-report {i}\n"
@@ -221,18 +391,44 @@ def _merge_reports(
             f"{body}\n\n"
             f"Cited URLs:\n{url_lines}\n"
         )
+    missing_block = ""
+    if missing:
+        lines = [
+            f"- Sub-question {m['index']} ({m['question']}): {m['reason']}"
+            for m in missing
+        ]
+        missing_block = (
+            "\n## Incomplete coverage (MUST include in output)\n"
+            "The following sub-questions did not produce a usable report. "
+            "State them plainly in a ## Missing sub-questions section — "
+            "do not invent findings for them:\n"
+            + "\n".join(lines)
+            + "\n"
+        )
+    citation_rows = _citation_union([(q, b, u) for _, q, b, u in reports])
+    cite_lines = "\n".join(
+        f"- {c['url']} (corroboration={c['count']}; {', '.join(c['reports'])})"
+        for c in citation_rows
+    ) or "- (none)"
+
     merge_prompt = (
-        "Merge the sub-reports below into a single markdown research brief.\n"
+        "Merge the completed sub-reports below into ONE markdown research brief.\n"
         "Requirements:\n"
-        "1. Union the findings. Every claim must have per-claim source "
-        "attribution of the form [report-NN.md | URL] (use the sub-report "
-        "filename and the cited URL that supports the claim; if no URL, "
-        "use [report-NN.md | no-url]).\n"
-        "2. Include an explicit ## Conflicts section listing points where "
-        "sub-reports disagree, with both sides attributed the same way.\n"
-        "3. Start with # Merged research and a short ## Summary.\n"
-        "4. Output markdown only.\n\n"
+        "1. Cluster related claims across sub-reports. Every claim must have "
+        "per-claim source attribution of the form [report-NN.md | URL].\n"
+        "2. Include ## Citations with the URL-normalized union below, preserving "
+        "corroboration counts (how many sub-reports independently cite each URL).\n"
+        "3. Include ## Contradictions listing every point where sub-reports "
+        "disagree. SURFACING is mandatory — do NOT pick a winner, reconcile, "
+        "or silently drop either side. Attribute both sides "
+        "[report-NN.md | URL].\n"
+        "4. If any sub-questions are missing, include ## Missing sub-questions "
+        "naming each and the reason (timed out / failed).\n"
+        "5. Start with # Merged research and a short ## Summary.\n"
+        "6. Output markdown only. One merge pass — do not invent sources.\n\n"
         f"Original question:\n{prompt}\n\n"
+        f"Citation union (normalized):\n{cite_lines}\n"
+        f"{missing_block}\n"
         + "\n".join(blocks)
     )
     resp = _call_cheap(api_key, merge_prompt)
@@ -241,6 +437,35 @@ def _merge_reports(
     text = _output_text(resp).strip()
     if not text:
         return None, "merge returned empty text", resp
+    return text, "", resp
+
+
+def _citation_check(
+    api_key: str, merged: str, reports: list[tuple[int, str, str, list[str]]]
+) -> tuple[str | None, str, dict]:
+    report_blobs = []
+    for i, question, body, urls in reports:
+        report_blobs.append(
+            f"report-{i:02d}.md | {question}\n"
+            f"URLs: {', '.join(urls) if urls else '(none)'}\n"
+            f"Excerpt:\n{body[:1500]}\n"
+        )
+    check_prompt = (
+        "Citation check pass. Given the merged brief and the sub-reports, "
+        "verify each claim in the merged brief actually traces to a cited "
+        "source present in the sub-reports. Return markdown:\n"
+        "## Citation check\n"
+        "- OK / WEAK / MISSING lines per claim (brief).\n"
+        "Do not rewrite the brief. Do not resolve contradictions.\n\n"
+        f"Merged brief:\n{merged}\n\n"
+        "Sub-reports:\n" + "\n".join(report_blobs)
+    )
+    resp = _call_cheap(api_key, check_prompt)
+    if resp.get("error"):
+        return None, f"citation check failed: {resp['error']}", resp
+    text = _output_text(resp).strip()
+    if not text:
+        return None, "citation check returned empty text", resp
     return text, "", resp
 
 
@@ -269,25 +494,12 @@ def _write_sub_report(
     path.write_text("\n".join(lines))
 
 
-def _poll_one(
-    api_key: str, response_id: str, label: str
-) -> tuple[str, dict]:
-    while True:
-        status_data = _check_status(api_key, response_id)
-        status = status_data.get("status", "unknown")
-        if status == "completed":
-            sys.stderr.write(f"[{label}] completed\n")
-            return "completed", status_data
-        if status == "failed":
-            sys.stderr.write(f"[{label}] failed\n")
-            return "failed", status_data
-        if status_data.get("error") and "status" not in status_data:
-            sys.stderr.write(f"[{label}] error: {status_data.get('error')}\n")
-            return "error", status_data
-        sys.stderr.write(
-            f"[{label}] status={status} — polling again in {POLL_INTERVAL_S}s\n"
-        )
-        time.sleep(POLL_INTERVAL_S)
+def _save_manifest(path: Path, manifest: dict) -> None:
+    path.write_text(json.dumps(manifest, indent=2) + "\n")
+
+
+def _save_job(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload, indent=2) + "\n")
 
 
 def run_research(prompt_parts: list[str]) -> int:
@@ -331,7 +543,29 @@ def run_research(prompt_parts: list[str]) -> int:
         time.sleep(30)
 
 
-def run_research_fanout(prompt_parts: list[str], n: int) -> int:
+def _plan_fanout(
+    api_key: str, prompt: str, n: int
+) -> tuple[str | None, list[dict] | None, list[str] | None, float, str]:
+    """Decompose + MMR select. Returns brief, selected, sub_prompts, cheap_cost, err."""
+    brief, candidates, err, decomp_resp = _brief_and_candidates(api_key, prompt)
+    if brief is None or candidates is None:
+        return None, None, None, 0.0, err
+    inp, out = _usage_tokens(decomp_resp)
+    cheap_cost = _est_cheap_usd(inp, out)
+    selected = mmr_select(candidates, n, lambda_=0.0)
+    if len(selected) < n:
+        return (
+            None,
+            None,
+            None,
+            cheap_cost,
+            f"MMR selected {len(selected)} candidates, need {n}",
+        )
+    sub_prompts = [_build_sub_prompt(prompt, brief, s, selected) for s in selected]
+    return brief, selected, sub_prompts, cheap_cost, ""
+
+
+def run_research_plan_only(prompt_parts: list[str], n: int) -> int:
     api_key = resolve("OPENAI_API_KEY")
     if not api_key:
         print(json.dumps({"error": "OPENAI_API_KEY not found (try: n0b secrets set OPENAI_API_KEY)"}))
@@ -339,170 +573,414 @@ def run_research_fanout(prompt_parts: list[str], n: int) -> int:
     if not prompt_parts:
         print(json.dumps({"error": "No prompt provided"}))
         return 1
-    if n < 2:
-        print(json.dumps({"error": "--fanout N requires N >= 2"}))
+
+    n, was_clamped = _clamp_fanout(n)
+    if was_clamped:
+        sys.stderr.write(f"Clamped --fanout to {n} (allowed {FANOUT_MIN}-{FANOUT_MAX})\n")
+
+    prompt = " ".join(prompt_parts)
+    brief, selected, _sub_prompts, cheap_cost, err = _plan_fanout(api_key, prompt, n)
+    if brief is None or selected is None:
+        print(json.dumps({"error": err}))
         return 1
+
+    sys.stderr.write(
+        f"Plan-only: {n} sub-questions selected from {CANDIDATE_MIN}+ candidates "
+        f"(cheap-call estimate ${cheap_cost:.4f}); no research jobs submitted.\n"
+    )
+    print(f"# Research plan (N={n})\n")
+    print("## Brief\n")
+    print(brief)
+    print()
+    print("## Selected sub-questions\n")
+    for i, s in enumerate(selected, start=1):
+        print(f"{i}. {s['angle']}")
+        print(f"   seed_query: {s['seed_query']}")
+    return 0
+
+
+def _poll_set(
+    api_key: str,
+    jobs: dict[int, dict],
+    run_dir: Path,
+    manifest: dict,
+    manifest_path: Path,
+    *,
+    timeout_s: float | None = None,
+) -> tuple[dict[int, dict], dict[int, str]]:
+    """Poll a set of background jobs until quorum or all settle.
+
+    ``jobs`` maps index -> job record with at least ``id``. Mutates manifest
+    job entries and persists each completion immediately (OpenAI retains
+    background results ~10 minutes).
+    """
+    if timeout_s is None:
+        timeout_s = float(JOB_TIMEOUT_S)
+    n = len(jobs)
+    quorum = math.ceil(n / 2)
+    completed: dict[int, dict] = {}
+    terminal: dict[int, str] = {}
+    started_at = {i: time.monotonic() for i in jobs}
+    pending = set(jobs)
+
+    # Already-finished jobs from a prior run (result on disk).
+    for i in list(pending):
+        job_meta = next(
+            (j for j in manifest["jobs"] if j["index"] == i), None
+        )
+        if not job_meta:
+            continue
+        result_path = run_dir / f"job-{i}-result.json"
+        if job_meta.get("state") == "completed" and result_path.is_file():
+            completed[i] = json.loads(result_path.read_text())
+            terminal[i] = "completed"
+            pending.discard(i)
+            sys.stderr.write(f"[job-{i}] already completed (resumed from disk)\n")
+
+    while pending:
+        for i in list(pending):
+            rid = jobs[i]["id"]
+            status_data = _check_status(api_key, rid)
+            status = status_data.get("status", "unknown")
+            if status == "completed":
+                completed[i] = status_data
+                terminal[i] = "completed"
+                pending.discard(i)
+                result_path = run_dir / f"job-{i}-result.json"
+                _save_job(result_path, status_data)
+                for j in manifest["jobs"]:
+                    if j["index"] == i:
+                        j["state"] = "completed"
+                        j["result_file"] = result_path.name
+                _save_manifest(manifest_path, manifest)
+                sys.stderr.write(f"[job-{i}] completed (persisted)\n")
+            elif status == "failed":
+                terminal[i] = "failed"
+                pending.discard(i)
+                fail_path = run_dir / f"job-{i}-result.json"
+                _save_job(fail_path, status_data)
+                for j in manifest["jobs"]:
+                    if j["index"] == i:
+                        j["state"] = "failed"
+                _save_manifest(manifest_path, manifest)
+                sys.stderr.write(f"[job-{i}] failed\n")
+            elif status_data.get("error") and "status" not in status_data:
+                terminal[i] = "error"
+                pending.discard(i)
+                for j in manifest["jobs"]:
+                    if j["index"] == i:
+                        j["state"] = "error"
+                        j["error"] = str(status_data.get("error"))
+                _save_manifest(manifest_path, manifest)
+                sys.stderr.write(
+                    f"[job-{i}] error: {status_data.get('error')}\n"
+                )
+            else:
+                elapsed = time.monotonic() - started_at[i]
+                if elapsed >= timeout_s:
+                    terminal[i] = "timed out"
+                    pending.discard(i)
+                    for j in manifest["jobs"]:
+                        if j["index"] == i:
+                            j["state"] = "timed_out"
+                    _save_manifest(manifest_path, manifest)
+                    sys.stderr.write(
+                        f"[job-{i}] timed out after {int(elapsed)}s\n"
+                    )
+                else:
+                    sys.stderr.write(
+                        f"[job-{i}] status={status} — "
+                        f"polling again in {POLL_INTERVAL_S}s\n"
+                    )
+
+        sys.stderr.write(
+            f"Progress: {len(completed)} completed, "
+            f"{len(terminal) - len(completed)} settled-other, "
+            f"{len(pending)} pending (quorum {quorum}/{n})\n"
+        )
+
+        if not pending:
+            break
+
+        # Once quorum is met, stop waiting on stragglers past their budget.
+        if len(completed) >= quorum and all(
+            (time.monotonic() - started_at[i]) >= timeout_s for i in pending
+        ):
+            for i in list(pending):
+                terminal[i] = "timed out"
+                pending.discard(i)
+                for j in manifest["jobs"]:
+                    if j["index"] == i:
+                        j["state"] = "timed_out"
+                sys.stderr.write(
+                    f"[job-{i}] abandoned after quorum (timed out)\n"
+                )
+            _save_manifest(manifest_path, manifest)
+            break
+
+        # If quorum already met, sleep only until the soonest job timeout.
+        if len(completed) >= quorum:
+            waits = [
+                max(0.0, timeout_s - (time.monotonic() - started_at[i]))
+                for i in pending
+            ]
+            sleep_for = min(POLL_INTERVAL_S, min(waits)) if waits else 0.0
+        else:
+            sleep_for = float(POLL_INTERVAL_S)
+        if sleep_for > 0:
+            time.sleep(sleep_for)
+
+    return completed, terminal
+
+
+def run_research_fanout(
+    prompt_parts: list[str], n: int, *, plan_only: bool = False
+) -> int:
+    if plan_only:
+        return run_research_plan_only(prompt_parts, n)
+
+    api_key = resolve("OPENAI_API_KEY")
+    if not api_key:
+        print(json.dumps({"error": "OPENAI_API_KEY not found (try: n0b secrets set OPENAI_API_KEY)"}))
+        return 1
+    if not prompt_parts:
+        print(json.dumps({"error": "No prompt provided"}))
+        return 1
+
+    n, was_clamped = _clamp_fanout(n)
+    if was_clamped:
+        sys.stderr.write(f"Clamped --fanout to {n} (allowed {FANOUT_MIN}-{FANOUT_MAX})\n")
+    if n == 1:
+        return run_research(prompt_parts)
 
     prompt = " ".join(prompt_parts)
     prompt_hash = _get_hash(prompt)
     run_dir = _research_cache_dir() / f"fanout-{prompt_hash}"
     run_dir.mkdir(parents=True, exist_ok=True)
-    meta_file = run_dir / "meta.json"
-
+    manifest_path = run_dir / "manifest.json"
+    tool_budget = _max_tool_calls(n)
     cheap_cost = 0.0
-    sub_questions: list[str]
 
-    if meta_file.is_file():
-        meta = json.loads(meta_file.read_text())
-        sub_questions = list(meta["sub_questions"])
-        if len(sub_questions) != n:
+    if manifest_path.is_file():
+        manifest = json.loads(manifest_path.read_text())
+        if int(manifest.get("n", 0)) != n:
             print(
                 json.dumps(
                     {
                         "error": (
-                            f"cached fanout has {len(sub_questions)} sub-questions, "
+                            f"cached fanout has n={manifest.get('n')}, "
                             f"but --fanout {n} was requested"
                         )
                     }
                 )
             )
             return 1
+        brief = manifest["brief"]
+        selected = list(manifest["selected"])
+        sub_prompts = list(manifest["sub_prompts"])
         sys.stderr.write(
-            f"Rejoining fanout run at {run_dir} ({n} sub-questions from cache)\n"
+            f"Resuming fanout run at {run_dir} "
+            f"({n} sub-questions from manifest)\n"
         )
     else:
-        sys.stderr.write(f"Decomposing into {n} complementary sub-questions…\n")
-        sub_questions, err, decomp_resp = _decompose(api_key, prompt, n)
-        if sub_questions is None:
+        sys.stderr.write(
+            f"Planning fanout: brief + {CANDIDATE_MIN}-{CANDIDATE_MAX} "
+            f"candidate angles, MMR-select {n}…\n"
+        )
+        brief, selected, sub_prompts, cheap_cost, err = _plan_fanout(
+            api_key, prompt, n
+        )
+        if brief is None or selected is None or sub_prompts is None:
             print(json.dumps({"error": err}))
             return 1
-        inp, out = _usage_tokens(decomp_resp)
-        cheap_cost += _est_cheap_usd(inp, out)
         sys.stderr.write(
-            f"Decompose done ({inp} in / {out} out tokens; "
-            f"cheap-call estimate ${cheap_cost:.4f})\n"
+            f"Plan ready (cheap-call estimate ${cheap_cost:.4f}); "
+            f"max_tool_calls={tool_budget} per job\n"
         )
-        for i, q in enumerate(sub_questions, start=1):
-            sys.stderr.write(f"  {i}. {q}\n")
-        meta_file.write_text(
-            json.dumps(
-                {"prompt": prompt, "n": n, "sub_questions": sub_questions},
-                indent=2,
-            )
-            + "\n"
-        )
+        for i, s in enumerate(selected, start=1):
+            sys.stderr.write(f"  {i}. {s['angle']}  [{s['seed_query']}]\n")
+        manifest = {
+            "prompt": prompt,
+            "n": n,
+            "model": RESEARCH_MODEL,
+            "brief": brief,
+            "selected": selected,
+            "sub_prompts": sub_prompts,
+            "max_tool_calls": tool_budget,
+            "jobs": [],
+        }
+        _save_manifest(manifest_path, manifest)
 
-    # Submit (or rejoin) all jobs — parallel submits, shared cache files.
-    job_ids: list[str] = []
-
-    def _submit_one(i: int, question: str) -> tuple[int, dict, bool]:
-        cache_file = run_dir / f"job-{i}.json"
-        rejoined = cache_file.is_file()
-        return i, _load_or_submit(api_key, question, cache_file), rejoined
-
-    with ThreadPoolExecutor(max_workers=min(n, 8)) as pool:
-        futures = [
-            pool.submit(_submit_one, i, q) for i, q in enumerate(sub_questions, start=1)
-        ]
-        results: dict[int, tuple[dict, bool]] = {}
-        for fut in as_completed(futures):
-            i, data, rejoined = fut.result()
-            results[i] = (data, rejoined)
+    # Sequential submit (background POSTs return immediately). Resume skips
+    # jobs that already have an id / completed result on disk.
+    job_records: dict[int, dict] = {}
+    existing_jobs = {j["index"]: j for j in manifest.get("jobs") or []}
 
     for i in range(1, n + 1):
-        data, rejoined = results[i]
+        question = selected[i - 1]["angle"]
+        sub_prompt = sub_prompts[i - 1]
+        key = _job_key(question, n, RESEARCH_MODEL)
+        cache_file = run_dir / f"job-{i}.json"
+        result_file = run_dir / f"job-{i}-result.json"
+        prior = existing_jobs.get(i)
+
+        if prior and prior.get("state") == "completed" and result_file.is_file():
+            job_records[i] = {
+                "id": prior.get("id") or "",
+                "key": key,
+                "state": "completed",
+            }
+            sys.stderr.write(f"[job-{i}] skip submit (already completed)\n")
+            continue
+
+        if cache_file.is_file():
+            data = json.loads(cache_file.read_text())
+            rid = data.get("id") or ""
+            if rid:
+                job_records[i] = {"id": rid, "key": key, "state": "submitted"}
+                if not prior or prior.get("id") != rid:
+                    existing_jobs[i] = {
+                        "index": i,
+                        "key": key,
+                        "id": rid,
+                        "question": question,
+                        "state": "submitted",
+                    }
+                sys.stderr.write(f"[job-{i}] rejoined id={rid}\n")
+                continue
+
+        data = _call_openai(api_key, sub_prompt, max_tool_calls=tool_budget)
         if data.get("error"):
-            job_ids.append("")
             sys.stderr.write(f"[job-{i}] submit error: {data.get('error')}\n")
+            existing_jobs[i] = {
+                "index": i,
+                "key": key,
+                "id": "",
+                "question": question,
+                "state": "submit_failed",
+                "error": str(data.get("error")),
+            }
             continue
         rid = data.get("id") or ""
-        job_ids.append(rid)
-        sys.stderr.write(
-            f"[job-{i}] {'rejoined' if rejoined else 'submitted'} id={rid}\n"
-        )
+        _save_job(cache_file, data)
+        job_records[i] = {"id": rid, "key": key, "state": "submitted"}
+        existing_jobs[i] = {
+            "index": i,
+            "key": key,
+            "id": rid,
+            "question": question,
+            "state": "submitted",
+        }
+        sys.stderr.write(f"[job-{i}] submitted id={rid}\n")
 
-    submitted = sum(1 for j in job_ids if j)
+    manifest["jobs"] = [existing_jobs[i] for i in range(1, n + 1) if i in existing_jobs]
+    _save_manifest(manifest_path, manifest)
+
+    live = {i: rec for i, rec in job_records.items() if rec.get("id")}
+    # Include already-completed so poll_set can load them; exclude submit failures.
+    for i, j in existing_jobs.items():
+        if j.get("state") == "completed" and i not in live:
+            live[i] = {"id": j.get("id") or "cached", "key": j.get("key", "")}
+
+    submitted = sum(
+        1
+        for j in manifest["jobs"]
+        if j.get("state") in ("submitted", "completed") and j.get("id")
+    )
     sys.stderr.write(
         f"Jobs submitted/rejoined: {submitted}/{n} "
         f"(estimate {submitted} x ${EST_RESEARCH_JOB_USD:.2f} = "
         f"${submitted * EST_RESEARCH_JOB_USD:.2f} research + "
-        f"${cheap_cost:.4f} cheap-calls)\n"
+        f"${cheap_cost:.4f} cheap-calls; max_tool_calls={tool_budget})\n"
     )
-    if submitted == 0:
+    if not live:
         print(json.dumps({"error": "all fanout submits failed"}))
         return 1
 
-    # Poll all jobs concurrently (each thread polls its own job).
-    completed: dict[int, dict] = {}
-    failed = 0
-    pending = {i: job_ids[i - 1] for i in range(1, n + 1) if job_ids[i - 1]}
+    completed, terminal = _poll_set(
+        api_key, live, run_dir, manifest, manifest_path
+    )
 
-    with ThreadPoolExecutor(max_workers=min(n, 8)) as pool:
-        future_map = {
-            pool.submit(_poll_one, api_key, rid, f"job-{i}"): i
-            for i, rid in pending.items()
-        }
-        done_count = 0
-        total = len(future_map)
-        for fut in as_completed(future_map):
-            i = future_map[fut]
-            status, data = fut.result()
-            done_count += 1
-            running = total - done_count
-            if status == "completed":
-                completed[i] = data
-                sys.stderr.write(
-                    f"Progress: {done_count} done, {running} running "
-                    f"(research estimate ${submitted * EST_RESEARCH_JOB_USD:.2f} + "
-                    f"cheap ${cheap_cost:.4f})\n"
-                )
-            else:
-                failed += 1
-                sys.stderr.write(
-                    f"Progress: {done_count} done ({failed} failed), {running} running\n"
-                )
+    quorum = math.ceil(n / 2)
+    if len(completed) < quorum:
+        print(
+            json.dumps(
+                {
+                    "error": (
+                        f"only {len(completed)}/{n} jobs completed "
+                        f"(need >= {quorum} for partial merge)"
+                    ),
+                    "run_dir": str(run_dir),
+                }
+            )
+        )
+        return 1
 
-    reports: list[tuple[str, str, list[str]]] = []
-    for i, question in enumerate(sub_questions, start=1):
+    reports: list[tuple[int, str, str, list[str]]] = []
+    missing: list[dict] = []
+    for i in range(1, n + 1):
+        question = selected[i - 1]["angle"]
         data = completed.get(i)
         if data is None:
-            body = "(job did not complete)"
-            urls: list[str] = []
-        else:
-            body = _output_text(data)
-            urls = _extract_urls(body)
-            # Also pull URL annotations if present.
-            for item in data.get("output") or []:
-                if not isinstance(item, dict):
-                    continue
-                for block in item.get("content") or []:
-                    if not isinstance(block, dict):
-                        continue
-                    for ann in block.get("annotations") or []:
-                        if isinstance(ann, dict) and ann.get("url"):
-                            u = ann["url"]
-                            if u not in urls:
-                                urls.append(u)
+            reason = terminal.get(i) or "failed"
+            missing.append({"index": i, "question": question, "reason": reason})
+            continue
+        body = _output_text(data)
+        urls = _urls_from_response(data, body)
         report_path = run_dir / f"report-{i:02d}.md"
         _write_sub_report(report_path, i, question, body, urls)
-        reports.append((question, body, urls))
+        reports.append((i, question, body, urls))
 
-    sys.stderr.write("Merging sub-reports…\n")
-    merged, err, merge_resp = _merge_reports(api_key, prompt, reports)
+    sys.stderr.write(
+        f"Merging {len(reports)}/{n} completed sub-reports "
+        f"({len(missing)} missing)…\n"
+    )
+    merged, err, merge_resp = _merge_reports(api_key, prompt, reports, missing)
     if merged is None:
         print(json.dumps({"error": err, "run_dir": str(run_dir)}))
         return 1
     inp, out = _usage_tokens(merge_resp)
     cheap_cost += _est_cheap_usd(inp, out)
-    (run_dir / "merged.md").write_text(merged if merged.endswith("\n") else merged + "\n")
 
+    check_text, check_err, check_resp = _citation_check(api_key, merged, reports)
+    if check_text is None:
+        sys.stderr.write(f"Citation check skipped: {check_err}\n")
+    else:
+        inp, out = _usage_tokens(check_resp)
+        cheap_cost += _est_cheap_usd(inp, out)
+        if not merged.endswith("\n"):
+            merged += "\n"
+        merged = merged + "\n" + check_text
+        if not merged.endswith("\n"):
+            merged += "\n"
+
+    if missing:
+        # Guarantee the partial-merge disclosure even if the model omitted it.
+        missing_section = "\n## Missing sub-questions\n\n"
+        for m in missing:
+            missing_section += (
+                f"- Sub-question {m['index']} ({m['question']}): {m['reason']}\n"
+            )
+        if "## Missing sub-questions" not in merged:
+            merged = merged.rstrip() + "\n" + missing_section + "\n"
+
+    (run_dir / "merged.md").write_text(
+        merged if merged.endswith("\n") else merged + "\n"
+    )
+    manifest["state"] = "merged"
+    manifest["completed"] = sorted(completed)
+    manifest["missing"] = missing
+    _save_manifest(manifest_path, manifest)
+
+    failed_or_missing = n - len(completed)
     est_total = submitted * EST_RESEARCH_JOB_USD + cheap_cost
     sys.stderr.write(
-        f"Fanout complete: {len(completed)}/{n} jobs ok, {failed} failed\n"
+        f"Fanout complete: {len(completed)}/{n} jobs ok, "
+        f"{failed_or_missing} missing/failed\n"
         f"Cost estimate: {submitted} research jobs x ${EST_RESEARCH_JOB_USD:.2f} "
         f"= ${submitted * EST_RESEARCH_JOB_USD:.2f} (estimate) + "
         f"cheap calls ${cheap_cost:.4f} (estimate) ≈ ${est_total:.2f}\n"
         f"Run directory: {run_dir}\n"
     )
     print(str(run_dir))
-    return 0 if failed == 0 and len(completed) == n else 1
+    return 0 if not missing else 1

--- a/apps/n0b/tests/test_research.py
+++ b/apps/n0b/tests/test_research.py
@@ -1,0 +1,321 @@
+"""Tests for n0b ai research + --fanout (HTTP stubbed; no live API)."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+N0B_PY = Path(__file__).resolve().parents[1] / "n0b.py"
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from cli import build_parser, main  # noqa: E402
+from research import (  # noqa: E402
+    run_research,
+    run_research_fanout,
+    _get_hash,
+)
+
+
+def run_n0b(*args: str):
+    import subprocess
+
+    return subprocess.run(
+        [sys.executable, str(N0B_PY), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _msg(text: str, usage: dict | None = None) -> dict:
+    out: dict = {
+        "output": [
+            {
+                "type": "message",
+                "content": [{"type": "output_text", "text": text}],
+            }
+        ]
+    }
+    if usage is not None:
+        out["usage"] = usage
+    return out
+
+
+def test_research_help_shows_fanout():
+    proc = run_n0b("ai", "research", "--help")
+    assert proc.returncode == 0
+    assert "--fanout" in proc.stdout
+    assert "N" in proc.stdout
+
+
+def test_ai_help_lists_research():
+    proc = run_n0b("ai", "--help")
+    assert proc.returncode == 0
+    assert "research" in proc.stdout
+
+
+def test_fanout_parses_before_remainder_prompt():
+    parser = build_parser()
+    args = parser.parse_args(["ai", "research", "--fanout", "3", "what", "is", "X"])
+    assert args.fanout == 3
+    assert args.prompt == ["what", "is", "X"]
+
+
+def test_fanout_absent_leaves_prompt_only():
+    parser = build_parser()
+    args = parser.parse_args(["ai", "research", "what", "is", "X"])
+    assert args.fanout is None
+    assert args.prompt == ["what", "is", "X"]
+
+
+def test_ai_research_requires_prompt():
+    proc = run_n0b("ai", "research")
+    assert proc.returncode == 2
+    assert "Usage: n0b ai research" in proc.stderr
+
+
+def test_fanout_requires_prompt():
+    proc = run_n0b("ai", "research", "--fanout", "3")
+    assert proc.returncode == 2
+    assert "Usage: n0b ai research" in proc.stderr
+
+
+def test_single_shot_untouched(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("research.BIN_ROOT", tmp_path)
+    monkeypatch.setattr("research.resolve", lambda _k: "sk-test")
+
+    submitted = {"id": "resp_single", "status": "queued"}
+    completed = {
+        "id": "resp_single",
+        "status": "completed",
+        "output": [{"type": "message", "content": [{"type": "output_text", "text": "ok"}]}],
+    }
+
+    with (
+        patch("research._call_openai", return_value=submitted) as submit,
+        patch("research._check_status", return_value=completed) as poll,
+        patch("research.time.sleep") as sleep,
+    ):
+        rc = run_research(["single", "shot", "prompt"])
+    assert rc == 0
+    submit.assert_called_once()
+    poll.assert_called_once_with("sk-test", "resp_single")
+    sleep.assert_not_called()
+    out = capsys.readouterr().out
+    assert json.loads(out) == completed
+    # Cache file written at the single-shot path, not under fanout-*.
+    files = list((tmp_path / ".files" / "research").glob("*.json"))
+    assert len(files) == 1
+    assert not files[0].name.startswith("fanout")
+
+
+def test_fanout_produces_reports_and_merged(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("research.BIN_ROOT", tmp_path)
+    monkeypatch.setattr("research.resolve", lambda _k: "sk-test")
+    monkeypatch.setattr("research.POLL_INTERVAL_S", 0)
+
+    questions = [
+        "What is the mechanism of X?",
+        "What evidence supports X?",
+        "What are the risks of X?",
+    ]
+    decomp = _msg(
+        json.dumps(questions),
+        usage={"input_tokens": 100, "output_tokens": 50},
+    )
+    merge_body = (
+        "# Merged research\n\n## Summary\nX works.\n\n"
+        "## Findings\n"
+        "- Mechanism is Y [report-01.md | https://example.com/a]\n"
+        "- Evidence is Z [report-02.md | https://example.com/b]\n\n"
+        "## Conflicts\n"
+        "- report-01 says safe [report-01.md | https://example.com/a]; "
+        "report-03 says risky [report-03.md | https://example.com/c]\n"
+    )
+    merge = _msg(merge_body, usage={"input_tokens": 200, "output_tokens": 80})
+
+    cheap_calls: list[str] = []
+
+    def fake_cheap(_key: str, prompt: str) -> dict:
+        cheap_calls.append(prompt)
+        if "Decompose" in prompt or "complementary" in prompt:
+            return decomp
+        return merge
+
+    submit_ids = {1: "resp_1", 2: "resp_2", 3: "resp_3"}
+    bodies = {
+        "resp_1": "Mechanism detail. https://example.com/a",
+        "resp_2": "Evidence detail. https://example.com/b",
+        "resp_3": "Risk detail. https://example.com/c",
+    }
+
+    def fake_submit(_key: str, prompt: str) -> dict:
+        for i, q in enumerate(questions, start=1):
+            if prompt == q:
+                return {"id": submit_ids[i], "status": "queued"}
+        raise AssertionError(f"unexpected submit prompt: {prompt!r}")
+
+    def fake_status(_key: str, response_id: str) -> dict:
+        return {
+            "id": response_id,
+            "status": "completed",
+            "output": [
+                {
+                    "type": "message",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": bodies[response_id],
+                        }
+                    ],
+                }
+            ],
+            "usage": {"input_tokens": 10, "output_tokens": 20},
+        }
+
+    with (
+        patch("research._call_cheap", side_effect=fake_cheap),
+        patch("research._call_openai", side_effect=fake_submit),
+        patch("research._check_status", side_effect=fake_status),
+        patch("research.time.sleep"),
+    ):
+        rc = run_research_fanout(["what", "is", "X"], 3)
+
+    assert rc == 0
+    prompt_hash = _get_hash("what is X")
+    run_dir = tmp_path / ".files" / "research" / f"fanout-{prompt_hash}"
+    assert run_dir.is_dir()
+    assert (run_dir / "meta.json").is_file()
+    assert (run_dir / "merged.md").is_file()
+    for i in range(1, 4):
+        assert (run_dir / f"job-{i}.json").is_file()
+        report = (run_dir / f"report-{i:02d}.md").read_text()
+        assert questions[i - 1] in report
+        assert f"https://example.com/{'abc'[i - 1]}" in report
+    merged = (run_dir / "merged.md").read_text()
+    assert "## Conflicts" in merged
+    assert "report-01.md" in merged
+    out = capsys.readouterr()
+    assert str(run_dir) in out.out
+    assert "Jobs submitted" in out.err or "submitted" in out.err
+    assert "estimate" in out.err.lower()
+    assert len(cheap_calls) == 2
+
+
+def test_fanout_rejoins_cached_jobs(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("research.BIN_ROOT", tmp_path)
+    monkeypatch.setattr("research.resolve", lambda _k: "sk-test")
+    monkeypatch.setattr("research.POLL_INTERVAL_S", 0)
+
+    questions = ["Angle A on topic?", "Angle B on topic?"]
+    prompt = "topic question"
+    prompt_hash = _get_hash(prompt)
+    run_dir = tmp_path / ".files" / "research" / f"fanout-{prompt_hash}"
+    run_dir.mkdir(parents=True)
+    (run_dir / "meta.json").write_text(
+        json.dumps({"prompt": prompt, "n": 2, "sub_questions": questions}) + "\n"
+    )
+    for i, rid in enumerate(["resp_a", "resp_b"], start=1):
+        (run_dir / f"job-{i}.json").write_text(
+            json.dumps({"id": rid, "status": "queued"})
+        )
+
+    submit = patch("research._call_openai")
+    decomp = patch("research._call_cheap")
+
+    def fake_status(_key: str, response_id: str) -> dict:
+        return {
+            "id": response_id,
+            "status": "completed",
+            "output": [
+                {
+                    "type": "message",
+                    "content": [
+                        {"type": "output_text", "text": f"done {response_id} https://ex.test/{response_id}"}
+                    ],
+                }
+            ],
+        }
+
+    merge = _msg(
+        "# Merged research\n\n## Summary\nok\n\n## Conflicts\n- none\n",
+        usage={"input_tokens": 1, "output_tokens": 1},
+    )
+
+    with (
+        submit as submit_mock,
+        decomp as cheap_mock,
+        patch("research._check_status", side_effect=fake_status),
+        patch("research.time.sleep"),
+    ):
+        cheap_mock.return_value = merge
+        rc = run_research_fanout(prompt.split(), 2)
+
+    assert rc == 0
+    submit_mock.assert_not_called()
+    # Only the merge cheap call — decompose skipped via meta cache.
+    assert cheap_mock.call_count == 1
+    err = capsys.readouterr().err
+    assert "Rejoining" in err
+    assert "rejoined" in err
+
+
+def test_malformed_decomposer_fails_cleanly(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("research.BIN_ROOT", tmp_path)
+    monkeypatch.setattr("research.resolve", lambda _k: "sk-test")
+
+    bad = _msg("sorry I cannot help with that")
+
+    with (
+        patch("research._call_cheap", return_value=bad),
+        patch("research._call_openai") as submit,
+    ):
+        rc = run_research_fanout(["what", "is", "X"], 3)
+
+    assert rc == 1
+    submit.assert_not_called()
+    err_obj = json.loads(capsys.readouterr().out)
+    assert "error" in err_obj
+    assert "JSON list" in err_obj["error"] or "decompose" in err_obj["error"]
+
+
+def test_malformed_decomposer_wrong_count(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("research.BIN_ROOT", tmp_path)
+    monkeypatch.setattr("research.resolve", lambda _k: "sk-test")
+
+    bad = _msg(json.dumps(["only one"]))
+
+    with patch("research._call_cheap", return_value=bad):
+        rc = run_research_fanout(["q"], 3)
+
+    assert rc == 1
+    err_obj = json.loads(capsys.readouterr().out)
+    assert "expected 3" in err_obj["error"]
+
+
+def test_fanout_n_less_than_two(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("research.resolve", lambda _k: "sk-test")
+    rc = run_research_fanout(["q"], 1)
+    assert rc == 1
+    assert "N >= 2" in capsys.readouterr().out
+
+
+def test_cli_dispatches_fanout(tmp_path, monkeypatch):
+    with patch("commands.ai_research_cmd.run_research_fanout", return_value=0) as fanout, patch(
+        "commands.ai_research_cmd.run_research", return_value=0
+    ) as single:
+        rc = main(["ai", "research", "--fanout", "4", "alpha", "beta"])
+    assert rc == 0
+    fanout.assert_called_once_with(["alpha", "beta"], 4)
+    single.assert_not_called()
+
+
+def test_cli_dispatches_single_shot():
+    with patch("commands.ai_research_cmd.run_research", return_value=0) as single, patch(
+        "commands.ai_research_cmd.run_research_fanout", return_value=0
+    ) as fanout:
+        rc = main(["ai", "research", "alpha", "beta"])
+    assert rc == 0
+    single.assert_called_once_with(["alpha", "beta"])
+    fanout.assert_not_called()

--- a/apps/n0b/tests/test_research.py
+++ b/apps/n0b/tests/test_research.py
@@ -13,7 +13,10 @@ from cli import build_parser, main  # noqa: E402
 from research import (  # noqa: E402
     run_research,
     run_research_fanout,
+    run_research_plan_only,
+    mmr_select,
     _get_hash,
+    _max_tool_calls,
 )
 
 
@@ -42,11 +45,39 @@ def _msg(text: str, usage: dict | None = None) -> dict:
     return out
 
 
-def test_research_help_shows_fanout():
+def _plan_payload(n_candidates: int = 12) -> dict:
+    candidates = []
+    angles = [
+        ("mechanism", "how does X work internally"),
+        ("evidence", "empirical evidence supporting X"),
+        ("counter-evidence", "studies that contradict X"),
+        ("adoption", "who uses X in practice"),
+        ("risks", "failure modes and risks of X"),
+        ("alternatives", "alternatives to X compared"),
+        ("history", "historical development of X"),
+        ("cost", "cost economics of deploying X"),
+        ("regulation", "regulatory status of X"),
+        ("ethics", "ethical concerns around X"),
+        ("measurement", "how X is measured evaluated"),
+        ("ecosystem", "tooling ecosystem around X"),
+        ("scalability", "scalability limits of X"),
+        ("security", "security properties of X"),
+        ("ux", "user experience tradeoffs of X"),
+        ("future", "roadmap future of X"),
+    ]
+    for angle, seed in angles[:n_candidates]:
+        candidates.append({"angle": angle, "seed_query": seed})
+    return {
+        "brief": "A short planning brief about researching X across dimensions.",
+        "candidates": candidates,
+    }
+
+
+def test_research_help_shows_fanout_and_plan_only():
     proc = run_n0b("ai", "research", "--help")
     assert proc.returncode == 0
     assert "--fanout" in proc.stdout
-    assert "N" in proc.stdout
+    assert "--plan-only" in proc.stdout
 
 
 def test_ai_help_lists_research():
@@ -69,6 +100,27 @@ def test_fanout_absent_leaves_prompt_only():
     assert args.prompt == ["what", "is", "X"]
 
 
+def test_fanout_bare_defaults_to_four_via_main():
+    with patch("commands.ai_research_cmd.run_research_fanout", return_value=0) as fanout, patch(
+        "commands.ai_research_cmd.run_research", return_value=0
+    ) as single:
+        rc = main(["ai", "research", "--fanout", "alpha", "beta"])
+    assert rc == 0
+    fanout.assert_called_once()
+    assert fanout.call_args[0][1] == 4
+    single.assert_not_called()
+
+
+def test_fanout_one_dispatches_single_shot():
+    with patch("commands.ai_research_cmd.run_research", return_value=0) as single, patch(
+        "commands.ai_research_cmd.run_research_fanout", return_value=0
+    ) as fanout:
+        rc = main(["ai", "research", "--fanout", "1", "alpha", "beta"])
+    assert rc == 0
+    single.assert_called_once_with(["alpha", "beta"])
+    fanout.assert_not_called()
+
+
 def test_ai_research_requires_prompt():
     proc = run_n0b("ai", "research")
     assert proc.returncode == 2
@@ -79,6 +131,32 @@ def test_fanout_requires_prompt():
     proc = run_n0b("ai", "research", "--fanout", "3")
     assert proc.returncode == 2
     assert "Usage: n0b ai research" in proc.stderr
+
+
+def test_mmr_skips_near_duplicate_candidates():
+    candidates = [
+        {"angle": "mechanism A", "seed_query": "how does quantum entanglement work"},
+        {"angle": "mechanism B", "seed_query": "how does quantum entanglement work exactly"},
+        {"angle": "economics", "seed_query": "market cost of quantum computing hardware"},
+        {"angle": "regulation", "seed_query": "export control laws for quantum tech"},
+        {"angle": "mechanism C", "seed_query": "how quantum entanglement works in detail"},
+    ]
+    selected = mmr_select(candidates, 3, lambda_=0.0)
+    assert len(selected) == 3
+    seeds = [s["seed_query"] for s in selected]
+    # First is always kept; the near-paraphrases of entanglement should not
+    # occupy both remaining slots when diverse alternatives exist.
+    entanglementish = [
+        s for s in seeds if "entanglement" in s or "entanglement" in s
+    ]
+    assert len(entanglementish) <= 1
+    assert any("market cost" in s or "export control" in s for s in seeds)
+
+
+def test_max_tool_calls_scales_down():
+    assert _max_tool_calls(1) == 50
+    assert _max_tool_calls(4) == 12
+    assert _max_tool_calls(8) == 10  # floor
 
 
 def test_single_shot_untouched(tmp_path, monkeypatch, capsys):
@@ -104,57 +182,128 @@ def test_single_shot_untouched(tmp_path, monkeypatch, capsys):
     sleep.assert_not_called()
     out = capsys.readouterr().out
     assert json.loads(out) == completed
-    # Cache file written at the single-shot path, not under fanout-*.
     files = list((tmp_path / ".files" / "research").glob("*.json"))
     assert len(files) == 1
     assert not files[0].name.startswith("fanout")
 
 
-def test_fanout_produces_reports_and_merged(tmp_path, monkeypatch, capsys):
+def test_fanout_one_byte_identical_to_single_shot(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("research.BIN_ROOT", tmp_path)
+    monkeypatch.setattr("research.resolve", lambda _k: "sk-test")
+
+    submitted = {"id": "resp_single", "status": "queued"}
+    completed = {
+        "id": "resp_single",
+        "status": "completed",
+        "output": [{"type": "message", "content": [{"type": "output_text", "text": "ok"}]}],
+    }
+
+    with (
+        patch("research._call_openai", return_value=submitted),
+        patch("research._check_status", return_value=completed),
+        patch("research.time.sleep"),
+    ):
+        rc1 = run_research(["same", "prompt"])
+    out1 = capsys.readouterr().out
+
+    # Reset cache so second path submits again the same way.
+    cache = tmp_path / ".files" / "research"
+    for f in cache.glob("*.json"):
+        f.unlink()
+
+    with (
+        patch("research._call_openai", return_value=submitted),
+        patch("research._check_status", return_value=completed),
+        patch("research.time.sleep"),
+    ):
+        rc2 = run_research_fanout(["same", "prompt"], 1)
+    out2 = capsys.readouterr().out
+
+    assert rc1 == rc2 == 0
+    assert out1 == out2
+
+
+def test_plan_only_submits_zero_research_jobs(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("research.BIN_ROOT", tmp_path)
+    monkeypatch.setattr("research.resolve", lambda _k: "sk-test")
+
+    plan = _msg(
+        json.dumps(_plan_payload()),
+        usage={"input_tokens": 50, "output_tokens": 80},
+    )
+
+    with (
+        patch("research._call_cheap", return_value=plan) as cheap,
+        patch("research._call_openai") as submit,
+    ):
+        rc = run_research_plan_only(["what", "is", "X"], 4)
+
+    assert rc == 0
+    submit.assert_not_called()
+    cheap.assert_called_once()
+    out = capsys.readouterr().out
+    assert "# Research plan" in out
+    assert "## Brief" in out
+    assert "seed_query:" in out
+
+
+def test_plan_only_via_fanout_kwarg(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("research.BIN_ROOT", tmp_path)
+    monkeypatch.setattr("research.resolve", lambda _k: "sk-test")
+    plan = _msg(json.dumps(_plan_payload()))
+
+    with (
+        patch("research._call_cheap", return_value=plan),
+        patch("research._call_openai") as submit,
+    ):
+        rc = run_research_fanout(["q"], 3, plan_only=True)
+
+    assert rc == 0
+    submit.assert_not_called()
+
+
+def test_fanout_produces_manifest_reports_and_merged(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr("research.BIN_ROOT", tmp_path)
     monkeypatch.setattr("research.resolve", lambda _k: "sk-test")
     monkeypatch.setattr("research.POLL_INTERVAL_S", 0)
 
-    questions = [
-        "What is the mechanism of X?",
-        "What evidence supports X?",
-        "What are the risks of X?",
-    ]
+    plan_obj = _plan_payload()
+    # Force MMR to pick the first 3 diverse angles from the payload.
     decomp = _msg(
-        json.dumps(questions),
+        json.dumps(plan_obj),
         usage={"input_tokens": 100, "output_tokens": 50},
     )
     merge_body = (
         "# Merged research\n\n## Summary\nX works.\n\n"
         "## Findings\n"
-        "- Mechanism is Y [report-01.md | https://example.com/a]\n"
-        "- Evidence is Z [report-02.md | https://example.com/b]\n\n"
-        "## Conflicts\n"
-        "- report-01 says safe [report-01.md | https://example.com/a]; "
-        "report-03 says risky [report-03.md | https://example.com/c]\n"
+        "- Mechanism is Y [report-01.md | https://example.com/a]\n\n"
+        "## Contradictions\n"
+        "- none noted\n\n"
+        "## Citations\n"
+        "- https://example.com/a (corroboration=1)\n"
     )
     merge = _msg(merge_body, usage={"input_tokens": 200, "output_tokens": 80})
+    cite_check = _msg(
+        "## Citation check\n- OK: Mechanism is Y\n",
+        usage={"input_tokens": 40, "output_tokens": 20},
+    )
 
     cheap_calls: list[str] = []
 
     def fake_cheap(_key: str, prompt: str) -> dict:
         cheap_calls.append(prompt)
-        if "Decompose" in prompt or "complementary" in prompt:
+        if "planning a multi-angle" in prompt or "candidate" in prompt.lower():
             return decomp
+        if "Citation check" in prompt:
+            return cite_check
         return merge
 
-    submit_ids = {1: "resp_1", 2: "resp_2", 3: "resp_3"}
-    bodies = {
-        "resp_1": "Mechanism detail. https://example.com/a",
-        "resp_2": "Evidence detail. https://example.com/b",
-        "resp_3": "Risk detail. https://example.com/c",
-    }
+    submit_count = {"n": 0}
 
-    def fake_submit(_key: str, prompt: str) -> dict:
-        for i, q in enumerate(questions, start=1):
-            if prompt == q:
-                return {"id": submit_ids[i], "status": "queued"}
-        raise AssertionError(f"unexpected submit prompt: {prompt!r}")
+    def fake_submit(_key: str, prompt: str, *, max_tool_calls: int | None = None) -> dict:
+        submit_count["n"] += 1
+        rid = f"resp_{submit_count['n']}"
+        return {"id": rid, "status": "queued"}
 
     def fake_status(_key: str, response_id: str) -> dict:
         return {
@@ -166,7 +315,7 @@ def test_fanout_produces_reports_and_merged(tmp_path, monkeypatch, capsys):
                     "content": [
                         {
                             "type": "output_text",
-                            "text": bodies[response_id],
+                            "text": f"Findings for {response_id}. https://example.com/{response_id}",
                         }
                     ],
                 }
@@ -186,43 +335,101 @@ def test_fanout_produces_reports_and_merged(tmp_path, monkeypatch, capsys):
     prompt_hash = _get_hash("what is X")
     run_dir = tmp_path / ".files" / "research" / f"fanout-{prompt_hash}"
     assert run_dir.is_dir()
-    assert (run_dir / "meta.json").is_file()
+    assert (run_dir / "manifest.json").is_file()
     assert (run_dir / "merged.md").is_file()
+    manifest = json.loads((run_dir / "manifest.json").read_text())
+    assert manifest["n"] == 3
+    assert "brief" in manifest
+    assert len(manifest["selected"]) == 3
     for i in range(1, 4):
         assert (run_dir / f"job-{i}.json").is_file()
-        report = (run_dir / f"report-{i:02d}.md").read_text()
-        assert questions[i - 1] in report
-        assert f"https://example.com/{'abc'[i - 1]}" in report
+        assert (run_dir / f"job-{i}-result.json").is_file()
+        assert (run_dir / f"report-{i:02d}.md").is_file()
     merged = (run_dir / "merged.md").read_text()
-    assert "## Conflicts" in merged
-    assert "report-01.md" in merged
+    assert "## Contradictions" in merged
+    assert "## Citation check" in merged
     out = capsys.readouterr()
     assert str(run_dir) in out.out
-    assert "Jobs submitted" in out.err or "submitted" in out.err
     assert "estimate" in out.err.lower()
-    assert len(cheap_calls) == 2
+    assert submit_count["n"] == 3
+    # plan + merge + citation-check
+    assert len(cheap_calls) == 3
+    # Sequential submit — no threads; max_tool_calls scaled.
+    assert _max_tool_calls(3) == 16
 
 
-def test_fanout_rejoins_cached_jobs(tmp_path, monkeypatch, capsys):
+def test_fanout_resumes_without_resubmitting_completed(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr("research.BIN_ROOT", tmp_path)
     monkeypatch.setattr("research.resolve", lambda _k: "sk-test")
     monkeypatch.setattr("research.POLL_INTERVAL_S", 0)
 
-    questions = ["Angle A on topic?", "Angle B on topic?"]
+    selected = [
+        {"angle": "Angle A", "seed_query": "seed a unique alpha"},
+        {"angle": "Angle B", "seed_query": "seed b unique beta"},
+    ]
     prompt = "topic question"
     prompt_hash = _get_hash(prompt)
     run_dir = tmp_path / ".files" / "research" / f"fanout-{prompt_hash}"
     run_dir.mkdir(parents=True)
-    (run_dir / "meta.json").write_text(
-        json.dumps({"prompt": prompt, "n": 2, "sub_questions": questions}) + "\n"
-    )
-    for i, rid in enumerate(["resp_a", "resp_b"], start=1):
-        (run_dir / f"job-{i}.json").write_text(
-            json.dumps({"id": rid, "status": "queued"})
-        )
 
-    submit = patch("research._call_openai")
-    decomp = patch("research._call_cheap")
+    sub_prompts = [f"sub for {s['angle']}" for s in selected]
+    completed_body = {
+        "id": "resp_a",
+        "status": "completed",
+        "output": [
+            {
+                "type": "message",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": "done A https://ex.test/a",
+                    }
+                ],
+            }
+        ],
+    }
+    (run_dir / "job-1.json").write_text(json.dumps({"id": "resp_a", "status": "queued"}))
+    (run_dir / "job-1-result.json").write_text(json.dumps(completed_body))
+    (run_dir / "job-2.json").write_text(json.dumps({"id": "resp_b", "status": "queued"}))
+
+    manifest = {
+        "prompt": prompt,
+        "n": 2,
+        "model": "gpt-5.6-sol",
+        "brief": "brief",
+        "selected": selected,
+        "sub_prompts": sub_prompts,
+        "max_tool_calls": 25,
+        "jobs": [
+            {
+                "index": 1,
+                "key": "k1",
+                "id": "resp_a",
+                "question": "Angle A",
+                "state": "completed",
+                "result_file": "job-1-result.json",
+            },
+            {
+                "index": 2,
+                "key": "k2",
+                "id": "resp_b",
+                "question": "Angle B",
+                "state": "submitted",
+            },
+        ],
+    }
+    (run_dir / "manifest.json").write_text(json.dumps(manifest) + "\n")
+
+    merge = _msg(
+        "# Merged research\n\n## Summary\nok\n\n## Contradictions\n- none\n",
+        usage={"input_tokens": 1, "output_tokens": 1},
+    )
+    cite = _msg("## Citation check\n- OK\n")
+
+    def fake_cheap(_key: str, prompt: str) -> dict:
+        if "Citation check" in prompt:
+            return cite
+        return merge
 
     def fake_status(_key: str, response_id: str) -> dict:
         return {
@@ -232,33 +439,171 @@ def test_fanout_rejoins_cached_jobs(tmp_path, monkeypatch, capsys):
                 {
                     "type": "message",
                     "content": [
-                        {"type": "output_text", "text": f"done {response_id} https://ex.test/{response_id}"}
+                        {
+                            "type": "output_text",
+                            "text": f"done {response_id} https://ex.test/{response_id}",
+                        }
                     ],
                 }
             ],
         }
 
-    merge = _msg(
-        "# Merged research\n\n## Summary\nok\n\n## Conflicts\n- none\n",
-        usage={"input_tokens": 1, "output_tokens": 1},
-    )
-
     with (
-        submit as submit_mock,
-        decomp as cheap_mock,
+        patch("research._call_openai") as submit_mock,
+        patch("research._call_cheap", side_effect=fake_cheap),
         patch("research._check_status", side_effect=fake_status),
         patch("research.time.sleep"),
     ):
-        cheap_mock.return_value = merge
         rc = run_research_fanout(prompt.split(), 2)
 
     assert rc == 0
     submit_mock.assert_not_called()
-    # Only the merge cheap call — decompose skipped via meta cache.
-    assert cheap_mock.call_count == 1
     err = capsys.readouterr().err
-    assert "Rejoining" in err
-    assert "rejoined" in err
+    assert "Resuming" in err
+    assert "skip submit" in err or "already completed" in err
+
+
+def test_partial_merge_on_timeout(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("research.BIN_ROOT", tmp_path)
+    monkeypatch.setattr("research.resolve", lambda _k: "sk-test")
+    monkeypatch.setattr("research.POLL_INTERVAL_S", 0)
+    monkeypatch.setattr("research.JOB_TIMEOUT_S", 0)
+
+    plan_obj = _plan_payload()
+    decomp = _msg(json.dumps(plan_obj), usage={"input_tokens": 10, "output_tokens": 10})
+    merge = _msg(
+        "# Merged research\n\n## Summary\npartial\n\n## Contradictions\n- none\n",
+        usage={"input_tokens": 10, "output_tokens": 10},
+    )
+    cite = _msg("## Citation check\n- OK\n")
+
+    def fake_cheap(_key: str, prompt: str) -> dict:
+        if "planning a multi-angle" in prompt or "candidate" in prompt.lower():
+            return decomp
+        if "Citation check" in prompt:
+            return cite
+        return merge
+
+    submit_ids = []
+
+    def fake_submit(_key: str, prompt: str, *, max_tool_calls: int | None = None) -> dict:
+        rid = f"resp_{len(submit_ids) + 1}"
+        submit_ids.append(rid)
+        return {"id": rid, "status": "queued"}
+
+    def fake_status(_key: str, response_id: str) -> dict:
+        # First two complete; third stays queued → times out (JOB_TIMEOUT_S=0).
+        if response_id in ("resp_1", "resp_2"):
+            return {
+                "id": response_id,
+                "status": "completed",
+                "output": [
+                    {
+                        "type": "message",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": f"ok {response_id} https://ex.test/{response_id}",
+                            }
+                        ],
+                    }
+                ],
+            }
+        return {"id": response_id, "status": "queued"}
+
+    with (
+        patch("research._call_cheap", side_effect=fake_cheap),
+        patch("research._call_openai", side_effect=fake_submit),
+        patch("research._check_status", side_effect=fake_status),
+        patch("research.time.sleep"),
+    ):
+        rc = run_research_fanout(["what", "is", "X"], 3)
+
+    # Partial success → non-zero, but merge happened.
+    assert rc == 1
+    prompt_hash = _get_hash("what is X")
+    run_dir = tmp_path / ".files" / "research" / f"fanout-{prompt_hash}"
+    merged = (run_dir / "merged.md").read_text()
+    assert "## Missing sub-questions" in merged
+    assert "timed out" in merged
+    manifest = json.loads((run_dir / "manifest.json").read_text())
+    assert len(manifest["missing"]) == 1
+    assert manifest["missing"][0]["index"] == 3
+
+
+def test_contradictions_surfaced_not_resolved(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("research.BIN_ROOT", tmp_path)
+    monkeypatch.setattr("research.resolve", lambda _k: "sk-test")
+    monkeypatch.setattr("research.POLL_INTERVAL_S", 0)
+
+    plan_obj = _plan_payload()
+    decomp = _msg(json.dumps(plan_obj))
+    merge_with_contradiction = _msg(
+        "# Merged research\n\n## Summary\nDisagreement on safety.\n\n"
+        "## Findings\n"
+        "- Report 1 says X is safe [report-01.md | https://a.test]\n"
+        "- Report 2 says X is unsafe [report-02.md | https://b.test]\n\n"
+        "## Contradictions\n"
+        "- Safety: report-01 says safe [report-01.md | https://a.test]; "
+        "report-02 says unsafe [report-02.md | https://b.test]. "
+        "Both sides retained; no winner chosen.\n"
+    )
+    cite = _msg("## Citation check\n- OK\n")
+
+    def fake_cheap(_key: str, prompt: str) -> dict:
+        if "planning a multi-angle" in prompt or "candidate" in prompt.lower():
+            return decomp
+        if "Citation check" in prompt:
+            return cite
+        assert "do NOT pick a winner" in prompt or "SURFACING" in prompt
+        assert "Contradictions" in prompt
+        return merge_with_contradiction
+
+    n_sub = {"n": 0}
+
+    def fake_submit(_key: str, prompt: str, *, max_tool_calls: int | None = None) -> dict:
+        n_sub["n"] += 1
+        return {"id": f"resp_{n_sub['n']}", "status": "queued"}
+
+    def fake_status(_key: str, response_id: str) -> dict:
+        texts = {
+            "resp_1": "X is safe. https://a.test",
+            "resp_2": "X is unsafe. https://b.test",
+        }
+        return {
+            "id": response_id,
+            "status": "completed",
+            "output": [
+                {
+                    "type": "message",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": texts.get(response_id, "ok https://c.test"),
+                        }
+                    ],
+                }
+            ],
+        }
+
+    with (
+        patch("research._call_cheap", side_effect=fake_cheap),
+        patch("research._call_openai", side_effect=fake_submit),
+        patch("research._check_status", side_effect=fake_status),
+        patch("research.time.sleep"),
+    ):
+        rc = run_research_fanout(["safety", "of", "X"], 2)
+
+    assert rc == 0
+    prompt_hash = _get_hash("safety of X")
+    merged = (
+        tmp_path / ".files" / "research" / f"fanout-{prompt_hash}" / "merged.md"
+    ).read_text()
+    assert "## Contradictions" in merged
+    assert "safe" in merged.lower() and "unsafe" in merged.lower()
+    # Must not collapse to a single resolved verdict in the contradictions section.
+    contra = merged.split("## Contradictions", 1)[1].split("##")[0]
+    assert "safe" in contra.lower() and "unsafe" in contra.lower()
 
 
 def test_malformed_decomposer_fails_cleanly(tmp_path, monkeypatch, capsys):
@@ -277,28 +622,29 @@ def test_malformed_decomposer_fails_cleanly(tmp_path, monkeypatch, capsys):
     submit.assert_not_called()
     err_obj = json.loads(capsys.readouterr().out)
     assert "error" in err_obj
-    assert "JSON list" in err_obj["error"] or "decompose" in err_obj["error"]
 
 
-def test_malformed_decomposer_wrong_count(tmp_path, monkeypatch, capsys):
+def test_malformed_decomposer_too_few_candidates(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr("research.BIN_ROOT", tmp_path)
     monkeypatch.setattr("research.resolve", lambda _k: "sk-test")
 
-    bad = _msg(json.dumps(["only one"]))
+    bad = _msg(
+        json.dumps(
+            {
+                "brief": "tiny brief",
+                "candidates": [
+                    {"angle": "only one", "seed_query": "only one query"},
+                ],
+            }
+        )
+    )
 
     with patch("research._call_cheap", return_value=bad):
         rc = run_research_fanout(["q"], 3)
 
     assert rc == 1
     err_obj = json.loads(capsys.readouterr().out)
-    assert "expected 3" in err_obj["error"]
-
-
-def test_fanout_n_less_than_two(tmp_path, monkeypatch, capsys):
-    monkeypatch.setattr("research.resolve", lambda _k: "sk-test")
-    rc = run_research_fanout(["q"], 1)
-    assert rc == 1
-    assert "N >= 2" in capsys.readouterr().out
+    assert "candidates" in err_obj["error"]
 
 
 def test_cli_dispatches_fanout(tmp_path, monkeypatch):
@@ -307,7 +653,20 @@ def test_cli_dispatches_fanout(tmp_path, monkeypatch):
     ) as single:
         rc = main(["ai", "research", "--fanout", "4", "alpha", "beta"])
     assert rc == 0
-    fanout.assert_called_once_with(["alpha", "beta"], 4)
+    fanout.assert_called_once()
+    assert fanout.call_args[0] == (["alpha", "beta"], 4)
+    assert fanout.call_args[1].get("plan_only") is False
+    single.assert_not_called()
+
+
+def test_cli_dispatches_plan_only():
+    with patch("commands.ai_research_cmd.run_research_fanout", return_value=0) as fanout, patch(
+        "commands.ai_research_cmd.run_research", return_value=0
+    ) as single:
+        rc = main(["ai", "research", "--fanout", "4", "--plan-only", "alpha"])
+    assert rc == 0
+    fanout.assert_called_once()
+    assert fanout.call_args[1].get("plan_only") is True
     single.assert_not_called()
 
 
@@ -319,3 +678,21 @@ def test_cli_dispatches_single_shot():
     assert rc == 0
     single.assert_called_once_with(["alpha", "beta"])
     fanout.assert_not_called()
+
+
+def test_fanout_clamp_noted_on_stderr(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("research.BIN_ROOT", tmp_path)
+    monkeypatch.setattr("research.resolve", lambda _k: "sk-test")
+    plan = _msg(json.dumps(_plan_payload(16)))
+
+    with (
+        patch("research._call_cheap", return_value=plan),
+        patch("research._call_openai") as submit,
+    ):
+        rc = run_research_plan_only(["q"], 99)
+
+    assert rc == 0
+    submit.assert_not_called()
+    err = capsys.readouterr().err
+    assert "Clamped" in err
+    assert "8" in err

--- a/apps/n0b/tests/test_research.py
+++ b/apps/n0b/tests/test_research.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import math
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -11,12 +12,18 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from cli import build_parser, main  # noqa: E402
 from research import (  # noqa: E402
+    FANOUT_AUTO,
+    QPD_WARN_THRESHOLD,
+    _citation_union,
+    _get_hash,
+    _max_tool_calls,
+    _merge_quorum,
+    _normalize_url,
+    mmr_select,
     run_research,
     run_research_fanout,
     run_research_plan_only,
-    mmr_select,
-    _get_hash,
-    _max_tool_calls,
+    select_with_adversarial,
 )
 
 
@@ -45,7 +52,12 @@ def _msg(text: str, usage: dict | None = None) -> dict:
     return out
 
 
-def _plan_payload(n_candidates: int = 12) -> dict:
+def _plan_payload(
+    n_candidates: int = 12,
+    *,
+    recommended_fanout: int = 4,
+    adversarial: dict | None = None,
+) -> dict:
     candidates = []
     angles = [
         ("mechanism", "how does X work internally"),
@@ -67,10 +79,79 @@ def _plan_payload(n_candidates: int = 12) -> dict:
     ]
     for angle, seed in angles[:n_candidates]:
         candidates.append({"angle": angle, "seed_query": seed})
+    if adversarial is None:
+        adversarial = {
+            "angle": "adversarial-skeptic",
+            "seed_query": "why X claims may be wrong or overstated",
+        }
     return {
         "brief": "A short planning brief about researching X across dimensions.",
+        "recommended_fanout": recommended_fanout,
         "candidates": candidates,
+        "adversarial": adversarial,
     }
+
+
+def _fake_status_factory(extra_output: list | None = None):
+    def fake_status(_key: str, response_id: str) -> dict:
+        output = list(extra_output or [])
+        output.append(
+            {
+                "type": "message",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": f"Findings for {response_id}. https://example.com/{response_id}",
+                    }
+                ],
+            }
+        )
+        return {
+            "id": response_id,
+            "status": "completed",
+            "output": output,
+            "usage": {"input_tokens": 10, "output_tokens": 20},
+        }
+
+    return fake_status
+
+
+def _cheap_router(decomp, compose=None, attach=None, cite=None):
+    """Route planner/sol text calls by prompt content."""
+    compose = compose or _msg(
+        "# Merged research\n\n## Summary\nok\n\n"
+        "## Contradictions\n"
+        "- A reports safe as of 2024-01-01; B reports unsafe as of 2025-06-01\n",
+        usage={"input_tokens": 20, "output_tokens": 10},
+    )
+    attach = attach or _msg(
+        "# Merged research\n\n## Summary\nok\n\n"
+        "## Findings\n- claim [report-01.md | https://example.com/a]\n\n"
+        "## Contradictions\n"
+        "- A reports safe as of 2024-01-01; B reports unsafe as of 2025-06-01\n\n"
+        "## Citations\n- https://example.com/a\n",
+        usage={"input_tokens": 20, "output_tokens": 10},
+    )
+    cite = cite or _msg(
+        "## Citation check\n- OK\n",
+        usage={"input_tokens": 10, "output_tokens": 5},
+    )
+
+    def router(_key: str, prompt: str) -> dict:
+        low = prompt.lower()
+        if "planning a multi-angle" in low or (
+            "recommended_fanout" in low and "candidates" in low
+        ):
+            return decomp
+        if "citation check" in low:
+            return cite
+        if "citation re-attachment" in low or "re-attach" in low:
+            return attach
+        if "composition pass" in low or "compose one markdown" in low:
+            return compose
+        return compose
+
+    return router
 
 
 def test_research_help_shows_fanout_and_plan_only():
@@ -100,14 +181,14 @@ def test_fanout_absent_leaves_prompt_only():
     assert args.prompt == ["what", "is", "X"]
 
 
-def test_fanout_bare_defaults_to_four_via_main():
+def test_fanout_bare_dispatches_auto_via_main():
     with patch("commands.ai_research_cmd.run_research_fanout", return_value=0) as fanout, patch(
         "commands.ai_research_cmd.run_research", return_value=0
     ) as single:
         rc = main(["ai", "research", "--fanout", "alpha", "beta"])
     assert rc == 0
     fanout.assert_called_once()
-    assert fanout.call_args[0][1] == 4
+    assert fanout.call_args[0][1] == FANOUT_AUTO
     single.assert_not_called()
 
 
@@ -144,19 +225,69 @@ def test_mmr_skips_near_duplicate_candidates():
     selected = mmr_select(candidates, 3, lambda_=0.0)
     assert len(selected) == 3
     seeds = [s["seed_query"] for s in selected]
-    # First is always kept; the near-paraphrases of entanglement should not
-    # occupy both remaining slots when diverse alternatives exist.
-    entanglementish = [
-        s for s in seeds if "entanglement" in s or "entanglement" in s
-    ]
+    entanglementish = [s for s in seeds if "entanglement" in s]
     assert len(entanglementish) <= 1
     assert any("market cost" in s or "export control" in s for s in seeds)
+
+
+def test_adversarial_always_present_even_when_lexically_near():
+    # Adversarial seed is near the first topical seed — MMR would reject it.
+    candidates = [
+        {"angle": "safety-case", "seed_query": "is product X safe for consumers"},
+        {"angle": "economics", "seed_query": "market cost of deploying product X"},
+        {"angle": "regulation", "seed_query": "export control laws for product X"},
+        {"angle": "history", "seed_query": "historical development of product X"},
+        {"angle": "adoption", "seed_query": "who uses product X in practice today"},
+        {"angle": "measurement", "seed_query": "how product X performance is measured"},
+        {"angle": "alternatives", "seed_query": "alternatives compared to product X"},
+        {"angle": "ecosystem", "seed_query": "tooling ecosystem around product X"},
+        {"angle": "ethics", "seed_query": "ethical concerns around product X use"},
+        {"angle": "scalability", "seed_query": "scalability limits of product X"},
+        {"angle": "security", "seed_query": "security properties of product X"},
+        {"angle": "ux", "seed_query": "user experience tradeoffs of product X"},
+    ]
+    adversarial = {
+        "angle": "skeptic",
+        "seed_query": "is product X safe for consumers really or overstated",
+    }
+    mmr_only = mmr_select(candidates + [adversarial], 3, lambda_=0.0)
+    assert adversarial not in mmr_only or mmr_only[0] is adversarial
+    # Even if MMR would skip the skeptic, the reserved slot keeps it.
+    selected = select_with_adversarial(candidates, adversarial, 3)
+    assert len(selected) == 3
+    assert selected[-1] is adversarial
+    assert selected[-1]["angle"] == "skeptic"
+    assert adversarial not in selected[:-1]
+
+
+def test_merge_quorum_ceil_067():
+    assert _merge_quorum(4) == 3
+    assert _merge_quorum(3) == math.ceil(0.67 * 3)
+    assert _merge_quorum(2) == math.ceil(0.67 * 2)
+    assert _merge_quorum(1) == 1
+    assert _merge_quorum(8) == math.ceil(0.67 * 8)
+
+
+def test_url_normalization_keeps_revisions_distinct():
+    a = "https://example.com/paper.pdf?rev=1"
+    b = "https://example.com/paper.pdf?rev=2"
+    assert _normalize_url(a) != _normalize_url(b)
+    union = _citation_union(
+        [
+            ("q1", "body", [a]),
+            ("q2", "body", [b]),
+        ]
+    )
+    norms = {row["norm"] for row in union}
+    assert _normalize_url(a) in norms
+    assert _normalize_url(b) in norms
+    assert len(union) == 2
 
 
 def test_max_tool_calls_scales_down():
     assert _max_tool_calls(1) == 50
     assert _max_tool_calls(4) == 12
-    assert _max_tool_calls(8) == 10  # floor
+    assert _max_tool_calls(8) == 10
 
 
 def test_single_shot_untouched(tmp_path, monkeypatch, capsys):
@@ -206,7 +337,6 @@ def test_fanout_one_byte_identical_to_single_shot(tmp_path, monkeypatch, capsys)
         rc1 = run_research(["same", "prompt"])
     out1 = capsys.readouterr().out
 
-    # Reset cache so second path submits again the same way.
     cache = tmp_path / ".files" / "research"
     for f in cache.glob("*.json"):
         f.unlink()
@@ -223,6 +353,104 @@ def test_fanout_one_byte_identical_to_single_shot(tmp_path, monkeypatch, capsys)
     assert out1 == out2
 
 
+def test_bare_fanout_honors_recommended(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("research.BIN_ROOT", tmp_path)
+    monkeypatch.setattr("research.resolve", lambda _k: "sk-test")
+    monkeypatch.setattr("research.POLL_INTERVAL_S", 0)
+
+    plan_obj = _plan_payload(recommended_fanout=3)
+    decomp = _msg(json.dumps(plan_obj), usage={"input_tokens": 50, "output_tokens": 40})
+    router = _cheap_router(decomp)
+
+    submit_count = {"n": 0}
+
+    def fake_submit(_key: str, prompt: str, *, max_tool_calls: int | None = None) -> dict:
+        submit_count["n"] += 1
+        return {"id": f"resp_{submit_count['n']}", "status": "queued"}
+
+    with (
+        patch("research._call_planner", side_effect=router),
+        patch("research._call_sol_text", side_effect=router),
+        patch("research._call_openai", side_effect=fake_submit),
+        patch("research._check_status", side_effect=_fake_status_factory()),
+        patch("research.time.sleep"),
+    ):
+        rc = run_research_fanout(["what", "is", "X"], FANOUT_AUTO)
+
+    assert rc == 0
+    assert submit_count["n"] == 3
+    err = capsys.readouterr().err
+    assert "Using fanout N=3 (from Stage 0 recommendation)" in err
+    prompt_hash = _get_hash("what is X")
+    manifest = json.loads(
+        (tmp_path / ".files" / "research" / f"fanout-{prompt_hash}" / "manifest.json").read_text()
+    )
+    assert manifest["n"] == 3
+    assert manifest["n_source"] == "recommendation"
+    assert manifest["selected"][-1]["angle"] == "adversarial-skeptic"
+
+
+def test_explicit_fanout_overrides_recommendation(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("research.BIN_ROOT", tmp_path)
+    monkeypatch.setattr("research.resolve", lambda _k: "sk-test")
+    monkeypatch.setattr("research.POLL_INTERVAL_S", 0)
+
+    plan_obj = _plan_payload(recommended_fanout=2)
+    decomp = _msg(json.dumps(plan_obj), usage={"input_tokens": 10, "output_tokens": 10})
+    router = _cheap_router(decomp)
+    submit_count = {"n": 0}
+
+    def fake_submit(_key: str, prompt: str, *, max_tool_calls: int | None = None) -> dict:
+        submit_count["n"] += 1
+        return {"id": f"resp_{submit_count['n']}", "status": "queued"}
+
+    with (
+        patch("research._call_planner", side_effect=router),
+        patch("research._call_sol_text", side_effect=router),
+        patch("research._call_openai", side_effect=fake_submit),
+        patch("research._check_status", side_effect=_fake_status_factory()),
+        patch("research.time.sleep"),
+    ):
+        rc = run_research_fanout(["what", "is", "X"], 4)
+
+    assert rc == 0
+    assert submit_count["n"] == 4
+    err = capsys.readouterr().err
+    assert "Using fanout N=4 (from --fanout flag" in err
+    assert "Stage 0 recommended 2" in err
+
+
+def test_recommended_fanout_one_zero_jobs(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("research.BIN_ROOT", tmp_path)
+    monkeypatch.setattr("research.resolve", lambda _k: "sk-test")
+
+    plan_obj = _plan_payload(recommended_fanout=1)
+    decomp = _msg(json.dumps(plan_obj), usage={"input_tokens": 10, "output_tokens": 10})
+    submitted = {"id": "resp_single", "status": "queued"}
+    completed = {
+        "id": "resp_single",
+        "status": "completed",
+        "output": [{"type": "message", "content": [{"type": "output_text", "text": "ok"}]}],
+    }
+
+    with (
+        patch("research._call_planner", return_value=decomp),
+        patch("research._call_openai", return_value=submitted) as submit,
+        patch("research._check_status", return_value=completed),
+        patch("research.time.sleep"),
+    ):
+        rc = run_research_fanout(["simple", "fact"], FANOUT_AUTO)
+
+    assert rc == 0
+    # Single-shot path: one research submit, zero fanout jobs on disk.
+    submit.assert_called_once()
+    err = capsys.readouterr().err
+    assert "Using fanout N=1 (from Stage 0 recommendation)" in err
+    assert "zero fanout jobs" in err
+    research_dir = tmp_path / ".files" / "research"
+    assert not any(p.name.startswith("fanout-") for p in research_dir.iterdir())
+
+
 def test_plan_only_submits_zero_research_jobs(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr("research.BIN_ROOT", tmp_path)
     monkeypatch.setattr("research.resolve", lambda _k: "sk-test")
@@ -233,18 +461,19 @@ def test_plan_only_submits_zero_research_jobs(tmp_path, monkeypatch, capsys):
     )
 
     with (
-        patch("research._call_cheap", return_value=plan) as cheap,
+        patch("research._call_planner", return_value=plan) as planner,
         patch("research._call_openai") as submit,
     ):
         rc = run_research_plan_only(["what", "is", "X"], 4)
 
     assert rc == 0
     submit.assert_not_called()
-    cheap.assert_called_once()
+    planner.assert_called_once()
     out = capsys.readouterr().out
     assert "# Research plan" in out
     assert "## Brief" in out
     assert "seed_query:" in out
+    assert "[adversarial]" in out
 
 
 def test_plan_only_via_fanout_kwarg(tmp_path, monkeypatch, capsys):
@@ -253,7 +482,7 @@ def test_plan_only_via_fanout_kwarg(tmp_path, monkeypatch, capsys):
     plan = _msg(json.dumps(_plan_payload()))
 
     with (
-        patch("research._call_cheap", return_value=plan),
+        patch("research._call_planner", return_value=plan),
         patch("research._call_openai") as submit,
     ):
         rc = run_research_fanout(["q"], 3, plan_only=True)
@@ -267,66 +496,25 @@ def test_fanout_produces_manifest_reports_and_merged(tmp_path, monkeypatch, caps
     monkeypatch.setattr("research.resolve", lambda _k: "sk-test")
     monkeypatch.setattr("research.POLL_INTERVAL_S", 0)
 
-    plan_obj = _plan_payload()
-    # Force MMR to pick the first 3 diverse angles from the payload.
     decomp = _msg(
-        json.dumps(plan_obj),
+        json.dumps(_plan_payload()),
         usage={"input_tokens": 100, "output_tokens": 50},
     )
-    merge_body = (
-        "# Merged research\n\n## Summary\nX works.\n\n"
-        "## Findings\n"
-        "- Mechanism is Y [report-01.md | https://example.com/a]\n\n"
-        "## Contradictions\n"
-        "- none noted\n\n"
-        "## Citations\n"
-        "- https://example.com/a (corroboration=1)\n"
-    )
-    merge = _msg(merge_body, usage={"input_tokens": 200, "output_tokens": 80})
-    cite_check = _msg(
-        "## Citation check\n- OK: Mechanism is Y\n",
-        usage={"input_tokens": 40, "output_tokens": 20},
-    )
-
-    cheap_calls: list[str] = []
-
-    def fake_cheap(_key: str, prompt: str) -> dict:
-        cheap_calls.append(prompt)
-        if "planning a multi-angle" in prompt or "candidate" in prompt.lower():
-            return decomp
-        if "Citation check" in prompt:
-            return cite_check
-        return merge
-
+    router = _cheap_router(decomp)
     submit_count = {"n": 0}
 
     def fake_submit(_key: str, prompt: str, *, max_tool_calls: int | None = None) -> dict:
         submit_count["n"] += 1
-        rid = f"resp_{submit_count['n']}"
-        return {"id": rid, "status": "queued"}
-
-    def fake_status(_key: str, response_id: str) -> dict:
-        return {
-            "id": response_id,
-            "status": "completed",
-            "output": [
-                {
-                    "type": "message",
-                    "content": [
-                        {
-                            "type": "output_text",
-                            "text": f"Findings for {response_id}. https://example.com/{response_id}",
-                        }
-                    ],
-                }
-            ],
-            "usage": {"input_tokens": 10, "output_tokens": 20},
-        }
+        assert "Global objective" in prompt or "global objective" in prompt.lower()
+        assert "Sibling assignments" in prompt or "sibling" in prompt.lower()
+        assert "contradiction" in prompt.lower()
+        return {"id": f"resp_{submit_count['n']}", "status": "queued"}
 
     with (
-        patch("research._call_cheap", side_effect=fake_cheap),
+        patch("research._call_planner", side_effect=router),
+        patch("research._call_sol_text", side_effect=router),
         patch("research._call_openai", side_effect=fake_submit),
-        patch("research._check_status", side_effect=fake_status),
+        patch("research._check_status", side_effect=_fake_status_factory()),
         patch("research.time.sleep"),
     ):
         rc = run_research_fanout(["what", "is", "X"], 3)
@@ -341,6 +529,8 @@ def test_fanout_produces_manifest_reports_and_merged(tmp_path, monkeypatch, caps
     assert manifest["n"] == 3
     assert "brief" in manifest
     assert len(manifest["selected"]) == 3
+    assert manifest["selected"][-1]["angle"] == "adversarial-skeptic"
+    assert "metrics" in manifest
     for i in range(1, 4):
         assert (run_dir / f"job-{i}.json").is_file()
         assert (run_dir / f"job-{i}-result.json").is_file()
@@ -350,12 +540,9 @@ def test_fanout_produces_manifest_reports_and_merged(tmp_path, monkeypatch, caps
     assert "## Citation check" in merged
     out = capsys.readouterr()
     assert str(run_dir) in out.out
-    assert "estimate" in out.err.lower()
+    assert "unverified" in out.err.lower()
+    assert "fanout metrics" in out.err
     assert submit_count["n"] == 3
-    # plan + merge + citation-check
-    assert len(cheap_calls) == 3
-    # Sequential submit — no threads; max_tool_calls scaled.
-    assert _max_tool_calls(3) == 16
 
 
 def test_fanout_resumes_without_resubmitting_completed(tmp_path, monkeypatch, capsys):
@@ -380,10 +567,7 @@ def test_fanout_resumes_without_resubmitting_completed(tmp_path, monkeypatch, ca
             {
                 "type": "message",
                 "content": [
-                    {
-                        "type": "output_text",
-                        "text": "done A https://ex.test/a",
-                    }
+                    {"type": "output_text", "text": "done A https://ex.test/a"}
                 ],
             }
         ],
@@ -420,16 +604,7 @@ def test_fanout_resumes_without_resubmitting_completed(tmp_path, monkeypatch, ca
     }
     (run_dir / "manifest.json").write_text(json.dumps(manifest) + "\n")
 
-    merge = _msg(
-        "# Merged research\n\n## Summary\nok\n\n## Contradictions\n- none\n",
-        usage={"input_tokens": 1, "output_tokens": 1},
-    )
-    cite = _msg("## Citation check\n- OK\n")
-
-    def fake_cheap(_key: str, prompt: str) -> dict:
-        if "Citation check" in prompt:
-            return cite
-        return merge
+    router = _cheap_router(_msg("{}"))
 
     def fake_status(_key: str, response_id: str) -> dict:
         return {
@@ -450,7 +625,8 @@ def test_fanout_resumes_without_resubmitting_completed(tmp_path, monkeypatch, ca
 
     with (
         patch("research._call_openai") as submit_mock,
-        patch("research._call_cheap", side_effect=fake_cheap),
+        patch("research._call_planner", side_effect=router),
+        patch("research._call_sol_text", side_effect=router),
         patch("research._check_status", side_effect=fake_status),
         patch("research.time.sleep"),
     ):
@@ -461,29 +637,22 @@ def test_fanout_resumes_without_resubmitting_completed(tmp_path, monkeypatch, ca
     err = capsys.readouterr().err
     assert "Resuming" in err
     assert "skip submit" in err or "already completed" in err
+    manifest2 = json.loads((run_dir / "manifest.json").read_text())
+    assert "metrics" in manifest2
 
 
-def test_partial_merge_on_timeout(tmp_path, monkeypatch, capsys):
+def test_partial_merge_quorum_067_n4(tmp_path, monkeypatch, capsys):
+    """N=4 → quorum 3: three completions merge; two do not."""
     monkeypatch.setattr("research.BIN_ROOT", tmp_path)
     monkeypatch.setattr("research.resolve", lambda _k: "sk-test")
     monkeypatch.setattr("research.POLL_INTERVAL_S", 0)
     monkeypatch.setattr("research.JOB_TIMEOUT_S", 0)
 
-    plan_obj = _plan_payload()
-    decomp = _msg(json.dumps(plan_obj), usage={"input_tokens": 10, "output_tokens": 10})
-    merge = _msg(
-        "# Merged research\n\n## Summary\npartial\n\n## Contradictions\n- none\n",
+    decomp = _msg(
+        json.dumps(_plan_payload()),
         usage={"input_tokens": 10, "output_tokens": 10},
     )
-    cite = _msg("## Citation check\n- OK\n")
-
-    def fake_cheap(_key: str, prompt: str) -> dict:
-        if "planning a multi-angle" in prompt or "candidate" in prompt.lower():
-            return decomp
-        if "Citation check" in prompt:
-            return cite
-        return merge
-
+    router = _cheap_router(decomp)
     submit_ids = []
 
     def fake_submit(_key: str, prompt: str, *, max_tool_calls: int | None = None) -> dict:
@@ -491,8 +660,51 @@ def test_partial_merge_on_timeout(tmp_path, monkeypatch, capsys):
         submit_ids.append(rid)
         return {"id": rid, "status": "queued"}
 
-    def fake_status(_key: str, response_id: str) -> dict:
-        # First two complete; third stays queued → times out (JOB_TIMEOUT_S=0).
+    def fake_status_three(_key: str, response_id: str) -> dict:
+        if response_id in ("resp_1", "resp_2", "resp_3"):
+            return {
+                "id": response_id,
+                "status": "completed",
+                "output": [
+                    {
+                        "type": "message",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": f"ok {response_id} https://ex.test/{response_id}",
+                            }
+                        ],
+                    }
+                ],
+            }
+        return {"id": response_id, "status": "queued"}
+
+    with (
+        patch("research._call_planner", side_effect=router),
+        patch("research._call_sol_text", side_effect=router),
+        patch("research._call_openai", side_effect=fake_submit),
+        patch("research._check_status", side_effect=fake_status_three),
+        patch("research.time.sleep"),
+    ):
+        rc = run_research_fanout(["what", "is", "X"], 4)
+
+    assert rc == 1
+    prompt_hash = _get_hash("what is X")
+    run_dir = tmp_path / ".files" / "research" / f"fanout-{prompt_hash}"
+    merged = (run_dir / "merged.md").read_text()
+    assert "## Missing sub-questions" in merged
+    manifest = json.loads((run_dir / "manifest.json").read_text())
+    assert len(manifest["missing"]) == 1
+    assert manifest["missing"][0]["index"] == 4
+    capsys.readouterr()  # drain stdout/stderr before the no-merge case
+
+    # Two completions < quorum 3 → no merge.
+    import shutil
+
+    shutil.rmtree(run_dir)
+    submit_ids.clear()
+
+    def fake_status_two(_key: str, response_id: str) -> dict:
         if response_id in ("resp_1", "resp_2"):
             return {
                 "id": response_id,
@@ -512,52 +724,48 @@ def test_partial_merge_on_timeout(tmp_path, monkeypatch, capsys):
         return {"id": response_id, "status": "queued"}
 
     with (
-        patch("research._call_cheap", side_effect=fake_cheap),
+        patch("research._call_planner", side_effect=router),
+        patch("research._call_sol_text", side_effect=router),
         patch("research._call_openai", side_effect=fake_submit),
-        patch("research._check_status", side_effect=fake_status),
+        patch("research._check_status", side_effect=fake_status_two),
         patch("research.time.sleep"),
     ):
-        rc = run_research_fanout(["what", "is", "X"], 3)
+        rc2 = run_research_fanout(["other", "question", "Y"], 4)
 
-    # Partial success → non-zero, but merge happened.
-    assert rc == 1
-    prompt_hash = _get_hash("what is X")
-    run_dir = tmp_path / ".files" / "research" / f"fanout-{prompt_hash}"
-    merged = (run_dir / "merged.md").read_text()
-    assert "## Missing sub-questions" in merged
-    assert "timed out" in merged
-    manifest = json.loads((run_dir / "manifest.json").read_text())
-    assert len(manifest["missing"]) == 1
-    assert manifest["missing"][0]["index"] == 3
+    assert rc2 == 1
+    out = json.loads(capsys.readouterr().out)
+    assert "need >= 3" in out["error"]
+    run_dir2 = (
+        tmp_path / ".files" / "research" / f"fanout-{_get_hash('other question Y')}"
+    )
+    assert not (run_dir2 / "merged.md").is_file()
 
 
-def test_contradictions_surfaced_not_resolved(tmp_path, monkeypatch, capsys):
+def test_contradictions_carry_observation_dates(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr("research.BIN_ROOT", tmp_path)
     monkeypatch.setattr("research.resolve", lambda _k: "sk-test")
     monkeypatch.setattr("research.POLL_INTERVAL_S", 0)
 
-    plan_obj = _plan_payload()
-    decomp = _msg(json.dumps(plan_obj))
-    merge_with_contradiction = _msg(
+    decomp = _msg(json.dumps(_plan_payload()))
+    compose = _msg(
+        "# Merged research\n\n## Summary\nDisagreement on safety.\n\n"
+        "## Contradictions\n"
+        "- A reports X is safe as of 2023-03-01; "
+        "B reports X is unsafe as of 2025-11-15\n"
+    )
+    attach = _msg(
         "# Merged research\n\n## Summary\nDisagreement on safety.\n\n"
         "## Findings\n"
         "- Report 1 says X is safe [report-01.md | https://a.test]\n"
         "- Report 2 says X is unsafe [report-02.md | https://b.test]\n\n"
         "## Contradictions\n"
-        "- Safety: report-01 says safe [report-01.md | https://a.test]; "
-        "report-02 says unsafe [report-02.md | https://b.test]. "
-        "Both sides retained; no winner chosen.\n"
+        "- A reports X is safe as of 2023-03-01 [report-01.md | https://a.test]; "
+        "B reports X is unsafe as of 2025-11-15 [report-02.md | https://b.test]\n\n"
+        "## Citations\n"
+        "- https://a.test\n- https://b.test\n"
     )
     cite = _msg("## Citation check\n- OK\n")
-
-    def fake_cheap(_key: str, prompt: str) -> dict:
-        if "planning a multi-angle" in prompt or "candidate" in prompt.lower():
-            return decomp
-        if "Citation check" in prompt:
-            return cite
-        assert "do NOT pick a winner" in prompt or "SURFACING" in prompt
-        assert "Contradictions" in prompt
-        return merge_with_contradiction
+    router = _cheap_router(decomp, compose=compose, attach=attach, cite=cite)
 
     n_sub = {"n": 0}
 
@@ -586,8 +794,15 @@ def test_contradictions_surfaced_not_resolved(tmp_path, monkeypatch, capsys):
             ],
         }
 
+    compose_prompts: list[str] = []
+
+    def tracking_sol(_key: str, prompt: str) -> dict:
+        compose_prompts.append(prompt)
+        return router(_key, prompt)
+
     with (
-        patch("research._call_cheap", side_effect=fake_cheap),
+        patch("research._call_planner", side_effect=router),
+        patch("research._call_sol_text", side_effect=tracking_sol),
         patch("research._call_openai", side_effect=fake_submit),
         patch("research._check_status", side_effect=fake_status),
         patch("research.time.sleep"),
@@ -595,15 +810,58 @@ def test_contradictions_surfaced_not_resolved(tmp_path, monkeypatch, capsys):
         rc = run_research_fanout(["safety", "of", "X"], 2)
 
     assert rc == 0
+    assert any("as of <date>" in p or "as of" in p for p in compose_prompts)
+    assert any("COMPOSITION pass" in p or "composition pass" in p.lower() for p in compose_prompts)
+    assert any("re-attachment" in p.lower() or "re-attach" in p.lower() for p in compose_prompts)
     prompt_hash = _get_hash("safety of X")
     merged = (
         tmp_path / ".files" / "research" / f"fanout-{prompt_hash}" / "merged.md"
     ).read_text()
-    assert "## Contradictions" in merged
-    assert "safe" in merged.lower() and "unsafe" in merged.lower()
-    # Must not collapse to a single resolved verdict in the contradictions section.
     contra = merged.split("## Contradictions", 1)[1].split("##")[0]
+    assert "as of 2023-03-01" in contra
+    assert "as of 2025-11-15" in contra
     assert "safe" in contra.lower() and "unsafe" in contra.lower()
+
+
+def test_metrics_block_and_qpd_warning(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("research.BIN_ROOT", tmp_path)
+    monkeypatch.setattr("research.resolve", lambda _k: "sk-test")
+    monkeypatch.setattr("research.POLL_INTERVAL_S", 0)
+
+    decomp = _msg(json.dumps(_plan_payload(recommended_fanout=2)))
+    router = _cheap_router(decomp)
+    submit_count = {"n": 0}
+
+    def fake_submit(_key: str, prompt: str, *, max_tool_calls: int | None = None) -> dict:
+        submit_count["n"] += 1
+        return {"id": f"resp_{submit_count['n']}", "status": "queued"}
+
+    # No web_search calls in output → QPD = 0 / docs = 0.0 < 0.4 → warn.
+    with (
+        patch("research._call_planner", side_effect=router),
+        patch("research._call_sol_text", side_effect=router),
+        patch("research._call_openai", side_effect=fake_submit),
+        patch("research._check_status", side_effect=_fake_status_factory()),
+        patch("research.time.sleep"),
+    ):
+        rc = run_research_fanout(["what", "is", "X"], 2)
+
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "fanout metrics" in err
+    assert "mean QPD:" in err
+    assert "citation overlap ratio:" in err
+    assert "unique authoritative domains:" in err
+    assert "contradiction count:" in err
+    assert "total cost:" in err
+    assert "WARNING: mean QPD" in err
+    assert str(QPD_WARN_THRESHOLD) in err
+    prompt_hash = _get_hash("what is X")
+    manifest = json.loads(
+        (tmp_path / ".files" / "research" / f"fanout-{prompt_hash}" / "manifest.json").read_text()
+    )
+    assert manifest["metrics"]["qpd_warning"] is True
+    assert manifest["metrics"]["mean_qpd"] < QPD_WARN_THRESHOLD
 
 
 def test_malformed_decomposer_fails_cleanly(tmp_path, monkeypatch, capsys):
@@ -613,7 +871,7 @@ def test_malformed_decomposer_fails_cleanly(tmp_path, monkeypatch, capsys):
     bad = _msg("sorry I cannot help with that")
 
     with (
-        patch("research._call_cheap", return_value=bad),
+        patch("research._call_planner", return_value=bad),
         patch("research._call_openai") as submit,
     ):
         rc = run_research_fanout(["what", "is", "X"], 3)
@@ -632,14 +890,19 @@ def test_malformed_decomposer_too_few_candidates(tmp_path, monkeypatch, capsys):
         json.dumps(
             {
                 "brief": "tiny brief",
+                "recommended_fanout": 3,
                 "candidates": [
                     {"angle": "only one", "seed_query": "only one query"},
                 ],
+                "adversarial": {
+                    "angle": "skeptic",
+                    "seed_query": "why this may be wrong",
+                },
             }
         )
     )
 
-    with patch("research._call_cheap", return_value=bad):
+    with patch("research._call_planner", return_value=bad):
         rc = run_research_fanout(["q"], 3)
 
     assert rc == 1
@@ -686,7 +949,7 @@ def test_fanout_clamp_noted_on_stderr(tmp_path, monkeypatch, capsys):
     plan = _msg(json.dumps(_plan_payload(16)))
 
     with (
-        patch("research._call_cheap", return_value=plan),
+        patch("research._call_planner", return_value=plan),
         patch("research._call_openai") as submit,
     ):
         rc = run_research_plan_only(["q"], 99)


### PR DESCRIPTION
Prototype of parallel deep-research fan-out for `n0b ai research`, built against the reconciled dual-source design (ar3 wiki: Plans-Deep-Research-Fanout).

Design points absorbed from the reconciliation:
- No concurrency machinery — background:true submission, poll loop (10-min retention window respected)
- Default fanout 1 (flag opt-in), sweet spot 4, partial-merge floor at 0.67N
- Diversity at query time (DivInit-style seeding, adversarial slot reserved by construction, MMR λ=0 for the rest)
- Merge claims, not prose — compose → cite-attach → cite-check as separate passes

117 n0b tests pass (HTTP stubbed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)