### PR TITLE
feat(n0b): markdown-aware speak with section pauses

### DIFF
--- a/apps/n0b/cli.py
+++ b/apps/n0b/cli.py
@@ -220,12 +220,14 @@ def build_parser() -> argparse.ArgumentParser:
             "  n0b ai speak notes.md -o notes.m4a    save file (no playback)\n"
             "  n0b ai speak -v Samantha \"hi\" --save sticky macOS voice\n"
             "  n0b ai speak doc.md --engine kokoro -o out.wav  offline/file\n"
+            "  n0b ai speak notes.md --pause-major 1.5 --pause-minor 0.8\n"
             "  n0b ai speak --replace '\\ba8s\\b => A eight S' --save\n"
             "\n"
-            "Without -o/--out, audio goes to speakers. With -o, only a file "
-            "is written (useful for tell --attach). Replacements and "
-            "pronunciations live in ~/.config/n0b/speak-*.txt; see "
-            "apps/n0b/docs/ai-speak.md."
+            "Markdown is detected automatically: headings get section pauses "
+            "(default 2s major / 1s minor) and bold/code get light emphasis. "
+            "Use --flat for the old single-pass cleanup. Without -o/--out, "
+            "audio goes to speakers. With -o, only a file is written (useful "
+            "for tell --attach). See apps/n0b/docs/ai-speak.md."
         ),
     )
     ai_speak.add_argument(
@@ -257,6 +259,37 @@ def build_parser() -> argparse.ArgumentParser:
     )
     ai_speak.add_argument(
         "--raw", action="store_true", help="Skip markdown-to-prose cleanup"
+    )
+    ai_speak.add_argument(
+        "--flat",
+        action="store_true",
+        help="Force single-pass speakable() cleanup (no section pauses)",
+    )
+    ai_speak.add_argument(
+        "--pause-major",
+        type=float,
+        default=2.0,
+        metavar="SEC",
+        help="Silence before H1/H2 sections in seconds (default: 2.0)",
+    )
+    ai_speak.add_argument(
+        "--pause-minor",
+        type=float,
+        default=1.0,
+        metavar="SEC",
+        help="Silence before H3–H6 sections in seconds (default: 1.0)",
+    )
+    ai_speak.add_argument(
+        "--pause-para",
+        type=float,
+        default=0.4,
+        metavar="SEC",
+        help="Silence between paragraphs in seconds (default: 0.4)",
+    )
+    ai_speak.add_argument(
+        "--no-emphasis",
+        action="store_true",
+        help="Disable bold/code emphasis (speed/slnc tweaks)",
     )
     ai_speak.add_argument(
         "--replace",
@@ -483,10 +516,15 @@ def dispatch(args: argparse.Namespace) -> int:
                 args.voice,
                 args.speed,
                 raw=args.raw,
+                flat=args.flat,
                 replaces=args.replaces,
                 pronounces=args.pronounces,
                 save=args.save,
                 engine=args.engine,
+                pause_major=args.pause_major,
+                pause_minor=args.pause_minor,
+                pause_para=args.pause_para,
+                emphasis=not args.no_emphasis,
             )
         if args.ai_kind == "transcribe":
             return cmd_transcribe(

--- a/apps/n0b/commands/ai_speak_cmd.py
+++ b/apps/n0b/commands/ai_speak_cmd.py
@@ -1,6 +1,7 @@
 """n0b ai speak — macOS say and Kokoro TTS."""
 from __future__ import annotations
 
+import json
 import re
 import shutil
 import subprocess
@@ -10,6 +11,17 @@ from pathlib import Path
 
 from ai_venv import ensure_kokoro
 from commands.ai_common import parse_cli_pairs, read_pair_file, save_pair_file
+from commands.speak_markdown import (
+    DEFAULT_PAUSE_MAJOR,
+    DEFAULT_PAUSE_MINOR,
+    DEFAULT_PAUSE_PARA,
+    PauseConfig,
+    looks_like_markdown,
+    map_span_text,
+    parse_markdown_blocks,
+    render_kokoro_pieces,
+    render_say_text,
+)
 
 SPEAK_REPLACEMENTS_FILE = Path.home() / ".config" / "n0b" / "speak-replacements.txt"
 SPEAK_PRONUNCIATIONS_FILE = Path.home() / ".config" / "n0b" / "speak-pronunciations.txt"
@@ -17,24 +29,34 @@ SPEAK_VOICE_FILE = Path.home() / ".config" / "n0b" / "speak-voice.txt"
 DEFAULT_SPEAK_VOICE = "af_heart"
 
 _KOKORO_SNIPPET = """\
+import json
 import sys
 
 import numpy as np
 import soundfile as sf
 from kokoro import KPipeline
 
-text_path, out_path, voice, speed = sys.argv[1:5]
-text = open(text_path, encoding="utf-8").read()
+manifest_path, out_path, voice = sys.argv[1:4]
+pieces = json.loads(open(manifest_path, encoding="utf-8").read())
 pipeline = KPipeline(lang_code=voice[0])
 chunks = []
-for i, result in enumerate(pipeline(text, voice=voice, speed=float(speed))):
-    audio = result[2]
-    chunks.append(audio.numpy() if hasattr(audio, "numpy") else audio)
-    print(f"  segment {i + 1}", file=sys.stderr)
+sr = 24000
+for i, piece in enumerate(pieces):
+    text = piece.get("text") or ""
+    speed = float(piece.get("speed", 1.0))
+    silence_after = float(piece.get("silence_after", 0.0))
+    if text.strip():
+        for j, result in enumerate(pipeline(text, voice=voice, speed=speed)):
+            audio = result[2]
+            chunks.append(audio.numpy() if hasattr(audio, "numpy") else audio)
+            print(f"  piece {i + 1}.{j + 1}", file=sys.stderr)
+    if silence_after > 0:
+        chunks.append(np.zeros(int(sr * silence_after), dtype=np.float32))
+        print(f"  silence {silence_after:.2f}s", file=sys.stderr)
 if not chunks:
     print("no audio produced", file=sys.stderr)
     sys.exit(1)
-sf.write(out_path, np.concatenate(chunks), 24000)
+sf.write(out_path, np.concatenate(chunks), sr)
 """
 
 _MD_URL_LINK_RE = re.compile(r"\[([^\]]+)\]\((?!/)[^)]*\)")
@@ -242,9 +264,8 @@ def _speak_say(
 
 
 def _speak_kokoro(
-    text: str,
+    pieces: list[dict],
     voice: str,
-    speed: float,
     out: Path | None,
 ) -> int:
     play = out is None
@@ -275,14 +296,20 @@ def _speak_kokoro(
         return 1
     wav_path = out_path.with_suffix(".tmp.wav") if convert else out_path
     with tempfile.NamedTemporaryFile(
-        "w", suffix=".txt", encoding="utf-8", delete=False
+        "w", suffix=".json", encoding="utf-8", delete=False
     ) as f:
-        f.write(text)
-        text_file = Path(f.name)
+        json.dump(pieces, f)
+        manifest_file = Path(f.name)
     try:
         proc = subprocess.run(
-            [str(python), "-c", _KOKORO_SNIPPET, str(text_file), str(wav_path),
-             voice, str(speed)],
+            [
+                str(python),
+                "-c",
+                _KOKORO_SNIPPET,
+                str(manifest_file),
+                str(wav_path),
+                voice,
+            ],
         )
         if proc.returncode != 0:
             return proc.returncode
@@ -295,7 +322,7 @@ def _speak_kokoro(
             if conv.returncode != 0:
                 return conv.returncode
     finally:
-        text_file.unlink(missing_ok=True)
+        manifest_file.unlink(missing_ok=True)
     if play:
         try:
             return play_audio(wav_path)
@@ -305,16 +332,61 @@ def _speak_kokoro(
     return 0
 
 
+def _apply_pairs_to_text(
+    text: str,
+    *,
+    engine_name: str,
+    replace_pairs: list[tuple[str, str]],
+    pronounce_pairs: list[tuple[str, str]],
+    file_replaces: list[tuple[str, str]],
+    cli_replaces: list[tuple[str, str]],
+    file_pronounces: list[tuple[str, str]],
+    cli_pronounces: list[tuple[str, str]],
+) -> str:
+    if pronounce_pairs and engine_name == "kokoro":
+        print(
+            f"pronunciations: {len(pronounce_pairs)} pattern(s) loaded "
+            f"({len(file_pronounces)} from {SPEAK_PRONUNCIATIONS_FILE}, "
+            f"{len(cli_pronounces)} from --pronounce)",
+            file=sys.stderr,
+        )
+        text, applied = apply_pronunciations(text, pronounce_pairs)
+        note = "; ".join(applied) if applied else "none matched"
+        print(f"pronunciations applied: {note}", file=sys.stderr)
+    elif pronounce_pairs:
+        print(
+            "n0b ai speak: pronunciations ignored for say engine "
+            "(use --engine kokoro)",
+            file=sys.stderr,
+        )
+    if replace_pairs:
+        print(
+            f"replacements: {len(replace_pairs)} pattern(s) loaded "
+            f"({len(file_replaces)} from {SPEAK_REPLACEMENTS_FILE}, "
+            f"{len(cli_replaces)} from --replace)",
+            file=sys.stderr,
+        )
+        text, applied = apply_speak_replacements(text, replace_pairs)
+        note = "; ".join(applied) if applied else "none matched"
+        print(f"replacements applied: {note}", file=sys.stderr)
+    return text
+
+
 def cmd_speak(
     source: list[str] | None,
     out: str | None,
     voice: str | None,
     speed: float,
     raw: bool = False,
+    flat: bool = False,
     replaces: list[str] | None = None,
     pronounces: list[str] | None = None,
     save: bool = False,
     engine: str | None = None,
+    pause_major: float = DEFAULT_PAUSE_MAJOR,
+    pause_minor: float = DEFAULT_PAUSE_MINOR,
+    pause_para: float = DEFAULT_PAUSE_PARA,
+    emphasis: bool = True,
 ) -> int:
     replaces = replaces or []
     pronounces = pronounces or []
@@ -342,46 +414,113 @@ def cmd_speak(
     print(f"engine: {engine_name}", file=sys.stderr)
     print(f"voice: {voice or 'default'} ({voice_src})", file=sys.stderr)
     text = load_speak_text(source or [])
-    if not raw:
-        text = speakable(text)
     file_replaces = read_pair_file(SPEAK_REPLACEMENTS_FILE, "n0b ai speak")
     cli_replaces = parse_cli_pairs(replaces, "n0b ai speak")
     replace_pairs = file_replaces + cli_replaces
     file_pronounces = read_pair_file(SPEAK_PRONUNCIATIONS_FILE, "n0b ai speak")
     cli_pronounces = parse_cli_pairs(pronounces, "n0b ai speak")
     pronounce_pairs = file_pronounces + cli_pronounces
-    if pronounce_pairs and engine_name == "kokoro":
+    out_path = Path(out).expanduser() if out else None
+    structured = (
+        not raw
+        and not flat
+        and looks_like_markdown(text)
+    )
+    if structured:
+        pauses = PauseConfig(pause_major, pause_minor, pause_para)
+        blocks = parse_markdown_blocks(text, pauses)
+        use_ipa = bool(pronounce_pairs) and engine_name == "kokoro"
+        if pronounce_pairs and not use_ipa:
+            print(
+                "n0b ai speak: pronunciations ignored for say engine "
+                "(use --engine kokoro)",
+                file=sys.stderr,
+            )
+        if use_ipa:
+            print(
+                f"pronunciations: {len(pronounce_pairs)} pattern(s) loaded "
+                f"({len(file_pronounces)} from {SPEAK_PRONUNCIATIONS_FILE}, "
+                f"{len(cli_pronounces)} from --pronounce)",
+                file=sys.stderr,
+            )
+        if replace_pairs:
+            print(
+                f"replacements: {len(replace_pairs)} pattern(s) loaded "
+                f"({len(file_replaces)} from {SPEAK_REPLACEMENTS_FILE}, "
+                f"{len(cli_replaces)} from --replace)",
+                file=sys.stderr,
+            )
+        ipa_notes: list[str] = []
+        repl_notes: list[str] = []
+
+        def transform(span_text: str) -> str:
+            out_text = span_text
+            if use_ipa:
+                out_text, applied = apply_pronunciations(out_text, pronounce_pairs)
+                ipa_notes.extend(applied)
+            if replace_pairs:
+                out_text, applied = apply_speak_replacements(out_text, replace_pairs)
+                repl_notes.extend(applied)
+            return out_text
+
+        blocks = map_span_text(blocks, transform)
+        if use_ipa:
+            note = "; ".join(ipa_notes) if ipa_notes else "none matched"
+            print(f"pronunciations applied: {note}", file=sys.stderr)
+        if replace_pairs:
+            note = "; ".join(repl_notes) if repl_notes else "none matched"
+            print(f"replacements applied: {note}", file=sys.stderr)
+        if not blocks:
+            print("n0b ai speak: nothing to say after cleanup", file=sys.stderr)
+            return 2
         print(
-            f"pronunciations: {len(pronounce_pairs)} pattern(s) loaded "
-            f"({len(file_pronounces)} from {SPEAK_PRONUNCIATIONS_FILE}, "
-            f"{len(cli_pronounces)} from --pronounce)",
+            f"markdown: {len(blocks)} block(s); "
+            f"pauses major={pauses.major}s minor={pauses.minor}s "
+            f"para={pauses.para}s; emphasis={'on' if emphasis else 'off'}",
             file=sys.stderr,
         )
-        text, applied = apply_pronunciations(text, pronounce_pairs)
-        note = "; ".join(applied) if applied else "none matched"
-        print(f"pronunciations applied: {note}", file=sys.stderr)
-    elif pronounce_pairs:
-        print(
-            "n0b ai speak: pronunciations ignored for say engine "
-            "(use --engine kokoro)",
-            file=sys.stderr,
-        )
-    if replace_pairs:
-        print(
-            f"replacements: {len(replace_pairs)} pattern(s) loaded "
-            f"({len(file_replaces)} from {SPEAK_REPLACEMENTS_FILE}, "
-            f"{len(cli_replaces)} from --replace)",
-            file=sys.stderr,
-        )
-        text, applied = apply_speak_replacements(text, replace_pairs)
-        note = "; ".join(applied) if applied else "none matched"
-        print(f"replacements applied: {note}", file=sys.stderr)
+        if engine_name == "say":
+            say_text = plain_for_say(render_say_text(blocks, emphasis=emphasis))
+            return _speak_say(say_text, voice, speed, out_path)
+        if voice is None:
+            voice = DEFAULT_SPEAK_VOICE
+        pieces = [
+            {
+                "text": p.text,
+                "speed": p.speed,
+                "silence_after": p.silence_after,
+            }
+            for p in render_kokoro_pieces(
+                blocks, base_speed=speed, emphasis=emphasis
+            )
+            if p.text.strip() or p.silence_after > 0
+        ]
+        if not any(p["text"].strip() for p in pieces):
+            print("n0b ai speak: nothing to say after cleanup", file=sys.stderr)
+            return 2
+        return _speak_kokoro(pieces, voice, out_path)
+
+    if not raw:
+        text = speakable(text)
+    text = _apply_pairs_to_text(
+        text,
+        engine_name=engine_name,
+        replace_pairs=replace_pairs,
+        pronounce_pairs=pronounce_pairs,
+        file_replaces=file_replaces,
+        cli_replaces=cli_replaces,
+        file_pronounces=file_pronounces,
+        cli_pronounces=cli_pronounces,
+    )
     if not text.strip():
         print("n0b ai speak: nothing to say after cleanup", file=sys.stderr)
         return 2
-    out_path = Path(out).expanduser() if out else None
     if engine_name == "say":
         return _speak_say(plain_for_say(text), voice, speed, out_path)
     if voice is None:
         voice = DEFAULT_SPEAK_VOICE
-    return _speak_kokoro(text, voice, speed, out_path)
+    return _speak_kokoro(
+        [{"text": text, "speed": speed, "silence_after": 0.0}],
+        voice,
+        out_path,
+    )

--- a/apps/n0b/commands/ai_speak_cmd.py
+++ b/apps/n0b/commands/ai_speak_cmd.py
@@ -59,10 +59,20 @@ if not chunks:
 sf.write(out_path, np.concatenate(chunks), sr)
 """
 
-_MD_URL_LINK_RE = re.compile(r"\[([^\]]+)\]\((?!/)[^)]*\)")
+_MD_LINK_RE = re.compile(r"\[([^\]]+)\]\([^)]*\)")
 _MD_NOISE_RE = re.compile(r"[*_`#>|]+")
 _MISAKI_PHONEME_RE = re.compile(r"\[([^\]]+)\]\(/[^/]+/\)")
+_MISAKI_KEEP_RE = re.compile(r"\[[^\]]+\]\(/[^/]+/\)")
 _KOKORO_VOICE_RE = re.compile(r"^[abdefhpijzm][fm]_")
+
+
+def _strip_md_links_keep_misaki(text: str) -> str:
+    def repl(m: re.Match[str]) -> str:
+        if _MISAKI_KEEP_RE.fullmatch(m.group(0)):
+            return m.group(0)
+        return m.group(1)
+
+    return _MD_LINK_RE.sub(repl, text)
 
 
 def speakable(markdown: str) -> str:
@@ -75,7 +85,7 @@ def speakable(markdown: str) -> str:
             continue
         if fenced or s.startswith("|"):
             continue
-        line = _MD_URL_LINK_RE.sub(r"\1", line)
+        line = _strip_md_links_keep_misaki(line)
         line = _MD_NOISE_RE.sub("", line)
         out.append(line)
     return "\n".join(out)

--- a/apps/n0b/commands/speak_markdown.py
+++ b/apps/n0b/commands/speak_markdown.py
@@ -20,7 +20,7 @@ _MD_HINT_RE = re.compile(
 _HEADING_RE = re.compile(r"^(#{1,6})\s+(.*)$")
 _LIST_RE = re.compile(r"^(\s{0,3})([-*+]|\d+\.)\s+(.*)$")
 _HR_RE = re.compile(r"^\s{0,3}([-*_])(?:\s*\1){2,}\s*$")
-_URL_LINK_RE = re.compile(r"\[([^\]]+)\]\((?!/)[^)]*\)")
+_MD_LINK_RE = re.compile(r"\[([^\]]+)\]\([^)]*\)")
 _MISAKI_RE = re.compile(r"\[[^\]]+\]\(/[^/]+/\)")
 
 
@@ -52,14 +52,31 @@ def looks_like_markdown(text: str) -> bool:
     return bool(_MD_HINT_RE.search(text))
 
 
+def _word_edge(text: str, i: int) -> bool:
+    return i <= 0 or i >= len(text) or not text[i].isalnum()
+
+
+def _strip_md_links(text: str) -> str:
+    def repl(m: re.Match[str]) -> str:
+        if _MISAKI_RE.fullmatch(m.group(0)):
+            return m.group(0)
+        return m.group(1)
+
+    return _MD_LINK_RE.sub(repl, text)
+
+
 def parse_inline_spans(text: str) -> tuple[SpeakSpan, ...]:
-    text = _URL_LINK_RE.sub(r"\1", text)
+    text = _strip_md_links(text)
     spans: list[SpeakSpan] = []
     i = 0
     n = len(text)
 
     def push(raw: str, style: Style) -> None:
-        if raw:
+        if not raw:
+            return
+        if spans and style == "plain" and spans[-1].style == "plain":
+            spans[-1] = SpeakSpan(spans[-1].text + raw, "plain")
+        else:
             spans.append(SpeakSpan(raw, style))
 
     while i < n:
@@ -74,9 +91,9 @@ def parse_inline_spans(text: str) -> tuple[SpeakSpan, ...]:
                 push(text[i + 2 : end], "strong")
                 i = end + 2
                 continue
-        if text.startswith("__", i):
+        if text.startswith("__", i) and _word_edge(text, i - 1):
             end = text.find("__", i + 2)
-            if end != -1:
+            if end != -1 and _word_edge(text, end + 2):
                 push(text[i + 2 : end], "strong")
                 i = end + 2
                 continue
@@ -86,10 +103,15 @@ def parse_inline_spans(text: str) -> tuple[SpeakSpan, ...]:
                 push(text[i + 1 : end], "code")
                 i = end + 1
                 continue
-        if text[i] in "*_":
-            marker = text[i]
-            end = text.find(marker, i + 1)
+        if text[i] == "*":
+            end = text.find("*", i + 1)
             if end != -1 and end > i + 1:
+                push(text[i + 1 : end], "strong")
+                i = end + 1
+                continue
+        if text[i] == "_" and _word_edge(text, i - 1):
+            end = text.find("_", i + 1)
+            if end != -1 and end > i + 1 and _word_edge(text, end + 1):
                 push(text[i + 1 : end], "strong")
                 i = end + 1
                 continue

--- a/apps/n0b/commands/speak_markdown.py
+++ b/apps/n0b/commands/speak_markdown.py
@@ -1,0 +1,277 @@
+"""Markdown-aware segmentation for n0b ai speak."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterator, Literal
+
+Style = Literal["plain", "strong", "code"]
+BlockKind = Literal["heading", "paragraph", "list_item"]
+
+DEFAULT_PAUSE_MAJOR = 2.0
+DEFAULT_PAUSE_MINOR = 1.0
+DEFAULT_PAUSE_PARA = 0.4
+
+_MD_HINT_RE = re.compile(
+    r"(?m)"
+    r"^(#{1,6}\s|\s{0,3}([-*+]|\d+\.)\s|>\s|```|\|)"
+    r"|(\*\*[^*\n]+\*\*|__[^_\n]+__|`[^`\n]+`)"
+)
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.*)$")
+_LIST_RE = re.compile(r"^(\s{0,3})([-*+]|\d+\.)\s+(.*)$")
+_HR_RE = re.compile(r"^\s{0,3}([-*_])(?:\s*\1){2,}\s*$")
+_URL_LINK_RE = re.compile(r"\[([^\]]+)\]\((?!/)[^)]*\)")
+_MISAKI_RE = re.compile(r"\[[^\]]+\]\(/[^/]+/\)")
+
+
+@dataclass(frozen=True)
+class SpeakSpan:
+    text: str
+    style: Style = "plain"
+
+
+@dataclass(frozen=True)
+class SpeakBlock:
+    kind: BlockKind
+    level: int
+    spans: tuple[SpeakSpan, ...]
+    pause_before: float = 0.0
+
+
+@dataclass(frozen=True)
+class PauseConfig:
+    major: float = DEFAULT_PAUSE_MAJOR
+    minor: float = DEFAULT_PAUSE_MINOR
+    para: float = DEFAULT_PAUSE_PARA
+
+    def before_heading(self, level: int) -> float:
+        return self.major if level <= 2 else self.minor
+
+
+def looks_like_markdown(text: str) -> bool:
+    return bool(_MD_HINT_RE.search(text))
+
+
+def parse_inline_spans(text: str) -> tuple[SpeakSpan, ...]:
+    text = _URL_LINK_RE.sub(r"\1", text)
+    spans: list[SpeakSpan] = []
+    i = 0
+    n = len(text)
+
+    def push(raw: str, style: Style) -> None:
+        if raw:
+            spans.append(SpeakSpan(raw, style))
+
+    while i < n:
+        misaki = _MISAKI_RE.match(text, i)
+        if misaki:
+            push(misaki.group(0), "plain")
+            i = misaki.end()
+            continue
+        if text.startswith("**", i):
+            end = text.find("**", i + 2)
+            if end != -1:
+                push(text[i + 2 : end], "strong")
+                i = end + 2
+                continue
+        if text.startswith("__", i):
+            end = text.find("__", i + 2)
+            if end != -1:
+                push(text[i + 2 : end], "strong")
+                i = end + 2
+                continue
+        if text[i] == "`":
+            end = text.find("`", i + 1)
+            if end != -1:
+                push(text[i + 1 : end], "code")
+                i = end + 1
+                continue
+        if text[i] in "*_":
+            marker = text[i]
+            end = text.find(marker, i + 1)
+            if end != -1 and end > i + 1:
+                push(text[i + 1 : end], "strong")
+                i = end + 1
+                continue
+        next_special = n
+        for token in ("**", "__", "`", "[", "*", "_"):
+            pos = text.find(token, i)
+            if pos != -1:
+                next_special = min(next_special, pos)
+        if next_special == i:
+            push(text[i], "plain")
+            i += 1
+            continue
+        push(text[i:next_special], "plain")
+        i = next_special
+    return tuple(spans)
+
+
+def _pause_for(
+    kind: BlockKind, level: int, *, first: bool, pauses: PauseConfig
+) -> float:
+    if first:
+        return 0.0
+    if kind == "heading":
+        return pauses.before_heading(level)
+    if kind == "list_item":
+        return min(pauses.para, 0.25)
+    return pauses.para
+
+
+def iter_markdown_blocks(
+    markdown: str, pauses: PauseConfig | None = None
+) -> Iterator[SpeakBlock]:
+    pauses = pauses or PauseConfig()
+    fenced = False
+    para_lines: list[str] = []
+    first = True
+
+    def flush_para() -> Iterator[SpeakBlock]:
+        nonlocal first, para_lines
+        if not para_lines:
+            return
+        text = " ".join(line.strip() for line in para_lines if line.strip())
+        para_lines = []
+        if not text:
+            return
+        spans = parse_inline_spans(text)
+        if not spans:
+            return
+        pause = _pause_for("paragraph", 0, first=first, pauses=pauses)
+        first = False
+        yield SpeakBlock("paragraph", 0, spans, pause)
+
+    for line in markdown.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            yield from flush_para()
+            fenced = not fenced
+            continue
+        if fenced or stripped.startswith("|") or _HR_RE.match(line):
+            continue
+        heading = _HEADING_RE.match(stripped)
+        if heading:
+            yield from flush_para()
+            level = len(heading.group(1))
+            spans = parse_inline_spans(heading.group(2).strip())
+            if not spans:
+                continue
+            pause = _pause_for("heading", level, first=first, pauses=pauses)
+            first = False
+            yield SpeakBlock("heading", level, spans, pause)
+            continue
+        list_item = _LIST_RE.match(line)
+        if list_item:
+            yield from flush_para()
+            spans = parse_inline_spans(list_item.group(3).strip())
+            if not spans:
+                continue
+            pause = _pause_for("list_item", 0, first=first, pauses=pauses)
+            first = False
+            yield SpeakBlock("list_item", 0, spans, pause)
+            continue
+        if stripped.startswith(">"):
+            para_lines.append(stripped.lstrip("> ").strip())
+            continue
+        if not stripped:
+            yield from flush_para()
+            continue
+        para_lines.append(line)
+    yield from flush_para()
+
+
+def parse_markdown_blocks(
+    markdown: str, pauses: PauseConfig | None = None
+) -> list[SpeakBlock]:
+    return list(iter_markdown_blocks(markdown, pauses))
+
+
+def map_span_text(
+    blocks: list[SpeakBlock], transform
+) -> list[SpeakBlock]:
+    out: list[SpeakBlock] = []
+    for block in blocks:
+        spans = tuple(
+            SpeakSpan(transform(span.text), span.style) for span in block.spans
+        )
+        spans = tuple(s for s in spans if s.text.strip())
+        if not spans:
+            continue
+        out.append(
+            SpeakBlock(block.kind, block.level, spans, block.pause_before)
+        )
+    return out
+
+
+def render_say_text(blocks: list[SpeakBlock], *, emphasis: bool = True) -> str:
+    parts: list[str] = []
+    for block in blocks:
+        if block.pause_before > 0:
+            ms = max(1, int(round(block.pause_before * 1000)))
+            parts.append(f"[[slnc {ms}]]")
+        chunk: list[str] = []
+        for span in block.spans:
+            text = span.text.strip()
+            if not text:
+                continue
+            if not emphasis or span.style == "plain":
+                chunk.append(text)
+                continue
+            if span.style == "code":
+                chunk.append(f"[[slnc 120]] {text} [[slnc 120]]")
+                continue
+            words = text.split()
+            chunk.append(" ".join(f"[[emph +]]{w}" for w in words))
+        spoken = " ".join(chunk).strip()
+        if spoken:
+            parts.append(spoken)
+    return "\n".join(parts)
+
+
+@dataclass(frozen=True)
+class KokoroPiece:
+    text: str
+    speed: float
+    silence_after: float = 0.0
+
+
+def render_kokoro_pieces(
+    blocks: list[SpeakBlock],
+    *,
+    base_speed: float = 1.0,
+    emphasis: bool = True,
+) -> list[KokoroPiece]:
+    pieces: list[KokoroPiece] = []
+    for block in blocks:
+        if block.pause_before > 0 and pieces:
+            last = pieces[-1]
+            pieces[-1] = KokoroPiece(
+                last.text, last.speed, last.silence_after + block.pause_before
+            )
+        elif block.pause_before > 0:
+            pieces.append(KokoroPiece("", base_speed, block.pause_before))
+
+        spans = [s for s in block.spans if s.text.strip()]
+        for i, span in enumerate(spans):
+            text = span.text.strip()
+            if span.style == "strong" and emphasis:
+                speed = base_speed * 0.92
+                silence_before = 0.08
+            elif span.style == "code" and emphasis:
+                speed = base_speed * 0.85
+                silence_before = 0.12
+            else:
+                speed = base_speed
+                silence_before = 0.0
+            if silence_before and pieces:
+                last = pieces[-1]
+                pieces[-1] = KokoroPiece(
+                    last.text, last.speed, last.silence_after + silence_before
+                )
+            trailing = 0.12 if span.style == "code" and emphasis else 0.0
+            if i < len(spans) - 1 and trailing == 0.0:
+                trailing = 0.05 if span.style != "plain" else 0.0
+            pieces.append(KokoroPiece(text, speed, trailing))
+    return [p for p in pieces if p.text.strip() or p.silence_after > 0]
+

--- a/apps/n0b/commands/speak_markdown.py
+++ b/apps/n0b/commands/speak_markdown.py
@@ -11,6 +11,7 @@ BlockKind = Literal["heading", "paragraph", "list_item"]
 DEFAULT_PAUSE_MAJOR = 2.0
 DEFAULT_PAUSE_MINOR = 1.0
 DEFAULT_PAUSE_PARA = 0.4
+LIST_PAUSE_CAP = 0.25
 
 _MD_HINT_RE = re.compile(
     r"(?m)"
@@ -137,7 +138,7 @@ def _pause_for(
     if kind == "heading":
         return pauses.before_heading(level)
     if kind == "list_item":
-        return min(pauses.para, 0.25)
+        return min(pauses.para, LIST_PAUSE_CAP)
     return pauses.para
 
 
@@ -171,6 +172,9 @@ def iter_markdown_blocks(
             fenced = not fenced
             continue
         if fenced or stripped.startswith("|") or _HR_RE.match(line):
+            continue
+        if re.match(r"^#{1,6}\s*$", stripped):
+            yield from flush_para()
             continue
         heading = _HEADING_RE.match(stripped)
         if heading:
@@ -226,6 +230,17 @@ def map_span_text(
     return out
 
 
+def _say_strong(text: str) -> str:
+    parts: list[str] = []
+    for token in re.finditer(r"\S+|\s+", text):
+        chunk = token.group(0)
+        if chunk.isspace():
+            parts.append(chunk)
+        else:
+            parts.append(f"[[emph +]]{chunk}")
+    return "".join(parts)
+
+
 def render_say_text(blocks: list[SpeakBlock], *, emphasis: bool = True) -> str:
     parts: list[str] = []
     for block in blocks:
@@ -234,18 +249,17 @@ def render_say_text(blocks: list[SpeakBlock], *, emphasis: bool = True) -> str:
             parts.append(f"[[slnc {ms}]]")
         chunk: list[str] = []
         for span in block.spans:
-            text = span.text.strip()
+            text = span.text
             if not text:
                 continue
             if not emphasis or span.style == "plain":
                 chunk.append(text)
                 continue
             if span.style == "code":
-                chunk.append(f"[[slnc 120]] {text} [[slnc 120]]")
+                chunk.append(f"[[slnc 120]]{text}[[slnc 120]]")
                 continue
-            words = text.split()
-            chunk.append(" ".join(f"[[emph +]]{w}" for w in words))
-        spoken = " ".join(chunk).strip()
+            chunk.append(_say_strong(text))
+        spoken = "".join(chunk).strip()
         if spoken:
             parts.append(spoken)
     return "\n".join(parts)
@@ -266,14 +280,8 @@ def render_kokoro_pieces(
 ) -> list[KokoroPiece]:
     pieces: list[KokoroPiece] = []
     for block in blocks:
-        if block.pause_before > 0 and pieces:
-            last = pieces[-1]
-            pieces[-1] = KokoroPiece(
-                last.text, last.speed, last.silence_after + block.pause_before
-            )
-        elif block.pause_before > 0:
+        if block.pause_before > 0:
             pieces.append(KokoroPiece("", base_speed, block.pause_before))
-
         spans = [s for s in block.spans if s.text.strip()]
         for i, span in enumerate(spans):
             text = span.text.strip()
@@ -286,11 +294,8 @@ def render_kokoro_pieces(
             else:
                 speed = base_speed
                 silence_before = 0.0
-            if silence_before and pieces:
-                last = pieces[-1]
-                pieces[-1] = KokoroPiece(
-                    last.text, last.speed, last.silence_after + silence_before
-                )
+            if silence_before:
+                pieces.append(KokoroPiece("", speed, silence_before))
             trailing = 0.12 if span.style == "code" and emphasis else 0.0
             if i < len(spans) - 1 and trailing == 0.0:
                 trailing = 0.05 if span.style != "plain" else 0.0

--- a/apps/n0b/commands/speak_markdown.py
+++ b/apps/n0b/commands/speak_markdown.py
@@ -294,7 +294,8 @@ def render_kokoro_pieces(
             else:
                 speed = base_speed
                 silence_before = 0.0
-            if silence_before:
+            already_paused = pieces and not pieces[-1].text.strip()
+            if silence_before and not already_paused:
                 pieces.append(KokoroPiece("", speed, silence_before))
             trailing = 0.12 if span.style == "code" and emphasis else 0.0
             if i < len(spans) - 1 and trailing == 0.0:

--- a/apps/n0b/docs/ai-speak.md
+++ b/apps/n0b/docs/ai-speak.md
@@ -19,6 +19,8 @@ n0b ai speak notes.md -o notes.m4a        # save file (no playback)
 n0b ai speak -v Samantha "hi" --save      # sticky macOS voice
 
 n0b ai speak notes.md --engine kokoro -o out.wav   # offline neural
+n0b ai speak notes.md --pause-major 1.5 --pause-minor 0.8
+n0b ai speak notes.md --flat              # old single-pass cleanup
 n0b ai speak --replace '\ba8s\b => A eight S' --save
 n0b ai speak --pronounce 'Pay-i => pˈeɪ ˈaɪ' --save   # kokoro only
 ```
@@ -41,10 +43,31 @@ n0b ai speak --pronounce 'Pay-i => pˈeɪ ˈaɪ' --save   # kokoro only
 
 ## Input
 
-Cleaned for listening by default: code fences and table rows dropped, URL
-links unwrapped, emphasis stripped. Misaki `[word](/ipa/)` overrides are
-kept for kokoro and flattened to the word for say. Pass `--raw` to skip
-cleanup.
+Plain text is spoken as-is (after optional replacements). Markdown is
+detected automatically and spoken in sections:
+
+- **Headings** — synthesized as their own unit; silence inserted before
+  each non-first heading (defaults below)
+- **Paragraphs / list items** — shorter inter-block pauses
+- **Bold / italic** — light emphasis (`[[emph +]]` on say; slightly
+  slower speed on kokoro)
+- **Inline code** — micro-pauses around the token; slower on kokoro
+- Code fences and table rows are skipped (same as before)
+
+Defaults (SSML-style section breathing, tuned for listening to docs):
+
+| Boundary | Flag | Default |
+|----------|------|---------|
+| Before H1 / H2 | `--pause-major` | `2.0` s |
+| Before H3–H6 | `--pause-minor` | `1.0` s |
+| Between paragraphs | `--pause-para` | `0.4` s |
+
+Use `--flat` for the previous single-pass `speakable()` cleanup (no
+section pauses). `--raw` skips cleanup entirely. `--no-emphasis` keeps
+section pauses but disables bold/code prosody tweaks.
+
+Misaki `[word](/ipa/)` overrides are kept for kokoro and flattened to the
+word for say.
 
 Inline text, a file path, `-`, or omitted (stdin) all work:
 

--- a/apps/n0b/tests/test_cli.py
+++ b/apps/n0b/tests/test_cli.py
@@ -621,6 +621,11 @@ def test_speakable_keeps_phoneme_overrides():
     assert speakable(md) == "See [Pay-i](/pˈeɪ ˈaɪ/) and docs."
 
 
+def test_speakable_strips_root_relative_links():
+    md = "Open [install](/docs/install) next."
+    assert speakable(md) == "Open install next."
+
+
 def test_speakable_drops_fences_and_tables():
     md = "# Title\n\n| a | b |\n|---|---|\n\nHello\n\n```py\nx=1\n```\n"
     assert speakable(md) == " Title\n\n\nHello\n"

--- a/apps/n0b/tests/test_cli.py
+++ b/apps/n0b/tests/test_cli.py
@@ -791,6 +791,128 @@ def test_speak_markdown_flat_skips_section_pauses(tmp_path):
     assert "[[slnc" not in spoken["text"]
 
 
+def test_speak_markdown_pause_overrides(tmp_path):
+    src = tmp_path / "notes.md"
+    src.write_text("# Alpha\n\nHello.\n\n## Beta\n\n### Gamma\n")
+    spoken: dict[str, str] = {}
+    with (
+        patch("commands.ai_speak_cmd.resolve_speak_engine", return_value="say"),
+        patch("commands.ai_speak_cmd.shutil.which", return_value="/usr/bin/say"),
+        patch("commands.ai_speak_cmd.subprocess.run") as run,
+    ):
+        def capture(cmd, **kwargs):
+            spoken["text"] = Path(cmd[cmd.index("-f") + 1]).read_text(
+                encoding="utf-8"
+            )
+            return subprocess.CompletedProcess(cmd, 0)
+
+        run.side_effect = capture
+        rc = cmd_speak(
+            [str(src)],
+            None,
+            None,
+            1.0,
+            engine="say",
+            pause_major=1.5,
+            pause_minor=0.8,
+            pause_para=0.2,
+        )
+    assert rc == 0
+    assert "[[slnc 1500]]" in spoken["text"]
+    assert "[[slnc 800]]" in spoken["text"]
+    assert "[[slnc 200]]" in spoken["text"]
+    assert "[[slnc 2000]]" not in spoken["text"]
+
+
+def test_speak_markdown_no_emphasis(tmp_path, capsys):
+    src = tmp_path / "notes.md"
+    src.write_text("# Title\n\nUse **care** with `x`.\n\n## Next\n")
+    spoken: dict[str, str] = {}
+    with (
+        patch("commands.ai_speak_cmd.resolve_speak_engine", return_value="say"),
+        patch("commands.ai_speak_cmd.shutil.which", return_value="/usr/bin/say"),
+        patch("commands.ai_speak_cmd.subprocess.run") as run,
+    ):
+        def capture(cmd, **kwargs):
+            spoken["text"] = Path(cmd[cmd.index("-f") + 1]).read_text(
+                encoding="utf-8"
+            )
+            return subprocess.CompletedProcess(cmd, 0)
+
+        run.side_effect = capture
+        rc = cmd_speak(
+            [str(src)], None, None, 1.0, engine="say", emphasis=False
+        )
+    assert rc == 0
+    assert "[[emph +]]" not in spoken["text"]
+    assert "[[slnc 2000]]" in spoken["text"]
+    assert "care" in spoken["text"]
+    assert "emphasis=off" in capsys.readouterr().err
+
+
+def test_speak_markdown_kokoro_manifest(tmp_path, capsys):
+    src = tmp_path / "notes.md"
+    src.write_text("# Alpha\n\n**bold** and `code`\n\n## Beta\n")
+    fake_python = tmp_path / "venv" / "bin" / "python3"
+    captured: dict[str, object] = {}
+    with (
+        patch("commands.ai_speak_cmd.ensure_kokoro", return_value=fake_python),
+        patch("commands.ai_speak_cmd.SPEAK_REPLACEMENTS_FILE", tmp_path / "r.txt"),
+        patch("commands.ai_speak_cmd.SPEAK_PRONUNCIATIONS_FILE", tmp_path / "p.txt"),
+        patch("commands.ai_speak_cmd.SPEAK_VOICE_FILE", tmp_path / "v.txt"),
+        patch("commands.ai_speak_cmd.subprocess.run") as run,
+    ):
+        def capture_run(cmd, **kwargs):
+            captured["pieces"] = json.loads(
+                Path(cmd[3]).read_text(encoding="utf-8")
+            )
+            return subprocess.CompletedProcess(cmd, 0)
+
+        run.side_effect = capture_run
+        rc = cmd_speak(
+            [str(src)], str(tmp_path / "out.wav"), None, 1.0, engine="kokoro"
+        )
+    assert rc == 0
+    pieces = captured["pieces"]
+    assert isinstance(pieces, list)
+    assert len(pieces) > 1
+    texts = [p["text"] for p in pieces if p["text"].strip()]
+    assert any("Alpha" in t for t in texts)
+    assert any("bold" in t for t in texts)
+    assert any("code" in t for t in texts)
+    assert any(p["silence_after"] >= 2.0 for p in pieces)
+    assert any(p["speed"] < 1.0 for p in pieces)
+    err = capsys.readouterr().err
+    assert "markdown:" in err
+    assert "emphasis=on" in err
+
+
+def test_speak_markdown_only_fences_returns_nothing(tmp_path, capsys):
+    src = tmp_path / "notes.md"
+    src.write_text("```\nsecret()\n```\n")
+    with (
+        patch("commands.ai_speak_cmd.resolve_speak_engine", return_value="say"),
+        patch("commands.ai_speak_cmd.shutil.which", return_value="/usr/bin/say"),
+        patch("commands.ai_speak_cmd.subprocess.run") as run,
+    ):
+        rc = cmd_speak([str(src)], None, None, 1.0, engine="say")
+    assert rc == 2
+    run.assert_not_called()
+    assert "nothing to say" in capsys.readouterr().err
+
+
+def test_speak_markdown_empty_input_returns_nothing(tmp_path, capsys):
+    with (
+        patch("commands.ai_speak_cmd.resolve_speak_engine", return_value="say"),
+        patch("commands.ai_speak_cmd.shutil.which", return_value="/usr/bin/say"),
+        patch("commands.ai_speak_cmd.subprocess.run") as run,
+    ):
+        rc = cmd_speak([""], None, None, 1.0, engine="say")
+    assert rc == 2
+    run.assert_not_called()
+    assert "nothing to say" in capsys.readouterr().err
+
+
 def test_speak_help():
     proc = run_n0b("ai", "speak", "--help")
     assert proc.returncode == 0
@@ -798,7 +920,10 @@ def test_speak_help():
     assert "--save" in proc.stdout
     assert "--engine" in proc.stdout
     assert "--pause-major" in proc.stdout
+    assert "--pause-minor" in proc.stdout
+    assert "--pause-para" in proc.stdout
     assert "--flat" in proc.stdout
+    assert "--no-emphasis" in proc.stdout
     assert "play on speakers" in proc.stdout
 
 

--- a/apps/n0b/tests/test_cli.py
+++ b/apps/n0b/tests/test_cli.py
@@ -23,9 +23,6 @@ from commands.ai_speak_cmd import (
     resolve_speak_voice,
     save_sticky_voice,
     speakable,
-    SPEAK_REPLACEMENTS_FILE,
-    SPEAK_PRONUNCIATIONS_FILE,
-    SPEAK_VOICE_FILE,
 )
 from commands.ai_transcribe_cmd import (
     apply_replacements,
@@ -707,32 +704,40 @@ def test_speak_applies_teachings_before_kokoro(tmp_path, capsys):
     repl = tmp_path / "speak-replacements.txt"
     repl.write_text("\\ba8s\\b => A eight S\n")
     fake_python = tmp_path / "venv" / "bin" / "python3"
-    captured: dict[str, str] = {}
+    captured: dict[str, object] = {}
     with (
         patch("commands.ai_speak_cmd.ensure_kokoro", return_value=fake_python),
         patch("commands.ai_speak_cmd.SPEAK_REPLACEMENTS_FILE", repl),
         patch("commands.ai_speak_cmd.SPEAK_PRONUNCIATIONS_FILE", tmp_path / "missing.txt"),
         patch("commands.ai_speak_cmd.SPEAK_VOICE_FILE", tmp_path / "missing-voice.txt"),
-        patch("commands.ai_transcribe_cmd.subprocess.run") as run,
+        patch("commands.ai_speak_cmd.subprocess.run") as run,
     ):
         def capture_run(cmd, **kwargs):
-            captured["text"] = Path(cmd[3]).read_text(encoding="utf-8")
-            run.return_value.returncode = 0
-            return run.return_value
+            import json
+
+            captured["pieces"] = json.loads(
+                Path(cmd[3]).read_text(encoding="utf-8")
+            )
+            return subprocess.CompletedProcess(cmd, 0)
 
         run.side_effect = capture_run
         rc = cmd_speak(
             [str(src)], str(tmp_path / "out.wav"), None, 1.0, engine="kokoro"
         )
     assert rc == 0
-    assert captured["text"] == "A eight S ready"
+    assert captured["pieces"] == [
+        {"text": "A eight S ready", "speed": 1.0, "silence_after": 0.0}
+    ]
     err = capsys.readouterr().err
     assert "replacements applied" in err
 
 
 def test_speak_say_play_inline(tmp_path):
-    with patch("commands.ai_speak_cmd.resolve_speak_engine", return_value="say"), \
-            patch("commands.ai_speak_cmd.subprocess.run") as run:
+    with (
+        patch("commands.ai_speak_cmd.resolve_speak_engine", return_value="say"),
+        patch("commands.ai_speak_cmd.shutil.which", return_value="/usr/bin/say"),
+        patch("commands.ai_speak_cmd.subprocess.run") as run,
+    ):
         run.return_value.returncode = 0
         rc = cmd_speak(["hello"], None, None, 1.0, engine="say")
     assert rc == 0
@@ -742,12 +747,58 @@ def test_speak_say_play_inline(tmp_path):
     assert "-o" not in argv
 
 
+def test_speak_markdown_say_uses_section_pauses(tmp_path):
+    src = tmp_path / "notes.md"
+    src.write_text("# Alpha\n\nHello.\n\n## Beta\n\nWorld.\n")
+    spoken: dict[str, str] = {}
+    with (
+        patch("commands.ai_speak_cmd.resolve_speak_engine", return_value="say"),
+        patch("commands.ai_speak_cmd.shutil.which", return_value="/usr/bin/say"),
+        patch("commands.ai_speak_cmd.subprocess.run") as run,
+    ):
+        def capture(cmd, **kwargs):
+            spoken["text"] = Path(cmd[cmd.index("-f") + 1]).read_text(
+                encoding="utf-8"
+            )
+            return subprocess.CompletedProcess(cmd, 0)
+
+        run.side_effect = capture
+        rc = cmd_speak([str(src)], None, None, 1.0, engine="say")
+    assert rc == 0
+    assert "[[slnc 2000]]" in spoken["text"]
+    assert "Alpha" in spoken["text"]
+    assert "Beta" in spoken["text"]
+
+
+def test_speak_markdown_flat_skips_section_pauses(tmp_path):
+    src = tmp_path / "notes.md"
+    src.write_text("# Alpha\n\nHello.\n\n## Beta\n")
+    spoken: dict[str, str] = {}
+    with (
+        patch("commands.ai_speak_cmd.resolve_speak_engine", return_value="say"),
+        patch("commands.ai_speak_cmd.shutil.which", return_value="/usr/bin/say"),
+        patch("commands.ai_speak_cmd.subprocess.run") as run,
+    ):
+        def capture(cmd, **kwargs):
+            spoken["text"] = Path(cmd[cmd.index("-f") + 1]).read_text(
+                encoding="utf-8"
+            )
+            return subprocess.CompletedProcess(cmd, 0)
+
+        run.side_effect = capture
+        rc = cmd_speak([str(src)], None, None, 1.0, engine="say", flat=True)
+    assert rc == 0
+    assert "[[slnc" not in spoken["text"]
+
+
 def test_speak_help():
     proc = run_n0b("ai", "speak", "--help")
     assert proc.returncode == 0
     assert "--pronounce" in proc.stdout
     assert "--save" in proc.stdout
     assert "--engine" in proc.stdout
+    assert "--pause-major" in proc.stdout
+    assert "--flat" in proc.stdout
     assert "play on speakers" in proc.stdout
 
 

--- a/apps/n0b/tests/test_speak_markdown.py
+++ b/apps/n0b/tests/test_speak_markdown.py
@@ -1,0 +1,111 @@
+"""Tests for markdown-aware n0b ai speak segmentation."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from commands.speak_markdown import (
+    PauseConfig,
+    SpeakSpan,
+    looks_like_markdown,
+    parse_inline_spans,
+    parse_markdown_blocks,
+    render_kokoro_pieces,
+    render_say_text,
+)
+
+
+def test_looks_like_markdown_detects_headings_and_emphasis():
+    assert looks_like_markdown("# Title\n\nHello")
+    assert looks_like_markdown("Use **bold** here")
+    assert looks_like_markdown("run `n0b` now")
+    assert not looks_like_markdown("plain hello world")
+
+
+def test_parse_inline_spans_styles_and_misaki():
+    spans = parse_inline_spans(
+        "See **bold** and `code` plus [Pay-i](/pˈeɪ ˈaɪ/) link [docs](https://x)"
+    )
+    assert spans == (
+        SpeakSpan("See ", "plain"),
+        SpeakSpan("bold", "strong"),
+        SpeakSpan(" and ", "plain"),
+        SpeakSpan("code", "code"),
+        SpeakSpan(" plus ", "plain"),
+        SpeakSpan("[Pay-i](/pˈeɪ ˈaɪ/)", "plain"),
+        SpeakSpan(" link docs", "plain"),
+    )
+
+
+def test_parse_markdown_blocks_pauses_by_heading_level():
+    md = "# One\n\nIntro.\n\n## Two\n\nBody.\n\n### Three\n\nMore.\n"
+    blocks = parse_markdown_blocks(md)
+    assert [b.kind for b in blocks] == [
+        "heading",
+        "paragraph",
+        "heading",
+        "paragraph",
+        "heading",
+        "paragraph",
+    ]
+    assert blocks[0].pause_before == 0.0
+    assert blocks[0].level == 1
+    assert blocks[2].level == 2
+    assert blocks[2].pause_before == 2.0
+    assert blocks[4].level == 3
+    assert blocks[4].pause_before == 1.0
+    assert blocks[1].pause_before == 0.4
+
+
+def test_parse_skips_fences_and_tables():
+    md = "# Title\n\n| a | b |\n|---|---|\n\nHello\n\n```py\nx=1\n```\n\nBye\n"
+    blocks = parse_markdown_blocks(md)
+    texts = [" ".join(s.text for s in b.spans) for b in blocks]
+    assert texts == ["Title", "Hello", "Bye"]
+
+
+def test_custom_pause_config():
+    md = "## A\n\npara\n\n### B\n"
+    blocks = parse_markdown_blocks(
+        md, PauseConfig(major=1.5, minor=0.75, para=0.2)
+    )
+    assert blocks[0].pause_before == 0.0
+    assert blocks[1].pause_before == 0.2
+    assert blocks[2].pause_before == 0.75
+
+
+def test_render_say_text_inserts_slnc_and_emph():
+    blocks = parse_markdown_blocks("# Hi\n\nUse **care** with `x`.\n")
+    rendered = render_say_text(blocks)
+    assert "[[slnc 400]]" in rendered
+    assert "[[emph +]]care" in rendered
+    assert "`" not in rendered
+    assert "[[slnc 120]]" in rendered
+
+
+def test_render_say_text_major_heading_silence():
+    blocks = parse_markdown_blocks("# A\n\ntext\n\n## B\n\nmore\n")
+    rendered = render_say_text(blocks)
+    assert "[[slnc 2000]]" in rendered
+
+
+def test_render_kokoro_pieces_compose_speeds_and_silence():
+    blocks = parse_markdown_blocks("# A\n\n**bold** and `code`\n\n## B\n")
+    pieces = render_kokoro_pieces(blocks, base_speed=1.0)
+    texts = [p.text for p in pieces if p.text.strip()]
+    assert "A" in texts[0]
+    assert any(p.speed < 1.0 and "bold" in p.text for p in pieces)
+    assert any(p.speed < 0.9 and "code" in p.text for p in pieces)
+    assert any(p.silence_after >= 2.0 for p in pieces)
+
+
+def test_no_emphasis_keeps_pauses():
+    blocks = parse_markdown_blocks("## A\n\n**bold**\n\n## B\n")
+    say = render_say_text(blocks, emphasis=False)
+    assert "[[emph +]]" not in say
+    assert "[[slnc 2000]]" in say
+    pieces = render_kokoro_pieces(blocks, emphasis=False)
+    assert all(p.speed == 1.0 for p in pieces if p.text.strip())
+    assert any(p.silence_after >= 2.0 for p in pieces)

--- a/apps/n0b/tests/test_speak_markdown.py
+++ b/apps/n0b/tests/test_speak_markdown.py
@@ -202,3 +202,30 @@ def test_looks_like_markdown_lists_quotes_and_fences():
 def test_render_kokoro_pieces_empty_blocks():
     assert render_kokoro_pieces([]) == []
     assert render_say_text([]) == ""
+
+
+def test_render_say_preserves_mid_word_markup():
+    spans = parse_inline_spans("a**b**c")
+    assert "".join(s.text for s in spans) == "abc"
+    blocks = parse_markdown_blocks("a**b**c\n")
+    rendered = render_say_text(blocks)
+    assert "a[[emph +]]b c" not in rendered
+    assert "a[[emph +]]bc" in rendered.replace("\n", "")
+
+
+def test_empty_heading_markers_are_skipped():
+    blocks = parse_markdown_blocks("#\n\nHi\n\n## \n\nBye\n")
+    texts = ["".join(s.text for s in b.spans) for b in blocks]
+    assert texts == ["Hi", "Bye"]
+
+
+def test_kokoro_section_pause_not_stacked_with_emphasis():
+    blocks = parse_markdown_blocks("# A\n\n`code`\n\n## B\n")
+    pieces = render_kokoro_pieces(blocks)
+    section = [p for p in pieces if p.silence_after == 2.0 and not p.text.strip()]
+    assert section, pieces
+    assert all(
+        abs(p.silence_after - 2.0) < 1e-9 or p.silence_after < 0.2
+        for p in pieces
+        if p.silence_after
+    )

--- a/apps/n0b/tests/test_speak_markdown.py
+++ b/apps/n0b/tests/test_speak_markdown.py
@@ -33,9 +33,18 @@ def test_parse_inline_spans_styles_and_misaki():
         SpeakSpan("bold", "strong"),
         SpeakSpan(" and ", "plain"),
         SpeakSpan("code", "code"),
-        SpeakSpan(" plus ", "plain"),
-        SpeakSpan("[Pay-i](/pˈeɪ ˈaɪ/)", "plain"),
-        SpeakSpan(" link docs", "plain"),
+        SpeakSpan(" plus [Pay-i](/pˈeɪ ˈaɪ/) link docs", "plain"),
+    )
+
+
+def test_parse_inline_spans_keeps_snake_case_and_root_links():
+    spans = parse_inline_spans(
+        "Set API_KEY via snake_case and _italic_ then [install](/docs/install)"
+    )
+    assert spans == (
+        SpeakSpan("Set API_KEY via snake_case and ", "plain"),
+        SpeakSpan("italic", "strong"),
+        SpeakSpan(" then install", "plain"),
     )
 
 

--- a/apps/n0b/tests/test_speak_markdown.py
+++ b/apps/n0b/tests/test_speak_markdown.py
@@ -224,8 +224,12 @@ def test_kokoro_section_pause_not_stacked_with_emphasis():
     pieces = render_kokoro_pieces(blocks)
     section = [p for p in pieces if p.silence_after == 2.0 and not p.text.strip()]
     assert section, pieces
+    configured = (2.0, 1.0, 0.4)
     assert all(
-        abs(p.silence_after - 2.0) < 1e-9 or p.silence_after < 0.2
+        any(abs(p.silence_after - c) < 1e-9 for c in configured)
+        or p.silence_after < 0.2
         for p in pieces
         if p.silence_after
     )
+    silent = [not p.text.strip() for p in pieces]
+    assert not any(a and b for a, b in zip(silent, silent[1:]))

--- a/apps/n0b/tests/test_speak_markdown.py
+++ b/apps/n0b/tests/test_speak_markdown.py
@@ -109,3 +109,87 @@ def test_no_emphasis_keeps_pauses():
     pieces = render_kokoro_pieces(blocks, emphasis=False)
     assert all(p.speed == 1.0 for p in pieces if p.text.strip())
     assert any(p.silence_after >= 2.0 for p in pieces)
+
+
+def test_empty_and_whitespace_markdown_yield_no_blocks():
+    assert parse_markdown_blocks("") == []
+    assert parse_markdown_blocks("   \n\n\t\n") == []
+    assert not looks_like_markdown("")
+
+
+def test_fenced_code_only_yields_no_blocks():
+    md = "```python\nprint(1)\n```\n"
+    assert looks_like_markdown(md)
+    assert parse_markdown_blocks(md) == []
+
+
+def test_list_item_pauses_capped_below_para():
+    blocks = parse_markdown_blocks("- alpha\n- beta\n- gamma\n")
+    assert [b.kind for b in blocks] == ["list_item", "list_item", "list_item"]
+    assert blocks[0].pause_before == 0.0
+    assert blocks[1].pause_before == 0.25
+    assert blocks[2].pause_before == 0.25
+    say = render_say_text(blocks)
+    assert "[[slnc 250]]" in say
+
+    short = parse_markdown_blocks(
+        "1. one\n2. two\n", PauseConfig(para=0.1)
+    )
+    assert short[1].pause_before == 0.1
+
+
+def test_nested_emphasis_stays_inside_outer_strong():
+    spans = parse_inline_spans("**bold *nested* more**")
+    assert spans == (SpeakSpan("bold *nested* more", "strong"),)
+
+
+def test_underscore_and_single_star_map_to_strong():
+    assert parse_inline_spans("use __strong__ here") == (
+        SpeakSpan("use ", "plain"),
+        SpeakSpan("strong", "strong"),
+        SpeakSpan(" here", "plain"),
+    )
+    assert parse_inline_spans("use *em* here") == (
+        SpeakSpan("use ", "plain"),
+        SpeakSpan("em", "strong"),
+        SpeakSpan(" here", "plain"),
+    )
+
+
+def test_unclosed_markers_fall_back_to_plain():
+    spans = parse_inline_spans("**no close and `also open")
+    assert all(s.style == "plain" for s in spans)
+    joined = "".join(s.text for s in spans)
+    assert "**" in joined or joined.startswith("*")
+    assert "`" in joined
+
+
+def test_horizontal_rule_skipped_between_paragraphs():
+    blocks = parse_markdown_blocks("Hi\n\n---\n\nBye\n")
+    texts = [" ".join(s.text for s in b.spans) for b in blocks]
+    assert texts == ["Hi", "Bye"]
+    assert blocks[1].pause_before == 0.4
+
+
+def test_blockquote_becomes_paragraph_with_inline_styles():
+    blocks = parse_markdown_blocks("> quoted **bold**\n\nnext\n")
+    assert blocks[0].kind == "paragraph"
+    assert blocks[0].spans == (
+        SpeakSpan("quoted ", "plain"),
+        SpeakSpan("bold", "strong"),
+    )
+    assert blocks[1].pause_before == 0.4
+
+
+def test_looks_like_markdown_lists_quotes_and_fences():
+    assert looks_like_markdown("- item one")
+    assert looks_like_markdown("1. first")
+    assert looks_like_markdown("> quoted")
+    assert looks_like_markdown("```\ncode\n```")
+    assert looks_like_markdown("| a | b |")
+    assert not looks_like_markdown("---")
+
+
+def test_render_kokoro_pieces_empty_blocks():
+    assert render_kokoro_pieces([]) == []
+    assert render_say_text([]) == ""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`n0b ai speak` now detects markdown and synthesizes it in sections instead of one flat pass.

- **Section pauses** before headings: `--pause-major` (default 2s for H1/H2), `--pause-minor` (1s for H3–H6), `--pause-para` (0.4s)
- **Emphasis**: bold/italic get light stress; inline code gets micro-pauses (and slower speed on Kokoro)
- **say**: embeds `[[slnc]]` / `[[emph +]]` in one render
- **kokoro**: composes multiple synthesis pieces + silence samples into one WAV
- `--flat` restores the previous single-pass `speakable()` cleanup; `--no-emphasis` keeps pauses only

## Test plan

- [x] `pytest apps/n0b/tests/test_speak_markdown.py apps/n0b/tests/test_cli.py -k speak` (40 passed)
- [ ] Manual: `n0b ai speak notes.md` on macOS and confirm heading gaps + bold stress
- [ ] Manual: `n0b ai speak notes.md --engine kokoro -o /tmp/out.wav` and inspect pauses

## Notes

Research-backed pacing usually suggests ~0.4–0.8s section breaks; defaults follow the requested 2s/1s major/minor for listening to docs and are tunable via flags.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb9f3-f6d2-7e9c-8f35-651ddab3c4bf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb9f3-f6d2-7e9c-8f35-651ddab3c4bf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

