### PR TITLE
fix(h4l): stop the shipped a8s wiring from deleting rooms on a timer

### DIFF
--- a/apps/h4l/README.md
+++ b/apps/h4l/README.md
@@ -46,6 +46,22 @@ tell chatroom '/list'
 The registered agent name (`chatroom`, `hall`, etc.) becomes `--node` / `$RECIPIENT`
 and appears in notification footers.
 
+### Retention is opt-in
+
+Rooms live under the agent root and are never swept on their own. `h4l clear
+--older-than <secs>` deletes whole rooms — the transcript, not just old lines —
+so nothing runs it for you.
+
+If you do want a node to forget quiet rooms, add an `idle` block yourself and
+pick a window you can live with losing:
+
+```json
+"idle": {
+  "timeout": 2592000,
+  "invoke": ["h4l", "clear", "--root", ".", "--older-than", "2592000"]
+}
+```
+
 ## IRC-style usage
 
 Post to a channel the IRC way — no slash command needed:

--- a/apps/h4l/connector-a8s/example-definition.json
+++ b/apps/h4l/connector-a8s/example-definition.json
@@ -11,16 +11,5 @@
     "$RECIPIENT",
     "--message",
     "$MESSAGE"
-  ],
-  "idle": {
-    "timeout": 86400,
-    "invoke": [
-      "h4l",
-      "clear",
-      "--root",
-      ".",
-      "--older-than",
-      "86400"
-    ]
-  }
+  ]
 }

--- a/apps/h4l/rooms.py
+++ b/apps/h4l/rooms.py
@@ -218,10 +218,14 @@ class RoomStore:
             raw = meta.get("last_activity", "")
             try:
                 dt = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
-                if dt.timestamp() >= cutoff:
-                    continue
             except ValueError:
-                pass
+                # An unreadable timestamp is not evidence of age. Deleting on
+                # it made a corrupt or hand-edited meta.json indistinguishable
+                # from an abandoned room, and this call deletes a whole
+                # transcript.
+                continue
+            if dt.timestamp() >= cutoff:
+                continue
             self._delete_room(slug)
             removed.append(slug)
         return removed

--- a/apps/h4l/tests/test_h4l.py
+++ b/apps/h4l/tests/test_h4l.py
@@ -725,6 +725,36 @@ class TestClear:
         assert "old" in removed
         assert "new" not in removed
 
+    def test_an_unreadable_timestamp_is_not_evidence_of_age(self, store):
+        # This call deletes a whole transcript. A corrupt or hand-edited
+        # meta.json used to be indistinguishable from an abandoned room.
+        store.ensure_room("keepme")
+        meta = store.load_meta("keepme")
+        meta["last_activity"] = "yesterday-ish"
+        store.save_meta("keepme", meta)
+        assert store.clear_older_than(1) == []
+        assert "keepme" in [m["slug"] for m in store.list_rooms()]
+
+    def test_a_missing_timestamp_is_not_evidence_of_age(self, store):
+        store.ensure_room("keepme")
+        meta = store.load_meta("keepme")
+        meta.pop("last_activity", None)
+        store.save_meta("keepme", meta)
+        assert store.clear_older_than(1) == []
+
+    def test_the_example_definition_sweeps_nothing(self):
+        # A chat room's whole value is its history, so the shipped wiring must
+        # not schedule a delete. This one swept every room quiet for a day,
+        # which on a low-traffic node means all of them.
+        import json
+        from pathlib import Path
+
+        spec = json.loads(
+            (Path(__file__).resolve().parents[1]
+             / "connector-a8s" / "example-definition.json").read_text()
+        )
+        assert "idle" not in spec
+
     def test_cli_clear_all(self, store, tmp_path, capsys):
         store.ensure_room("a")
         store.ensure_room("b")


### PR DESCRIPTION
## What happened

A node reported h4l "broken — lost all its data after an update". It was not the update. From that node's a8s log:

```
2026-08-05T15:24:14Z [chatroom] idle 86400s ≥ 86400s — firing idle invoke
2026-08-05T15:24:14Z [chatroom] idle exec: h4l clear --root . --older-than 86400
2026-08-05T15:24:15Z chatroom> cleared 3 room(s): 146, amperup, demopony
```

The daemon had been attached since the day before. Nothing restarted, nothing was upgraded. A scheduled sweep deleted three rooms, and the loss only surfaced on the next visit — which is why it read as an upgrade wiping state.

## Why the default was wrong

`example-definition.json` shipped an `idle` block running `h4l clear --older-than 86400`. Two things make that worse than it looks:

- `clear` is **not** a prune. It `rmtree`s the whole room directory — meta, membership and every message.
- On a low-traffic node, *every* room is quiet for a day. The 24-hour window does not select abandoned rooms; it selects all of them.

A chat room's whole value is its history. Nothing schedules a delete now. Retention is opt-in and documented, with a window the operator picks deliberately.

## A second bug in the same function

```python
try:
    dt = datetime.fromisoformat(...)
    if dt.timestamp() >= cutoff:
        continue
except ValueError:
    pass
self._delete_room(slug)
```

The `try` wrapped both the parse *and* the comparison, so a corrupt or hand-edited `meta.json` fell through to the same `rmtree` as a genuinely abandoned room. An unreadable timestamp is not evidence of age — it skips now.

## Tests

Three added, all confirmed failing without the fix:

- `test_an_unreadable_timestamp_is_not_evidence_of_age`
- `test_a_missing_timestamp_is_not_evidence_of_age`
- `test_the_example_definition_sweeps_nothing` — reads the shipped JSON and asserts no `idle` key, so the default cannot regress silently

`apps/h4l/tests`: 66 passed.

## Note for the reviewer

`apps/h4l/tests` is not in `.github/workflows/test.yml` — CI runs `apps/l9m` and `apps/q3w` only. This fix is verified locally. Adding h4l to CI is a separate change and not in this PR.