### PR TITLE
feat(n0b): fancy video transcription via Ollama vision

### DIFF
--- a/apps/n0b/README.md
+++ b/apps/n0b/README.md
@@ -26,7 +26,7 @@ Detailed docs live in [`docs/`](docs/):
 | [secrets.md](docs/secrets.md) | `n0b secrets` | Get/set secrets — env, `~/lib`, Keychain, dotenv |
 | [ai-speak.md](docs/ai-speak.md) | `n0b ai speak` | Text-to-speech — macOS `say` or offline Kokoro |
 | [z-image.md](docs/z-image.md) | `n0b ai image` | Z-Image-Turbo text-to-image and `--ref` img2img |
-| [transcribe.md](docs/transcribe.md) | `n0b ai transcribe` | Local Whisper speech-to-text, hints + replacement files |
+| [transcribe.md](docs/transcribe.md) | `n0b ai transcribe` | Local Whisper STT; fancy video narrative via Ollama vision |
 | [quota.md](docs/quota.md) | `n0b quota` | Live AI tool rate limits (Antigravity / `agy`) |
 
 ### Quick reference (no separate doc yet)
@@ -50,7 +50,7 @@ Detailed docs live in [`docs/`](docs/):
 | `n0b ai video` | LTX-Video 1/2, MLX on Apple Silicon | `--install`, `--install-ltx1`, `-1`, `-2` |
 | `n0b ai audio` | AudioLDM / Bark (`<bin>/.venv`) | `--model bark`, `-o`, `--install` |
 | `n0b ai speak` | macOS `say` (auto), Kokoro offline (`<bin>/.venv`) | `--engine`, `--voice`, `-o` |
-| `n0b ai transcribe` | Whisper `turbo` (local, `<bin>/.venv`) | `--model tiny|base|small|medium|large` |
+| `n0b ai transcribe` | Whisper `turbo` (local); fancy video → Ollama `qwen3.6` | `--flavor`, `--model`, `--vision-model` |
 
 ## Layout
 

--- a/apps/n0b/cli.py
+++ b/apps/n0b/cli.py
@@ -289,10 +289,11 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     ai_transcribe = ai_sub.add_parser(
-        "transcribe", help="Transcribe an audio file locally with Whisper"
+        "transcribe",
+        help="Transcribe audio/video locally (Whisper; fancy video via Ollama vision)",
     )
     ai_transcribe.add_argument(
-        "audio", nargs="?", help="Audio file (anything ffmpeg reads)"
+        "audio", nargs="?", help="Audio or video file (anything ffmpeg reads)"
     )
     ai_transcribe.add_argument(
         "--hint",
@@ -310,6 +311,23 @@ def build_parser() -> argparse.ArgumentParser:
     )
     ai_transcribe.add_argument(
         "--model", default="turbo", help="Whisper model (default: turbo)"
+    )
+    ai_transcribe.add_argument(
+        "--flavor",
+        choices=("auto", "plain", "fancy"),
+        default="auto",
+        help=(
+            "Output style: auto uses fancy for video streams else plain; "
+            "plain/fancy override detection (default: auto)"
+        ),
+    )
+    ai_transcribe.add_argument(
+        "--vision-model",
+        default=None,
+        help=(
+            "Ollama vision model for --flavor fancy "
+            "(default: N0B_TRANSCRIBE_VISION_MODEL or qwen3.6)"
+        ),
     )
     ai_transcribe.add_argument(
         "--replace",
@@ -455,6 +473,8 @@ def dispatch(args: argparse.Namespace) -> int:
                 args.model,
                 save=args.save,
                 replaces=args.replaces,
+                flavor=args.flavor,
+                vision_model=args.vision_model,
             )
         if args.ai_kind == "image":
             return cmd_image(

--- a/apps/n0b/commands/ai_ollama.py
+++ b/apps/n0b/commands/ai_ollama.py
@@ -1,0 +1,117 @@
+"""Minimal Ollama helpers for n0b ai (vision chat)."""
+from __future__ import annotations
+
+import base64
+import json
+import os
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+OLLAMA_URL = os.environ.get("OLLAMA_URL", "http://localhost:11434")
+DEFAULT_VISION_MODEL = "qwen3.6"
+SUGGESTED_VISION_PULL = "qwen3.6"
+
+
+class OllamaError(Exception):
+    pass
+
+
+def resolve_vision_model(cli_model: str | None = None) -> str:
+    if cli_model and cli_model.strip():
+        return cli_model.strip()
+    env = os.environ.get("N0B_TRANSCRIBE_VISION_MODEL", "").strip()
+    if env:
+        return env
+    return DEFAULT_VISION_MODEL
+
+
+def _request(method: str, path: str, body: dict | None = None, timeout: float = 30) -> dict:
+    data = None if body is None else json.dumps(body).encode()
+    req = urllib.request.Request(
+        f"{OLLAMA_URL}{path}",
+        data=data,
+        headers={"Content-Type": "application/json"} if data is not None else {},
+        method=method,
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode()
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode(errors="replace").strip()
+        raise OllamaError(f"HTTP {exc.code} from Ollama {path}: {detail or exc.reason}") from exc
+    except urllib.error.URLError as exc:
+        raise OllamaError(
+            f"Ollama not reachable at {OLLAMA_URL} ({exc.reason}); "
+            "start it with: ollama serve"
+        ) from exc
+    if not raw:
+        return {}
+    return json.loads(raw)
+
+
+def ensure_ollama_running() -> None:
+    _request("GET", "/api/tags", timeout=5)
+
+
+def model_capabilities(model: str) -> list[str]:
+    data = _request("POST", "/api/show", {"name": model}, timeout=30)
+    caps = data.get("capabilities") or []
+    return [str(c) for c in caps]
+
+
+def ensure_vision_model(model: str) -> None:
+    ensure_ollama_running()
+    try:
+        caps = model_capabilities(model)
+    except OllamaError as exc:
+        msg = str(exc)
+        if "HTTP 404" in msg or "not found" in msg.lower():
+            raise OllamaError(
+                f"model {model!r} is not installed; try: ollama pull {SUGGESTED_VISION_PULL}"
+            ) from exc
+        raise
+    if "vision" not in caps:
+        raise OllamaError(
+            f"model {model!r} has no vision support; try: ollama pull {SUGGESTED_VISION_PULL}"
+        )
+
+
+def _b64_image(path: Path) -> str:
+    return base64.b64encode(path.read_bytes()).decode("ascii")
+
+
+def chat_with_images(
+    model: str,
+    prompt: str,
+    image_paths: list[Path],
+    *,
+    system: str | None = None,
+    timeout: float = 600,
+) -> str:
+    messages: list[dict] = []
+    if system:
+        messages.append({"role": "system", "content": system})
+    messages.append(
+        {
+            "role": "user",
+            "content": prompt,
+            "images": [_b64_image(p) for p in image_paths],
+        }
+    )
+    data = _request(
+        "POST",
+        "/api/chat",
+        {
+            "model": model,
+            "messages": messages,
+            "stream": False,
+            "think": False,
+        },
+        timeout=timeout,
+    )
+    message = data.get("message") or {}
+    content = (message.get("content") or "").strip()
+    if not content:
+        raise OllamaError("empty response from vision model")
+    return content

--- a/apps/n0b/commands/ai_transcribe_cmd.py
+++ b/apps/n0b/commands/ai_transcribe_cmd.py
@@ -1,10 +1,12 @@
-"""n0b ai transcribe — local Whisper."""
+"""n0b ai transcribe — local Whisper, optional fancy video via Ollama vision."""
 from __future__ import annotations
 
+import json
 import re
 import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 from ai_venv import ensure_whisper
@@ -16,9 +18,33 @@ from commands.ai_common import (
     save_pair_file,
     split_cli_hints,
 )
+from commands.ai_ollama import (
+    OllamaError,
+    chat_with_images,
+    ensure_vision_model,
+    resolve_vision_model,
+)
 
 HINTS_FILE = Path.home() / ".config" / "n0b" / "transcribe-hints.txt"
 REPLACEMENTS_FILE = Path.home() / ".config" / "n0b" / "transcribe-replacements.txt"
+
+MAX_FRAMES = 50
+MAX_FPS = 1.0
+FRAME_SCALE = 512
+
+_FANCY_SYSTEM = "You are my very helpful videographer analyst"
+
+_FANCY_PROMPT = """\
+I am analyzing a video via this sequence of images extracted from the frames at {fps} FPS as well as the audio transcript (which is below). I want to combine both of these to create a fancy transcription of the video.
+
+First give a quick synopsis of what the entire video seems to be about in a short paragraph.
+
+Next enumerate each distinct scene in order and with timing. Describe each in detail considering both the imagery and probable audio involved by matching times to frames. Figure out if any existing speech or sound effects are from a narrator, character, person, actor, or object in the environment and associate to them in the writing as dialog if appropriate (e.g. so-and-so says). I want to match audio visual reconstruct a rich narrative for each scene.
+
+And finally at the end I'd like a summary of the entire video given all of the scene text already created in a short conclusive paragraph.
+
+{speech}
+"""
 
 _WHISPER_SNIPPET = """\
 import sys
@@ -36,6 +62,37 @@ result = model.transcribe(
     verbose=False,
 )
 print(result["text"].strip())
+"""
+
+_WHISPER_TIMED_SNIPPET = """\
+import json
+import sys
+import whisper
+
+audio, model_name, language, prompt = sys.argv[1:5]
+print(f"loading model {model_name}...", file=sys.stderr)
+model = whisper.load_model(model_name)
+print(f"transcribing (language: {language or 'auto-detect'})...", file=sys.stderr)
+result = model.transcribe(
+    audio,
+    language=language or None,
+    initial_prompt=prompt or None,
+    fp16=False,
+    verbose=False,
+)
+out = {
+    "language": result.get("language") or "",
+    "text": (result.get("text") or "").strip(),
+    "segments": [
+        {
+            "start": float(seg.get("start") or 0),
+            "end": float(seg.get("end") or 0),
+            "text": (seg.get("text") or "").strip(),
+        }
+        for seg in (result.get("segments") or [])
+    ],
+}
+print(json.dumps(out))
 """
 
 
@@ -72,6 +129,244 @@ def save_replacements(cli_replaces: list[str], replacements_file: Path) -> int:
     return save_pair_file(cli_replaces, replacements_file, "n0b ai transcribe")
 
 
+def has_video_stream(path: Path) -> bool:
+    if shutil.which("ffprobe") is None:
+        return False
+    proc = subprocess.run(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-select_streams",
+            "v",
+            "-show_entries",
+            "stream=codec_type",
+            "-of",
+            "csv=p=0",
+            str(path),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return any(line.strip() == "video" for line in proc.stdout.splitlines())
+
+
+def resolve_flavor(flavor: str, path: Path) -> str:
+    if flavor in ("plain", "fancy"):
+        return flavor
+    return "fancy" if has_video_stream(path) else "plain"
+
+
+def probe_duration_seconds(path: Path) -> float | None:
+    proc = subprocess.run(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-show_entries",
+            "format=duration",
+            "-of",
+            "default=noprint_wrappers=1:nokey=1",
+            str(path),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    raw = proc.stdout.strip()
+    if not raw:
+        return None
+    try:
+        duration = float(raw)
+    except ValueError:
+        return None
+    if duration <= 0:
+        return None
+    return duration
+
+
+def calc_fps(path: Path, max_frames: int = MAX_FRAMES, max_fps: float = MAX_FPS) -> float:
+    duration = probe_duration_seconds(path)
+    if duration is None:
+        print(
+            f"n0b ai transcribe: no duration; using max fps {max_fps}",
+            file=sys.stderr,
+        )
+        return max_fps
+    fps = max_frames / duration
+    if fps > max_fps:
+        return max_fps
+    return round(fps, 2)
+
+
+def extract_frames(
+    path: Path,
+    frames_dir: Path,
+    fps: float,
+    scale: int = FRAME_SCALE,
+) -> list[Path]:
+    frames_dir.mkdir(parents=True, exist_ok=True)
+    pattern = frames_dir / "%04d.png"
+    print(f"extracting frames at {fps} FPS...", file=sys.stderr)
+    proc = subprocess.run(
+        [
+            "ffmpeg",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            str(path),
+            "-vf",
+            f"fps={fps},scale='min({scale},iw):-2'",
+            str(pattern),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "").strip()
+        raise RuntimeError(detail or "ffmpeg frame extract failed")
+    frames = sorted(frames_dir.glob("*.png"))
+    if not frames:
+        raise RuntimeError("no frames extracted")
+    print(f"extracted {len(frames)} frame(s)", file=sys.stderr)
+    return frames
+
+
+def format_timed_speech(payload: dict) -> str:
+    language = payload.get("language") or ""
+    text = (payload.get("text") or "").strip()
+    lines = [
+        f"Language: {language}" if language else "Language: unknown",
+        f"Full Speech Transcript: {text}",
+        "",
+    ]
+    for seg in payload.get("segments") or []:
+        start = round(float(seg.get("start") or 0), 2)
+        end = round(float(seg.get("end") or 0), 2)
+        seg_text = (seg.get("text") or "").strip()
+        lines.append(f"[Speech Transcript from {start} to {end} seconds]")
+        lines.append(seg_text)
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _run_whisper(
+    python: Path,
+    path: Path,
+    model: str,
+    language: str | None,
+    prompt: str,
+    *,
+    timed: bool,
+) -> tuple[int, str]:
+    snippet = _WHISPER_TIMED_SNIPPET if timed else _WHISPER_SNIPPET
+    proc = subprocess.run(
+        [str(python), "-c", snippet, str(path), model, language or "", prompt],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    return proc.returncode, proc.stdout
+
+
+def _plain_transcribe(
+    path: Path,
+    python: Path,
+    model: str,
+    language: str | None,
+    prompt: str,
+    pairs: list[tuple[str, str]],
+) -> int:
+    rc, stdout = _run_whisper(python, path, model, language, prompt, timed=False)
+    if rc != 0:
+        return rc
+    text, applied = apply_replacements(stdout.strip(), pairs)
+    if pairs:
+        note = "; ".join(applied) if applied else "none matched"
+        print(f"replacements applied: {note}", file=sys.stderr)
+    print(text)
+    return 0
+
+
+def _fancy_transcribe(
+    path: Path,
+    python: Path,
+    model: str,
+    language: str | None,
+    prompt: str,
+    pairs: list[tuple[str, str]],
+    vision_model: str,
+) -> int:
+    if shutil.which("ffprobe") is None:
+        print(
+            "n0b ai transcribe: ffprobe not found (try: brew install ffmpeg)",
+            file=sys.stderr,
+        )
+        return 1
+    if not has_video_stream(path):
+        print(
+            "n0b ai transcribe: --flavor fancy requires a video stream "
+            "(use --flavor plain or auto)",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        ensure_vision_model(vision_model)
+    except OllamaError as exc:
+        print(f"n0b ai transcribe: {exc}", file=sys.stderr)
+        return 1
+
+    fps = calc_fps(path)
+    rc, stdout = _run_whisper(python, path, model, language, prompt, timed=True)
+    if rc != 0:
+        return rc
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError:
+        print(
+            "n0b ai transcribe: Whisper timed output was not JSON",
+            file=sys.stderr,
+        )
+        return 1
+
+    speech = format_timed_speech(payload)
+    speech, applied = apply_replacements(speech, pairs)
+    if pairs:
+        note = "; ".join(applied) if applied else "none matched"
+        print(f"replacements applied: {note}", file=sys.stderr)
+    if not speech.strip():
+        speech = "No audio transcript available! Use images only"
+
+    user_prompt = _FANCY_PROMPT.format(fps=fps, speech=speech)
+    with tempfile.TemporaryDirectory(prefix="n0b-transcribe-") as tmp:
+        frames_dir = Path(tmp) / "frames"
+        try:
+            frames = extract_frames(path, frames_dir, fps)
+        except RuntimeError as exc:
+            print(f"n0b ai transcribe: {exc}", file=sys.stderr)
+            return 1
+        print(
+            f"vision model: {vision_model} ({len(frames)} frame(s))...",
+            file=sys.stderr,
+        )
+        try:
+            narrative = chat_with_images(
+                vision_model,
+                user_prompt,
+                frames,
+                system=_FANCY_SYSTEM,
+            )
+        except OllamaError as exc:
+            print(f"n0b ai transcribe: {exc}", file=sys.stderr)
+            return 1
+    print(narrative)
+    return 0
+
+
 def cmd_transcribe(
     audio: str | None,
     hints: list[str],
@@ -79,6 +374,8 @@ def cmd_transcribe(
     model: str,
     save: bool = False,
     replaces: list[str] | None = None,
+    flavor: str = "auto",
+    vision_model: str | None = None,
 ) -> int:
     replaces = replaces or []
     if save:
@@ -110,6 +407,10 @@ def cmd_transcribe(
             file=sys.stderr,
         )
         return 1
+
+    resolved = resolve_flavor(flavor, path)
+    print(f"flavor: {resolved} (from {flavor})", file=sys.stderr)
+
     file_hints = read_hints(HINTS_FILE)
     cli_hints = split_cli_hints(hints)
     prompt = ", ".join(file_hints + cli_hints)
@@ -132,16 +433,11 @@ def cmd_transcribe(
     except subprocess.CalledProcessError as exc:
         print(f"n0b ai transcribe: Whisper setup failed: {exc}", file=sys.stderr)
         return 1
-    proc = subprocess.run(
-        [str(python), "-c", _WHISPER_SNIPPET, str(path), model, language or "", prompt],
-        stdout=subprocess.PIPE,
-        text=True,
+
+    if resolved == "plain":
+        return _plain_transcribe(path, python, model, language, prompt, pairs)
+
+    vision = resolve_vision_model(vision_model)
+    return _fancy_transcribe(
+        path, python, model, language, prompt, pairs, vision
     )
-    if proc.returncode != 0:
-        return proc.returncode
-    text, applied = apply_replacements(proc.stdout.strip(), pairs)
-    if pairs:
-        note = "; ".join(applied) if applied else "none matched"
-        print(f"replacements applied: {note}", file=sys.stderr)
-    print(text)
-    return 0

--- a/apps/n0b/commands/ai_transcribe_cmd.py
+++ b/apps/n0b/commands/ai_transcribe_cmd.py
@@ -47,6 +47,8 @@ And finally at the end I'd like a summary of the entire video given all of the s
 """
 
 _WHISPER_SNIPPET = """\
+import contextlib
+import io
 import sys
 import whisper
 
@@ -54,17 +56,21 @@ audio, model_name, language, prompt = sys.argv[1:5]
 print(f"loading model {model_name}...", file=sys.stderr)
 model = whisper.load_model(model_name)
 print(f"transcribing (language: {language or 'auto-detect'})...", file=sys.stderr)
-result = model.transcribe(
-    audio,
-    language=language or None,
-    initial_prompt=prompt or None,
-    fp16=False,
-    verbose=False,
-)
+# whisper prints "Detected language: ..." to stdout even with verbose=False
+with contextlib.redirect_stdout(io.StringIO()):
+    result = model.transcribe(
+        audio,
+        language=language or None,
+        initial_prompt=prompt or None,
+        fp16=False,
+        verbose=False,
+    )
 print(result["text"].strip())
 """
 
 _WHISPER_TIMED_SNIPPET = """\
+import contextlib
+import io
 import json
 import sys
 import whisper
@@ -73,13 +79,15 @@ audio, model_name, language, prompt = sys.argv[1:5]
 print(f"loading model {model_name}...", file=sys.stderr)
 model = whisper.load_model(model_name)
 print(f"transcribing (language: {language or 'auto-detect'})...", file=sys.stderr)
-result = model.transcribe(
-    audio,
-    language=language or None,
-    initial_prompt=prompt or None,
-    fp16=False,
-    verbose=False,
-)
+# whisper prints "Detected language: ..." to stdout even with verbose=False
+with contextlib.redirect_stdout(io.StringIO()):
+    result = model.transcribe(
+        audio,
+        language=language or None,
+        initial_prompt=prompt or None,
+        fp16=False,
+        verbose=False,
+    )
 out = {
     "language": result.get("language") or "",
     "text": (result.get("text") or "").strip(),
@@ -94,6 +102,30 @@ out = {
 }
 print(json.dumps(out))
 """
+
+
+def parse_whisper_timed_stdout(stdout: str) -> dict:
+    """Parse timed Whisper JSON; tolerate stray non-JSON lines on stdout."""
+    text = stdout.strip()
+    if not text:
+        raise ValueError("empty Whisper timed output")
+    try:
+        payload = json.loads(text)
+        if isinstance(payload, dict):
+            return payload
+    except json.JSONDecodeError:
+        pass
+    for line in reversed(text.splitlines()):
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            return payload
+    raise ValueError("Whisper timed output was not JSON")
 
 
 def read_replacements(replacements_file: Path) -> list[tuple[str, str]]:
@@ -325,12 +357,9 @@ def _fancy_transcribe(
     if rc != 0:
         return rc
     try:
-        payload = json.loads(stdout)
-    except json.JSONDecodeError:
-        print(
-            "n0b ai transcribe: Whisper timed output was not JSON",
-            file=sys.stderr,
-        )
+        payload = parse_whisper_timed_stdout(stdout)
+    except ValueError as exc:
+        print(f"n0b ai transcribe: {exc}", file=sys.stderr)
         return 1
 
     speech = format_timed_speech(payload)

--- a/apps/n0b/docs/transcribe.md
+++ b/apps/n0b/docs/transcribe.md
@@ -1,14 +1,18 @@
 ---
 name: "n0b-transcribe"
-description: "Transcribe an audio file to text with a local Whisper model. Use when the user provides audio (voice memo, recording) and wants its text."
+description: "Transcribe audio or video to text with local Whisper; video gets a fancy narrative via Ollama vision. Use when the user provides a recording or video and wants its text."
 allowed-tools: Bash(n0b ai transcribe *)
 ---
 
 # n0b ai transcribe
 
 Local speech-to-text via [openai-whisper](https://github.com/openai/whisper).
-No API key; the model runs on this machine. Transcription goes to stdout,
-everything else (setup, progress) to stderr, so output is pipe-safe.
+No API key; the model runs on this machine. For files with a video stream,
+`--flavor auto` (default) also samples frames and asks a local Ollama vision
+model for a Surfey-style fancy narrative (synopsis, timed scenes, summary).
+
+Transcription goes to stdout; everything else (setup, progress) to stderr,
+so output is pipe-safe.
 
 ## Usage
 
@@ -16,9 +20,16 @@ everything else (setup, progress) to stderr, so output is pipe-safe.
 n0b ai transcribe memo.m4a
 n0b ai transcribe memo.m4a > memo.txt
 
+n0b ai transcribe clip.mp4                 # auto → fancy when video stream present
+n0b ai transcribe clip.mp4 --flavor plain  # Whisper text only
+n0b ai transcribe memo.m4a --flavor fancy  # errors: no video stream
+
 n0b ai transcribe memo.m4a --hint "Pay-i" --hint "a8s, r4t"   # bias proper nouns
 n0b ai transcribe memo.m4a --language en                       # skip auto-detect
-n0b ai transcribe memo.m4a --model base                        # smaller/faster model
+n0b ai transcribe memo.m4a --model base                        # smaller/faster Whisper
+
+n0b ai transcribe clip.mp4 --vision-model qwen3.6              # Ollama vision model
+n0b ai transcribe clip.mp4 --vision-model qwen3.5:4b
 
 n0b ai transcribe --hint "Pay-i, k7e" --save                   # add to the global hints file
 n0b ai transcribe memo.m4a --hint "Pay-i" --save               # save, then transcribe
@@ -27,11 +38,36 @@ n0b ai transcribe memo.m4a --replace 'Jerry => Gerry'          # annotate known 
 n0b ai transcribe --replace 'Jerry => Gerry' --save            # add to the global replacements file
 ```
 
-stderr reports the hints in effect (and where each came from), model
-loading, and a progress bar over the audio, so a long silence is never
-ambiguous.
+stderr reports the flavor in effect, hints, model loading, and progress so a
+long silence is never ambiguous.
 
 Any format ffmpeg can read works: m4a, mp3, wav, aiff, ogg, mp4, ...
+
+## Flavor
+
+`--flavor` controls output style:
+
+| Value | Behavior |
+|-------|----------|
+| `auto` (default) | Fancy if ffprobe finds a video stream; else plain Whisper text |
+| `plain` | Always Whisper text (works on video audio tracks too) |
+| `fancy` | Always fancy narrative; requires a video stream |
+
+Fancy path: extract ≤50 frames at ≤1 FPS (scaled to 512px), timed Whisper
+speech, then one Ollama `/api/chat` call with those images + the Surfey-style
+prompt. Ollama must already be running (`ollama serve`).
+
+## Vision model
+
+`--vision-model` (or `N0B_TRANSCRIBE_VISION_MODEL`, default `qwen3.6`) selects
+the Ollama model. Capabilities are checked via `/api/show`; if the model is
+missing or lacks `"vision"`, the command fails with a clear pull hint:
+
+```text
+n0b ai transcribe: model 'qwen3:4b' has no vision support; try: ollama pull qwen3.6
+```
+
+No auto-pull. Override the Ollama host with `OLLAMA_URL` if needed.
 
 ## Hints
 
@@ -51,8 +87,9 @@ it saves and exits.
 ## Replacements
 
 Hints only bias decoding; some words lose anyway ("Gerry" always comes out
-"Jerry"). Replacements run **after** transcription: each is a regex plus the
-likely correction, and every match gets annotated in place —
+"Jerry"). Replacements run **after** Whisper (and before the vision call for
+fancy): each is a regex plus the likely correction, and every match gets
+annotated in place —
 
 > Jerry (possible transcribe error, might be 'Gerry') said blah
 
@@ -75,5 +112,7 @@ use `base` when speed matters more than proper nouns.
 ## First run
 
 Bootstraps `<bin>/.venv` on first use from `requirements/ai*.txt` (shared repo
-venv; torch installs once) and downloads the model to `~/.cache/whisper/`.
-One-time cost of a few GB; subsequent runs are offline. Requires `ffmpeg` on PATH.
+venv; torch installs once) and downloads the Whisper model to
+`~/.cache/whisper/`. One-time cost of a few GB; subsequent runs are offline
+for plain flavor. Fancy also needs a local vision model via Ollama. Requires
+`ffmpeg` (and `ffprobe` for flavor detection / fancy) on PATH.

--- a/apps/n0b/tests/test_cli.py
+++ b/apps/n0b/tests/test_cli.py
@@ -29,11 +29,19 @@ from commands.ai_speak_cmd import (
 )
 from commands.ai_transcribe_cmd import (
     apply_replacements,
+    calc_fps,
     cmd_transcribe,
+    format_timed_speech,
     read_replacements,
+    resolve_flavor,
     save_replacements,
     HINTS_FILE,
     REPLACEMENTS_FILE,
+)
+from commands.ai_ollama import (
+    OllamaError,
+    ensure_vision_model,
+    resolve_vision_model,
 )
 from commands.ai_audio_cmd import cmd_audio  # noqa: E402
 from commands.ai_video_cmd import cmd_video, parse_video_args  # noqa: E402
@@ -406,7 +414,7 @@ def test_transcribe_applies_replacements(tmp_path, capsys):
     ):
         run.return_value.returncode = 0
         run.return_value.stdout = "Jerry said hi.\n"
-        rc = cmd_transcribe(str(audio), [], "en", "base")
+        rc = cmd_transcribe(str(audio), [], "en", "base", flavor="plain")
     assert rc == 0
     out, err = capsys.readouterr()
     assert out == "Jerry (possible transcribe error, might be 'Gerry') said hi.\n"
@@ -425,7 +433,7 @@ def test_transcribe_invokes_whisper_venv(tmp_path):
     ):
         run.return_value.returncode = 0
         run.return_value.stdout = "hello\n"
-        rc = cmd_transcribe(str(audio), ["Pay-i"], "en", "base")
+        rc = cmd_transcribe(str(audio), ["Pay-i"], "en", "base", flavor="plain")
         assert rc == 0
         argv = run.call_args[0][0]
         assert argv[0] == str(fake_python)
@@ -438,7 +446,160 @@ def test_transcribe_help():
     assert proc.returncode == 0
     assert "--hint" in proc.stdout
     assert "--language" in proc.stdout
+    assert "--flavor" in proc.stdout
+    assert "--vision-model" in proc.stdout
 
+
+def test_resolve_flavor_overrides():
+    path = Path("/tmp/x")
+    assert resolve_flavor("plain", path) == "plain"
+    assert resolve_flavor("fancy", path) == "fancy"
+
+
+def test_resolve_flavor_auto_uses_video_detect(tmp_path):
+    media = tmp_path / "clip.mp4"
+    media.write_bytes(b"x")
+    with patch("commands.ai_transcribe_cmd.has_video_stream", return_value=True):
+        assert resolve_flavor("auto", media) == "fancy"
+    with patch("commands.ai_transcribe_cmd.has_video_stream", return_value=False):
+        assert resolve_flavor("auto", media) == "plain"
+
+
+def test_format_timed_speech():
+    text = format_timed_speech(
+        {
+            "language": "en",
+            "text": "Hello world",
+            "segments": [
+                {"start": 0.0, "end": 1.25, "text": "Hello"},
+                {"start": 1.25, "end": 2.0, "text": "world"},
+            ],
+        }
+    )
+    assert "Language: en" in text
+    assert "Full Speech Transcript: Hello world" in text
+    assert "[Speech Transcript from 0.0 to 1.25 seconds]" in text
+    assert "Hello" in text
+
+
+def test_calc_fps_caps_and_spreads(tmp_path):
+    media = tmp_path / "clip.mp4"
+    media.write_bytes(b"x")
+    with patch("commands.ai_transcribe_cmd.probe_duration_seconds", return_value=10.0):
+        assert calc_fps(media) == 1.0
+    with patch("commands.ai_transcribe_cmd.probe_duration_seconds", return_value=100.0):
+        assert calc_fps(media) == 0.5
+    with patch("commands.ai_transcribe_cmd.probe_duration_seconds", return_value=None):
+        assert calc_fps(media) == 1.0
+
+
+def test_transcribe_fancy_requires_video(tmp_path, capsys):
+    audio = tmp_path / "memo.wav"
+    audio.write_bytes(b"RIFF")
+    fake_python = tmp_path / "venv" / "bin" / "python3"
+    with (
+        patch("commands.ai_transcribe_cmd.ensure_whisper", return_value=fake_python),
+        patch("commands.ai_transcribe_cmd.HINTS_FILE", tmp_path / "missing.txt"),
+        patch("commands.ai_transcribe_cmd.REPLACEMENTS_FILE", tmp_path / "missing2.txt"),
+        patch("commands.ai_transcribe_cmd.has_video_stream", return_value=False),
+    ):
+        rc = cmd_transcribe(str(audio), [], None, "base", flavor="fancy")
+    assert rc == 2
+    assert "requires a video stream" in capsys.readouterr().err
+
+
+def test_transcribe_fancy_vision_model_lacks_vision(tmp_path, capsys):
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"x")
+    fake_python = tmp_path / "venv" / "bin" / "python3"
+    with (
+        patch("commands.ai_transcribe_cmd.ensure_whisper", return_value=fake_python),
+        patch("commands.ai_transcribe_cmd.HINTS_FILE", tmp_path / "missing.txt"),
+        patch("commands.ai_transcribe_cmd.REPLACEMENTS_FILE", tmp_path / "missing2.txt"),
+        patch("commands.ai_transcribe_cmd.has_video_stream", return_value=True),
+        patch(
+            "commands.ai_transcribe_cmd.ensure_vision_model",
+            side_effect=OllamaError(
+                "model 'qwen3:4b' has no vision support; try: ollama pull qwen3.6"
+            ),
+        ),
+    ):
+        rc = cmd_transcribe(
+            str(video), [], None, "base", flavor="fancy", vision_model="qwen3:4b"
+        )
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "no vision support" in err
+    assert "ollama pull qwen3.6" in err
+
+
+def test_transcribe_auto_picks_fancy_for_video(tmp_path, capsys):
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"x")
+    fake_python = tmp_path / "venv" / "bin" / "python3"
+    timed = json.dumps(
+        {
+            "language": "en",
+            "text": "hi",
+            "segments": [{"start": 0, "end": 1, "text": "hi"}],
+        }
+    )
+    frame = tmp_path / "0001.png"
+    frame.write_bytes(b"\x89PNG\r\n\x1a\n")
+    with (
+        patch("commands.ai_transcribe_cmd.ensure_whisper", return_value=fake_python),
+        patch("commands.ai_transcribe_cmd.HINTS_FILE", tmp_path / "missing.txt"),
+        patch("commands.ai_transcribe_cmd.REPLACEMENTS_FILE", tmp_path / "missing2.txt"),
+        patch("commands.ai_transcribe_cmd.has_video_stream", return_value=True),
+        patch("commands.ai_transcribe_cmd.ensure_vision_model"),
+        patch("commands.ai_transcribe_cmd.calc_fps", return_value=0.5),
+        patch("commands.ai_transcribe_cmd.extract_frames", return_value=[frame]),
+        patch(
+            "commands.ai_transcribe_cmd.chat_with_images",
+            return_value="Synopsis: a clip.",
+        ) as chat,
+        patch("commands.ai_transcribe_cmd._run_whisper", return_value=(0, timed)),
+    ):
+        rc = cmd_transcribe(str(video), [], "en", "base", flavor="auto")
+    assert rc == 0
+    out, err = capsys.readouterr()
+    assert out == "Synopsis: a clip.\n"
+    assert "flavor: fancy" in err
+    chat.assert_called_once()
+    assert chat.call_args[0][0] == "qwen3.6"
+
+
+def test_resolve_vision_model_precedence(monkeypatch):
+    monkeypatch.delenv("N0B_TRANSCRIBE_VISION_MODEL", raising=False)
+    assert resolve_vision_model(None) == "qwen3.6"
+    monkeypatch.setenv("N0B_TRANSCRIBE_VISION_MODEL", "qwen3.5:4b")
+    assert resolve_vision_model(None) == "qwen3.5:4b"
+    assert resolve_vision_model("custom-vl") == "custom-vl"
+
+
+def test_ensure_vision_model_rejects_text_only(monkeypatch):
+    monkeypatch.setattr(
+        "commands.ai_ollama.ensure_ollama_running", lambda: None
+    )
+    monkeypatch.setattr(
+        "commands.ai_ollama.model_capabilities",
+        lambda model: ["completion", "tools"],
+    )
+    with pytest.raises(OllamaError, match="no vision support"):
+        ensure_vision_model("qwen3:4b")
+
+
+def test_ensure_vision_model_missing(monkeypatch):
+    monkeypatch.setattr(
+        "commands.ai_ollama.ensure_ollama_running", lambda: None
+    )
+
+    def boom(model: str):
+        raise OllamaError("HTTP 404 from Ollama /api/show: model not found")
+
+    monkeypatch.setattr("commands.ai_ollama.model_capabilities", boom)
+    with pytest.raises(OllamaError, match="ollama pull qwen3.6"):
+        ensure_vision_model("missing-vl")
 
 def test_speakable_keeps_phoneme_overrides():
     md = "See [Pay-i](/pˈeɪ ˈaɪ/) and [docs](https://example.com/x)."

--- a/apps/n0b/tests/test_cli.py
+++ b/apps/n0b/tests/test_cli.py
@@ -32,6 +32,7 @@ from commands.ai_transcribe_cmd import (
     calc_fps,
     cmd_transcribe,
     format_timed_speech,
+    parse_whisper_timed_stdout,
     read_replacements,
     resolve_flavor,
     save_replacements,
@@ -480,6 +481,22 @@ def test_format_timed_speech():
     assert "Full Speech Transcript: Hello world" in text
     assert "[Speech Transcript from 0.0 to 1.25 seconds]" in text
     assert "Hello" in text
+
+
+def test_parse_whisper_timed_stdout_tolerates_detected_language():
+    payload = {
+        "language": "en",
+        "text": "hello",
+        "segments": [{"start": 0, "end": 1, "text": "hello"}],
+    }
+    contaminated = "Detected language: English\n" + json.dumps(payload) + "\n"
+    assert parse_whisper_timed_stdout(contaminated) == payload
+    assert parse_whisper_timed_stdout(json.dumps(payload)) == payload
+
+
+def test_parse_whisper_timed_stdout_rejects_garbage():
+    with pytest.raises(ValueError, match="not JSON"):
+        parse_whisper_timed_stdout("Detected language: English\nhello\n")
 
 
 def test_calc_fps_caps_and_spreads(tmp_path):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends `n0b ai transcribe` with Surfey-style fancy video transcription: Whisper timed speech + ffmpeg frames + local Ollama vision narrative.

- `--flavor auto|plain|fancy` (default `auto`): video stream → fancy; otherwise plain Whisper text
- `--vision-model` / `N0B_TRANSCRIBE_VISION_MODEL` (default `qwen3.6`)
- Vision capability checked via Ollama `/api/show`; missing/no-vision fails with `ollama pull qwen3.6` (no auto-pull)

### Follow-up fix

Whisper prints `Detected language: ...` to stdout even with `verbose=False`, which broke fancy JSON parsing. Snippets now redirect that noise; timed stdout parsing is also more defensive.

## PR Checklist

### Code Quality
- [x] No `__pycache__` or `.pyc` files in git
- [x] No hardcoded secrets (API keys, passwords, bridge URLs, MQTT creds)
- [x] No PII in committed code or PR description (real emails, phone numbers — use example.com)
- [x] No SQL string interpolation (all queries use `?` parameters)
- [x] No raw `except:` without specific exception types
- [x] No dead imports or unused variables
- [x] Runtime artifacts gitignored (`.db`, `.log`, `.count`, `health.txt`, `stimulus.txt`)

### Testing
- [ ] Integration tests pass (`lifetime.sh`)
- [x] Unit tests pass (if applicable: `pytest`) — 18 new/updated transcribe tests
- [ ] Manual verification of new features

### Documentation
- [ ] Textbook updated if architecture changed
- [x] README updated if organ/CLI interface changed

### Review
- [ ] Critic agent reviewed before merge
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-289859f1-d700-4c8a-9c8b-49deb59cc05c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-289859f1-d700-4c8a-9c8b-49deb59cc05c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

