### PR TITLE
feat(n0b): video gif conversion via Surfey-style palette

### DIFF
--- a/apps/n0b/README.md
+++ b/apps/n0b/README.md
@@ -26,7 +26,7 @@ Detailed docs live in [`docs/`](docs/):
 | [secrets.md](docs/secrets.md) | `n0b secrets` | Get/set secrets — env, `~/lib`, Keychain, dotenv |
 | [ai-speak.md](docs/ai-speak.md) | `n0b ai speak` | Text-to-speech — macOS `say` or offline Kokoro |
 | [z-image.md](docs/z-image.md) | `n0b ai image` | Z-Image-Turbo text-to-image and `--ref` img2img |
-| [transcribe.md](docs/transcribe.md) | `n0b ai transcribe` | Local Whisper STT; fancy video narrative via Ollama vision |
+| [video.md](docs/video.md) | `n0b video` | Video utilities: last-frame, gif (Surfey-style palette) |
 | [quota.md](docs/quota.md) | `n0b quota` | Live AI tool rate limits (Antigravity / `agy`) |
 
 ### Quick reference (no separate doc yet)
@@ -38,7 +38,7 @@ Detailed docs live in [`docs/`](docs/):
 | `gpu` | `cuda`, `mps`, `mlx`, `mb-free` | GPU / MLX checks; free MiB |
 | `mqtt` | `pub`, `sub` | `mosquitto_*` with `MQTT_HOST`, `MQTT_PORT`, `MQTT_USER`, `MQTT_PASS` |
 | `ai` | `image`, `video`, `audio`, `research`, `speak`, `transcribe` | See [ltx-video.md](docs/ltx-video.md) for video; [research.md](docs/research.md) for deep research; [ai-speak.md](docs/ai-speak.md) for text-to-speech; [transcribe.md](docs/transcribe.md) for speech-to-text |
-| `video` | `last-frame` | Extract last frame with `ffmpeg` |
+| `video` | `last-frame`, `gif` | Extract last frame; convert video to palette GIF |
 | `quota` | `[agy]` | Live AI tool quotas (`agy` = Antigravity language-server API) |
 
 ### AI model defaults

--- a/apps/n0b/cli.py
+++ b/apps/n0b/cli.py
@@ -17,7 +17,7 @@ from commands.mqtt_cmd import cmd_pub, cmd_sub
 from commands.ports_cmd import cmd_free, cmd_listen
 from commands.quota_cmd import cmd_quota
 from commands.secrets_cmd import cmd_get, cmd_set
-from commands.video_cmd import cmd_last_frame
+from commands.video_cmd import cmd_gif, cmd_last_frame
 
 
 def _add_image_args(p: argparse.ArgumentParser) -> None:
@@ -387,6 +387,29 @@ def build_parser() -> argparse.ArgumentParser:
     last_frame = video_sub.add_parser("last-frame", help="Extract last frame with ffmpeg")
     last_frame.add_argument("video")
     last_frame.add_argument("-o", "--output")
+    gif_p = video_sub.add_parser(
+        "gif",
+        help="Convert a video to an animated GIF (Surfey-style palette)",
+    )
+    gif_p.add_argument("video", help="Input video file")
+    gif_p.add_argument("-o", "--output", help="Output GIF path (default: <stem>.gif)")
+    gif_p.add_argument(
+        "--preset",
+        choices=("thumb", "small"),
+        default="thumb",
+        help=(
+            "thumb: adaptive ≤1 FPS / ≤50 frames, 320px, 64 colors (default); "
+            "small: 8 FPS, 800px, 32 colors"
+        ),
+    )
+    gif_p.add_argument("--fps", type=float, help="Override GIF frame rate")
+    gif_p.add_argument("--width", type=int, help="Override GIF max width in pixels")
+    gif_p.add_argument("--colors", type=int, help="Override palette max colors")
+    gif_p.add_argument(
+        "--max-frames",
+        type=int,
+        help="Override max frames for thumb adaptive FPS (default: 50)",
+    )
 
     quota_p = sub.add_parser("quota", help="Check AI tool usage quotas")
     quota_p.add_argument(
@@ -506,6 +529,16 @@ def dispatch(args: argparse.Namespace) -> int:
     if group == "video":
         if args.video_cmd == "last-frame":
             return cmd_last_frame(args.video, args.output)
+        if args.video_cmd == "gif":
+            return cmd_gif(
+                args.video,
+                args.output,
+                preset=args.preset,
+                fps=args.fps,
+                width=args.width,
+                colors=args.colors,
+                max_frames=args.max_frames,
+            )
     if group == "quota":
         return cmd_quota(args.tools, as_json=args.json, raw=args.raw)
     print(f"n0b: unhandled command group {group!r}", file=sys.stderr)

--- a/apps/n0b/commands/video_cmd.py
+++ b/apps/n0b/commands/video_cmd.py
@@ -1,15 +1,44 @@
 """Video utilities."""
 from __future__ import annotations
 
+import shutil
 import subprocess
 import sys
+import tempfile
 from datetime import datetime
 from pathlib import Path
 
+MAX_FRAMES_THUMB = 50
+MAX_FPS_THUMB = 1.0
+FRAME_SCALE_THUMB = 512
+
+PRESETS = {
+    "thumb": {
+        "width": 320,
+        "colors": 64,
+        "palette_fps": 2.0,
+        "palette_scale": 320,
+        "adaptive": True,
+        "max_frames": MAX_FRAMES_THUMB,
+        "max_fps": MAX_FPS_THUMB,
+        "fps": None,
+        "gif_scale_from_frames": True,
+    },
+    "small": {
+        "width": 800,
+        "colors": 32,
+        "palette_fps": 8.0,
+        "palette_scale": 640,
+        "adaptive": False,
+        "max_frames": None,
+        "max_fps": None,
+        "fps": 8.0,
+        "gif_scale_from_frames": False,
+    },
+}
+
 
 def cmd_last_frame(video: str, output: str | None) -> int:
-    import shutil
-
     video_path = Path(video)
     if not video_path.is_file():
         print(f"Error: Video file not found: {video}", file=sys.stderr)
@@ -38,3 +67,297 @@ def cmd_last_frame(video: str, output: str | None) -> int:
     if rc == 0:
         print(f"Last frame saved to: {out}")
     return rc if rc is not None else 1
+
+
+def _probe_duration_seconds(path: Path) -> float | None:
+    if shutil.which("ffprobe") is None:
+        return None
+    proc = subprocess.run(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-show_entries",
+            "format=duration",
+            "-of",
+            "default=noprint_wrappers=1:nokey=1",
+            str(path),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    raw = proc.stdout.strip()
+    if not raw:
+        return None
+    try:
+        duration = float(raw)
+    except ValueError:
+        return None
+    if duration <= 0:
+        return None
+    return duration
+
+
+def calc_gif_fps(
+    path: Path,
+    *,
+    max_frames: int = MAX_FRAMES_THUMB,
+    max_fps: float = MAX_FPS_THUMB,
+) -> float:
+    duration = _probe_duration_seconds(path)
+    if duration is None:
+        print(
+            f"n0b video gif: no duration; using max fps {max_fps}",
+            file=sys.stderr,
+        )
+        return max_fps
+    fps = max_frames / duration
+    if fps > max_fps:
+        return max_fps
+    return round(fps, 2)
+
+
+def _run_ffmpeg(argv: list[str]) -> None:
+    proc = subprocess.run(
+        argv,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "").strip()
+        raise RuntimeError(detail or "ffmpeg failed")
+
+
+def _create_palette(
+    source: Path,
+    palette_path: Path,
+    *,
+    fps: float,
+    scale: int,
+    colors: int,
+) -> None:
+    print(
+        f"creating palette ({colors} colors, fps={fps}, scale={scale})...",
+        file=sys.stderr,
+    )
+    _run_ffmpeg(
+        [
+            "ffmpeg",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            str(source),
+            "-vf",
+            f"fps={fps},scale={scale}:-1:flags=lanczos,"
+            f"palettegen=stats_mode=diff:max_colors={colors}",
+            str(palette_path),
+        ]
+    )
+
+
+def _extract_frames(path: Path, frames_dir: Path, fps: float, scale: int) -> list[Path]:
+    frames_dir.mkdir(parents=True, exist_ok=True)
+    pattern = frames_dir / "%04d.png"
+    print(f"extracting frames at {fps} FPS (scale={scale})...", file=sys.stderr)
+    _run_ffmpeg(
+        [
+            "ffmpeg",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            str(path),
+            "-vf",
+            f"fps={fps},scale='min({scale},iw):-2'",
+            str(pattern),
+        ]
+    )
+    frames = sorted(frames_dir.glob("*.png"))
+    if not frames:
+        raise RuntimeError("no frames extracted")
+    print(f"extracted {len(frames)} frame(s)", file=sys.stderr)
+    return frames
+
+
+def _assemble_gif_from_frames(
+    frames_dir: Path,
+    palette_path: Path,
+    output: Path,
+    *,
+    fps: float,
+    width: int,
+) -> None:
+    print(f"creating GIF ({width}px, {fps} FPS)...", file=sys.stderr)
+    _run_ffmpeg(
+        [
+            "ffmpeg",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-framerate",
+            str(fps),
+            "-i",
+            str(frames_dir / "%04d.png"),
+            "-i",
+            str(palette_path),
+            "-filter_complex",
+            f"fps={fps},scale={width}:-1:flags=lanczos[x];"
+            f"[x][1:v]paletteuse=dither=sierra2_4a",
+            str(output),
+        ]
+    )
+
+
+def _assemble_gif_from_video(
+    video_path: Path,
+    palette_path: Path,
+    output: Path,
+    *,
+    fps: float,
+    width: int,
+) -> None:
+    print(f"creating GIF ({width}px, {fps} FPS)...", file=sys.stderr)
+    _run_ffmpeg(
+        [
+            "ffmpeg",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            str(video_path),
+            "-i",
+            str(palette_path),
+            "-filter_complex",
+            f"fps={fps},scale={width}:-1:flags=lanczos[x];"
+            f"[x][1:v]paletteuse=dither=sierra2_4a",
+            str(output),
+        ]
+    )
+
+
+def resolve_gif_settings(
+    preset: str,
+    *,
+    fps: float | None = None,
+    width: int | None = None,
+    colors: int | None = None,
+    max_frames: int | None = None,
+) -> dict:
+    if preset not in PRESETS:
+        raise ValueError(f"unknown preset: {preset}")
+    settings = dict(PRESETS[preset])
+    if fps is not None:
+        settings["fps"] = fps
+        settings["adaptive"] = False
+    if width is not None:
+        settings["width"] = width
+    if colors is not None:
+        settings["colors"] = colors
+    if max_frames is not None:
+        settings["max_frames"] = max_frames
+    return settings
+
+
+def cmd_gif(
+    video: str,
+    output: str | None = None,
+    *,
+    preset: str = "thumb",
+    fps: float | None = None,
+    width: int | None = None,
+    colors: int | None = None,
+    max_frames: int | None = None,
+) -> int:
+    video_path = Path(video).expanduser()
+    if not video_path.is_file():
+        print(f"n0b video gif: no such file: {video}", file=sys.stderr)
+        return 1
+    if not shutil.which("ffmpeg"):
+        print(
+            "n0b video gif: ffmpeg not found (try: brew install ffmpeg)",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        settings = resolve_gif_settings(
+            preset,
+            fps=fps,
+            width=width,
+            colors=colors,
+            max_frames=max_frames,
+        )
+    except ValueError as exc:
+        print(f"n0b video gif: {exc}", file=sys.stderr)
+        return 2
+
+    out_path = Path(output).expanduser() if output else Path(f"{video_path.stem}.gif")
+    gif_fps = settings["fps"]
+    if settings["adaptive"]:
+        gif_fps = calc_gif_fps(
+            video_path,
+            max_frames=int(settings["max_frames"]),
+            max_fps=float(settings["max_fps"]),
+        )
+
+    print(
+        f"preset: {preset} (fps={gif_fps}, width={settings['width']}, "
+        f"colors={settings['colors']})",
+        file=sys.stderr,
+    )
+
+    try:
+        with tempfile.TemporaryDirectory(prefix="n0b-gif-") as tmp:
+            tmp_dir = Path(tmp)
+            palette_path = tmp_dir / "palette.png"
+
+            if settings["gif_scale_from_frames"]:
+                frames_dir = tmp_dir / "frames"
+                _extract_frames(
+                    video_path,
+                    frames_dir,
+                    float(gif_fps),
+                    FRAME_SCALE_THUMB,
+                )
+                _create_palette(
+                    video_path,
+                    palette_path,
+                    fps=float(settings["palette_fps"]),
+                    scale=int(settings["palette_scale"]),
+                    colors=int(settings["colors"]),
+                )
+                _assemble_gif_from_frames(
+                    frames_dir,
+                    palette_path,
+                    out_path,
+                    fps=float(gif_fps),
+                    width=int(settings["width"]),
+                )
+            else:
+                _create_palette(
+                    video_path,
+                    palette_path,
+                    fps=float(gif_fps),
+                    scale=int(settings["palette_scale"]),
+                    colors=int(settings["colors"]),
+                )
+                _assemble_gif_from_video(
+                    video_path,
+                    palette_path,
+                    out_path,
+                    fps=float(gif_fps),
+                    width=int(settings["width"]),
+                )
+    except RuntimeError as exc:
+        print(f"n0b video gif: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"GIF saved to: {out_path}")
+    return 0

--- a/apps/n0b/docs/video.md
+++ b/apps/n0b/docs/video.md
@@ -1,0 +1,43 @@
+---
+name: "n0b-video"
+description: "Video file utilities: extract last frame or convert a video to an animated GIF. Use when the user wants a still or GIF preview from a video file."
+allowed-tools: Bash(n0b video *)
+---
+
+# n0b video
+
+Local ffmpeg utilities for video files. Not generative (`n0b ai video` is LTX/MLX).
+
+## last-frame
+
+```bash
+n0b video last-frame clip.mp4
+n0b video last-frame clip.mp4 -o end.png
+```
+
+Extracts the final video frame as a PNG.
+
+## gif
+
+Convert a video to an animated GIF using a palette (Surfey-style `palettegen` /
+`paletteuse=dither=sierra2_4a`).
+
+```bash
+n0b video gif clip.mp4
+n0b video gif clip.mp4 -o preview.gif
+n0b video gif clip.mp4 --preset thumb    # default
+n0b video gif clip.mp4 --preset small
+n0b video gif clip.mp4 --fps 8 --width 320 --colors 64
+```
+
+### Presets
+
+| Preset | FPS | Width | Colors | Notes |
+|--------|-----|-------|--------|-------|
+| `thumb` (default) | adaptive ≤1 (≤50 frames) | 320 | 64 | Matches Surfey `thumb-gif` |
+| `small` | 8 | 800 | 32 | Matches Surfey `quick-gif-small` |
+
+`--fps`, `--width`, `--colors`, and `--max-frames` override the preset.
+Default output is `<stem>.gif` in the current directory.
+
+Requires `ffmpeg` on PATH (`ffprobe` recommended for `thumb` adaptive FPS).

--- a/apps/n0b/tests/test_cli.py
+++ b/apps/n0b/tests/test_cli.py
@@ -47,6 +47,7 @@ from commands.ai_ollama import (
 from commands.ai_audio_cmd import cmd_audio  # noqa: E402
 from commands.ai_video_cmd import cmd_video, parse_video_args  # noqa: E402
 from commands.secrets_cmd import cmd_set, resolve  # noqa: E402
+from commands.video_cmd import cmd_gif, cmd_last_frame, resolve_gif_settings  # noqa: E402
 from cli import parse_audio_argv, parse_image_argv  # noqa: E402
 
 
@@ -748,3 +749,98 @@ def test_speak_help():
     assert "--save" in proc.stdout
     assert "--engine" in proc.stdout
     assert "play on speakers" in proc.stdout
+
+
+def test_video_gif_help():
+    proc = run_n0b("video", "gif", "--help")
+    assert proc.returncode == 0
+    assert "--preset" in proc.stdout
+    assert "--fps" in proc.stdout
+    assert "--width" in proc.stdout
+
+
+def test_resolve_gif_settings_presets_and_overrides():
+    thumb = resolve_gif_settings("thumb")
+    assert thumb["adaptive"] is True
+    assert thumb["width"] == 320
+    assert thumb["colors"] == 64
+    small = resolve_gif_settings("small")
+    assert small["adaptive"] is False
+    assert small["fps"] == 8.0
+    assert small["width"] == 800
+    assert small["colors"] == 32
+    overridden = resolve_gif_settings("thumb", fps=5.0, width=400, colors=128)
+    assert overridden["adaptive"] is False
+    assert overridden["fps"] == 5.0
+    assert overridden["width"] == 400
+    assert overridden["colors"] == 128
+
+
+def test_cmd_gif_missing_file(tmp_path, capsys):
+    rc = cmd_gif(str(tmp_path / "missing.mp4"))
+    assert rc == 1
+    assert "no such file" in capsys.readouterr().err
+
+
+def test_cmd_gif_small_preset_invokes_ffmpeg(tmp_path, capsys):
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"fake")
+    out = tmp_path / "out.gif"
+    calls: list[list[str]] = []
+
+    def fake_run(argv, **kwargs):
+        calls.append(list(argv))
+        if "palettegen" in " ".join(argv):
+            Path(argv[-1]).write_bytes(b"pal")
+        else:
+            Path(argv[-1]).write_bytes(b"GIF89a")
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    with patch("commands.video_cmd.subprocess.run", side_effect=fake_run):
+        rc = cmd_gif(str(video), str(out), preset="small")
+    assert rc == 0
+    assert out.is_file()
+    assert len(calls) == 2
+    assert "palettegen" in " ".join(calls[0])
+    assert "paletteuse=dither=sierra2_4a" in " ".join(calls[1])
+    assert "fps=8" in " ".join(calls[0])
+    assert "scale=800:-1:flags=lanczos" in " ".join(calls[1])
+    assert f"GIF saved to: {out}" in capsys.readouterr().out
+
+
+def test_cmd_gif_thumb_preset_extracts_frames(tmp_path, capsys):
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"fake")
+    out = tmp_path / "thumb.gif"
+    calls: list[list[str]] = []
+
+    def fake_run(argv, **kwargs):
+        calls.append(list(argv))
+        joined = " ".join(argv)
+        if "%04d.png" in joined:
+            frames_dir = Path(argv[-1]).parent
+            frames_dir.mkdir(parents=True, exist_ok=True)
+            (frames_dir / "0001.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+        elif "palettegen" in joined:
+            Path(argv[-1]).write_bytes(b"pal")
+        else:
+            Path(argv[-1]).write_bytes(b"GIF89a")
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    with (
+        patch("commands.video_cmd.subprocess.run", side_effect=fake_run),
+        patch("commands.video_cmd.calc_gif_fps", return_value=0.5),
+    ):
+        rc = cmd_gif(str(video), str(out), preset="thumb")
+    assert rc == 0
+    assert any("%04d.png" in " ".join(c) for c in calls)
+    assert any("palettegen" in " ".join(c) for c in calls)
+    assert any("paletteuse=dither=sierra2_4a" in " ".join(c) for c in calls)
+    assert "scale=320:-1:flags=lanczos" in " ".join(calls[-1])
+    assert f"GIF saved to: {out}" in capsys.readouterr().out
+
+
+def test_cmd_last_frame_missing(tmp_path, capsys):
+    rc = cmd_last_frame(str(tmp_path / "nope.mp4"), None)
+    assert rc == 1
+    assert "not found" in capsys.readouterr().err.lower()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `n0b video gif` — local video→GIF conversion using Surfey’s palette pipeline (`palettegen` + `paletteuse=dither=sierra2_4a`). No runtime link to archived Surfey; behavior ported into this repo.

```bash
n0b video gif clip.mp4
n0b video gif clip.mp4 --preset thumb   # default: adaptive ≤1 FPS, 320px, 64 colors
n0b video gif clip.mp4 --preset small   # 8 FPS, 800px, 32 colors
n0b video gif clip.mp4 -o out.gif --fps 8 --width 320
```

## PR Checklist

### Code Quality
- [x] No `__pycache__` or `.pyc` files in git
- [x] No hardcoded secrets (API keys, passwords, bridge URLs, MQTT creds)
- [x] No PII in committed code or PR description (real emails, phone numbers — use example.com)
- [x] No SQL string interpolation (all queries use `?` parameters)
- [x] No raw `except:` without specific exception types
- [x] No dead imports or unused variables
- [x] Runtime artifacts gitignored (`.db`, `.log`, `.count`, `health.txt`, `stimulus.txt`)

### Testing
- [ ] Integration tests pass (`lifetime.sh`)
- [x] Unit tests pass (if applicable: `pytest`) — gif help/settings/ffmpeg mocks + smoke with real ffmpeg
- [x] Manual verification of new features — generated thumb/small GIFs from a 1s test clip

### Documentation
- [ ] Textbook updated if architecture changed
- [x] README updated if organ/CLI interface changed

### Review
- [ ] Critic agent reviewed before merge
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-289859f1-d700-4c8a-9c8b-49deb59cc05c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-289859f1-d700-4c8a-9c8b-49deb59cc05c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

